### PR TITLE
Implement Console.CancelKeyPress on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/libcoreclr/Interop.SetConsoleCtrlHandler.cs
+++ b/src/Common/src/Interop/Unix/libcoreclr/Interop.SetConsoleCtrlHandler.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class libcoreclr
+    {
+        internal const int CTRL_C_EVENT = 0;
+        internal const int CTRL_BREAK_EVENT = 1;
+
+        internal const int ERROR_NOT_ENOUGH_MEMORY = 0x8;
+        internal const int ERROR_INVALID_PARAMETER = 0x57;
+
+        internal delegate bool ConsoleCtrlHandlerRoutine(int controlType);
+
+        [DllImport(Libraries.LibCoreClr, SetLastError = true)]
+        internal static extern bool SetConsoleCtrlHandler(ConsoleCtrlHandlerRoutine handler, bool addOrRemove);
+    }
+}

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -136,6 +136,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
       <Link>Common\Interop\Unix\Interop.GetFileInformation.cs"</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.SetConsoleCtrlHandler.cs">
+      <Link>Common\Interop\Unix\Interop.SetConsoleCtrlHandler.cs"</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Errors.cs">

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1173,15 +1173,34 @@ namespace System
 
         internal sealed class ControlCHandlerRegistrar
         {
-            internal void Register()
+            private readonly Interop.libcoreclr.ConsoleCtrlHandlerRoutine _handler;
+            private bool _handlerRegistered;
+
+            internal ControlCHandlerRegistrar()
             {
-                // UNIXTODO: Install SIGINT signal handler.
+                _handler = new Interop.libcoreclr.ConsoleCtrlHandlerRoutine(c =>
+                    (c == Interop.libcoreclr.CTRL_C_EVENT || c == Interop.libcoreclr.CTRL_BREAK_EVENT) &&
+                    Console.HandleBreakEvent(c == Interop.libcoreclr.CTRL_C_EVENT ? ConsoleSpecialKey.ControlC : ConsoleSpecialKey.ControlBreak));
             }
 
-            internal void Unregister()
+            internal void Register() { RegisterOrUnregister(true); }
+
+            internal void Unregister() { RegisterOrUnregister(false); }
+
+            private void RegisterOrUnregister(bool register)
             {
-                // UNIXTODO: remove handler.
+                Debug.Assert(register == !_handlerRegistered);
+                if (!Interop.libcoreclr.SetConsoleCtrlHandler(_handler, register))
+                {
+                    int error = Marshal.GetLastWin32Error(); // Win32 error code from coreclr PAL, not a Unix errno value
+                    throw Interop.GetExceptionForIoErrno(
+                        error == Interop.libcoreclr.ERROR_INVALID_PARAMETER ? Interop.Errors.EINVAL :
+                        error == Interop.libcoreclr.ERROR_NOT_ENOUGH_MEMORY ? Interop.Errors.ENOMEM :
+                        Interop.Errors.EIO);
+                }
+                _handlerRegistered = register;
             }
         }
+
     }
 }


### PR DESCRIPTION
Implements the currently stubbed out ControlCHandlerRegistrar in terms of libcoreclr's SetConsoleCtrlHandler, so as to play nicely with any other handlers registered by the runtime / debugger and with signal handling in general.

(Note that this functionality will be a nop until https://github.com/dotnet/coreclr/issues/1094 is fixed in coreclr.)

Fixes #1723 