### PR TITLE
Fix System.IO.Pipes bugs (src and test)

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/IOCancellationHelper.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/IOCancellationHelper.Windows.cs
@@ -43,7 +43,7 @@ namespace System.IO.Pipes
             }
             else
             {
-                this._cancellationRegistration = this._cancellationToken.Register(Cancel);
+                this._cancellationRegistration = this._cancellationToken.Register(s => ((IOCancellationHelper)s).Cancel(), this);
             }
         }
 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -16,6 +16,11 @@ namespace System.IO.Pipes
         [SecurityCritical]
         private bool TryConnect(int timeout, CancellationToken cancellationToken)
         {
+            // timeout and cancellationToken are currently ignored: [ActiveIssue(812, PlatformID.AnyUnix)]
+            // We should figure out if there's a good way to cancel calls to Open, such as
+            // by sending a signal that causes an EINTR, and then in handling the EINTR result
+            // poll the cancellationToken to see if cancellation was requested.
+
             try
             {
                 // Open the file.  For In or Out, this will block until a client has connected.

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -86,6 +86,10 @@ namespace System.IO.Pipes
         public void WaitForConnection()
         {
             CheckConnectOperationsServer();
+            if (State == PipeState.Connected)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_PipeAlreadyConnected);
+            }
 
             // Open the file.  For In or Out, this will block until a client has connected.
             // Unfortunately for InOut it won't, which is different from the Windows behavior;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -185,15 +185,11 @@ namespace System.IO.Pipes
             {
                 throw new InvalidOperationException(SR.InvalidOperation_PipeAlreadyDisconnected);
             }
-            if (InternalHandle == null)
+            if (CheckOperationsRequiresSetHandle && InternalHandle == null)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_PipeHandleNotSet);
             }
-            if (State == PipeState.Closed)
-            {
-                throw __Error.GetPipeNotOpen();
-            }
-            if (InternalHandle.IsClosed)
+            if ((State == PipeState.Closed) || (InternalHandle != null && InternalHandle.IsClosed))
             {
                 throw __Error.GetPipeNotOpen();
             }

--- a/src/System.IO.Pipes/tests/AnonymousPipesSimpleTest.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipesSimpleTest.cs
@@ -57,7 +57,7 @@ public class AnonymousPipesSimpleTest
     }
 
     [Fact]
-    public static void ServerSendsByteClientReceivesAsync()
+    public static async Task ServerSendsByteClientReceivesAsync()
     {
         using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
         {
@@ -69,13 +69,9 @@ public class AnonymousPipesSimpleTest
 
                 byte[] sent = new byte[] { 123 };
                 byte[] received = new byte[] { 0 };
-                Task writeTask = server.WriteAsync(sent, 0, 1);
-                writeTask.Wait();
+                await server.WriteAsync(sent, 0, 1);
 
-                Task<int> readTask = client.ReadAsync(received, 0, 1);
-                readTask.Wait();
-
-                Assert.Equal(1, readTask.Result);
+                Assert.Equal(1, await client.ReadAsync(received, 0, 1));
                 Assert.Equal(sent[0], received[0]);
             }
         }
@@ -131,7 +127,7 @@ public class AnonymousPipesSimpleTest
     }
 
     [Fact]
-    public static void ServerPInvokeChecks()
+    public static async Task ServerPInvokeChecks()
     {
         // calling every API related to server and client to detect any bad PInvokes
         using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
@@ -158,7 +154,7 @@ public class AnonymousPipesSimpleTest
             Assert.Equal(PipeTransmissionMode.Byte, server.TransmissionMode);
 
             server.Write(new byte[] { 123 }, 0, 1);
-            server.WriteAsync(new byte[] { 124 }, 0, 1).Wait();
+            await server.WriteAsync(new byte[] { 124 }, 0, 1);
             server.Flush();
             if (Interop.IsWindows)
             {
@@ -169,7 +165,7 @@ public class AnonymousPipesSimpleTest
                 Assert.Throws<PlatformNotSupportedException>(() => server.WaitForPipeDrain());
             }
 
-            clientTask.Wait();
+            await clientTask;
             server.DisposeLocalCopyOfClientHandle();
         }
 
@@ -191,12 +187,12 @@ public class AnonymousPipesSimpleTest
             Assert.Equal(123, readData[0]);
             Assert.Equal(124, readData[1]);
 
-            clientTask.Wait();
+            await clientTask;
         }
     }
 
     [Fact]
-    public static void ClientPInvokeChecks()
+    public static async Task ClientPInvokeChecks()
     {
         using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.In))
         {
@@ -223,7 +219,7 @@ public class AnonymousPipesSimpleTest
                 Assert.Equal(PipeTransmissionMode.Byte, client.TransmissionMode);
 
                 client.Write(new byte[] { 123 }, 0, 1);
-                client.WriteAsync(new byte[] { 124 }, 0, 1).Wait();
+                await client.WriteAsync(new byte[] { 124 }, 0, 1);
                 if (Interop.IsWindows)
                 {
                     client.WaitForPipeDrain();
@@ -234,7 +230,7 @@ public class AnonymousPipesSimpleTest
                 }
                 client.Flush();
 
-                serverTask.Wait();
+                await serverTask;
             }
         }
 
@@ -258,7 +254,7 @@ public class AnonymousPipesSimpleTest
                 Assert.Equal(123, readData[0]);
                 Assert.Equal(124, readData[1]);
 
-                serverTask.Wait();
+                await serverTask;
             }
         }
     }

--- a/src/System.IO.Pipes/tests/AnonymousPipesThrowsTests.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipesThrowsTests.cs
@@ -1,17 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO.Pipes;
-using System.Threading.Tasks;
-using Xunit;
-
 using Microsoft.Win32.SafeHandles;
+using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
     public class AnonymousPipesThrowsTests
     {
+        private static void NotReachable(object obj) { Assert.True(false, "This should not be reached."); }
+
         // Server parameter validation tests
         [Fact]
         public static void ServerBadPipeDirectionThrows()
@@ -78,8 +76,7 @@ namespace System.IO.Pipes.Tests
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None))
             {
                 Assert.Throws<ArgumentNullException>(() => server.Write(null, 0, 1));
-
-                Assert.ThrowsAsync<ArgumentNullException>(() => server.WriteAsync(null, 0, 1));
+                Assert.Throws<ArgumentNullException>(() => NotReachable(server.WriteAsync(null, 0, 1)));
             }
         }
 
@@ -92,15 +89,13 @@ namespace System.IO.Pipes.Tests
 
                 // array is checked first
                 Assert.Throws<ArgumentNullException>(() => server.Write(null, -1, 1));
-
-                Assert.ThrowsAsync<ArgumentNullException>(() => server.WriteAsync(null, -1, 1));
+                Assert.Throws<ArgumentNullException>(() => NotReachable(server.WriteAsync(null, -1, 1)));
             }
         }
 
         [Fact]
         public static void ServerWriteNegativeCountThrows()
         {
-
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => server.Write(new byte[5], 0, -1));
@@ -111,13 +106,13 @@ namespace System.IO.Pipes.Tests
                 // array is checked first
                 Assert.Throws<ArgumentNullException>(() => server.Write(null, -1, -1));
 
-                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => server.WriteAsync(new byte[5], 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => NotReachable(server.WriteAsync(new byte[5], 0, -1)));
 
                 // offset is checked before count
-                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => server.WriteAsync(new byte[1], -1, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => NotReachable(server.WriteAsync(new byte[1], -1, -1)));
 
                 // array is checked first
-                Assert.ThrowsAsync<ArgumentNullException>(() => server.WriteAsync(null, -1, -1));
+                Assert.Throws<ArgumentNullException>(() => NotReachable(server.WriteAsync(null, -1, -1)));
             }
         }
 
@@ -145,22 +140,22 @@ namespace System.IO.Pipes.Tests
                 Assert.Throws<ArgumentException>(() => server.Write(new byte[5], 3, 4));
 
                 // offset out of bounds
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.WriteAsync(new byte[1], 1, 1));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.WriteAsync(new byte[1], 1, 1)));
 
                 // offset out of bounds for 0 count read
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.WriteAsync(new byte[1], 2, 0));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.WriteAsync(new byte[1], 2, 0)));
 
                 // offset out of bounds even for 0 length buffer
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.WriteAsync(new byte[0], 1, 0));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.WriteAsync(new byte[0], 1, 0)));
 
                 // combination offset and count out of bounds
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.WriteAsync(new byte[2], 1, 2));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.WriteAsync(new byte[2], 1, 2)));
 
                 // edges
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.WriteAsync(new byte[0], int.MaxValue, 0));
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.WriteAsync(new byte[0], int.MaxValue, int.MaxValue));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.WriteAsync(new byte[0], int.MaxValue, 0)));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.WriteAsync(new byte[0], int.MaxValue, int.MaxValue)));
 
-                Assert.ThrowsAsync<ArgumentException>(() => server.WriteAsync(new byte[5], 3, 4));
+                Assert.Throws<ArgumentException>(() => NotReachable(server.WriteAsync(new byte[5], 3, 4)));
             }
         }
 
@@ -179,7 +174,7 @@ namespace System.IO.Pipes.Tests
 
                 Assert.Throws<NotSupportedException>(() => server.WaitForPipeDrain());
 
-                Assert.ThrowsAsync<NotSupportedException>(() => server.WriteAsync(new byte[5], 0, 5));
+                Assert.Throws<NotSupportedException>(() => NotReachable(server.WriteAsync(new byte[5], 0, 5)));
             }
         }
 
@@ -190,7 +185,7 @@ namespace System.IO.Pipes.Tests
             {
                 Assert.Throws<ArgumentNullException>(() => server.Read(null, 0, 1));
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => server.ReadAsync(null, 0, 1));
+                Assert.Throws<ArgumentNullException>(() => NotReachable(server.ReadAsync(null, 0, 1)));
             }
         }
 
@@ -204,10 +199,10 @@ namespace System.IO.Pipes.Tests
                 // array is checked first
                 Assert.Throws<ArgumentNullException>(() => server.Read(null, -1, 1));
 
-                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => server.ReadAsync(new byte[5], -1, 1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => NotReachable(server.ReadAsync(new byte[5], -1, 1)));
 
                 // array is checked first
-                Assert.ThrowsAsync<ArgumentNullException>(() => server.ReadAsync(null, -1, 1));
+                Assert.Throws<ArgumentNullException>(() => NotReachable(server.ReadAsync(null, -1, 1)));
             }
         }
 
@@ -224,13 +219,13 @@ namespace System.IO.Pipes.Tests
                 // array is checked first
                 Assert.Throws<ArgumentNullException>(() => server.Read(null, -1, -1));
 
-                Assert.ThrowsAsync<System.ArgumentOutOfRangeException>(() => server.ReadAsync(new byte[5], 0, -1));
+                Assert.Throws<System.ArgumentOutOfRangeException>(() => NotReachable(server.ReadAsync(new byte[5], 0, -1)));
 
                 // offset is checked before count
-                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => server.ReadAsync(new byte[1], -1, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => NotReachable(server.ReadAsync(new byte[1], -1, -1)));
 
                 // array is checked first
-                Assert.ThrowsAsync<ArgumentNullException>(() => server.ReadAsync(null, -1, -1));
+                Assert.Throws<ArgumentNullException>(() => NotReachable(server.ReadAsync(null, -1, -1)));
             }
         }
 
@@ -258,22 +253,22 @@ namespace System.IO.Pipes.Tests
                 Assert.Throws<ArgumentException>(() => server.Read(new byte[5], 3, 4));
 
                 // offset out of bounds
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.ReadAsync(new byte[1], 1, 1));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.ReadAsync(new byte[1], 1, 1)));
 
                 // offset out of bounds for 0 count read
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.ReadAsync(new byte[1], 2, 0));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.ReadAsync(new byte[1], 2, 0)));
 
                 // offset out of bounds even for 0 length buffer
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.ReadAsync(new byte[0], 1, 0));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.ReadAsync(new byte[0], 1, 0)));
 
                 // combination offset and count out of bounds
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.ReadAsync(new byte[2], 1, 2));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.ReadAsync(new byte[2], 1, 2)));
 
                 // edges
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.ReadAsync(new byte[0], int.MaxValue, 0));
-                Assert.ThrowsAsync<ArgumentException>(null, () => server.ReadAsync(new byte[0], int.MaxValue, int.MaxValue));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.ReadAsync(new byte[0], int.MaxValue, 0)));
+                Assert.Throws<ArgumentException>(null, () => NotReachable(server.ReadAsync(new byte[0], int.MaxValue, int.MaxValue)));
 
-                Assert.ThrowsAsync<ArgumentException>(() => server.ReadAsync(new byte[5], 3, 4));
+                Assert.Throws<ArgumentException>(() => NotReachable(server.ReadAsync(new byte[5], 3, 4)));
             }
         }
 
@@ -288,7 +283,7 @@ namespace System.IO.Pipes.Tests
 
                 Assert.Throws<NotSupportedException>(() => server.InBufferSize);
 
-                Assert.ThrowsAsync<NotSupportedException>(() => server.ReadAsync(new byte[5], 0, 5));
+                Assert.Throws<NotSupportedException>(() => NotReachable(server.ReadAsync(new byte[5], 0, 5)));
             }
         }
 

--- a/src/System.IO.Pipes/tests/NamedPipesSimpleTest.cs
+++ b/src/System.IO.Pipes/tests/NamedPipesSimpleTest.cs
@@ -37,7 +37,7 @@ public class NamedPipesSimpleTest
         }
     }
 
-    static byte[] ReadBytesAsync(PipeStream pipeStream, int length)
+    static async Task<byte[]> ReadBytesAsync(PipeStream pipeStream, int length)
     {
         Assert.True(pipeStream.IsConnected);
 
@@ -48,22 +48,19 @@ public class NamedPipesSimpleTest
 
         while (readSoFar < length)
         {
-            Task<int> readTask = pipeStream.ReadAsync(buffer, readSoFar, length - readSoFar);
-            readTask.Wait();
-            int len = readTask.Result;
+            int len = await pipeStream.ReadAsync(buffer, readSoFar, length - readSoFar);
+            if (len == 0) break;
             readSoFar += len;
         }
 
         return buffer;
     }
 
-    static void WriteBytesAsync(PipeStream pipeStream, byte[] buffer)
+    static Task WriteBytesAsync(PipeStream pipeStream, byte[] buffer)
     {
         Assert.True(pipeStream.IsConnected);
         Assert.True(buffer.Length > 0);
-
-        Task writeTask = pipeStream.WriteAsync(buffer, 0, buffer.Length);
-        writeTask.Wait();
+        return pipeStream.WriteAsync(buffer, 0, buffer.Length);
     }
 
     static byte[] sendBytes = new byte[] { 123, 234 };
@@ -101,7 +98,7 @@ public class NamedPipesSimpleTest
     [InlineData("TestInD", PipeDirection.In, true, true, true, false)]
     [InlineData("TestInE", PipeDirection.In, true, true, false, true)]
     [InlineData("TestInF", PipeDirection.In, true, true, true, true)]
-    public static void ClientServerOneWayOperations(
+    public static async Task ClientServerOneWayOperations(
         string pipeName, PipeDirection serverDirection,
         bool asyncServerPipe, bool asyncClientPipe,
         bool asyncServerOps, bool asyncClientOps)
@@ -113,20 +110,20 @@ public class NamedPipesSimpleTest
         using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName, serverDirection, 1, PipeTransmissionMode.Byte, serverOptions))
         {
             byte[] received = new byte[] { 0 };
-            Task clientTask = Task.Run(() =>
+            Task clientTask = Task.Run(async () =>
             {
                 using (NamedPipeClientStream client = new NamedPipeClientStream(".", pipeName, clientDirection, clientOptions))
                 {
                     if (asyncClientOps)
                     {
-                        client.ConnectAsync().Wait();
+                        await client.ConnectAsync();
                         if (clientDirection == PipeDirection.In)
                         {
-                            received = ReadBytesAsync(client, sendBytes.Length);
+                            received = await ReadBytesAsync(client, sendBytes.Length);
                         }
                         else
                         {
-                            WriteBytesAsync(client, sendBytes);
+                            await WriteBytesAsync(client, sendBytes);
                         }
                     }
                     else
@@ -146,14 +143,14 @@ public class NamedPipesSimpleTest
 
             if (asyncServerOps)
             {
-                server.WaitForConnectionAsync().Wait();
+                await server.WaitForConnectionAsync();
                 if (serverDirection == PipeDirection.Out)
                 {
-                    WriteBytesAsync(server, sendBytes);
+                    await WriteBytesAsync(server, sendBytes);
                 }
                 else
                 {
-                    received = ReadBytesAsync(server, sendBytes.Length);
+                    received = await ReadBytesAsync(server, sendBytes.Length);
                 }
             }
             else {
@@ -168,7 +165,7 @@ public class NamedPipesSimpleTest
                 }
             }
 
-            clientTask.Wait();
+            await clientTask;
             Assert.Equal(sendBytes, received);
 
             server.Disconnect();
@@ -208,7 +205,7 @@ public class NamedPipesSimpleTest
     }
 
     [Fact]
-    public static void ServerPInvokeChecks()
+    public static async Task ServerPInvokeChecks()
     {
         // calling every API related to server and client to detect any bad PInvokes
         using (NamedPipeServerStream server = new NamedPipeServerStream("foo", PipeDirection.Out))
@@ -235,7 +232,7 @@ public class NamedPipesSimpleTest
             Assert.Equal(PipeTransmissionMode.Byte, server.TransmissionMode);
 
             server.Write(new byte[] { 123 }, 0, 1);
-            server.WriteAsync(new byte[] { 124 }, 0, 1).Wait();
+            await server.WriteAsync(new byte[] { 124 }, 0, 1);
             server.Flush();
             if (Interop.IsWindows)
             {
@@ -246,7 +243,7 @@ public class NamedPipesSimpleTest
                 Assert.Throws<PlatformNotSupportedException>(() => server.WaitForPipeDrain());
             }
 
-            clientTask.Wait();
+            await clientTask;
         }
 
         using (NamedPipeServerStream server = new NamedPipeServerStream("foo", PipeDirection.In))
@@ -271,7 +268,7 @@ public class NamedPipesSimpleTest
     }
 
     [Fact]
-    public static void ClientPInvokeChecks()
+    public static async Task ClientPInvokeChecks()
     {
         using (NamedPipeServerStream server = new NamedPipeServerStream("foo", PipeDirection.In))
         {
@@ -299,7 +296,7 @@ public class NamedPipesSimpleTest
                 Assert.Equal(PipeTransmissionMode.Byte, client.TransmissionMode);
 
                 client.Write(new byte[] { 123 }, 0, 1);
-                client.WriteAsync(new byte[] { 124 }, 0, 1).Wait();
+                await client.WriteAsync(new byte[] { 124 }, 0, 1);
                 if (Interop.IsWindows)
                 {
                     client.WaitForPipeDrain();
@@ -310,7 +307,7 @@ public class NamedPipesSimpleTest
                 }
                 client.Flush();
 
-                serverTask.Wait();
+                await serverTask;
             }
         }
 
@@ -335,7 +332,7 @@ public class NamedPipesSimpleTest
                 Assert.Equal(123, readData[0]);
                 Assert.Equal(124, readData[1]);
 
-                serverTask.Wait();
+                await serverTask;
             }
         }
     }
@@ -392,81 +389,68 @@ public class NamedPipesSimpleTest
     }
 
     [Fact]
-    [ActiveIssue(1766)]
-    public static void ServerCloneTests()
+    public static async Task ServerCloneTests()
     {
         const string pipeName = "fooclone";
         byte[] msg1 = new byte[] { 5, 7, 9, 10 };
         byte[] received1 = new byte[] { 0, 0, 0, 0 };
 
-        using (NamedPipeServerStream serverBase = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
+        using (NamedPipeServerStream serverBase = new NamedPipeServerStream(pipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte))
+        using (NamedPipeClientStream client = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.None))
         {
-            using (NamedPipeServerStream server = new NamedPipeServerStream(PipeDirection.InOut, false, false, serverBase.SafePipeHandle))
+            Task clientTask = Task.Run(() =>
             {
-                using (NamedPipeClientStream client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None))
+                client.Connect();
+                client.Write(msg1, 0, msg1.Length);
+                if (Interop.IsWindows)
                 {
-                    Task clientTask = Task.Run(() =>
-                    {
-                        client.Connect();
-
-                        client.Write(msg1, 0, msg1.Length);
-
-                        int serverCount = client.NumberOfServerInstances;
-                        Assert.Equal(1, serverCount);
-                    });
+                    Assert.Equal(1, client.NumberOfServerInstances);
                 }
+            });
 
-                server.WaitForConnection();
+            serverBase.WaitForConnection();
+            using (NamedPipeServerStream server = new NamedPipeServerStream(PipeDirection.In, false, true, serverBase.SafePipeHandle))
+            {
                 int len1 = server.Read(received1, 0, msg1.Length);
                 Assert.Equal(msg1.Length, len1);
                 Assert.Equal(msg1, received1);
+                await clientTask;
             }
         }
     }
 
     [Fact]
-    public static void ClientCloneTests()
+    public static async Task ClientCloneTests()
     {
         const string pipeName = "fooClientclone";
-        
+
         byte[] msg1 = new byte[] { 5, 7, 9, 10 };
         byte[] received0 = new byte[] { };
         byte[] received1 = new byte[] { 0, 0, 0, 0 };
 
-        using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
+        using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte))
+        using (NamedPipeClientStream clientBase = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.None))
         {
-            using (NamedPipeClientStream clientBase = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None))
+            await Task.WhenAll(server.WaitForConnectionAsync(), clientBase.ConnectAsync());
+
+            using (NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.Out, false, true, clientBase.SafePipeHandle))
             {
-                Task clientTask = Task.Run(() =>
+                if (Interop.IsWindows)
                 {
-                    clientBase.Connect();
+                    Assert.Equal(1, client.NumberOfServerInstances);
+                }
+                Assert.Equal(PipeTransmissionMode.Byte, client.TransmissionMode);
 
-                    using (NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.InOut, false, true, clientBase.SafePipeHandle))
-                    {
-                        client.Write(msg1, 0, msg1.Length);
-
-                        int serverCount = client.NumberOfServerInstances;
-                        Assert.Equal(1, serverCount);
-                        Assert.Equal(PipeTransmissionMode.Byte, client.TransmissionMode);
-                    }
-                });
-
-                server.WaitForConnection();
+                Task clientTask = Task.Run(() => client.Write(msg1, 0, msg1.Length));
                 int len1 = server.Read(received1, 0, msg1.Length);
+                await clientTask;
                 Assert.Equal(msg1.Length, len1);
                 Assert.Equal(msg1, received1);
 
                 // test special cases of buffer lengths = 0
                 int len0 = server.Read(received0, 0, 0);
                 Assert.Equal(0, len0);
-
-                server.Write(received0, 0, 0);
-
-                Task<int> serverTaskRead = server.ReadAsync(received0, 0, 0);
-                serverTaskRead.Wait();
-                Assert.Equal(0, serverTaskRead.Result);
-
-                server.WriteAsync(received0, 0, 0).Wait();
+                Assert.Equal(0, await server.ReadAsync(received0, 0, 0));
             }
         }
     }


### PR DESCRIPTION
Fix multiple test bugs in System.IO.Pipes.Tests and multiple product bugs in the Unix implementation of System.IO.Pipes, primarily around error cases surfacing an exception or the right exception and at the right time.

Product changes:
- In the Windows implementation, avoids a few unnecessary allocations when registring for cancellation.
- Common code shared between Windows and Unix is used to check the state of the streams prior to various operations, including validating the current state of the pipe's handle.  On Windows, the handle is always initialized at creation, whereas in the current Unix implementation, the handle's creation is deferred until the connection is established.  As such, code that checked the validity of the handle needed to be updated to not require that the handle be set on Unix.
- The Unix NamedPipeServerStream.WaitForConnection implementation was missing a check to fail if the connection was already established.  On Windows, this is handled by the underlying OS function; on Unix, we just open a file, which any number of consumers can do, so there's no valdation provided by the OS for the constraint we need.
- The Unix implementation of PipeStream was not overriding Read/WriteAsync, such that validation of the inputs was happening asynchronously.  I've refactored out the Read/WriteAsync validation logic to be shared between Windows and Unix, with the shared code overriding these methods.
- In the Unix implementation, if any operation detects that the pipe has been broken, it needs to transition the pipe to a state of Broken.  The Windows implementation was already doing this.

Test changes:
- A bunch of calls to Assert.ThrowsAsync were ignoring the returned Task, which meant that a) any assertion failures were being ignored, b) operations may have continued to run well past the end of the test, and c) race conditions were occurring due to unexpected concurrency between operations.  These have been addressed by either awaiting on the resulting task (when the operation is expected to run asynchronously) or by changing to using Throw instead of ThrowAsync (when we expect the exception to propagate out synchronously).
- Some tasks were being waited on synchronously, which could have potentially led to deadlock situations in the tests.  I changed everything relevant to use async/await.
- The ServerCloneTests was failing (on both Windows and Unix) because it was closing the client stream prior to being done with the test.  I fixed up the disposal ordering and re-enabled the test. I also had to change the order in which operations occurred around waiting for the connection, due to the Unix implementation not establishing the handle until the connection is established, rather than during construction.
- I added some Interop.IsWindows checks for functionality known to be unavailable on Unix, e.g. NumberOfServerInstances.
- I changed a few tests to use In vs Out rather than InOut, to focus the test on what specifically was being tested, and because the Unix support for InOut isn't quite the same as on Windows.

Fixes #1762, #1763, #1764, #1765, #1766, #1772.

(This commit also currently includes the changes in #1871; I will fix those appropriately once #1871 is merged.)