### PR TITLE
Update System.Text.Encoding.CodePage tests.

### DIFF
--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.Data.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.Data.cs
@@ -16,7 +16,7 @@ namespace System.Text
         // Using indices from s_encodingNamesIndices, we binary search this string when mapping
         // an encoding name to a codepage. Note that these names are all lowercase and are
         // sorted alphabetically.
-        // 
+        //
         private const string s_encodingNames =
             "437" + // 437
             "arabic" + // 28596
@@ -755,7 +755,7 @@ namespace System.Text
             3406
         };
 
-        // 
+        //
         // s_codePagesByName contains the list of supported codepages which match the encoding
         // names listed in s_encodingNames. The way mapping works is we binary search
         // s_encodingNames using s_encodingNamesIndices until we find a match for a given name.
@@ -1129,7 +1129,7 @@ namespace System.Text
             950 // x-x-big5
         };
 
-        // 
+        //
         // When retrieving the value for System.Text.Encoding.WebName or
         // System.Text.Encoding.EncodingName given System.Text.Encoding.CodePage,
         // we perform a linear search on s_mappedCodePages to find the index of the
@@ -1250,6 +1250,7 @@ namespace System.Text
             28599, // iso-8859-9
             28603, // iso-8859-13
             28605, // iso-8859-15
+            29001, // x-europa
             38598, // iso-8859-8-i
             50220, // iso-2022-jp
             50221, // csiso2022jp
@@ -1273,7 +1274,7 @@ namespace System.Text
             57011 // x-iscii-pa
         };
 
-        // 
+        //
         // s_webNames is a concatenation of the default encoding names
         // for each code page. It is used in retrieving the value for
         // System.Text.Encoding.WebName given System.Text.Encoding.CodePage.
@@ -1391,6 +1392,7 @@ namespace System.Text
             "iso-8859-9" + // 28599
             "iso-8859-13" + // 28603
             "iso-8859-15" + // 28605
+            "x-europa" + // 29001
             "iso-8859-8-i" + // 38598
             "iso-2022-jp" + // 50220
             "csiso2022jp" + // 50221
@@ -1413,7 +1415,7 @@ namespace System.Text
             "x-iscii-gu" + // 57010
             "x-iscii-pa"; // 57011
 
-        // 
+        //
         // s_webNameIndices contains the start index of each code page's default
         // web name in the string s_webNames. It is indexed by an index into
         // s_mappedCodePages.
@@ -1530,37 +1532,38 @@ namespace System.Text
             956, // iso-8859-9 (28599)
             966, // iso-8859-13 (28603)
             977, // iso-8859-15 (28605)
-            988, // iso-8859-8-i (38598)
-            1000, // iso-2022-jp (50220)
-            1011, // csiso2022jp (50221)
-            1022, // iso-2022-jp (50222)
-            1033, // iso-2022-kr (50225)
-            1044, // x-cp50227 (50227)
-            1053, // euc-jp (51932)
-            1059, // euc-cn (51936)
-            1065, // euc-kr (51949)
-            1071, // hz-gb-2312 (52936)
-            1081, // gb18030 (54936)
-            1088, // x-iscii-de (57002)
-            1098, // x-iscii-be (57003)
-            1108, // x-iscii-ta (57004)
-            1118, // x-iscii-te (57005)
-            1128, // x-iscii-as (57006)
-            1138, // x-iscii-or (57007)
-            1148, // x-iscii-ka (57008)
-            1158, // x-iscii-ma (57009)
-            1168, // x-iscii-gu (57010)
-            1178, // x-iscii-pa (57011)
-            1188
+            988, // x-europa (29001)
+            996, // iso-8859-8-i (38598)
+            1008, // iso-2022-jp (50220)
+            1019, // csiso2022jp (50221)
+            1030, // iso-2022-jp (50222)
+            1041, // iso-2022-kr (50225)
+            1052, // x-cp50227 (50227)
+            1061, // euc-jp (51932)
+            1067, // euc-cn (51936)
+            1073, // euc-kr (51949)
+            1079, // hz-gb-2312 (52936)
+            1089, // gb18030 (54936)
+            1096, // x-iscii-de (57002)
+            1106, // x-iscii-be (57003)
+            1116, // x-iscii-ta (57004)
+            1126, // x-iscii-te (57005)
+            1136, // x-iscii-as (57006)
+            1146, // x-iscii-or (57007)
+            1156, // x-iscii-ka (57008)
+            1166, // x-iscii-ma (57009)
+            1176, // x-iscii-gu (57010)
+            1186, // x-iscii-pa (57011)
+            1196
         };
 
-        // 
+        //
         // s_englishNames is the concatenation of the English names for each codepage.
         // It is used in retrieving the value for System.Text.Encoding.EncodingName
         // given System.Text.Encoding.CodePage.
         // This is done rather than using a large readonly array of strings to avoid
         // generating a large amount of code in the static constructor.
-        // 
+        //
         private const string s_englishNames =
             "IBM EBCDIC (US-Canada)" + // 37
             "OEM United States" + // 437
@@ -1672,6 +1675,7 @@ namespace System.Text
             "Turkish (ISO)" + // 28599
             "Estonian (ISO)" + // 28603
             "Latin 9 (ISO)" + // 28605
+            "Europa" + // 29001
             "Hebrew (ISO-Logical)" + // 38598
             "Japanese (JIS)" + // 50220
             "Japanese (JIS-Allow 1 byte Kana)" + // 50221
@@ -1694,7 +1698,7 @@ namespace System.Text
             "ISCII Gujarati" + // 57010
             "ISCII Punjabi"; // 57011
 
-        // 
+        //
         // s_englishNameIndices contains the start index of each code page's English
         // name in the string s_englishNames. It is indexed by an index into
         // s_mappedCodePages.
@@ -1811,28 +1815,29 @@ namespace System.Text
             2008, // Turkish (ISO) (28599)
             2021, // Estonian (ISO) (28603)
             2035, // Latin 9 (ISO) (28605)
-            2048, // Hebrew (ISO-Logical) (38598)
-            2068, // Japanese (JIS) (50220)
-            2082, // Japanese (JIS-Allow 1 byte Kana) (50221)
-            2114, // Japanese (JIS-Allow 1 byte Kana - SO/SI) (50222)
-            2154, // Korean (ISO) (50225)
-            2166, // Chinese Simplified (ISO-2022) (50227)
-            2195, // Japanese (EUC) (51932)
-            2209, // Chinese Simplified (EUC) (51936)
-            2233, // Korean (EUC) (51949)
-            2245, // Chinese Simplified (HZ) (52936)
-            2268, // Chinese Simplified (GB18030) (54936)
-            2296, // ISCII Devanagari (57002)
-            2312, // ISCII Bengali (57003)
-            2325, // ISCII Tamil (57004)
-            2336, // ISCII Telugu (57005)
-            2348, // ISCII Assamese (57006)
-            2362, // ISCII Oriya (57007)
-            2373, // ISCII Kannada (57008)
-            2386, // ISCII Malayalam (57009)
-            2401, // ISCII Gujarati (57010)
-            2415, // ISCII Punjabi (57011)
-            2428
+            2048, // Europa (29001)
+            2054, // Hebrew (ISO-Logical) (38598)
+            2074, // Japanese (JIS) (50220)
+            2088, // Japanese (JIS-Allow 1 byte Kana) (50221)
+            2120, // Japanese (JIS-Allow 1 byte Kana - SO/SI) (50222)
+            2160, // Korean (ISO) (50225)
+            2172, // Chinese Simplified (ISO-2022) (50227)
+            2201, // Japanese (EUC) (51932)
+            2215, // Chinese Simplified (EUC) (51936)
+            2239, // Korean (EUC) (51949)
+            2251, // Chinese Simplified (HZ) (52936)
+            2274, // Chinese Simplified (GB18030) (54936)
+            2302, // ISCII Devanagari (57002)
+            2318, // ISCII Bengali (57003)
+            2331, // ISCII Tamil (57004)
+            2342, // ISCII Telugu (57005)
+            2354, // ISCII Assamese (57006)
+            2368, // ISCII Oriya (57007)
+            2379, // ISCII Kannada (57008)
+            2392, // ISCII Malayalam (57009)
+            2407, // ISCII Gujarati (57010)
+            2421, // ISCII Punjabi (57011)
+            2434
         };
     }
 }

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -506,7 +506,6 @@ namespace Test
 
         [Theory]
         [MemberData("SpecificCodepageEncodings")]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestRoundtrippingSpecificCodepageEncoding(string encodingName, byte[] bytes, string expected)
         {
             Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(encodingName);

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -18,25 +18,6 @@ namespace Test
             // xUnit will keep track of it, do nothing.
         }
 
-        // The characters to encode:
-        //    Latin Small Letter Z (U+007A)
-        //    Latin Small Letter A (U+0061)
-        //    Combining Breve (U+0306)
-        //    Latin Small Letter AE With Acute (U+01FD)
-        //    Greek Small Letter Beta (U+03B2)
-        //    a high-surrogate value (U+D8FF)
-        //    a low-surrogate value (U+DCFF)
-        private static char[] s_myChars = new char[] { 'z', 'a', '\u0306', '\u01FD', '\u03B2', '\uD8FF', '\uDCFF' };
-
-        private static string s_myString = new String(s_myChars);
-        private static byte[] s_leBytes = new byte[] { 0x7A, 0x00, 0x61, 0x00, 0x06, 0x03, 0xFD, 0x01, 0xB2, 0x03, 0xFF, 0xD8, 0xFF, 0xDC };
-        private static byte[] s_beBytes = new byte[] { 0x00, 0x7A, 0x00, 0x61, 0x03, 0x06, 0x01, 0xFD, 0x03, 0xB2, 0xD8, 0xFF, 0xDC, 0xFF };
-        private static byte[] s_utf8Bytes = new byte[] { 0x7A, 0x61, 0xCC, 0x86, 0xC7, 0xBD, 0xCE, 0xB2, 0xF1, 0x8F, 0xB3, 0xBF };
-
-        private static byte[] s_utf8PreambleBytes = new byte[] { 0xEF, 0xBB, 0xBF };
-        private static byte[] s_unicodePreambleBytes = new byte[] { 0xFF, 0xFE };
-        private static byte[] s_unicodeBigEndianPreambleBytes = new byte[] { 0xFE, 0xFF };
-
         public static IEnumerable<object[]> CodePageInfo()
         {
             // The layout is code page, IANA(web) name, and query string.

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -453,8 +453,7 @@ namespace Test
         }
 
         [Fact]
-        // Specific asserts which would fail on Unix are conditionally not run.
-        // [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestDefaultEncodings()
         {
             ValidateDefaultEncodings();
@@ -508,11 +507,8 @@ namespace Test
             {
                 Encoding encoding = Encoding.GetEncoding(mapping.Key);
                 Assert.NotNull(encoding);
-#if !PLATFORM_UNIX
-                // Currently Unix returns different results depending on how the encoding is requested.
                 Assert.Equal(encoding, Encoding.GetEncoding(mapping.Value));
                 Assert.Equal(mapping.Value, encoding.WebName);
-#endif
             }
         }
 

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -508,9 +508,9 @@ namespace Test
             {
                 Encoding encoding = Encoding.GetEncoding(mapping.Key);
                 Assert.NotNull(encoding);
-                Assert.Equal(encoding, Encoding.GetEncoding(mapping.Value));
 #if !PLATFORM_UNIX
-                // Currently Unix seems to only have UTF-8 as a default...
+                // Currently Unix returns different results depending on how the encoding is requested.
+                Assert.Equal(encoding, Encoding.GetEncoding(mapping.Value));
                 Assert.Equal(mapping.Value, encoding.WebName);
 #endif
             }

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -2,911 +2,591 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
-
 using Xunit;
 
-public class EncodingTest
+namespace Test
 {
-    // The characters to encode:
-    //    Latin Small Letter Z (U+007A)
-    //    Latin Small Letter A (U+0061)
-    //    Combining Breve (U+0306)
-    //    Latin Small Letter AE With Acute (U+01FD)
-    //    Greek Small Letter Beta (U+03B2)
-    //    a high-surrogate value (U+D8FF)
-    //    a low-surrogate value (U+DCFF)
-    private static char[] s_myChars = new char[] { 'z', 'a', '\u0306', '\u01FD', '\u03B2', '\uD8FF', '\uDCFF' };
-    private static string s_myString = new String(s_myChars);
-    private static byte[] s_leBytes = new byte[] { 0x7A, 0x00, 0x61, 0x00, 0x06, 0x03, 0xFD, 0x01, 0xB2, 0x03, 0xFF, 0xD8, 0xFF, 0xDC };
-    private static byte[] s_beBytes = new byte[] { 0x00, 0x7A, 0x00, 0x61, 0x03, 0x06, 0x01, 0xFD, 0x03, 0xB2, 0xD8, 0xFF, 0xDC, 0xFF };
-    private static byte[] s_utf8Bytes = new byte[] { 0x7A, 0x61, 0xCC, 0x86, 0xC7, 0xBD, 0xCE, 0xB2, 0xF1, 0x8F, 0xB3, 0xBF };
-
-    private static byte[] s_utf8PreambleBytes = new byte[] { 0xEF, 0xBB, 0xBF };
-    private static byte[] s_unicodePreambleBytes = new byte[] { 0xFF, 0xFE };
-    private static byte[] s_unicodeBigEndianPreambleBytes = new byte[] { 0xFE, 0xFF };
-
-    private static bool s_IsInitialized = false;
-
-    static internal void EnsureInitialization()
+    public class EncodingTest : IClassFixture<CultureSetup>
     {
-        if (!s_IsInitialized)
+        public EncodingTest(CultureSetup setup)
         {
+            // Setting up the culture happens externally, and only once, which is what we want.
+            // xUnit will keep track of it, do nothing.
+        }
+
+        // The characters to encode:
+        //    Latin Small Letter Z (U+007A)
+        //    Latin Small Letter A (U+0061)
+        //    Combining Breve (U+0306)
+        //    Latin Small Letter AE With Acute (U+01FD)
+        //    Greek Small Letter Beta (U+03B2)
+        //    a high-surrogate value (U+D8FF)
+        //    a low-surrogate value (U+DCFF)
+        private static char[] s_myChars = new char[] { 'z', 'a', '\u0306', '\u01FD', '\u03B2', '\uD8FF', '\uDCFF' };
+
+        private static string s_myString = new String(s_myChars);
+        private static byte[] s_leBytes = new byte[] { 0x7A, 0x00, 0x61, 0x00, 0x06, 0x03, 0xFD, 0x01, 0xB2, 0x03, 0xFF, 0xD8, 0xFF, 0xDC };
+        private static byte[] s_beBytes = new byte[] { 0x00, 0x7A, 0x00, 0x61, 0x03, 0x06, 0x01, 0xFD, 0x03, 0xB2, 0xD8, 0xFF, 0xDC, 0xFF };
+        private static byte[] s_utf8Bytes = new byte[] { 0x7A, 0x61, 0xCC, 0x86, 0xC7, 0xBD, 0xCE, 0xB2, 0xF1, 0x8F, 0xB3, 0xBF };
+
+        private static byte[] s_utf8PreambleBytes = new byte[] { 0xEF, 0xBB, 0xBF };
+        private static byte[] s_unicodePreambleBytes = new byte[] { 0xFF, 0xFE };
+        private static byte[] s_unicodeBigEndianPreambleBytes = new byte[] { 0xFE, 0xFF };
+
+        public static IEnumerable<object[]> CodePageInfo()
+        {
+            // The layout is code page, IANA(web) name, and query string.
+            // Query strings may be undocumented, and IANA names will be returned from Encoding objects.
+            // Entries are sorted by code page.
+            yield return new object[] { 37, "ibm037", "ibm037" };
+            yield return new object[] { 37, "ibm037", "cp037" };
+            yield return new object[] { 37, "ibm037", "csibm037" };
+            yield return new object[] { 37, "ibm037", "ebcdic-cp-ca" };
+            yield return new object[] { 37, "ibm037", "ebcdic-cp-nl" };
+            yield return new object[] { 37, "ibm037", "ebcdic-cp-us" };
+            yield return new object[] { 37, "ibm037", "ebcdic-cp-wt" };
+            yield return new object[] { 437, "ibm437", "ibm437" };
+            yield return new object[] { 437, "ibm437", "437" };
+            yield return new object[] { 437, "ibm437", "cp437" };
+            yield return new object[] { 437, "ibm437", "cspc8codepage437" };
+            yield return new object[] { 500, "ibm500", "ibm500" };
+            yield return new object[] { 500, "ibm500", "cp500" };
+            yield return new object[] { 500, "ibm500", "csibm500" };
+            yield return new object[] { 500, "ibm500", "ebcdic-cp-be" };
+            yield return new object[] { 500, "ibm500", "ebcdic-cp-ch" };
+            yield return new object[] { 708, "asmo-708", "asmo-708" };
+            yield return new object[] { 720, "dos-720", "dos-720" };
+            yield return new object[] { 737, "ibm737", "ibm737" };
+            yield return new object[] { 775, "ibm775", "ibm775" };
+            yield return new object[] { 850, "ibm850", "ibm850" };
+            yield return new object[] { 850, "ibm850", "cp850" };
+            yield return new object[] { 852, "ibm852", "ibm852" };
+            yield return new object[] { 852, "ibm852", "cp852" };
+            yield return new object[] { 855, "ibm855", "ibm855" };
+            yield return new object[] { 855, "ibm855", "cp855" };
+            yield return new object[] { 857, "ibm857", "ibm857" };
+            yield return new object[] { 857, "ibm857", "cp857" };
+            yield return new object[] { 858, "ibm00858", "ibm00858" };
+            yield return new object[] { 858, "ibm00858", "ccsid00858" };
+            yield return new object[] { 858, "ibm00858", "cp00858" };
+            yield return new object[] { 858, "ibm00858", "cp858" };
+            yield return new object[] { 858, "ibm00858", "pc-multilingual-850+euro" };
+            yield return new object[] { 860, "ibm860", "ibm860" };
+            yield return new object[] { 860, "ibm860", "cp860" };
+            yield return new object[] { 861, "ibm861", "ibm861" };
+            yield return new object[] { 861, "ibm861", "cp861" };
+            yield return new object[] { 862, "dos-862", "dos-862" };
+            yield return new object[] { 862, "dos-862", "cp862" };
+            yield return new object[] { 862, "dos-862", "ibm862" };
+            yield return new object[] { 863, "ibm863", "ibm863" };
+            yield return new object[] { 863, "ibm863", "cp863" };
+            yield return new object[] { 864, "ibm864", "ibm864" };
+            yield return new object[] { 864, "ibm864", "cp864" };
+            yield return new object[] { 865, "ibm865", "ibm865" };
+            yield return new object[] { 865, "ibm865", "cp865" };
+            yield return new object[] { 866, "cp866", "cp866" };
+            yield return new object[] { 866, "cp866", "ibm866" };
+            yield return new object[] { 869, "ibm869", "ibm869" };
+            yield return new object[] { 869, "ibm869", "cp869" };
+            yield return new object[] { 870, "ibm870", "ibm870" };
+            yield return new object[] { 870, "ibm870", "cp870" };
+            yield return new object[] { 870, "ibm870", "csibm870" };
+            yield return new object[] { 870, "ibm870", "ebcdic-cp-roece" };
+            yield return new object[] { 870, "ibm870", "ebcdic-cp-yu" };
+            yield return new object[] { 874, "windows-874", "windows-874" };
+            yield return new object[] { 874, "windows-874", "dos-874" };
+            yield return new object[] { 874, "windows-874", "iso-8859-11" };
+            yield return new object[] { 874, "windows-874", "tis-620" };
+            yield return new object[] { 875, "cp875", "cp875" };
+            yield return new object[] { 932, "shift_jis", "shift_jis" };
+            yield return new object[] { 932, "shift_jis", "csshiftjis" };
+            yield return new object[] { 932, "shift_jis", "cswindows31j" };
+            yield return new object[] { 932, "shift_jis", "ms_kanji" };
+            yield return new object[] { 932, "shift_jis", "shift-jis" };
+            yield return new object[] { 932, "shift_jis", "sjis" };
+            yield return new object[] { 932, "shift_jis", "x-ms-cp932" };
+            yield return new object[] { 932, "shift_jis", "x-sjis" };
+            yield return new object[] { 936, "gb2312", "gb2312" };
+            yield return new object[] { 936, "gb2312", "chinese" };
+            yield return new object[] { 936, "gb2312", "cn-gb" };
+            yield return new object[] { 936, "gb2312", "csgb2312" };
+            yield return new object[] { 936, "gb2312", "csgb231280" };
+            yield return new object[] { 936, "gb2312", "csiso58gb231280" };
+            yield return new object[] { 936, "gb2312", "gb_2312-80" };
+            yield return new object[] { 936, "gb2312", "gb231280" };
+            yield return new object[] { 936, "gb2312", "gb2312-80" };
+            yield return new object[] { 936, "gb2312", "gbk" };
+            yield return new object[] { 936, "gb2312", "iso-ir-58" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ks_c_5601-1987" };
+            yield return new object[] { 949, "ks_c_5601-1987", "csksc56011987" };
+            yield return new object[] { 949, "ks_c_5601-1987", "iso-ir-149" };
+            yield return new object[] { 949, "ks_c_5601-1987", "korean" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ks_c_5601" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ks_c_5601_1987" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ks_c_5601-1989" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ksc_5601" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ksc5601" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ks-c5601" };
+            yield return new object[] { 949, "ks_c_5601-1987", "ks-c-5601" };
+            yield return new object[] { 950, "big5", "big5" };
+            yield return new object[] { 950, "big5", "big5-hkscs" };
+            yield return new object[] { 950, "big5", "cn-big5" };
+            yield return new object[] { 950, "big5", "csbig5" };
+            yield return new object[] { 950, "big5", "x-x-big5" };
+            yield return new object[] { 1026, "ibm1026", "ibm1026" };
+            yield return new object[] { 1026, "ibm1026", "cp1026" };
+            yield return new object[] { 1026, "ibm1026", "csibm1026" };
+            yield return new object[] { 1047, "ibm01047", "ibm01047" };
+            yield return new object[] { 1140, "ibm01140", "ibm01140" };
+            yield return new object[] { 1140, "ibm01140", "ccsid01140" };
+            yield return new object[] { 1140, "ibm01140", "cp01140" };
+            yield return new object[] { 1140, "ibm01140", "ebcdic-us-37+euro" };
+            yield return new object[] { 1141, "ibm01141", "ibm01141" };
+            yield return new object[] { 1141, "ibm01141", "ccsid01141" };
+            yield return new object[] { 1141, "ibm01141", "cp01141" };
+            yield return new object[] { 1141, "ibm01141", "ebcdic-de-273+euro" };
+            yield return new object[] { 1142, "ibm01142", "ibm01142" };
+            yield return new object[] { 1142, "ibm01142", "ccsid01142" };
+            yield return new object[] { 1142, "ibm01142", "cp01142" };
+            yield return new object[] { 1142, "ibm01142", "ebcdic-dk-277+euro" };
+            yield return new object[] { 1142, "ibm01142", "ebcdic-no-277+euro" };
+            yield return new object[] { 1143, "ibm01143", "ibm01143" };
+            yield return new object[] { 1143, "ibm01143", "ccsid01143" };
+            yield return new object[] { 1143, "ibm01143", "cp01143" };
+            yield return new object[] { 1143, "ibm01143", "ebcdic-fi-278+euro" };
+            yield return new object[] { 1143, "ibm01143", "ebcdic-se-278+euro" };
+            yield return new object[] { 1144, "ibm01144", "ibm01144" };
+            yield return new object[] { 1144, "ibm01144", "ccsid01144" };
+            yield return new object[] { 1144, "ibm01144", "cp01144" };
+            yield return new object[] { 1144, "ibm01144", "ebcdic-it-280+euro" };
+            yield return new object[] { 1145, "ibm01145", "ibm01145" };
+            yield return new object[] { 1145, "ibm01145", "ccsid01145" };
+            yield return new object[] { 1145, "ibm01145", "cp01145" };
+            yield return new object[] { 1145, "ibm01145", "ebcdic-es-284+euro" };
+            yield return new object[] { 1146, "ibm01146", "ibm01146" };
+            yield return new object[] { 1146, "ibm01146", "ccsid01146" };
+            yield return new object[] { 1146, "ibm01146", "cp01146" };
+            yield return new object[] { 1146, "ibm01146", "ebcdic-gb-285+euro" };
+            yield return new object[] { 1147, "ibm01147", "ibm01147" };
+            yield return new object[] { 1147, "ibm01147", "ccsid01147" };
+            yield return new object[] { 1147, "ibm01147", "cp01147" };
+            yield return new object[] { 1147, "ibm01147", "ebcdic-fr-297+euro" };
+            yield return new object[] { 1148, "ibm01148", "ibm01148" };
+            yield return new object[] { 1148, "ibm01148", "ccsid01148" };
+            yield return new object[] { 1148, "ibm01148", "cp01148" };
+            yield return new object[] { 1148, "ibm01148", "ebcdic-international-500+euro" };
+            yield return new object[] { 1149, "ibm01149", "ibm01149" };
+            yield return new object[] { 1149, "ibm01149", "ccsid01149" };
+            yield return new object[] { 1149, "ibm01149", "cp01149" };
+            yield return new object[] { 1149, "ibm01149", "ebcdic-is-871+euro" };
+            yield return new object[] { 1250, "windows-1250", "windows-1250" };
+            yield return new object[] { 1250, "windows-1250", "x-cp1250" };
+            yield return new object[] { 1251, "windows-1251", "windows-1251" };
+            yield return new object[] { 1251, "windows-1251", "x-cp1251" };
+            yield return new object[] { 1252, "windows-1252", "windows-1252" };
+            yield return new object[] { 1252, "windows-1252", "x-ansi" };
+            yield return new object[] { 1253, "windows-1253", "windows-1253" };
+            yield return new object[] { 1254, "windows-1254", "windows-1254" };
+            yield return new object[] { 1255, "windows-1255", "windows-1255" };
+            yield return new object[] { 1256, "windows-1256", "windows-1256" };
+            yield return new object[] { 1256, "windows-1256", "cp1256" };
+            yield return new object[] { 1257, "windows-1257", "windows-1257" };
+            yield return new object[] { 1258, "windows-1258", "windows-1258" };
+            yield return new object[] { 1361, "johab", "johab" };
+            yield return new object[] { 10000, "macintosh", "macintosh" };
+            yield return new object[] { 10001, "x-mac-japanese", "x-mac-japanese" };
+            yield return new object[] { 10002, "x-mac-chinesetrad", "x-mac-chinesetrad" };
+            yield return new object[] { 10003, "x-mac-korean", "x-mac-korean" };
+            yield return new object[] { 10004, "x-mac-arabic", "x-mac-arabic" };
+            yield return new object[] { 10005, "x-mac-hebrew", "x-mac-hebrew" };
+            yield return new object[] { 10006, "x-mac-greek", "x-mac-greek" };
+            yield return new object[] { 10007, "x-mac-cyrillic", "x-mac-cyrillic" };
+            yield return new object[] { 10008, "x-mac-chinesesimp", "x-mac-chinesesimp" };
+            yield return new object[] { 10010, "x-mac-romanian", "x-mac-romanian" };
+            yield return new object[] { 10017, "x-mac-ukrainian", "x-mac-ukrainian" };
+            yield return new object[] { 10021, "x-mac-thai", "x-mac-thai" };
+            yield return new object[] { 10029, "x-mac-ce", "x-mac-ce" };
+            yield return new object[] { 10079, "x-mac-icelandic", "x-mac-icelandic" };
+            yield return new object[] { 10081, "x-mac-turkish", "x-mac-turkish" };
+            yield return new object[] { 10082, "x-mac-croatian", "x-mac-croatian" };
+            yield return new object[] { 20000, "x-chinese-cns", "x-chinese-cns" };
+            yield return new object[] { 20001, "x-cp20001", "x-cp20001" };
+            yield return new object[] { 20002, "x-chinese-eten", "x-chinese-eten" };
+            yield return new object[] { 20003, "x-cp20003", "x-cp20003" };
+            yield return new object[] { 20004, "x-cp20004", "x-cp20004" };
+            yield return new object[] { 20005, "x-cp20005", "x-cp20005" };
+            yield return new object[] { 20105, "x-ia5", "x-ia5" };
+            yield return new object[] { 20105, "x-ia5", "irv" };
+            yield return new object[] { 20106, "x-ia5-german", "x-ia5-german" };
+            yield return new object[] { 20106, "x-ia5-german", "din_66003" };
+            yield return new object[] { 20106, "x-ia5-german", "german" };
+            yield return new object[] { 20107, "x-ia5-swedish", "x-ia5-swedish" };
+            yield return new object[] { 20107, "x-ia5-swedish", "sen_850200_b" };
+            yield return new object[] { 20107, "x-ia5-swedish", "swedish" };
+            yield return new object[] { 20108, "x-ia5-norwegian", "x-ia5-norwegian" };
+            yield return new object[] { 20108, "x-ia5-norwegian", "norwegian" };
+            yield return new object[] { 20108, "x-ia5-norwegian", "ns_4551-1" };
+            yield return new object[] { 20261, "x-cp20261", "x-cp20261" };
+            yield return new object[] { 20269, "x-cp20269", "x-cp20269" };
+            yield return new object[] { 20273, "ibm273", "ibm273" };
+            yield return new object[] { 20273, "ibm273", "cp273" };
+            yield return new object[] { 20273, "ibm273", "csibm273" };
+            yield return new object[] { 20277, "ibm277", "ibm277" };
+            yield return new object[] { 20277, "ibm277", "csibm277" };
+            yield return new object[] { 20277, "ibm277", "ebcdic-cp-dk" };
+            yield return new object[] { 20277, "ibm277", "ebcdic-cp-no" };
+            yield return new object[] { 20278, "ibm278", "ibm278" };
+            yield return new object[] { 20278, "ibm278", "cp278" };
+            yield return new object[] { 20278, "ibm278", "csibm278" };
+            yield return new object[] { 20278, "ibm278", "ebcdic-cp-fi" };
+            yield return new object[] { 20278, "ibm278", "ebcdic-cp-se" };
+            yield return new object[] { 20280, "ibm280", "ibm280" };
+            yield return new object[] { 20280, "ibm280", "cp280" };
+            yield return new object[] { 20280, "ibm280", "csibm280" };
+            yield return new object[] { 20280, "ibm280", "ebcdic-cp-it" };
+            yield return new object[] { 20284, "ibm284", "ibm284" };
+            yield return new object[] { 20284, "ibm284", "cp284" };
+            yield return new object[] { 20284, "ibm284", "csibm284" };
+            yield return new object[] { 20284, "ibm284", "ebcdic-cp-es" };
+            yield return new object[] { 20285, "ibm285", "ibm285" };
+            yield return new object[] { 20285, "ibm285", "cp285" };
+            yield return new object[] { 20285, "ibm285", "csibm285" };
+            yield return new object[] { 20285, "ibm285", "ebcdic-cp-gb" };
+            yield return new object[] { 20290, "ibm290", "ibm290" };
+            yield return new object[] { 20290, "ibm290", "cp290" };
+            yield return new object[] { 20290, "ibm290", "csibm290" };
+            yield return new object[] { 20290, "ibm290", "ebcdic-jp-kana" };
+            yield return new object[] { 20297, "ibm297", "ibm297" };
+            yield return new object[] { 20297, "ibm297", "cp297" };
+            yield return new object[] { 20297, "ibm297", "csibm297" };
+            yield return new object[] { 20297, "ibm297", "ebcdic-cp-fr" };
+            yield return new object[] { 20420, "ibm420", "ibm420" };
+            yield return new object[] { 20420, "ibm420", "cp420" };
+            yield return new object[] { 20420, "ibm420", "csibm420" };
+            yield return new object[] { 20420, "ibm420", "ebcdic-cp-ar1" };
+            yield return new object[] { 20423, "ibm423", "ibm423" };
+            yield return new object[] { 20423, "ibm423", "cp423" };
+            yield return new object[] { 20423, "ibm423", "csibm423" };
+            yield return new object[] { 20423, "ibm423", "ebcdic-cp-gr" };
+            yield return new object[] { 20424, "ibm424", "ibm424" };
+            yield return new object[] { 20424, "ibm424", "cp424" };
+            yield return new object[] { 20424, "ibm424", "csibm424" };
+            yield return new object[] { 20424, "ibm424", "ebcdic-cp-he" };
+            yield return new object[] { 20833, "x-ebcdic-koreanextended", "x-ebcdic-koreanextended" };
+            yield return new object[] { 20838, "ibm-thai", "ibm-thai" };
+            yield return new object[] { 20838, "ibm-thai", "csibmthai" };
+            yield return new object[] { 20866, "koi8-r", "koi8-r" };
+            yield return new object[] { 20866, "koi8-r", "cskoi8r" };
+            yield return new object[] { 20866, "koi8-r", "koi" };
+            yield return new object[] { 20866, "koi8-r", "koi8" };
+            yield return new object[] { 20866, "koi8-r", "koi8r" };
+            yield return new object[] { 20871, "ibm871", "ibm871" };
+            yield return new object[] { 20871, "ibm871", "cp871" };
+            yield return new object[] { 20871, "ibm871", "csibm871" };
+            yield return new object[] { 20871, "ibm871", "ebcdic-cp-is" };
+            yield return new object[] { 20880, "ibm880", "ibm880" };
+            yield return new object[] { 20880, "ibm880", "cp880" };
+            yield return new object[] { 20880, "ibm880", "csibm880" };
+            yield return new object[] { 20880, "ibm880", "ebcdic-cyrillic" };
+            yield return new object[] { 20905, "ibm905", "ibm905" };
+            yield return new object[] { 20905, "ibm905", "cp905" };
+            yield return new object[] { 20905, "ibm905", "csibm905" };
+            yield return new object[] { 20905, "ibm905", "ebcdic-cp-tr" };
+            yield return new object[] { 20924, "ibm00924", "ibm00924" };
+            yield return new object[] { 20924, "ibm00924", "ccsid00924" };
+            yield return new object[] { 20924, "ibm00924", "cp00924" };
+            yield return new object[] { 20924, "ibm00924", "ebcdic-latin9--euro" };
+            yield return new object[] { 20936, "x-cp20936", "x-cp20936" };
+            yield return new object[] { 20949, "x-cp20949", "x-cp20949" };
+            yield return new object[] { 21025, "cp1025", "cp1025" };
+            yield return new object[] { 21866, "koi8-u", "koi8-u" };
+            yield return new object[] { 21866, "koi8-u", "koi8-ru" };
+            yield return new object[] { 28592, "iso-8859-2", "iso-8859-2" };
+            yield return new object[] { 28592, "iso-8859-2", "csisolatin2" };
+            yield return new object[] { 28592, "iso-8859-2", "iso_8859-2" };
+            yield return new object[] { 28592, "iso-8859-2", "iso_8859-2:1987" };
+            yield return new object[] { 28592, "iso-8859-2", "iso8859-2" };
+            yield return new object[] { 28592, "iso-8859-2", "iso-ir-101" };
+            yield return new object[] { 28592, "iso-8859-2", "l2" };
+            yield return new object[] { 28592, "iso-8859-2", "latin2" };
+            yield return new object[] { 28593, "iso-8859-3", "iso-8859-3" };
+            yield return new object[] { 28593, "iso-8859-3", "csisolatin3" };
+            yield return new object[] { 28593, "iso-8859-3", "iso_8859-3" };
+            yield return new object[] { 28593, "iso-8859-3", "iso_8859-3:1988" };
+            yield return new object[] { 28593, "iso-8859-3", "iso-ir-109" };
+            yield return new object[] { 28593, "iso-8859-3", "l3" };
+            yield return new object[] { 28593, "iso-8859-3", "latin3" };
+            yield return new object[] { 28594, "iso-8859-4", "iso-8859-4" };
+            yield return new object[] { 28594, "iso-8859-4", "csisolatin4" };
+            yield return new object[] { 28594, "iso-8859-4", "iso_8859-4" };
+            yield return new object[] { 28594, "iso-8859-4", "iso_8859-4:1988" };
+            yield return new object[] { 28594, "iso-8859-4", "iso-ir-110" };
+            yield return new object[] { 28594, "iso-8859-4", "l4" };
+            yield return new object[] { 28594, "iso-8859-4", "latin4" };
+            yield return new object[] { 28595, "iso-8859-5", "iso-8859-5" };
+            yield return new object[] { 28595, "iso-8859-5", "csisolatincyrillic" };
+            yield return new object[] { 28595, "iso-8859-5", "cyrillic" };
+            yield return new object[] { 28595, "iso-8859-5", "iso_8859-5" };
+            yield return new object[] { 28595, "iso-8859-5", "iso_8859-5:1988" };
+            yield return new object[] { 28595, "iso-8859-5", "iso-ir-144" };
+            yield return new object[] { 28596, "iso-8859-6", "iso-8859-6" };
+            yield return new object[] { 28596, "iso-8859-6", "arabic" };
+            yield return new object[] { 28596, "iso-8859-6", "csisolatinarabic" };
+            yield return new object[] { 28596, "iso-8859-6", "ecma-114" };
+            yield return new object[] { 28596, "iso-8859-6", "iso_8859-6" };
+            yield return new object[] { 28596, "iso-8859-6", "iso_8859-6:1987" };
+            yield return new object[] { 28596, "iso-8859-6", "iso-ir-127" };
+            yield return new object[] { 28597, "iso-8859-7", "iso-8859-7" };
+            yield return new object[] { 28597, "iso-8859-7", "csisolatingreek" };
+            yield return new object[] { 28597, "iso-8859-7", "ecma-118" };
+            yield return new object[] { 28597, "iso-8859-7", "elot_928" };
+            yield return new object[] { 28597, "iso-8859-7", "greek" };
+            yield return new object[] { 28597, "iso-8859-7", "greek8" };
+            yield return new object[] { 28597, "iso-8859-7", "iso_8859-7" };
+            yield return new object[] { 28597, "iso-8859-7", "iso_8859-7:1987" };
+            yield return new object[] { 28597, "iso-8859-7", "iso-ir-126" };
+            yield return new object[] { 28598, "iso-8859-8", "iso-8859-8" };
+            yield return new object[] { 28598, "iso-8859-8", "csisolatinhebrew" };
+            yield return new object[] { 28598, "iso-8859-8", "hebrew" };
+            yield return new object[] { 28598, "iso-8859-8", "iso_8859-8" };
+            yield return new object[] { 28598, "iso-8859-8", "iso_8859-8:1988" };
+            yield return new object[] { 28598, "iso-8859-8", "iso-8859-8 visual" };
+            yield return new object[] { 28598, "iso-8859-8", "iso-ir-138" };
+            yield return new object[] { 28598, "iso-8859-8", "logical" };
+            yield return new object[] { 28598, "iso-8859-8", "visual" };
+            yield return new object[] { 28599, "iso-8859-9", "iso-8859-9" };
+            yield return new object[] { 28599, "iso-8859-9", "csisolatin5" };
+            yield return new object[] { 28599, "iso-8859-9", "iso_8859-9" };
+            yield return new object[] { 28599, "iso-8859-9", "iso_8859-9:1989" };
+            yield return new object[] { 28599, "iso-8859-9", "iso-ir-148" };
+            yield return new object[] { 28599, "iso-8859-9", "l5" };
+            yield return new object[] { 28599, "iso-8859-9", "latin5" };
+            yield return new object[] { 28603, "iso-8859-13", "iso-8859-13" };
+            yield return new object[] { 28605, "iso-8859-15", "iso-8859-15" };
+            yield return new object[] { 28605, "iso-8859-15", "csisolatin9" };
+            yield return new object[] { 28605, "iso-8859-15", "iso_8859-15" };
+            yield return new object[] { 28605, "iso-8859-15", "l9" };
+            yield return new object[] { 28605, "iso-8859-15", "latin9" };
+            yield return new object[] { 29001, "x-europa", "x-europa" };
+            yield return new object[] { 38598, "iso-8859-8-i", "iso-8859-8-i" };
+            yield return new object[] { 50220, "iso-2022-jp", "iso-2022-jp" };
+            yield return new object[] { 50221, "csiso2022jp", "csiso2022jp" };
+            yield return new object[] { 50225, "iso-2022-kr", "iso-2022-kr" };
+            yield return new object[] { 50225, "iso-2022-kr", "csiso2022kr" };
+            yield return new object[] { 50225, "iso-2022-kr", "iso-2022-kr-7" };
+            yield return new object[] { 50225, "iso-2022-kr", "iso-2022-kr-7bit" };
+            yield return new object[] { 50227, "x-cp50227", "x-cp50227" };
+            yield return new object[] { 50227, "x-cp50227", "cp50227" };
+            yield return new object[] { 51932, "euc-jp", "euc-jp" };
+            yield return new object[] { 51932, "euc-jp", "cseucpkdfmtjapanese" };
+            yield return new object[] { 51932, "euc-jp", "extended_unix_code_packed_format_for_japanese" };
+            yield return new object[] { 51932, "euc-jp", "iso-2022-jpeuc" };
+            yield return new object[] { 51932, "euc-jp", "x-euc" };
+            yield return new object[] { 51932, "euc-jp", "x-euc-jp" };
+            yield return new object[] { 51936, "euc-cn", "euc-cn" };
+            yield return new object[] { 51936, "euc-cn", "x-euc-cn" };
+            yield return new object[] { 51949, "euc-kr", "euc-kr" };
+            yield return new object[] { 51949, "euc-kr", "cseuckr" };
+            yield return new object[] { 51949, "euc-kr", "iso-2022-kr-8" };
+            yield return new object[] { 51949, "euc-kr", "iso-2022-kr-8bit" };
+            yield return new object[] { 52936, "hz-gb-2312", "hz-gb-2312" };
+            yield return new object[] { 54936, "gb18030", "gb18030" };
+            yield return new object[] { 57002, "x-iscii-de", "x-iscii-de" };
+            yield return new object[] { 57003, "x-iscii-be", "x-iscii-be" };
+            yield return new object[] { 57004, "x-iscii-ta", "x-iscii-ta" };
+            yield return new object[] { 57005, "x-iscii-te", "x-iscii-te" };
+            yield return new object[] { 57006, "x-iscii-as", "x-iscii-as" };
+            yield return new object[] { 57007, "x-iscii-or", "x-iscii-or" };
+            yield return new object[] { 57008, "x-iscii-ka", "x-iscii-ka" };
+            yield return new object[] { 57009, "x-iscii-ma", "x-iscii-ma" };
+            yield return new object[] { 57010, "x-iscii-gu", "x-iscii-gu" };
+            yield return new object[] { 57011, "x-iscii-pa", "x-iscii-pa" };
+        }
+
+        public static IEnumerable<object[]> SpecificCodepageEncodings()
+        {
+            // Layout is codepage encoding, bytes, and matching unicode string.
+            yield return new object[] { "Windows-1256", new byte[] { 0xC7, 0xE1, 0xE1, 0xE5, 0x20, 0xC7, 0xCD, 0xCF }, "\x0627\x0644\x0644\x0647\x0020\x0627\x062D\x062F" };
+            yield return new object[] {"Windows-1252", new byte[] { 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF } ,
+                    "\x00D0\x00D1\x00D2\x00D3\x00D4\x00D5\x00D6\x00D7\x00D8\x00D9\x00DA\x00DB\x00DC\x00DD\x00DE\x00DF"};
+            yield return new object[] { "GB2312", new byte[] { 0xCD, 0xE2, 0xCD, 0xE3, 0xCD, 0xE4 }, "\x5916\x8C4C\x5F2F" };
+            yield return new object[] {"GB18030", new byte[] { 0x81, 0x30, 0x89, 0x37, 0x81, 0x30, 0x89, 0x38, 0xA8, 0xA4, 0xA8, 0xA2, 0x81, 0x30, 0x89, 0x39, 0x81, 0x30, 0x8A, 0x30 } ,
+                    "\x00DE\x00DF\x00E0\x00E1\x00E2\x00E3"};
+        }
+
+        public static IEnumerable<object[]> MultibyteCharacterEncodings()
+        {
+            // Layout is the encoding, bytes, and expected result.
+            yield return new object[] { "iso-2022-jp",
+                new byte[] { 0xA,
+                    0x1B, 0x24, 0x42, 0x25, 0x4A, 0x25, 0x4A,
+                    0x1B, 0x28, 0x42,
+                    0x1B, 0x24, 0x42, 0x25, 0x4A,
+                    0x1B, 0x28, 0x42,
+                    0x1B, 0x24, 0x42, 0x25, 0x4A,
+                    0x1B, 0x28, 0x42,
+                    0x1B, 0x1, 0x2, 0x3, 0x4,
+                    0x1B, 0x24, 0x42, 0x25, 0x4A, 0x0E, 0x25, 0x4A,
+                    0x1B, 0x28, 0x42, 0x41, 0x42, 0x0E, 0x25, 0x0F, 0x43 },
+                new int[] { 0xA, 0x30CA, 0x30CA, 0x30CA, 0x30CA, 0x1B, 0x1, 0x2, 0x3, 0x4,
+                    0x30CA, 0xFF65, 0xFF8A, 0x41, 0x42, 0xFF65, 0x43}
+            };
+
+            yield return new object[] { "GB18030",
+                new byte[] { 0x41, 0x42, 0x43, 0x81, 0x40, 0x82, 0x80, 0x81, 0x30, 0x82, 0x31, 0x81, 0x20 },
+                 new int[] { 0x41, 0x42, 0x43, 0x4E02, 0x500B, 0x8B, 0x3F, 0x20 }
+            };
+
+            yield return new object[] { "shift_jis",
+                new byte[] { 0x41, 0x42, 0x43, 0x81, 0x42, 0xE0, 0x43, 0x44, 0x45 },
+                new int[] { 0x41, 0x42, 0x43, 0x3002, 0x6F86, 0x44, 0x45 }
+            };
+
+            yield return new object[] { "iso-2022-kr",
+                new byte[] { 0x0E, 0x21, 0x7E, 0x1B, 0x24, 0x29, 0x43, 0x21, 0x7E, 0x0F, 0x21, 0x7E, 0x1B, 0x24, 0x29, 0x43, 0x21, 0x7E },
+                new int[] { 0xFFE2, 0xFFE2, 0x21, 0x7E, 0x21, 0x7E }
+            };
+
+            yield return new object[] { "hz-gb-2312",
+                new byte[] { 0x7E, 0x42, 0x7E, 0x7E, 0x7E, 0x7B, 0x21, 0x7E, 0x7E, 0x7D, 0x42, 0x42, 0x7E, 0xA, 0x43, 0x43 },
+                new int[] { 0x7E, 0x42, 0x7E, 0x3013, 0x42, 0x42, 0x43, 0x43, }
+            };
+        }
+
+        private static IEnumerable<KeyValuePair<int, string>> CrossplatformDefaultEncodings()
+        {
+            yield return Map(1200, "utf-16");
+            yield return Map(12000, "utf-32");
+            yield return Map(20127, "us-ascii");
+            yield return Map(65000, "utf-7");
+            yield return Map(65001, "utf-8");
+        }
+
+        private static KeyValuePair<int, string> Map(int codePage, string webName)
+        {
+            return new KeyValuePair<int, string>(codePage, webName);
+        }
+
+        [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
+        public static void TestDefaultEncodings()
+        {
+            // Check which encodings are available by default.
+            foreach (var mapping in CrossplatformDefaultEncodings())
+            {
+                Encoding encoding = Encoding.GetEncoding(mapping.Key);
+                Assert.NotNull(encoding);
+                Assert.Equal(mapping.Value, encoding.WebName);
+            }
+            // Currently the class EncodingInfo isn't present in corefx, but this method should check for the exhaustive list
+            // When it is, comment out this line and remove the previous foreach/assert.
+            // Assert.Equal(CrossplatformDefaultEncodings, Encoding.GetEncodings().OrderBy(i => i.CodePage).Select(i => Map(i.CodePage, i.WebName)));
+
+            // UTF-8 potentially isn't the default everywhere if a user changes a setting, but we can hope!
+            Assert.Equal(Encoding.UTF8, Encoding.GetEncoding(0));
+
+            // Add the code page provider.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            s_IsInitialized = true;
-        }
-    }
 
-    internal class EncodingId
-    {
-        internal EncodingId(string name, int codepage)
-        {
-            _name = name;
-            _codepage = codepage;
-        }
-
-        internal string Name { get { return _name; } }
-        internal int Codepage { get { return _codepage; } }
-
-        private int _codepage;
-        private string _name;
-    }
-
-    internal class CodePageToWebNameMapping
-    {
-        public CodePageToWebNameMapping(int codePage, string webName)
-        {
-            _codePage = codePage;
-            _webName = webName;
-        }
-
-        public int CodePage { get { return _codePage; } }
-        public string WebName { get { return _webName; } }
-
-        private int _codePage;
-        private string _webName;
-    }
-
-    [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
-    public static void TestDefaultCodePage()
-    {
-
-        Assert.False(s_IsInitialized);
-        Encoding utf8Encoding = Encoding.GetEncoding(0);
-        Assert.Equal(Encoding.UTF8.CodePage, utf8Encoding.CodePage);
-        Assert.Equal(Encoding.UTF8.WebName, utf8Encoding.WebName);
-
-        EnsureInitialization();
-
-        Encoding encoding = Encoding.GetEncoding(0);
-        Assert.True(encoding.CodePage != 0);
-        Assert.True(encoding.WebName != Encoding.UTF8.WebName);
-    }
-
-    private static void TestRoundtrippingCodepageEncoding(string encodingName, byte[] bytes, string s)
-    {
-        Encoding enc = Encoding.GetEncoding(encodingName);
-        string resultString = enc.GetString(bytes, 0, bytes.Length);
-        Assert.True(s.Equals(resultString));
-        byte[] resultBytes = enc.GetBytes(resultString);
-
-        Assert.Equal(bytes.Length, resultBytes.Length);
-        for (int i = 0; i < bytes.Length; i++)
-        {
-            Assert.True(bytes[i] == resultBytes[i], "encodingName: " + encodingName);
-        }
-    }
-
-    [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
-    public static void TestSpecificCodepageEncodings()
-    {
-        EnsureInitialization();
-
-        byte[] bytes = new byte[] {
-            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
-            0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF
-            };
-        string unicodeStr = "\x00A0\x00A1\x00A2\x00A3\x00A4\x00A5\x00A6\x00A7\x00A8\x00A9\x00AA\x00AB\x00AC\x00AD\x00AE\x00AF\x00C0\x00C1\x00C2\x00C3\x00C4" +
-                            "\x00C5\x00C6\x00C7\x00C8\x00C9\x00CA\x00CB\x00CC\x00CD\x00CE\x00CF";
-
-        TestRoundtrippingCodepageEncoding("iso-8859-1", bytes, unicodeStr);
-
-        bytes = new byte[] { 0xC7, 0xE1, 0xE1, 0xE5, 0x20, 0xC7, 0xCD, 0xCF };
-        unicodeStr = "\x0627\x0644\x0644\x0647\x0020\x0627\x062D\x062F";
-        TestRoundtrippingCodepageEncoding("Windows-1256", bytes, unicodeStr);
-
-        bytes = new byte[] { 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF };
-        unicodeStr = "\x00D0\x00D1\x00D2\x00D3\x00D4\x00D5\x00D6\x00D7\x00D8\x00D9\x00DA\x00DB\x00DC\x00DD\x00DE\x00DF";
-        TestRoundtrippingCodepageEncoding("Windows-1252", bytes, unicodeStr);
-
-        bytes = new byte[] { 0xCD, 0xE2, 0xCD, 0xE3, 0xCD, 0xE4 };
-        unicodeStr = "\x5916\x8C4C\x5F2F";
-        TestRoundtrippingCodepageEncoding("GB2312", bytes, unicodeStr);
-
-        bytes = new byte[] { 0x81, 0x30, 0x89, 0x37, 0x81, 0x30, 0x89, 0x38, 0xA8, 0xA4, 0xA8, 0xA2, 0x81, 0x30, 0x89, 0x39, 0x81, 0x30, 0x8A, 0x30 };
-        unicodeStr = "\x00DE\x00DF\x00E0\x00E1\x00E2\x00E3";
-        TestRoundtrippingCodepageEncoding("GB18030", bytes, unicodeStr);
-
-        bytes = new byte[] { 0x5B, 0x5C, 0x5D, 0x5E, 0x7B, 0x7C, 0x7D, 0x7E };
-        unicodeStr = "\x005B\x005C\x005D\x005E\x007B\x007C\x007D\x007E";
-        TestRoundtrippingCodepageEncoding("us-ascii", bytes, unicodeStr);
-    }
-
-    [Fact]
-    public static void TestCodepageEncoding()
-    {
-        EnsureInitialization();
-
-        foreach (var id in s_encodingIdTable)
-        {
-            // Console.WriteLine(id.Name);
-            Encoding enc = Encoding.GetEncoding(id.Name);
-            byte[] bytes = enc.GetBytes("Az");
-            char[] chars = enc.GetChars(bytes);
-            Assert.True(chars.Length == 2 && chars[0] == 'A' && chars[1] == 'z');
-            // Encoding.GetEncoding(id.Codepage);
-        }
-    }
-
-    [Fact]
-    public static void TestDecodingIso2022()
-    {
-        EnsureInitialization();
-
-        byte[] japaneseEncodedBuffer = new byte[]
+            // Adding the code page provider should keep the originals, too.
+            foreach (var mapping in CrossplatformDefaultEncodings().Union(CodePageInfo().Select(i => Map((int)i[0], (string)i[1]))))
             {
-                0xA,
-                0x1B, 0x24, 0x42, 0x25, 0x4A, 0x25, 0x4A,
-                0x1B, 0x28, 0x42,
-                0x1B, 0x24, 0x42, 0x25, 0x4A,
-                0x1B, 0x28, 0x42,
-                0x1B, 0x24, 0x42, 0x25, 0x4A,
-                0x1B, 0x28, 0x42,
-                0x1B, 0x1, 0x2, 0x3, 0x4,
-                0x1B, 0x24, 0x42, 0x25, 0x4A, 0x0E, 0x25, 0x4A,
-                0x1B, 0x28, 0x42, 0x41, 0x42, 0x0E, 0x25, 0x0F, 0x43
-            };
-
-        string codepageName = "iso-2022-jp";
-        Decoder jpDecoder = Encoding.GetEncoding(codepageName).GetDecoder();
-        const int BUFFER_SIZE = 100;
-        char[] buffer = new char[BUFFER_SIZE];
-
-        int byteIndex = 0;
-        int charIndex = 0;
-
-        while (byteIndex < japaneseEncodedBuffer.Length)
-        {
-            int charCount = jpDecoder.GetChars(japaneseEncodedBuffer, byteIndex, 1, buffer, charIndex);
-            if (charCount > 0)
-            {
-                charIndex += charCount;
+                Encoding encoding = Encoding.GetEncoding(mapping.Key);
+                Assert.NotNull(encoding);
+                Assert.Equal(mapping.Value, encoding.WebName);
             }
-            byteIndex++;
+            // Currently the class EncodingInfo isn't present in corefx, but this method should check for the exhaustive list
+            // When it is, comment out this line and remove the previous foreach/assert.
+            // Assert.Equal(CrossplatformDefaultEncodings().Union(CodePageInfo().Select(i => Map((int)i[0], (string)i[1])).OrderBy(i => i.Key)),
+            //               Encoding.GetEncodings().OrderBy(i => i.CodePage).Select(i => Map(i.CodePage, i.WebName)));
+
+#if !PLATFORM_UNIX
+            Encoding defaultCodePage = Encoding.GetEncoding(0);
+            Assert.True(defaultCodePage.CodePage != 0);
+            Assert.True(defaultCodePage.WebName != Encoding.UTF8.WebName);
+#else
+        // Probably Unix sticks with UTF by default?
+        Assert.Equal(Encoding.UTF8, Encoding.GetEncoding(0));
+#endif
         }
 
-        int[] expectedResult = new int[] { 0xA, 0x30CA, 0x30CA, 0x30CA, 0x30CA, 0x1B, 0x1, 0x2, 0x3, 0x4, 0x30CA, 0xFF65,
-                                                 0xFF8A, 0x41, 0x42, 0xFF65, 0x43};
-        Assert.True(charIndex == expectedResult.Length);
-        for (int i = 0; i < charIndex; i++)
-            Assert.True(expectedResult[i] == (int)buffer[i]);
-    }
-
-    [Fact]
-    public static void TestDecodingGB18030()
-    {
-        EnsureInitialization();
-
-        string codepageName = "GB18030"; // 54936 codepage 
-
-        byte[] chineseBuffer = new byte[]
-            {
-                0x41, 0x42, 0x43,
-                0x81, 0x40,
-                0x82, 0x80,
-                0x81, 0x30, 0x82, 0x31,
-                0x81, 0x20
-            };
-
-        Decoder chineseDecoder = Encoding.GetEncoding(codepageName).GetDecoder();
-        const int BUFFER_SIZE = 100;
-        char[] buffer = new char[BUFFER_SIZE];
-
-        int byteIndex = 0;
-        int charIndex = 0;
-
-        while (byteIndex < chineseBuffer.Length)
+        [Theory]
+        [MemberData("SpecificCodepageEncodings")]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
+        public static void TestRoundtrippingSpecificCodepageEncoding(string encodingName, byte[] bytes, string expected)
         {
-            int charCount = chineseDecoder.GetChars(chineseBuffer, byteIndex, 1, buffer, charIndex);
-            if (charCount > 0)
+            Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(encodingName);
+            string encoded = encoding.GetString(bytes, 0, bytes.Length);
+            Assert.Equal(expected, encoded);
+            Assert.Equal(bytes, encoding.GetBytes(encoded));
+            byte[] resultBytes = encoding.GetBytes(encoded);
+        }
+
+        [Theory]
+        [MemberData("CodePageInfo")]
+        public static void TestCodepageEncoding(int codePage, string webName, string queryString)
+        {
+            Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(queryString);
+            Assert.NotNull(encoding);
+            Assert.Equal(codePage, encoding.CodePage);
+            Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(codePage));
+            Assert.Equal(webName, encoding.WebName);
+            Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(webName));
+
+            // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
+            // Start with space.
+            string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+            char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
+            Assert.Equal(asciiPrintable.ToCharArray(), traveled);
+        }
+
+        [Theory]
+        [MemberData("MultibyteCharacterEncodings")]
+        public static void TestSpecificMultibyteCharacterEncodings(string codepageName, byte[] bytes, int[] expected)
+        {
+            Decoder decoder = CodePagesEncodingProvider.Instance.GetEncoding(codepageName).GetDecoder();
+            char[] buffer = new char[expected.Length];
+
+            for (int byteIndex = 0, charIndex = 0, charCount = 0; byteIndex < bytes.Length; byteIndex++, charIndex += charCount)
             {
-                charIndex += charCount;
+                charCount = decoder.GetChars(bytes, byteIndex, 1, buffer, charIndex);
             }
-            byteIndex++;
+
+            Assert.Equal(expected, buffer.Select(c => (int)c));
         }
 
-        int[] expectedResult = new int[] { 0x41, 0x42, 0x43, 0x4E02, 0x500B, 0x8B, 0x3F, 0x20 };
-        Assert.True(charIndex == expectedResult.Length);
-        for (int i = 0; i < charIndex; i++)
-            Assert.True(expectedResult[i] == (int)buffer[i]);
-    }
-
-    [Fact]
-    public static void TestDecodingDBCS()
-    {
-        EnsureInitialization();
-
-        string codepageName = "shift_jis"; // 932 codepage 
-
-        byte[] shiftJapaneseBuffer = new byte[]
+        [Theory]
+        [MemberData("CodePageInfo")]
+        public static void TestEncodingDisplayNames(int codePage, string webName, string queryString)
         {
-            0x41, 0x42, 0x43,   // Single byte
-            0x81, 0x42,         // Double bytes
-            0xE0, 0x43,         // Double bytes
-            0x44, 0x45          // Single byte
-        };
+            var encoding = CodePagesEncodingProvider.Instance.GetEncoding(codePage);
 
-        Decoder jpDecoder = Encoding.GetEncoding(codepageName).GetDecoder();
-        const int BUFFER_SIZE = 100;
-        char[] buffer = new char[BUFFER_SIZE];
+            string name = encoding.EncodingName;
 
-        int byteIndex = 0;
-        int charIndex = 0;
-
-        while (byteIndex < shiftJapaneseBuffer.Length)
-        {
-            int charCount = jpDecoder.GetChars(shiftJapaneseBuffer, byteIndex, 1, buffer, charIndex);
-            if (charCount > 0)
-            {
-                charIndex += charCount;
-            }
-            byteIndex++;
-        }
-
-        int[] expectedResult = new int[] { 0x41, 0x42, 0x43, 0x3002, 0x6F86, 0x44, 0x45 };
-        Assert.True(charIndex == expectedResult.Length);
-        for (int i = 0; i < charIndex; i++)
-            Assert.True(expectedResult[i] == (int)buffer[i]);
-    }
-
-    [Fact]
-    public static void TestDecodingIso2022KR()
-    {
-        EnsureInitialization();
-
-        byte[] koreanEncodedBuffer = new byte[]
-            {
-                0x0E, 0x21, 0x7E,
-                0x1B, 0x24, 0x29, 0x43, 0x21, 0x7E,
-                0x0F, 0x21, 0x7E,
-                0x1B, 0x24, 0x29, 0x43, 0x21, 0x7E
-            };
-
-        string codepageName = "iso-2022-kr";
-        Decoder krDecoder = Encoding.GetEncoding(codepageName).GetDecoder();
-        const int BUFFER_SIZE = 100;
-        char[] buffer = new char[BUFFER_SIZE];
-
-        int byteIndex = 0;
-        int charIndex = 0;
-
-        while (byteIndex < koreanEncodedBuffer.Length)
-        {
-            int charCount = krDecoder.GetChars(koreanEncodedBuffer, byteIndex, 1, buffer, charIndex);
-            if (charCount > 0)
-            {
-                charIndex += charCount;
-            }
-            byteIndex++;
-        }
-
-        int[] expectedResult = new int[] { 0xFFE2, 0xFFE2, 0x21, 0x7E, 0x21, 0x7E };
-        Assert.True(charIndex == expectedResult.Length);
-        for (int i = 0; i < charIndex; i++)
-            Assert.True(expectedResult[i] == (int)buffer[i]);
-    }
-
-    [Fact]
-    public static void TestDecoding2312HZ()
-    {
-        EnsureInitialization();
-
-        byte[] hzEncodedBuffer = new byte[]
-            {
-                0x7E, 0x42,
-                0x7E, 0x7E,
-                0x7E, 0x7B, 0x21, 0x7E,
-                0x7E, 0x7D, 0x42, 0x42,
-                0x7E, 0xA, 0x43, 0x43
-            };
-
-        string codepageName = "hz-gb-2312";
-        Decoder krDecoder = Encoding.GetEncoding(codepageName).GetDecoder();
-        const int BUFFER_SIZE = 100;
-        char[] buffer = new char[BUFFER_SIZE];
-
-        int byteIndex = 0;
-        int charIndex = 0;
-
-        while (byteIndex < hzEncodedBuffer.Length)
-        {
-            int charCount = krDecoder.GetChars(hzEncodedBuffer, byteIndex, 1, buffer, charIndex);
-            if (charCount > 0)
-            {
-                charIndex += charCount;
-            }
-            byteIndex++;
-        }
-
-        int[] expectedResult = new int[] { 0x7E, 0x42, 0x7E, 0x3013, 0x42, 0x42, 0x43, 0x43, };
-        Assert.True(charIndex == expectedResult.Length);
-        for (int i = 0; i < charIndex; i++)
-            Assert.True(expectedResult[i] == (int)buffer[i]);
-    }
-
-    [Fact]
-    public static void TestEudcEncoding()
-    {
-        EnsureInitialization();
-
-        Encoding.GetEncoding(51932);
-        // new EncodingId("csEUCPkdFmtJapanese", 51932), 
-    }
-
-    [Fact]
-    public static void TestCodePageToWebNameMappings()
-    {
-        EnsureInitialization();
-
-        foreach (var mapping in s_codePageToWebNameTable)
-        {
-            var encoding = Encoding.GetEncoding(mapping.CodePage);
-            Assert.True(string.Equals(mapping.WebName, encoding.WebName, StringComparison.OrdinalIgnoreCase));
+            // Names can't be empty, and must be printable characters.
+            Assert.False(string.IsNullOrWhiteSpace(name));
+            Assert.All(name, c => Assert.True(c >= ' ' && c < '~' + 1, "Name: " + name + " contains character: " + c));
         }
     }
 
-    [Fact]
-    public static void TestEncodingDisplayNames()
+    public class CultureSetup : IDisposable
     {
-        CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
-        try
+        private readonly CultureInfo _originalUICulture;
+
+        public CultureSetup()
         {
+            _originalUICulture = CultureInfo.CurrentUICulture;
             CultureInfo.CurrentUICulture = new CultureInfo("en-US");
-
-            EnsureInitialization();
-
-            foreach (var mapping in s_codePageToWebNameTable)
-            {
-                var encoding = Encoding.GetEncoding(mapping.CodePage);
-
-                string name = encoding.EncodingName;
-
-                if (string.IsNullOrEmpty(name))
-                {
-                    Assert.True(false, "failed to get the display name of the encoding: " + encoding.WebName);
-                }
-
-                for (int i = 0; i < name.Length; ++i)
-                {
-                    int ch = (int)name[i];
-
-                    if (ch > 127)
-                    {
-                        Assert.True(false,
-                            string.Format("English name '{0}' for encoding '{1}' contains non-ASCII character: {2}",
-                                name, encoding.WebName, ch));
-                    }
-                }
-            }
         }
-        finally
+
+        public void Dispose()
         {
-            CultureInfo.CurrentUICulture = originalUICulture;
+            CultureInfo.CurrentUICulture = _originalUICulture;
         }
     }
-
-    private static EncodingId[] s_encodingIdTable = new EncodingId[]
-    {
-        new EncodingId("437", 437),
-        new EncodingId("arabic", 28596),
-        new EncodingId("asmo-708", 708),
-        new EncodingId("big5", 950),
-        new EncodingId("big5-hkscs", 950),
-        new EncodingId("ccsid00858", 858),
-        new EncodingId("ccsid00924", 20924),
-        new EncodingId("ccsid01140", 1140),
-        new EncodingId("ccsid01141", 1141),
-        new EncodingId("ccsid01142", 1142),
-        new EncodingId("ccsid01143", 1143),
-        new EncodingId("ccsid01144", 1144),
-        new EncodingId("ccsid01145", 1145),
-        new EncodingId("ccsid01146", 1146),
-        new EncodingId("ccsid01147", 1147),
-        new EncodingId("ccsid01148", 1148),
-        new EncodingId("ccsid01149", 1149),
-        new EncodingId("chinese", 936),
-        new EncodingId("cn-big5", 950),
-        new EncodingId("cn-gb", 936),
-        new EncodingId("cp00858", 858),
-        new EncodingId("cp00924", 20924),
-        new EncodingId("cp01140", 1140),
-        new EncodingId("cp01141", 1141),
-        new EncodingId("cp01142", 1142),
-        new EncodingId("cp01143", 1143),
-        new EncodingId("cp01144", 1144),
-        new EncodingId("cp01145", 1145),
-        new EncodingId("cp01146", 1146),
-        new EncodingId("cp01147", 1147),
-        new EncodingId("cp01148", 1148),
-        new EncodingId("cp01149", 1149),
-        new EncodingId("cp037", 37),
-        new EncodingId("cp1025", 21025),
-        new EncodingId("cp1026", 1026),
-        new EncodingId("cp1256", 1256),
-        new EncodingId("cp273", 20273),
-        new EncodingId("cp278", 20278),
-        new EncodingId("cp280", 20280),
-        new EncodingId("cp284", 20284),
-        new EncodingId("cp285", 20285),
-        new EncodingId("cp290", 20290),
-        new EncodingId("cp297", 20297),
-        new EncodingId("cp420", 20420),
-        new EncodingId("cp423", 20423),
-        new EncodingId("cp424", 20424),
-        new EncodingId("cp437", 437),
-        new EncodingId("cp500", 500),
-        new EncodingId("cp50227", 50227),
-        new EncodingId("cp850", 850),
-        new EncodingId("cp852", 852),
-        new EncodingId("cp855", 855),
-        new EncodingId("cp857", 857),
-        new EncodingId("cp858", 858),
-        new EncodingId("cp860", 860),
-        new EncodingId("cp861", 861),
-        new EncodingId("cp862", 862),
-        new EncodingId("cp863", 863),
-        new EncodingId("cp864", 864),
-        new EncodingId("cp865", 865),
-        new EncodingId("cp866", 866),
-        new EncodingId("cp869", 869),
-        new EncodingId("cp870", 870),
-        new EncodingId("cp871", 20871),
-        new EncodingId("cp875", 875),
-        new EncodingId("cp880", 20880),
-        new EncodingId("cp905", 20905),
-        new EncodingId("csbig5", 950),
-        new EncodingId("cseuckr", 51949),
-        new EncodingId("cseucpkdfmtjapanese", 51932),
-        new EncodingId("csgb2312", 936),
-        new EncodingId("csgb231280", 936),
-        new EncodingId("csibm037", 37),
-        new EncodingId("csibm1026", 1026),
-        new EncodingId("csibm273", 20273),
-        new EncodingId("csibm277", 20277),
-        new EncodingId("csibm278", 20278),
-        new EncodingId("csibm280", 20280),
-        new EncodingId("csibm284", 20284),
-        new EncodingId("csibm285", 20285),
-        new EncodingId("csibm290", 20290),
-        new EncodingId("csibm297", 20297),
-        new EncodingId("csibm420", 20420),
-        new EncodingId("csibm423", 20423),
-        new EncodingId("csibm424", 20424),
-        new EncodingId("csibm500", 500),
-        new EncodingId("csibm870", 870),
-        new EncodingId("csibm871", 20871),
-        new EncodingId("csibm880", 20880),
-        new EncodingId("csibm905", 20905),
-        new EncodingId("csibmthai", 20838),
-        new EncodingId("csiso2022jp", 50221),
-        new EncodingId("csiso2022kr", 50225),
-        new EncodingId("csiso58gb231280", 936),
-        new EncodingId("csisolatin2", 28592),
-        new EncodingId("csisolatin3", 28593),
-        new EncodingId("csisolatin4", 28594),
-        new EncodingId("csisolatin5", 28599),
-        new EncodingId("csisolatin9", 28605),
-        new EncodingId("csisolatinarabic", 28596),
-        new EncodingId("csisolatincyrillic", 28595),
-        new EncodingId("csisolatingreek", 28597),
-        new EncodingId("csisolatinhebrew", 28598),
-        new EncodingId("cskoi8r", 20866),
-        new EncodingId("csksc56011987", 949),
-        new EncodingId("cspc8codepage437", 437),
-        new EncodingId("csshiftjis", 932),
-        new EncodingId("cswindows31j", 932),
-        new EncodingId("cyrillic", 28595),
-        new EncodingId("din_66003", 20106),
-        new EncodingId("dos-720", 720),
-        new EncodingId("dos-862", 862),
-        new EncodingId("dos-874", 874),
-        new EncodingId("ebcdic-cp-ar1", 20420),
-        new EncodingId("ebcdic-cp-be", 500),
-        new EncodingId("ebcdic-cp-ca", 37),
-        new EncodingId("ebcdic-cp-ch", 500),
-        new EncodingId("ebcdic-cp-dk", 20277),
-        new EncodingId("ebcdic-cp-es", 20284),
-        new EncodingId("ebcdic-cp-fi", 20278),
-        new EncodingId("ebcdic-cp-fr", 20297),
-        new EncodingId("ebcdic-cp-gb", 20285),
-        new EncodingId("ebcdic-cp-gr", 20423),
-        new EncodingId("ebcdic-cp-he", 20424),
-        new EncodingId("ebcdic-cp-is", 20871),
-        new EncodingId("ebcdic-cp-it", 20280),
-        new EncodingId("ebcdic-cp-nl", 37),
-        new EncodingId("ebcdic-cp-no", 20277),
-        new EncodingId("ebcdic-cp-roece", 870),
-        new EncodingId("ebcdic-cp-se", 20278),
-        new EncodingId("ebcdic-cp-tr", 20905),
-        new EncodingId("ebcdic-cp-us", 37),
-        new EncodingId("ebcdic-cp-wt", 37),
-        new EncodingId("ebcdic-cp-yu", 870),
-        new EncodingId("ebcdic-cyrillic", 20880),
-        new EncodingId("ebcdic-de-273+euro", 1141),
-        new EncodingId("ebcdic-dk-277+euro", 1142),
-        new EncodingId("ebcdic-es-284+euro", 1145),
-        new EncodingId("ebcdic-fi-278+euro", 1143),
-        new EncodingId("ebcdic-fr-297+euro", 1147),
-        new EncodingId("ebcdic-gb-285+euro", 1146),
-        new EncodingId("ebcdic-international-500+euro", 1148),
-        new EncodingId("ebcdic-is-871+euro", 1149),
-        new EncodingId("ebcdic-it-280+euro", 1144),
-        new EncodingId("ebcdic-jp-kana", 20290),
-        new EncodingId("ebcdic-latin9--euro", 20924),
-        new EncodingId("ebcdic-no-277+euro", 1142),
-        new EncodingId("ebcdic-se-278+euro", 1143),
-        new EncodingId("ebcdic-us-37+euro", 1140),
-        new EncodingId("ecma-114", 28596),
-        new EncodingId("ecma-118", 28597),
-        new EncodingId("elot_928", 28597),
-        new EncodingId("euc-cn", 51936),
-        new EncodingId("euc-jp", 51932),
-        new EncodingId("euc-kr", 51949),
-        new EncodingId("extended_unix_code_packed_format_for_japanese", 51932),
-        new EncodingId("gb18030", 54936),
-        new EncodingId("gb2312", 936),
-        new EncodingId("gb2312-80", 936),
-        new EncodingId("gb231280", 936),
-        new EncodingId("gbk", 936),
-        new EncodingId("gb_2312-80", 936),
-        new EncodingId("german", 20106),
-        new EncodingId("greek", 28597),
-        new EncodingId("greek8", 28597),
-        new EncodingId("hebrew", 28598),
-        new EncodingId("hz-gb-2312", 52936),
-        new EncodingId("ibm-thai", 20838),
-        new EncodingId("ibm00858", 858),
-        new EncodingId("ibm00924", 20924),
-        new EncodingId("ibm01047", 1047),
-        new EncodingId("ibm01140", 1140),
-        new EncodingId("ibm01141", 1141),
-        new EncodingId("ibm01142", 1142),
-        new EncodingId("ibm01143", 1143),
-        new EncodingId("ibm01144", 1144),
-        new EncodingId("ibm01145", 1145),
-        new EncodingId("ibm01146", 1146),
-        new EncodingId("ibm01147", 1147),
-        new EncodingId("ibm01148", 1148),
-        new EncodingId("ibm01149", 1149),
-        new EncodingId("ibm037", 37),
-        new EncodingId("ibm1026", 1026),
-        new EncodingId("ibm273", 20273),
-        new EncodingId("ibm277", 20277),
-        new EncodingId("ibm278", 20278),
-        new EncodingId("ibm280", 20280),
-        new EncodingId("ibm284", 20284),
-        new EncodingId("ibm285", 20285),
-        new EncodingId("ibm290", 20290),
-        new EncodingId("ibm297", 20297),
-        new EncodingId("ibm420", 20420),
-        new EncodingId("ibm423", 20423),
-        new EncodingId("ibm424", 20424),
-        new EncodingId("ibm437", 437),
-        new EncodingId("ibm500", 500),
-        new EncodingId("ibm737", 737),
-        new EncodingId("ibm775", 775),
-        new EncodingId("ibm850", 850),
-        new EncodingId("ibm852", 852),
-        new EncodingId("ibm855", 855),
-        new EncodingId("ibm857", 857),
-        new EncodingId("ibm860", 860),
-        new EncodingId("ibm861", 861),
-        new EncodingId("ibm862", 862),
-        new EncodingId("ibm863", 863),
-        new EncodingId("ibm864", 864),
-        new EncodingId("ibm865", 865),
-        new EncodingId("ibm866", 866),
-        new EncodingId("ibm869", 869),
-        new EncodingId("ibm870", 870),
-        new EncodingId("ibm871", 20871),
-        new EncodingId("ibm880", 20880),
-        new EncodingId("ibm905", 20905),
-        new EncodingId("irv", 20105),
-        new EncodingId("iso-2022-jp", 50220),
-        new EncodingId("iso-2022-jpeuc", 51932),
-        new EncodingId("iso-2022-kr", 50225),
-        new EncodingId("iso-2022-kr-7", 50225),
-        new EncodingId("iso-2022-kr-7bit", 50225),
-        new EncodingId("iso-2022-kr-8", 51949),
-        new EncodingId("iso-2022-kr-8bit", 51949),
-        new EncodingId("iso-8859-11", 874),
-        new EncodingId("iso-8859-13", 28603),
-        new EncodingId("iso-8859-15", 28605),
-        new EncodingId("iso-8859-2", 28592),
-        new EncodingId("iso-8859-3", 28593),
-        new EncodingId("iso-8859-4", 28594),
-        new EncodingId("iso-8859-5", 28595),
-        new EncodingId("iso-8859-6", 28596),
-        new EncodingId("iso-8859-7", 28597),
-        new EncodingId("iso-8859-8", 28598),
-        new EncodingId("iso-8859-8 visual", 28598),
-        new EncodingId("iso-8859-8-i", 38598),
-        new EncodingId("iso-8859-9", 28599),
-        new EncodingId("iso-ir-101", 28592),
-        new EncodingId("iso-ir-109", 28593),
-        new EncodingId("iso-ir-110", 28594),
-        new EncodingId("iso-ir-126", 28597),
-        new EncodingId("iso-ir-127", 28596),
-        new EncodingId("iso-ir-138", 28598),
-        new EncodingId("iso-ir-144", 28595),
-        new EncodingId("iso-ir-148", 28599),
-        new EncodingId("iso-ir-149", 949),
-        new EncodingId("iso-ir-58", 936),
-        new EncodingId("iso8859-2", 28592),
-        new EncodingId("iso_8859-15", 28605),
-        new EncodingId("iso_8859-2", 28592),
-        new EncodingId("iso_8859-2:1987", 28592),
-        new EncodingId("iso_8859-3", 28593),
-        new EncodingId("iso_8859-3:1988", 28593),
-        new EncodingId("iso_8859-4", 28594),
-        new EncodingId("iso_8859-4:1988", 28594),
-        new EncodingId("iso_8859-5", 28595),
-        new EncodingId("iso_8859-5:1988", 28595),
-        new EncodingId("iso_8859-6", 28596),
-        new EncodingId("iso_8859-6:1987", 28596),
-        new EncodingId("iso_8859-7", 28597),
-        new EncodingId("iso_8859-7:1987", 28597),
-        new EncodingId("iso_8859-8", 28598),
-        new EncodingId("iso_8859-8:1988", 28598),
-        new EncodingId("iso_8859-9", 28599),
-        new EncodingId("iso_8859-9:1989", 28599),
-        new EncodingId("johab", 1361),
-        new EncodingId("koi", 20866),
-        new EncodingId("koi8", 20866),
-        new EncodingId("koi8-r", 20866),
-        new EncodingId("koi8-ru", 21866),
-        new EncodingId("koi8-u", 21866),
-        new EncodingId("koi8r", 20866),
-        new EncodingId("korean", 949),
-        new EncodingId("ks-c-5601", 949),
-        new EncodingId("ks-c5601", 949),
-        new EncodingId("ksc5601", 949),
-        new EncodingId("ksc_5601", 949),
-        new EncodingId("ks_c_5601", 949),
-        new EncodingId("ks_c_5601-1987", 949),
-        new EncodingId("ks_c_5601-1989", 949),
-        new EncodingId("ks_c_5601_1987", 949),
-        new EncodingId("l2", 28592),
-        new EncodingId("l3", 28593),
-        new EncodingId("l4", 28594),
-        new EncodingId("l5", 28599),
-        new EncodingId("l9", 28605),
-        new EncodingId("latin2", 28592),
-        new EncodingId("latin3", 28593),
-        new EncodingId("latin4", 28594),
-        new EncodingId("latin5", 28599),
-        new EncodingId("latin9", 28605),
-        new EncodingId("logical", 28598),
-        new EncodingId("macintosh", 10000),
-        new EncodingId("ms_kanji", 932),
-        new EncodingId("norwegian", 20108),
-        new EncodingId("ns_4551-1", 20108),
-        new EncodingId("pc-multilingual-850+euro", 858),
-        new EncodingId("sen_850200_b", 20107),
-        new EncodingId("shift-jis", 932),
-        new EncodingId("shift_jis", 932),
-        new EncodingId("sjis", 932),
-        new EncodingId("swedish", 20107),
-        new EncodingId("tis-620", 874),
-        new EncodingId("visual", 28598),
-        new EncodingId("windows-1250", 1250),
-        new EncodingId("windows-1251", 1251),
-        new EncodingId("windows-1252", 1252),
-        new EncodingId("windows-1253", 1253),
-        new EncodingId("windows-1254", 1254),
-        new EncodingId("windows-1255", 1255),
-        new EncodingId("windows-1256", 1256),
-        new EncodingId("windows-1257", 1257),
-        new EncodingId("windows-1258", 1258),
-        new EncodingId("windows-874", 874),
-        new EncodingId("x-ansi", 1252),
-        new EncodingId("x-chinese-cns", 20000),
-        new EncodingId("x-chinese-eten", 20002),
-        new EncodingId("x-cp1250", 1250),
-        new EncodingId("x-cp1251", 1251),
-        new EncodingId("x-cp20001", 20001),
-        new EncodingId("x-cp20003", 20003),
-        new EncodingId("x-cp20004", 20004),
-        new EncodingId("x-cp20005", 20005),
-        new EncodingId("x-cp20261", 20261),
-        new EncodingId("x-cp20269", 20269),
-        new EncodingId("x-cp20936", 20936),
-        new EncodingId("x-cp20949", 20949),
-        new EncodingId("x-cp50227", 50227),
-        new EncodingId("x-ebcdic-koreanextended", 20833),
-        new EncodingId("x-euc", 51932),
-        new EncodingId("x-euc-cn", 51936),
-        new EncodingId("x-euc-jp", 51932),
-        new EncodingId("x-europa", 29001),
-        new EncodingId("x-ia5", 20105),
-        new EncodingId("x-ia5-german", 20106),
-        new EncodingId("x-ia5-norwegian", 20108),
-        new EncodingId("x-ia5-swedish", 20107),
-        new EncodingId("x-iscii-as", 57006),
-        new EncodingId("x-iscii-be", 57003),
-        new EncodingId("x-iscii-de", 57002),
-        new EncodingId("x-iscii-gu", 57010),
-        new EncodingId("x-iscii-ka", 57008),
-        new EncodingId("x-iscii-ma", 57009),
-        new EncodingId("x-iscii-or", 57007),
-        new EncodingId("x-iscii-pa", 57011),
-        new EncodingId("x-iscii-ta", 57004),
-        new EncodingId("x-iscii-te", 57005),
-        new EncodingId("x-mac-arabic", 10004),
-        new EncodingId("x-mac-ce", 10029),
-        new EncodingId("x-mac-chinesesimp", 10008),
-        new EncodingId("x-mac-chinesetrad", 10002),
-        new EncodingId("x-mac-croatian", 10082),
-        new EncodingId("x-mac-cyrillic", 10007),
-        new EncodingId("x-mac-greek", 10006),
-        new EncodingId("x-mac-hebrew", 10005),
-        new EncodingId("x-mac-icelandic", 10079),
-        new EncodingId("x-mac-japanese", 10001),
-        new EncodingId("x-mac-korean", 10003),
-        new EncodingId("x-mac-romanian", 10010),
-        new EncodingId("x-mac-thai", 10021),
-        new EncodingId("x-mac-turkish", 10081),
-        new EncodingId("x-mac-ukrainian", 10017),
-        new EncodingId("x-ms-cp932", 932),
-        new EncodingId("x-sjis", 932),
-        new EncodingId("x-x-big5", 950)
-    };
-
-    private static readonly CodePageToWebNameMapping[] s_codePageToWebNameTable = new[]
-    {
-        new CodePageToWebNameMapping(37, "ibm037"),
-        new CodePageToWebNameMapping(437, "ibm437"),
-        new CodePageToWebNameMapping(500, "ibm500"),
-        new CodePageToWebNameMapping(708, "asmo-708"),
-        new CodePageToWebNameMapping(720, "dos-720"),
-        new CodePageToWebNameMapping(737, "ibm737"),
-        new CodePageToWebNameMapping(775, "ibm775"),
-        new CodePageToWebNameMapping(850, "ibm850"),
-        new CodePageToWebNameMapping(852, "ibm852"),
-        new CodePageToWebNameMapping(855, "ibm855"),
-        new CodePageToWebNameMapping(857, "ibm857"),
-        new CodePageToWebNameMapping(858, "ibm00858"),
-        new CodePageToWebNameMapping(860, "ibm860"),
-        new CodePageToWebNameMapping(861, "ibm861"),
-        new CodePageToWebNameMapping(862, "dos-862"),
-        new CodePageToWebNameMapping(863, "ibm863"),
-        new CodePageToWebNameMapping(864, "ibm864"),
-        new CodePageToWebNameMapping(865, "ibm865"),
-        new CodePageToWebNameMapping(866, "cp866"),
-        new CodePageToWebNameMapping(869, "ibm869"),
-        new CodePageToWebNameMapping(870, "ibm870"),
-        new CodePageToWebNameMapping(874, "windows-874"),
-        new CodePageToWebNameMapping(875, "cp875"),
-        new CodePageToWebNameMapping(932, "shift_jis"),
-        new CodePageToWebNameMapping(936, "gb2312"),
-        new CodePageToWebNameMapping(949, "ks_c_5601-1987"),
-        new CodePageToWebNameMapping(950, "big5"),
-        new CodePageToWebNameMapping(1026, "ibm1026"),
-        new CodePageToWebNameMapping(1047, "ibm01047"),
-        new CodePageToWebNameMapping(1140, "ibm01140"),
-        new CodePageToWebNameMapping(1141, "ibm01141"),
-        new CodePageToWebNameMapping(1142, "ibm01142"),
-        new CodePageToWebNameMapping(1143, "ibm01143"),
-        new CodePageToWebNameMapping(1144, "ibm01144"),
-        new CodePageToWebNameMapping(1145, "ibm01145"),
-        new CodePageToWebNameMapping(1146, "ibm01146"),
-        new CodePageToWebNameMapping(1147, "ibm01147"),
-        new CodePageToWebNameMapping(1148, "ibm01148"),
-        new CodePageToWebNameMapping(1149, "ibm01149"),
-        new CodePageToWebNameMapping(1250, "windows-1250"),
-        new CodePageToWebNameMapping(1251, "windows-1251"),
-        new CodePageToWebNameMapping(1252, "windows-1252"),
-        new CodePageToWebNameMapping(1253, "windows-1253"),
-        new CodePageToWebNameMapping(1254, "windows-1254"),
-        new CodePageToWebNameMapping(1255, "windows-1255"),
-        new CodePageToWebNameMapping(1256, "windows-1256"),
-        new CodePageToWebNameMapping(1257, "windows-1257"),
-        new CodePageToWebNameMapping(1258, "windows-1258"),
-        new CodePageToWebNameMapping(1361, "johab"),
-        new CodePageToWebNameMapping(10000, "macintosh"),
-        new CodePageToWebNameMapping(10001, "x-mac-japanese"),
-        new CodePageToWebNameMapping(10002, "x-mac-chinesetrad"),
-        new CodePageToWebNameMapping(10003, "x-mac-korean"),
-        new CodePageToWebNameMapping(10004, "x-mac-arabic"),
-        new CodePageToWebNameMapping(10005, "x-mac-hebrew"),
-        new CodePageToWebNameMapping(10006, "x-mac-greek"),
-        new CodePageToWebNameMapping(10007, "x-mac-cyrillic"),
-        new CodePageToWebNameMapping(10008, "x-mac-chinesesimp"),
-        new CodePageToWebNameMapping(10010, "x-mac-romanian"),
-        new CodePageToWebNameMapping(10017, "x-mac-ukrainian"),
-        new CodePageToWebNameMapping(10021, "x-mac-thai"),
-        new CodePageToWebNameMapping(10029, "x-mac-ce"),
-        new CodePageToWebNameMapping(10079, "x-mac-icelandic"),
-        new CodePageToWebNameMapping(10081, "x-mac-turkish"),
-        new CodePageToWebNameMapping(10082, "x-mac-croatian"),
-        new CodePageToWebNameMapping(20000, "x-chinese-cns"),
-        new CodePageToWebNameMapping(20001, "x-cp20001"),
-        new CodePageToWebNameMapping(20002, "x-chinese-eten"),
-        new CodePageToWebNameMapping(20003, "x-cp20003"),
-        new CodePageToWebNameMapping(20004, "x-cp20004"),
-        new CodePageToWebNameMapping(20005, "x-cp20005"),
-        new CodePageToWebNameMapping(20105, "x-ia5"),
-        new CodePageToWebNameMapping(20106, "x-ia5-german"),
-        new CodePageToWebNameMapping(20107, "x-ia5-swedish"),
-        new CodePageToWebNameMapping(20108, "x-ia5-norwegian"),
-        new CodePageToWebNameMapping(20261, "x-cp20261"),
-        new CodePageToWebNameMapping(20269, "x-cp20269"),
-        new CodePageToWebNameMapping(20273, "ibm273"),
-        new CodePageToWebNameMapping(20277, "ibm277"),
-        new CodePageToWebNameMapping(20278, "ibm278"),
-        new CodePageToWebNameMapping(20280, "ibm280"),
-        new CodePageToWebNameMapping(20284, "ibm284"),
-        new CodePageToWebNameMapping(20285, "ibm285"),
-        new CodePageToWebNameMapping(20290, "ibm290"),
-        new CodePageToWebNameMapping(20297, "ibm297"),
-        new CodePageToWebNameMapping(20420, "ibm420"),
-        new CodePageToWebNameMapping(20423, "ibm423"),
-        new CodePageToWebNameMapping(20424, "ibm424"),
-        new CodePageToWebNameMapping(20833, "x-ebcdic-koreanextended"),
-        new CodePageToWebNameMapping(20838, "ibm-thai"),
-        new CodePageToWebNameMapping(20866, "koi8-r"),
-        new CodePageToWebNameMapping(20871, "ibm871"),
-        new CodePageToWebNameMapping(20880, "ibm880"),
-        new CodePageToWebNameMapping(20905, "ibm905"),
-        new CodePageToWebNameMapping(20924, "ibm00924"),
-        new CodePageToWebNameMapping(20932, "euc-jp"),
-        new CodePageToWebNameMapping(20936, "x-cp20936"),
-        new CodePageToWebNameMapping(20949, "x-cp20949"),
-        new CodePageToWebNameMapping(21025, "cp1025"),
-        new CodePageToWebNameMapping(21866, "koi8-u"),
-        new CodePageToWebNameMapping(28592, "iso-8859-2"),
-        new CodePageToWebNameMapping(28593, "iso-8859-3"),
-        new CodePageToWebNameMapping(28594, "iso-8859-4"),
-        new CodePageToWebNameMapping(28595, "iso-8859-5"),
-        new CodePageToWebNameMapping(28596, "iso-8859-6"),
-        new CodePageToWebNameMapping(28597, "iso-8859-7"),
-        new CodePageToWebNameMapping(28598, "iso-8859-8"),
-        new CodePageToWebNameMapping(28599, "iso-8859-9"),
-        new CodePageToWebNameMapping(28603, "iso-8859-13"),
-        new CodePageToWebNameMapping(28605, "iso-8859-15"),
-        new CodePageToWebNameMapping(38598, "iso-8859-8-i"),
-        new CodePageToWebNameMapping(50220, "iso-2022-jp"),
-        new CodePageToWebNameMapping(50221, "csiso2022jp"),
-        new CodePageToWebNameMapping(50222, "iso-2022-jp"),
-        new CodePageToWebNameMapping(50225, "iso-2022-kr"),
-        new CodePageToWebNameMapping(50227, "x-cp50227"),
-        new CodePageToWebNameMapping(51932, "euc-jp"),
-        new CodePageToWebNameMapping(51936, "euc-cn"),
-        new CodePageToWebNameMapping(51949, "euc-kr"),
-        new CodePageToWebNameMapping(52936, "hz-gb-2312"),
-        new CodePageToWebNameMapping(54936, "gb18030"),
-        new CodePageToWebNameMapping(57002, "x-iscii-de"),
-        new CodePageToWebNameMapping(57003, "x-iscii-be"),
-        new CodePageToWebNameMapping(57004, "x-iscii-ta"),
-        new CodePageToWebNameMapping(57005, "x-iscii-te"),
-        new CodePageToWebNameMapping(57006, "x-iscii-as"),
-        new CodePageToWebNameMapping(57007, "x-iscii-or"),
-        new CodePageToWebNameMapping(57008, "x-iscii-ka"),
-        new CodePageToWebNameMapping(57009, "x-iscii-ma"),
-        new CodePageToWebNameMapping(57010, "x-iscii-gu"),
-        new CodePageToWebNameMapping(57011, "x-iscii-pa")
-    };
 }


### PR DESCRIPTION
Updated (existant) tests for System.Text.Encoding.CodePage, in response to #1872 .
Tests no longer require a specific run order, and should be safer to run in multiple threads (one other test had potential race conditions as a result of conversion...)

All tests passing on Windows.  An attempt was made to fix one of the tests failing in Unix (due to issue #846 ), but I have no way to verify this myself (`ActiveIssue` attribute left on).

There also appeared to be some entries missing for retrieving a 'WebName' from a given encoding (Europa, code page 29001).  The encoding could be retrieved, and even used to perform encodings, but attempting to call `WebName` would complain that such did not exist.  Given:
 1. The encoders existence and working implementation
 2. A returned value in the current implementation.
 3. An entry on the relevant MSDN page.

... this was judged to be a bug, and corrected accordingly. 

<hr />
Squashed commits:

Remove `EnsureInitialization` and pre-existing-encodings tests.
Ask CodePagesEncodingProvider directly for encodings.

Move encoding mapping data into member in prep for adding Theory attribute.

Add missing Europa (code page 29001) strings.
No obvious way to test "English" strings (unused!), leaving in for now.

Test for existence of all available default encodings.
Test replacement/supplementary behavior with addition of code-page mapping.
Attempt to add Unix-specific test (but not able to personally test, due to being on windows...).

Update TestCodepageEncoding to use Theory/MemberData.
Expand range of characters round-tripped (potentially more can be added, but additional tests for exceptions should be added).
Bring in code-page->webname mapping tests.

Remove existence test for Eudc encoding (part of testing data).

Update TestEncodingDisplayNames to use Theory/MemberData.
Raise lower bound of acceptable characters to only printable, and not solely whitespace.
Externalize culture setup to class load-time (in-method not thread safe!)

Move test classes out of default namespace.

Update TestSpecificCodepageEncodings
Extract test data to member.
Loft tests to method, use more idiomatic xUnit.

Update multibyte encoding tests.
Extract data to member.
Condense test methods into one.