### PR TITLE
Fix buffer overrun in BigIntegerCalculator.Subtract

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
@@ -197,7 +197,7 @@ namespace System.Numerics
                 bits[i] = (uint)digit;
                 carry = digit >> 32;
             }
-            bits[i] = (uint)carry;
+            Debug.Assert(carry == 0);
         }
 
         [SecuritySafeCritical]


### PR DESCRIPTION
The Subtract method wasn't allocating enough space for 'bits' to hold a carry digit.