### PR TITLE
Fix XmlSerializer issue when deserializing type with protected parameterless constructor

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2109,3 +2109,13 @@ public class TypeWithXmlDocumentProperty
 {
     public XmlDocument Document;
 }
+
+public class TypeWithNonParameterlessConstructor
+{
+    public string StringProperty { get; set; }
+
+    public TypeWithNonParameterlessConstructor(string value)
+    {
+        StringProperty = value;
+    }
+}

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -2419,8 +2419,8 @@ namespace System.Xml.Serialization
             Label labelReturn = ilg.DefineLabel();
             Label labelEndIf = ilg.DefineLabel();
 
-            // Type typeInfo = type.GetTypeInfo();
-            LocalBuilder typeInfo = ilg.DeclareLocal(typeof(TypeInfo), "typeInfo");
+            // TypeInfo typeInfo = type.GetTypeInfo();
+            // typeInfo not declared explicitly
             ilg.Ldc(type);
             MethodInfo getTypeInfoMehod = typeof(IntrospectionExtensions).GetMethod(
                   "GetTypeInfo",
@@ -2429,11 +2429,10 @@ namespace System.Xml.Serialization
                   );
             ilg.Call(getTypeInfoMehod);
 
-            // IEnumerator e = typeInfo.DeclaredConstructors.GetEnumerator();
-            LocalBuilder enumerator = ilg.DeclareLocal(typeof(IEnumerator), "e");
+            // IEnumerator<ConstructorInfo> e = typeInfo.DeclaredConstructors.GetEnumerator();
+            LocalBuilder enumerator = ilg.DeclareLocal(typeof(IEnumerator<>).MakeGenericType(typeof(ConstructorInfo)), "e");
             MethodInfo getDeclaredConstructors = typeof(TypeInfo).GetMethod("get_DeclaredConstructors");
-            MethodInfo getEnumerator =
-                typeof(IEnumerable<>).MakeGenericType(typeof(ConstructorInfo)).GetMethod("GetEnumerator");
+            MethodInfo getEnumerator = typeof(IEnumerable<>).MakeGenericType(typeof(ConstructorInfo)).GetMethod("GetEnumerator");
             ilg.Call(getDeclaredConstructors);
             ilg.Call(getEnumerator);
             ilg.Stloc(enumerator);
@@ -2446,7 +2445,7 @@ namespace System.Xml.Serialization
             LocalBuilder constructorInfo = ilg.DeclareLocal(typeof(ConstructorInfo), "constructorInfo");
             ilg.Stloc(constructorInfo);
 
-            // if (!constructorInfo.IsStatic || constructorInfo.GetParameters.Length() == 0)
+            // if (!constructorInfo.IsStatic && constructorInfo.GetParameters.Length() == 0)
             ilg.Ldloc(constructorInfo);
             MethodInfo constructorIsStatic = typeof(ConstructorInfo).GetMethod("get_IsStatic");
             ilg.Call(constructorIsStatic);

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -2416,6 +2416,67 @@ namespace System.Xml.Serialization
                 }
             }
 
+            Label labelReturn = ilg.DefineLabel();
+            Label labelEndIf = ilg.DefineLabel();
+
+            // Type typeInfo = type.GetTypeInfo();
+            LocalBuilder typeInfo = ilg.DeclareLocal(typeof(TypeInfo), "typeInfo");
+            ilg.Ldc(type);
+            MethodInfo getTypeInfoMehod = typeof(IntrospectionExtensions).GetMethod(
+                  "GetTypeInfo",
+                  CodeGenerator.StaticBindingFlags,
+                  new[] { typeof(Type) }
+                  );
+            ilg.Call(getTypeInfoMehod);
+
+            // IEnumerator e = typeInfo.DeclaredConstructors.GetEnumerator();
+            LocalBuilder enumerator = ilg.DeclareLocal(typeof(IEnumerator), "e");
+            MethodInfo getDeclaredConstructors = typeof(TypeInfo).GetMethod("get_DeclaredConstructors");
+            MethodInfo getEnumerator =
+                typeof(IEnumerable<>).MakeGenericType(typeof(ConstructorInfo)).GetMethod("GetEnumerator");
+            ilg.Call(getDeclaredConstructors);
+            ilg.Call(getEnumerator);
+            ilg.Stloc(enumerator);
+
+            ilg.WhileBegin();
+            // ConstructorInfo constructorInfo = e.Current();
+            MethodInfo enumeratorCurrent = typeof(IEnumerator).GetMethod("get_Current");
+            ilg.Ldloc(enumerator);
+            ilg.Call(enumeratorCurrent);
+            LocalBuilder constructorInfo = ilg.DeclareLocal(typeof(ConstructorInfo), "constructorInfo");
+            ilg.Stloc(constructorInfo);
+
+            // if (!constructorInfo.IsStatic || constructorInfo.GetParameters.Length() == 0)
+            ilg.Ldloc(constructorInfo);
+            MethodInfo constructorIsStatic = typeof(ConstructorInfo).GetMethod("get_IsStatic");
+            ilg.Call(constructorIsStatic);
+            ilg.Brtrue(labelEndIf);
+            ilg.Ldloc(constructorInfo);
+            MethodInfo constructorGetParameters = typeof(ConstructorInfo).GetMethod("GetParameters");
+            ilg.Call(constructorGetParameters);
+            ilg.Ldlen();
+            ilg.Ldc(0);
+            ilg.Cne();
+            ilg.Brtrue(labelEndIf);
+
+            // constructorInfo.Invoke(null);
+            MethodInfo constructorInvoke = typeof(ConstructorInfo).GetMethod("Invoke", new Type[] { typeof(object[]) });
+            ilg.Ldloc(constructorInfo);
+            ilg.Load(null);
+            ilg.Call(constructorInvoke);
+            ilg.Br(labelReturn);
+
+            ilg.MarkLabel(labelEndIf);
+            ilg.WhileBeginCondition(); // while (e.MoveNext())
+            MethodInfo IEnumeratorMoveNext = typeof(IEnumerator).GetMethod(
+                "MoveNext",
+                CodeGenerator.InstanceBindingFlags,
+                Array.Empty<Type>());
+            ilg.Ldloc(enumerator);
+            ilg.Call(IEnumeratorMoveNext);
+            ilg.WhileEndCondition();
+            ilg.WhileEnd();
+
             MethodInfo Activator_CreateInstance = typeof(Activator).GetMethod(
                   "CreateInstance",
                   CodeGenerator.StaticBindingFlags,
@@ -2425,6 +2486,7 @@ namespace System.Xml.Serialization
             ilg.Call(Activator_CreateInstance);
             if (cast != null)
                 ilg.ConvertValue(Activator_CreateInstance.ReturnType, cast);
+            ilg.MarkLabel(labelReturn);
         }
 
         internal void WriteLocalDecl(string variableName, SourceInfo initValue)

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.Linq;
@@ -1114,12 +1115,19 @@ public class XmlSerializerTests
     [Fact]
     public static void Xml_TypeWithNonPublicDefaultConstructor()
     {
-        System.Reflection.TypeInfo ti = System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(TypeWithNonPublicDefaultConstructor));
+        TypeInfo ti = IntrospectionExtensions.GetTypeInfo(typeof(TypeWithNonPublicDefaultConstructor));
         TypeWithNonPublicDefaultConstructor value = null;
         value = (TypeWithNonPublicDefaultConstructor)FindDefaultConstructor(ti).Invoke(null);
         Assert.StrictEqual("Mr. FooName", value.Name);
-        var actual = SerializeAndDeserialize<TypeWithNonPublicDefaultConstructor>(value, "<?xml version=\"1.0\"?>\r\n<TypeWithNonPublicDefaultConstructor xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <Name>Mr. FooName</Name>\r\n</TypeWithNonPublicDefaultConstructor>");
+        var actual = SerializeAndDeserialize(value, "<?xml version=\"1.0\"?>" + Environment.NewLine + "<TypeWithNonPublicDefaultConstructor xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine + "  <Name>Mr. FooName</Name>" + Environment.NewLine + "</TypeWithNonPublicDefaultConstructor>");
         Assert.StrictEqual(value.Name, actual.Name);
+    }
+
+    [Fact]
+    public static void Xml_TypeWithNonParameterlessConstructor()
+    {
+        var obj = new TypeWithNonParameterlessConstructor("string value");
+        Assert.Throws<InvalidOperationException>(() => { SerializeAndDeserialize(obj, string.Empty); });
     }
 
     private static T SerializeAndDeserialize<T>(T value, string baseline, Func<XmlSerializer> serializerFactory = null)

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -1111,6 +1111,17 @@ public class XmlSerializerTests
         Assert.StrictEqual(value.IntValue, actual.IntValue);
     }
 
+    [Fact]
+    public static void Xml_TypeWithNonPublicDefaultConstructor()
+    {
+        System.Reflection.TypeInfo ti = System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(TypeWithNonPublicDefaultConstructor));
+        TypeWithNonPublicDefaultConstructor value = null;
+        value = (TypeWithNonPublicDefaultConstructor)FindDefaultConstructor(ti).Invoke(null);
+        Assert.StrictEqual("Mr. FooName", value.Name);
+        var actual = SerializeAndDeserialize<TypeWithNonPublicDefaultConstructor>(value, "<?xml version=\"1.0\"?>\r\n<TypeWithNonPublicDefaultConstructor xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <Name>Mr. FooName</Name>\r\n</TypeWithNonPublicDefaultConstructor>");
+        Assert.StrictEqual(value.Name, actual.Name);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, Func<XmlSerializer> serializerFactory = null)
     {
         XmlSerializer serializer = new XmlSerializer(typeof(T));


### PR DESCRIPTION
When deserialize types with non-public default constructor, generated code from XmlSerializer throws missing method exception because no constructor is available for Activator.CreateInstance. This is affecting debugging scenario for some apps.

This is to port the change we did in NetNative.