### PR TITLE
Update project.json with xunit.netcore.extensions "1.0.0-prerelease-*"

### DIFF
--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -16,7 +16,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Collections.Specialized/tests/project.lock.json
+++ b/src/System.Collections.Specialized/tests/project.lock.json
@@ -309,7 +309,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -709,11 +709,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -753,7 +753,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -7,7 +7,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.lock.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.lock.json
@@ -212,7 +212,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -514,11 +514,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -533,7 +533,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -6,7 +6,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.ComponentModel.Primitives/tests/project.lock.json
+++ b/src/System.ComponentModel.Primitives/tests/project.lock.json
@@ -223,7 +223,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -535,11 +535,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -553,7 +553,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -5,7 +5,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.ComponentModel/tests/project.lock.json
+++ b/src/System.ComponentModel/tests/project.lock.json
@@ -212,7 +212,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -512,11 +512,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -529,7 +529,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -10,7 +10,7 @@ using Xunit;
 public class Color
 {
     [Fact]
-    [PlatformSpecific(PlatformID.Linux | PlatformID.OSX)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
     public static void RedirectedOutputDoesNotUseAnsiSequences()
     {
         // Make sure that redirecting to a memory stream causes Console not to write out the ANSI sequences
@@ -38,7 +38,7 @@ public class Color
     }
 
     //[Fact] // the CI system redirects stdout, so we can't easily test non-redirected behavior
-    [PlatformSpecific(PlatformID.Linux | PlatformID.OSX)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
     public static void NonRedirectedOutputDoesUseAnsiSequences()
     {
         // Make sure that when writing out to a UnixConsoleStream, the ANSI escape sequences are properly

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -18,7 +18,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Console/tests/project.lock.json
+++ b/src/System.Console/tests/project.lock.json
@@ -365,7 +365,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -818,11 +818,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -864,7 +864,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -8,7 +8,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Diagnostics.Contracts/tests/project.lock.json
+++ b/src/System.Diagnostics.Contracts/tests/project.lock.json
@@ -247,7 +247,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -592,11 +592,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -612,7 +612,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.json
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.json
@@ -21,7 +21,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.lock.json
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.lock.json
@@ -368,7 +368,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -816,11 +816,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -865,7 +865,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -22,7 +22,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.Compression.ZipFile/tests/project.lock.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.lock.json
@@ -346,7 +346,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -873,11 +873,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -907,7 +907,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -20,7 +20,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.Compression/tests/project.lock.json
+++ b/src/System.IO.Compression/tests/project.lock.json
@@ -345,7 +345,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -718,7 +718,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -1091,7 +1091,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -1627,11 +1627,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -1659,7 +1659,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -5,7 +5,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.FileSystem.Primitives/tests/project.lock.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.lock.json
@@ -212,7 +212,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -512,11 +512,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -529,7 +529,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -18,7 +18,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.FileSystem.Watcher/tests/project.lock.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.lock.json
@@ -318,7 +318,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -732,11 +732,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -778,7 +778,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -20,7 +20,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.FileSystem/tests/project.lock.json
+++ b/src/System.IO.FileSystem/tests/project.lock.json
@@ -338,7 +338,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -763,11 +763,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -795,7 +795,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/project.json
@@ -21,7 +21,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/project.lock.json
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/project.lock.json
@@ -455,7 +455,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -969,11 +969,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -1002,7 +1002,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/project.json
@@ -21,7 +21,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/project.lock.json
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/project.lock.json
@@ -455,7 +455,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -969,11 +969,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -1002,7 +1002,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -9,7 +9,7 @@
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Linq/tests/project.lock.json
+++ b/src/System.Linq/tests/project.lock.json
@@ -275,7 +275,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -652,11 +652,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -673,7 +673,7 @@
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void GetScalarValueFromUtf16()
         {
-            // TODO: [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
+            // TODO: [ActiveIssue(846, PlatformID.AnyUnix)]
             // This loop should instead be implemented as a [Theory] with multiple [InlineData]s.
             // However, until globalization support is implemented on Unix, this causes failures when
             // the xunit runner is configured with -xml to trace out results.  When it does so with 

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -8,7 +8,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.lock.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.lock.json
@@ -212,7 +212,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -515,11 +515,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -551,7 +551,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -10,7 +10,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.lock.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.lock.json
@@ -212,7 +212,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -517,11 +517,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -555,7 +555,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -15,7 +15,7 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021",
-    "xunit.netcore.extensions": "1.0.0-prerelease"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.lock.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.lock.json
@@ -334,7 +334,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00041": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -746,11 +746,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00041": {
-      "sha512": "5LbvNLWGILcHZ744JZQ586i8CqbWyde+XFY5m90VL55aQ7kCPdnGN6siRfYAUex09mFlU2VzKeXkl6GQQUgSGw==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00041.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -789,7 +789,7 @@
       "xunit.assert >= 2.0.0-beta5-build2785",
       "xunit.core.netcore >= 1.0.1-prerelease",
       "xunit.runner.visualstudio >= 0.99.9-build1021",
-      "xunit.netcore.extensions >= 1.0.0-prerelease"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }


### PR DESCRIPTION
Some of the project.json files were referencing xunit.netcore.extensions with ""1.0.0-prerelease" rather than "1.0.0-prerelease-*".  As a result, I was unable to use more recent additions, like PlatformID.AnyUnix.  This change just updates them to use the -* versions, and changes the few remaining places that were using PlatformID.Linux | PlatformID.OSX to instead use PlatformID.AnyUnix.  The project.lock.json files were automatically updated by my building locally.

Fixes #1906