### PR TITLE
Fix bug in Process' AsyncStreamReader.BeginReadLine

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -69,8 +69,7 @@ namespace System.Diagnostics
             if (_sb == null)
             {
                 _sb = new StringBuilder(DefaultBufferSize);
-                _readToBufferTask = Task.Factory.StartNew(s => ((AsyncStreamReader)s).ReadBuffer(),
-                    this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                _readToBufferTask = Task.Run((Func<Task>)ReadBufferAsync);
             }
             else
             {
@@ -84,7 +83,7 @@ namespace System.Diagnostics
         }
 
         // This is the async callback function. Only one thread could/should call this.
-        private async Task ReadBuffer()
+        private async Task ReadBufferAsync()
         {
             while (true)
             {


### PR DESCRIPTION
BeginReadLine is kicking off a Task to asynchronously run the ReadBuffer method.  ReadBuffer is itself an async method, returning a Task.  But Task.Factory.StartNew was being used to invoke ReadBuffer, such that StartNew was returning a Task<Task>, and StartNew doesn't automatically unwrap such inner Tasks.  This meant that the _readToBufferTask was completing as soon as the first await yielded, which meant that Process.WaitForExit wouldn't actually wait for the async reading to complete.  This change simply switches to using Task.Run, which automatically unwraps the inner task due to its overload that takes a Func<Task> delegate.

Fixes #1932.