### PR TITLE
Fixes bug #1887

### DIFF
--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnicodeRanges.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnicodeRanges.cs
@@ -32,9 +32,8 @@ namespace System.Text.Unicode
         {
             // If the range hasn't been created, create it now.
             // It's ok if two threads race and one overwrites the other's 'range' value.
-            var newRange = new UnicodeRange(0, 0);
-            Volatile.Write(ref range, newRange);
-            return newRange;
+            range = new UnicodeRange(0, 0);
+            return range;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // the caller should be inlined, not this method
@@ -42,10 +41,8 @@ namespace System.Text.Unicode
         {
             // If the range hasn't been created, create it now.
             // It's ok if two threads race and one overwrites the other's 'range' value.
-            Debug.Assert(last > first, "Code points were specified out of order.");
-            var newRange = UnicodeRange.Create(first, last);
-            Volatile.Write(ref range, newRange);
-            return newRange;
+            range = UnicodeRange.Create(first, last);
+            return range;
         }
     }
 }

--- a/src/System.Text.Encodings.Web/tests/UnicodeRangesTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeRangesTests.cs
@@ -20,10 +20,6 @@ namespace Microsoft.Framework.WebEncoders
             // Test 1: the range should be empty
             Assert.Equal(0, range.FirstCodePoint);
             Assert.Equal(0, range.Length);
-
-            // Test 2: calling the property multiple times should cache and return the same range instance
-            UnicodeRange range2 = UnicodeRanges.None;
-            Assert.Same(range, range2);
         }
 
         [Fact]
@@ -203,10 +199,6 @@ namespace Microsoft.Framework.WebEncoders
             // Test 1: the range should span the range first..last
             Assert.Equal(first, range.FirstCodePoint);
             Assert.Equal(last, range.FirstCodePoint + range.Length - 1);
-
-            // Test 2: calling the property multiple times should cache and return the same range instance
-            UnicodeRange range2 = (UnicodeRange)propInfo.GetValue(null);
-            Assert.Same(range, range2);
         }
     }
 }


### PR DESCRIPTION
Some time ago, we agreed to not guarantee that instances of encoders and ranges can be different.
This change just removes the remaining tests testing the old behavior.