### PR TITLE
Fix inaccurate doc comment for SectionHeader.Name.

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionHeader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionHeader.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.PortableExecutable
         private readonly SectionCharacteristics _sectionCharacteristics;
 
         /// <summary>
-        /// An 8-byte, null-padded UTF-8 encoded string. If the string is exactly 8 characters long, there is no terminating null. 
+        /// The name of the section.
         /// </summary>
         public string Name { get { return _name; } }
 


### PR DESCRIPTION
After resolving #1805 (excluding trailing nulls from parsed PE section-header names), the doc comment for `SectionHeader.Name` is incorrect.  This diff removes mention of null padding, which is no longer part of the value.

`Name` to me seems very self-explanatory, and so this replacement is perhaps too obvious to be useful (besides, you know, _not being wrong_); suggestions or improvements are very welcome!