### PR TITLE
Output Console ANSI sequences on Unix only for CHR devices

### DIFF
--- a/src/Common/src/Interop/Unix/libcoreclr/Interop.GetFileInformation.cs
+++ b/src/Common/src/Interop/Unix/libcoreclr/Interop.GetFileInformation.cs
@@ -29,6 +29,7 @@ internal static partial class Interop
         { 
             internal const int S_IFMT  = 0xF000;
             internal const int S_IFIFO = 0x1000;
+            internal const int S_IFCHR = 0x2000;
             internal const int S_IFDIR = 0x4000;
             internal const int S_IFREG = 0x8000;
             internal const int S_IFLNK = 0xA000;

--- a/src/System.Console/src/System/IO/SyncTextWriter.cs
+++ b/src/System.Console/src/System/IO/SyncTextWriter.cs
@@ -12,7 +12,7 @@ namespace System.IO
     internal sealed class SyncTextWriter : TextWriter, IDisposable
     {
         private readonly object _methodLock = new object();
-        private TextWriter _out;
+        internal readonly TextWriter _out;
 
         internal static TextWriter GetSynchronizedTextWriter(TextWriter writer)
         {

--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+public class Color
+{
+    [Fact]
+    [PlatformSpecific(PlatformID.Linux | PlatformID.OSX)]
+    public static void RedirectedOutputDoesNotUseAnsiSequences()
+    {
+        // Make sure that redirecting to a memory stream causes Console not to write out the ANSI sequences
+        MemoryStream data = new MemoryStream();
+        TextWriter savedOut = Console.Out;
+        try
+        {
+            Console.SetOut(new StreamWriter(data, new UTF8Encoding(false), 0x1000, leaveOpen: true) { AutoFlush = true });
+            Console.Write('1');
+            Console.ForegroundColor = ConsoleColor.Blue;
+            Console.Write('2');
+            Console.BackgroundColor = ConsoleColor.Red;
+            Console.Write('3');
+            Console.ResetColor();
+            Console.Write('4');
+        }
+        finally
+        {
+            Console.SetOut(savedOut);
+        }
+
+        const char Esc = (char)0x1B;
+        Assert.Equal(0, Encoding.UTF8.GetString(data.ToArray()).ToCharArray().Count(c => c == Esc));
+        Assert.Equal("1234", Encoding.UTF8.GetString(data.ToArray()));
+    }
+
+    //[Fact] // the CI system redirects stdout, so we can't easily test non-redirected behavior
+    [PlatformSpecific(PlatformID.Linux | PlatformID.OSX)]
+    public static void NonRedirectedOutputDoesUseAnsiSequences()
+    {
+        // Make sure that when writing out to a UnixConsoleStream, the ANSI escape sequences are properly
+        // written out.
+        MemoryStream data = new MemoryStream();
+        TextWriter savedOut = Console.Out;
+        try
+        {
+            Console.SetOut(
+                new InterceptStreamWriter(
+                    Console.OpenStandardOutput(),
+                    new StreamWriter(data, new UTF8Encoding(false), 0x1000, leaveOpen: true) { AutoFlush = true },
+                    new UTF8Encoding(false), 0x1000, leaveOpen: true) { AutoFlush = true });
+            Console.ForegroundColor = ConsoleColor.Blue;
+            Console.BackgroundColor = ConsoleColor.Red;
+            Console.ResetColor();
+        }
+        finally
+        {
+            Console.SetOut(savedOut);
+        }
+
+        const char Esc = (char)0x1B;
+        Assert.Equal(3, Encoding.UTF8.GetString(data.ToArray()).ToCharArray().Count(c => c == Esc));
+    }
+
+    private sealed class InterceptStreamWriter : StreamWriter
+    {
+        private readonly StreamWriter _wrappedWriter;
+
+        public InterceptStreamWriter(Stream baseStream, StreamWriter wrappedWriter, Encoding encoding, int bufferSize, bool leaveOpen) : 
+            base(baseStream, encoding, bufferSize, leaveOpen)
+        {
+            _wrappedWriter = wrappedWriter;
+        }
+
+        public override void Write(string value)
+        {
+            base.Write(value);
+            _wrappedWriter.Write(value);
+        }
+
+        public override void Write(char value)
+        {
+            base.Write(value);
+            _wrappedWriter.Write(value);
+        }
+    }
+
+}

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="ReadAndWrite.cs" />
     <Compile Include="SetError.cs" />
     <Compile Include="SetIn.cs" />
+    <Compile Include="Color.cs" />
     <Compile Include="SetOut.cs" />
     <Compile Include="NegativeTesting.cs" />
     <Compile Include="SyncTextReader.cs" />


### PR DESCRIPTION
Modifies Console.*Color to output ANSI escape sequences only when wrapping a UnixConsoleStream that itself has an underlying file descriptor for a character device.  This is done to try to avoid outputting escape sequence gibberish when Console.SetOut is used to target an arbitrary stream or when Unix redirection is used to redirect stdout.  This commit includes adding a Unix-only test to verify we're outputting ANSI escape sequences and that we don't do so when SetOut is used to target an arbitrary stream.

Fixes #1806.