### PR TITLE
Disable StrangeFiles4 System.IO.Compression test on Unix

### DIFF
--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -185,6 +185,7 @@ namespace System.IO.Compression.Test
         }
 
         [Fact]
+        [ActiveIssue(1904, PlatformID.AnyUnix)]
         public static async Task StrangeFiles4()
         {
             ZipTest.IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(


### PR DESCRIPTION
This test fails when Path.AltDirectorySeparatorChar is fixed to be '/' instead of '\'.