### PR TITLE
Disable System.Text.Encoding.Extensions tests failing on Unix

### DIFF
--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/ASCII.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/ASCII.cs
@@ -103,6 +103,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequences()
         {
             s_encodingUtil_ASCII.GetCharsTest(new Byte[] { 0x7F }, 0, 1, -1, 0, "", 1);
@@ -125,6 +126,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_ASCII.GetMaxCharCountTest(0, 0);
@@ -135,6 +137,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_ASCII.GetMaxByteCountTest(0, 1);
@@ -145,12 +148,14 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_ASCII.GetPreambleTest(new Byte[] { });
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void DefaultFallback()
         {
             s_encodingUtil_ASCII.GetBytesTest("\u0080\u00FF\u0B71\uFFFF\uD800\uDFFF", 0, 6, -1, 0, new Byte[] { 0x3F, 0x3F, 0x3F, 0x3F, 0x3F, 0x3F }, 6);

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/ISO-8859-1.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/ISO-8859-1.cs
@@ -73,6 +73,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ValidCodes()
         {
             s_encodingUtil_Latin1.GetCharsTest(new Byte[] { 0x01, 0x09, 0x10, 0x3F, 0x5C, 0x9F, 0xCB, 0xE7, 0xFF }, 0, 9, -1, 0, "\u0001\u0009\u0010\u003F\u005C\u009F\u00CB\u00E7\u00FF", 9);
@@ -82,6 +83,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_Latin1.GetMaxCharCountTest(0, 0);
@@ -92,6 +94,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_Latin1.GetMaxByteCountTest(0, 1);
@@ -102,12 +105,14 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_Latin1.GetPreambleTest(new Byte[] { });
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void DefaultFallback()
         {
             s_encodingUtil_Latin1.GetBytesTest("\uD800\uDFFF", 0, 2, -1, 0, new Byte[] { 0x3F, 0x3F }, 2);

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF16BE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF16BE.cs
@@ -12,6 +12,7 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF16BE = new EncodingTestHelper("UTF-16BE");
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF16BE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -29,6 +30,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -86,6 +88,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0x00, 0x61, 0x00, 0x62, 0x00, 0x63 }, 0, 6, -2, 0, String.Empty, 0));
@@ -103,6 +106,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -120,6 +124,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -135,6 +140,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -150,12 +156,14 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void BasicValidInputs()
         {
             s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0x00, 0x61 }, 0, 2, -1, 0, "a", 1);
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequences()
         {
             s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0x00, 0x61, 0x00 }, 0, 3, -1, 0, "\u0061\uFFFD", 2);
@@ -166,6 +174,7 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFFD
@@ -180,6 +189,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0xD8, 0x00, 0xDC, 0x00 }, 0, 4, -1, 0, "\uD800\uDC00", 2);
@@ -222,6 +232,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF16BE.GetMaxCharCountTest(0, 1);
@@ -233,6 +244,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF16BE.GetMaxByteCountTest(0, 2);
@@ -246,6 +258,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF16BE.GetPreambleTest(new Byte[] { 0xFE, 0xFF });

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF16LE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF16LE.cs
@@ -12,6 +12,7 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF16LE = new EncodingTestHelper("UTF-16LE");
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF16LE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -29,6 +30,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -86,6 +88,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x62, 0x00, 0x63, 0x00 }, 0, 6, -2, 0, String.Empty, 0));
@@ -103,6 +106,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -120,6 +124,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -135,6 +140,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -150,12 +156,14 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void BasicValidInputs()
         {
             s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x61, 0x00 }, 0, 2, -1, 0, "a", 1);
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequences()
         {
             s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00 }, 0, 3, -1, 0, "\u0061\uFFFD", 2);
@@ -166,6 +174,7 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFF
@@ -180,6 +189,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x00, 0xD8, 0x00, 0xDC }, 0, 4, -1, 0, "\uD800\uDC00", 2);
@@ -212,6 +222,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF16LE.GetMaxCharCountTest(0, 1);
@@ -223,6 +234,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF16LE.GetMaxByteCountTest(0, 2);
@@ -236,6 +248,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF16LE.GetPreambleTest(new Byte[] { 0xFF, 0xFE });

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF32BE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF32BE.cs
@@ -12,6 +12,7 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF32BE = new EncodingTestHelper("UTF-32BE");
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF32BE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -29,6 +30,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -87,6 +89,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetCharsTest(new Byte[] { 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x62 }, 0, 8, -2, 0, String.Empty, 0));
@@ -104,6 +107,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -121,6 +125,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -136,6 +141,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -151,6 +157,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ValidCodePoints()
         {
             s_encodingUtil_UTF32BE.GetCharsTest(new Byte[] { 0x00, 0x00, 0x00, 0x61 }, 0, 4, -1, 0, "a", 1);
@@ -158,6 +165,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_InvalidSequence_OddNumberOfByte()
         {
             s_encodingUtil_UTF32BE.GetCharsTest(new Byte[] { 0x00, 0x61, 0x00 }, 0, 3, -1, 0, "\uFFFD", 1);
@@ -173,6 +181,7 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFFD
@@ -198,6 +207,7 @@ namespace EncodingTests
         /// DBFF + DFFF: 110110-1111-111111 110111-1111111111: U+000-10000-11111111-11111111
         /// </summary>
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF32BE.GetBytesTest("\uD800\uDC00", 0, 2, -1, 0, new Byte[] { 0x00, 0x01, 0x00, 0x00 }, 4);
@@ -248,6 +258,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetMaxCount()
         {
             s_encodingUtil_UTF32BE.GetMaxCharCountTest(0, 2);
@@ -269,6 +280,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetPreamble()
         {
             s_encodingUtil_UTF32BE.GetPreambleTest(false, false, new Byte[] { });

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF32LE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF32LE.cs
@@ -12,6 +12,7 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF32LE = new EncodingTestHelper("UTF-32LE");
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF32LE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -29,6 +30,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -87,6 +89,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00, 0x00, 0x62, 0x00, 0x00, 0x00 }, 0, 8, -2, 0, String.Empty, 0));
@@ -104,6 +107,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -121,6 +125,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -136,6 +141,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -151,6 +157,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ValidCodePoints()
         {
             s_encodingUtil_UTF32LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00, 0x00 }, 0, 4, -1, 0, "a", 1);
@@ -158,6 +165,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequenceOddNumberOfBytes()
         {
             s_encodingUtil_UTF32LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00 }, 0, 3, -1, 0, "\uFFFD", 1);
@@ -173,6 +181,7 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFFD
@@ -198,6 +207,7 @@ namespace EncodingTests
         /// DBFF + DFFF: 110110-1111-111111 110111-1111111111: U+000-10000-11111111-1111111
         /// </summary>
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF32LE.GetBytesTest("\uD800\uDC00", 0, 2, -1, 0, new Byte[] { 0x00, 0x00, 0x01, 0x00 }, 4);
@@ -243,6 +253,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF32LE.GetMaxByteCountTest(0, 4);
@@ -253,6 +264,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF32LE.GetMaxCharCountTest(0, 2);
@@ -274,6 +286,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF32LE.GetPreambleTest(false, false, new Byte[] { });

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF7.cs
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/UTF7.cs
@@ -150,6 +150,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void CorrectClassesOfInput()
         {
             s_encodingUtil_UTF7.GetCharsTest(new Byte[] { 0x41, 0x09, 0x0D, 0x0A, 0x20, 0x2F, 0x7A }, 0, 7, -1, 0, "A\t\r\n /z", 7);
@@ -246,6 +247,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF7.GetMaxCharCountTest(0, 1);
@@ -256,6 +258,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF7.GetMaxByteCountTest(0, 2);
@@ -270,6 +273,7 @@ namespace EncodingTests
         }
 
         [Fact]
+        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF7.GetPreambleTest(new Byte[] { });

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/project.json
@@ -11,6 +11,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "xunit.runner.visualstudio": "0.99.9-build1021"
   },
   "frameworks": {

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/project.lock.json
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/project.lock.json
@@ -33,6 +33,17 @@
           "lib/DNXCore50/System.Console.dll"
         ]
       },
+      "System.Diagnostics.Debug/4.0.10-beta-22816": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22816"
+        },
+        "compile": [
+          "lib/contract/System.Diagnostics.Debug.dll"
+        ],
+        "runtime": [
+          "lib/aspnetcore50/System.Diagnostics.Debug.dll"
+        ]
+      },
       "System.Globalization/4.0.10-beta-22927": {
         "dependencies": {
           "System.Runtime": "4.0.0-beta-22927"
@@ -68,19 +79,34 @@
           "lib/any/System.IO.FileSystem.Primitives.dll"
         ]
       },
+      "System.Linq/4.0.0-beta-22816": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-22816",
+          "System.Runtime": "4.0.20-beta-22816"
+        },
+        "compile": [
+          "lib/contract/System.Linq.dll"
+        ],
+        "runtime": [
+          "lib/aspnetcore50/System.Linq.dll"
+        ]
+      },
       "System.Private.Uri/4.0.0-beta-22927": {
         "runtime": [
           "lib/DNXCore50/System.Private.Uri.dll"
         ]
       },
-      "System.Reflection/4.0.0-beta-22927": {
+      "System.Reflection/4.0.10-beta-22816": {
         "dependencies": {
-          "System.IO": "4.0.0-beta-22927",
-          "System.Reflection.Primitives": "4.0.0-beta-22927",
-          "System.Runtime": "4.0.0-beta-22927"
+          "System.IO": "4.0.10-beta-22816",
+          "System.Reflection.Primitives": "4.0.0-beta-22816",
+          "System.Runtime": "4.0.20-beta-22816"
         },
         "compile": [
-          "ref/any/System.Reflection.dll"
+          "lib/contract/System.Reflection.dll"
+        ],
+        "runtime": [
+          "lib/aspnetcore50/System.Reflection.dll"
         ]
       },
       "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -252,6 +278,30 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-22703",
+          "System.IO": "4.0.10-beta-22703",
+          "System.Linq": "4.0.0-beta-22703",
+          "System.Reflection": "4.0.10-beta-22703",
+          "System.Reflection.Primitives": "4.0.0-beta-22703",
+          "System.Runtime": "4.0.20-beta-22703",
+          "System.Runtime.Extensions": "4.0.10-beta-22703",
+          "System.Runtime.Handles": "4.0.0-beta-22703",
+          "System.Runtime.InteropServices": "4.0.20-beta-22703",
+          "System.Text.Encoding": "4.0.10-beta-22703",
+          "System.Threading": "4.0.10-beta-22703",
+          "System.Threading.Tasks": "4.0.10-beta-22703",
+          "xunit.abstractions.netcore": "1.0.0-prerelease",
+          "xunit.core.netcore": "1.0.0-prerelease"
+        },
+        "compile": [
+          "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
+        ]
+      },
       "xunit.runner.visualstudio/0.99.9-build1021": {}
     }
   },
@@ -281,6 +331,19 @@
         "ref/any/System.Console.dll",
         "ref/net46/System.Console.dll",
         "runtimes/win8-aot/lib/netcore50/System.Console.dll"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10-beta-22816": {
+      "sha512": "sFAWo06FoJmZLT0oH/HzbpWUdaEPK6ao58ttrdqnQ6QXRtTH85NXHRrhxpU/tDSODX1fPuwIEf+i5vSVJvoCOQ==",
+      "files": [
+        "License.rtf",
+        "System.Diagnostics.Debug.4.0.10-beta-22816.nupkg",
+        "System.Diagnostics.Debug.4.0.10-beta-22816.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
+        "lib/aspnetcore50/System.Diagnostics.Debug.dll",
+        "lib/contract/System.Diagnostics.Debug.dll",
+        "lib/net45/System.Diagnostics.Debug.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Diagnostics.Debug.dll"
       ]
     },
     "System.Globalization/4.0.10-beta-22927": {
@@ -323,6 +386,19 @@
         "ref/net46/System.IO.FileSystem.Primitives.dll"
       ]
     },
+    "System.Linq/4.0.0-beta-22816": {
+      "sha512": "QlwRD8FTiYAZ7BxEjB5u9vjKaAHZ6KvuZYm+4tjYduTIWpFI3o34UjowJXCaPlLwc8USRshAXLgnsQ3iaOjv8Q==",
+      "files": [
+        "License.rtf",
+        "System.Linq.4.0.0-beta-22816.nupkg",
+        "System.Linq.4.0.0-beta-22816.nupkg.sha512",
+        "System.Linq.nuspec",
+        "lib/aspnetcore50/System.Linq.dll",
+        "lib/contract/System.Linq.dll",
+        "lib/net45/System.Linq.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Linq.dll"
+      ]
+    },
     "System.Private.Uri/4.0.0-beta-22927": {
       "sha512": "iugPtkQOqHeCuyvBsQ3Z8vc+4YgL1ySVhe5IiMYIJ5J9kVqMGC9/9tb7SNd80nVSMYIOV/L/SPI1dTDYC+FOvA==",
       "files": [
@@ -336,18 +412,17 @@
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
-    "System.Reflection/4.0.0-beta-22927": {
-      "sha512": "L7aRhzNCaasOUPMWH1kmvofKHFvmZfvb4sS0FGK2SkEZi1ZfYBGaWd1N9GYoIGOQwNgmMrmO/fLEY9VeIRYbDw==",
+    "System.Reflection/4.0.10-beta-22816": {
+      "sha512": "YzEbWoLTsPOUL4mPRbeRkhfJ12VgIJVy7fwoKnp0RgxXwuQQ2CPFt2E3qjl2TWzMpnhyRBtM2L/qkt4Dlg8Okw==",
       "files": [
         "License.rtf",
-        "System.Reflection.4.0.0-beta-22927.nupkg",
-        "System.Reflection.4.0.0-beta-22927.nupkg.sha512",
+        "System.Reflection.4.0.10-beta-22816.nupkg",
+        "System.Reflection.4.0.10-beta-22816.nupkg.sha512",
         "System.Reflection.nuspec",
-        "lib/net45/_._",
-        "lib/win8/_._",
-        "ref/any/System.Reflection.dll",
-        "ref/net45/_._",
-        "ref/win8/_._"
+        "lib/aspnetcore50/System.Reflection.dll",
+        "lib/contract/System.Reflection.dll",
+        "lib/net45/System.Reflection.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Reflection.dll"
       ]
     },
     "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -580,6 +655,15 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
+      "files": [
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
+        "xunit.netcore.extensions.nuspec",
+        "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
+      ]
+    },
     "xunit.runner.visualstudio/0.99.9-build1021": {
       "sha512": "W6ek3CWXplJa0Bd21yk00D6+cgZxCgWR6vTyUpq8lGcUFRAUiXi0PLxQMq2k7hFBA7epJuxHOjXfVmC+J5p9Tg==",
       "files": [
@@ -610,6 +694,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*",
       "xunit.runner.visualstudio >= 0.99.9-build1021"
     ],
     "DNXCore,Version=v5.0": []


### PR DESCRIPTION
65 of the 121 System.Text.Encoding.Extensions tests are failing on Unix due to lack of globalization support.  Disabling for now.