### PR TITLE
Modify ZipFile tests to remove temporary garbage

### DIFF
--- a/src/Common/tests/Compression/Utilities/StreamHelpers.cs
+++ b/src/Common/tests/Compression/Utilities/StreamHelpers.cs
@@ -2,42 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 
 public static partial class StreamHelpers
 {
-    public static String GetTmpFileName()
-    {
-        return Path.GetRandomFileName();
-    }
-
-    private const string dirPrefix = "ZipTests";
-    private static int s_dirCount = 1;
-    public static String GetTmpPath(bool create = false)
-    {
-        var root = Path.GetTempPath();
-        string subDir = dirPrefix + s_dirCount.ToString();
-        var tempPath = Path.Combine(root, subDir);
-        s_dirCount++;
-
-        while (Directory.Exists(tempPath))
-        {
-            subDir = dirPrefix + s_dirCount.ToString();
-            tempPath = Path.Combine(root, subDir);
-            s_dirCount++;
-        }
-
-        if (create)
-        {
-            Directory.CreateDirectory(tempPath);
-        }
-
-        return tempPath;
-    }
-
     public static async Task<Stream> CreateTempCopyStream(String path)
     {
         var bytes = File.ReadAllBytes(path);
@@ -47,16 +16,5 @@ public static partial class StreamHelpers
         ms.Position = 0;
 
         return ms;
-    }
-
-    public static String CreateTempCopyFile(String path)
-    {
-        var bytes = File.ReadAllBytes(path);
-
-        var dir = Path.GetDirectoryName(path);
-        var newN = Path.Combine(dir, GetTmpFileName());
-        File.WriteAllBytes(newN, bytes);
-
-        return newN;
     }
 }

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
-    <ProjectGuid>{ED453083-A80F-480c-AD25-5B8618E8A303}</ProjectGuid>
+    <ProjectGuid>{ED453083-A80F-480C-AD25-5B8618E8A303}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Compression.ZipFile.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ZipFileConvenienceMethods.cs" />
+    <Compile Include="ZipFileTests.cs" />
     <Compile Include="ZipFileInvalidFileTests.cs" />
     <Compile Include="ZipFileReadOpenUpdateTests.cs" />
     <Compile Include="$(CommonTestPath)\Compression\Utilities\CRC.cs" />

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -10,7 +10,7 @@ namespace System.IO.Compression.Test
     public partial class ZipTest
     {
         [Fact]
-        public static async Task CreateFromDirectoryNormal()
+        public async Task CreateFromDirectoryNormal()
         {
             await TestCreateDirectory(zfolder("normal"), true);
             if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.AnyUnix)]
@@ -19,22 +19,22 @@ namespace System.IO.Compression.Test
             }
         }
 
-        private static async Task TestCreateDirectory(String folderName, Boolean testWithBaseDir)
+        private async Task TestCreateDirectory(string folderName, Boolean testWithBaseDir)
         {
-            String noBaseDir = StreamHelpers.GetTmpFileName();
+            string noBaseDir = GetTmpFilePath();
             ZipFile.CreateFromDirectory(folderName, noBaseDir);
 
             await IsZipSameAsDirAsync(noBaseDir, folderName, ZipArchiveMode.Read, true, true);
 
             if (testWithBaseDir)
             {
-                String withBaseDir = StreamHelpers.GetTmpFileName();
+                string withBaseDir = GetTmpFilePath();
                 ZipFile.CreateFromDirectory(folderName, withBaseDir, CompressionLevel.Optimal, true);
                 SameExceptForBaseDir(noBaseDir, withBaseDir, folderName);
             }
         }
 
-        private static void SameExceptForBaseDir(String zipNoBaseDir, String zipBaseDir, String baseDir)
+        private static void SameExceptForBaseDir(string zipNoBaseDir, string zipBaseDir, string baseDir)
         {
             //b has the base dir
             using (ZipArchive a = ZipFile.Open(zipNoBaseDir, ZipArchiveMode.Read),
@@ -62,7 +62,7 @@ namespace System.IO.Compression.Test
         }
 
         [Fact]
-        public static void ExtractToDirectoryNormal()
+        public void ExtractToDirectoryNormal()
         {
             TestExtract(zfile("normal.zip"), zfolder("normal"));
             if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.AnyUnix)]
@@ -77,24 +77,37 @@ namespace System.IO.Compression.Test
             TestExtract(zfile("noexplicitdir.zip"), zfolder("explicitdir"));
         }
 
-        private static void TestExtract(String zipFileName, String folderName)
+        private void TestExtract(string zipFileName, string folderName)
         {
-            String tempFolder = StreamHelpers.GetTmpPath(true);
+            string tempFolder = GetTmpDirPath(true);
             ZipFile.ExtractToDirectory(zipFileName, tempFolder);
             DirsEqual(tempFolder, folderName);
+
+            Assert.Throws<ArgumentNullException>(() => ZipFile.ExtractToDirectory(null, tempFolder));
         }
 
         #region "Extension Methods"
 
-        [Fact]
-        public static async Task CreateEntryFromFileTest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CreateEntryFromFileTest(bool withCompressionLevel)
         {
             //add file
-            String testArchive = StreamHelpers.CreateTempCopyFile(zfile("normal.zip"));
+            string testArchive = CreateTempCopyFile(zfile("normal.zip"));
 
             using (ZipArchive archive = ZipFile.Open(testArchive, ZipArchiveMode.Update))
             {
-                ZipArchiveEntry e = archive.CreateEntryFromFile(zmodified(Path.Combine("addFile", "added.txt")), "added.txt");
+                string entryName = "added.txt";
+                string sourceFilePath = zmodified(Path.Combine("addFile", entryName));
+
+                Assert.Throws<ArgumentNullException>(() => ((ZipArchive)null).CreateEntryFromFile(sourceFilePath, entryName));
+                Assert.Throws<ArgumentNullException>(() => archive.CreateEntryFromFile(null, entryName));
+                Assert.Throws<ArgumentNullException>(() => archive.CreateEntryFromFile(sourceFilePath, null));
+
+                ZipArchiveEntry e = withCompressionLevel ?
+                    archive.CreateEntryFromFile(sourceFilePath, entryName) :
+                    archive.CreateEntryFromFile(sourceFilePath, entryName, CompressionLevel.Fastest);
                 Assert.NotNull(e);
             }
 
@@ -102,12 +115,15 @@ namespace System.IO.Compression.Test
         }
 
         [Fact]
-        public static void ExtractToFileTest()
+        public void ExtractToFileTest()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("normal.zip"), ZipArchiveMode.Read))
             {
-                String file = StreamHelpers.GetTmpFileName();
+                string file = GetTmpFilePath();
                 ZipArchiveEntry e = archive.GetEntry("first.txt");
+
+                Assert.Throws<ArgumentNullException>(() => ((ZipArchiveEntry)null).ExtractToFile(file));
+                Assert.Throws<ArgumentNullException>(() => e.ExtractToFile(null));
 
                 //extract when there is nothing there
                 e.ExtractToFile(file);
@@ -133,11 +149,13 @@ namespace System.IO.Compression.Test
         }
 
         [Fact]
-        public static void ExtractToDirectoryTest()
+        public void ExtractToDirectoryTest()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("normal.zip"), ZipArchiveMode.Read))
             {
-                String tempFolder = StreamHelpers.GetTmpPath(false);
+                string tempFolder = GetTmpDirPath(false);
+                Assert.Throws<ArgumentNullException>(() => ((ZipArchive)null).ExtractToDirectory(tempFolder));
+                Assert.Throws<ArgumentNullException>(() => archive.ExtractToDirectory(null));
                 archive.ExtractToDirectory(tempFolder);
 
                 DirsEqual(tempFolder, zfolder("normal"));
@@ -147,11 +165,45 @@ namespace System.IO.Compression.Test
             {
                 using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
                 {
-                    String tempFolder = StreamHelpers.GetTmpPath(false);
+                    string tempFolder = GetTmpDirPath(false);
                     archive.ExtractToDirectory(tempFolder);
 
                     DirsEqual(tempFolder, zfolder("unicode"));
                 }
+            }
+        }
+
+        [Fact]
+        public void CreatedEmptyDirectoriesRoundtrip()
+        {
+            DirectoryInfo rootDir = new DirectoryInfo(GetTmpDirPath(create: true));
+            rootDir.CreateSubdirectory("empty1");
+
+            string archivePath = GetTmpFilePath();
+            ZipFile.CreateFromDirectory(
+                rootDir.FullName, archivePath,
+                CompressionLevel.Optimal, false, Encoding.UTF8);
+
+            using (ZipArchive archive = ZipFile.OpenRead(archivePath))
+            {
+                Assert.Equal(1, archive.Entries.Count);
+                Assert.True(archive.Entries[0].FullName.StartsWith("empty1"));
+            }
+        }
+
+        [Fact]
+        public void CreatedEmptyRootDirectoryRoundtrips()
+        {
+            DirectoryInfo emptyRoot = new DirectoryInfo(GetTmpDirPath(create: true));
+
+            string archivePath = GetTmpFilePath();
+            ZipFile.CreateFromDirectory(
+                emptyRoot.FullName, archivePath,
+                CompressionLevel.Optimal, true);
+
+            using (ZipArchive archive = ZipFile.OpenRead(archivePath))
+            {
+                Assert.Equal(1, archive.Entries.Count);
             }
         }
 

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileReadOpenUpdateTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileReadOpenUpdateTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Compression.Test
     public partial class ZipTest
     {
         [Fact]
-        public static void ReadStreamOps()
+        public void ReadStreamOps()
         {
             using (ZipArchive archive = ZipFile.OpenRead(zfile("normal.zip")))
             {
@@ -27,12 +27,12 @@ namespace System.IO.Compression.Test
         }
 
         [Fact]
-        public static void UpdateReadTwice()
+        public void UpdateReadTwice()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("small.zip"), ZipArchiveMode.Update))
             {
                 ZipArchiveEntry entry = archive.Entries[0];
-                String contents1, contents2;
+                string contents1, contents2;
                 using (StreamReader s = new StreamReader(entry.Open()))
                 {
                     contents1 = s.ReadToEnd();
@@ -46,10 +46,10 @@ namespace System.IO.Compression.Test
         }
 
         [Fact]
-        public static async Task UpdateAddFile()
+        public async Task UpdateAddFile()
         {
             //add file
-            String testArchive = StreamHelpers.CreateTempCopyFile(zfile("normal.zip"));
+            string testArchive = CreateTempCopyFile(zfile("normal.zip"));
 
             using (ZipArchive archive = ZipFile.Open(testArchive, ZipArchiveMode.Update))
             {
@@ -59,7 +59,7 @@ namespace System.IO.Compression.Test
             await IsZipSameAsDirAsync(testArchive, zmodified("addFile"), ZipArchiveMode.Read);
 
             //add file and read entries before
-            testArchive = StreamHelpers.CreateTempCopyFile(zfile("normal.zip"));
+            testArchive = CreateTempCopyFile(zfile("normal.zip"));
 
             using (ZipArchive archive = ZipFile.Open(testArchive, ZipArchiveMode.Update))
             {
@@ -72,7 +72,7 @@ namespace System.IO.Compression.Test
 
 
             //add file and read entries after
-            testArchive = StreamHelpers.CreateTempCopyFile(zfile("normal.zip"));
+            testArchive = CreateTempCopyFile(zfile("normal.zip"));
 
             using (ZipArchive archive = ZipFile.Open(testArchive, ZipArchiveMode.Update))
             {
@@ -84,9 +84,9 @@ namespace System.IO.Compression.Test
             await IsZipSameAsDirAsync(testArchive, zmodified("addFile"), ZipArchiveMode.Read);
         }
 
-        private static async Task UpdateArchive(ZipArchive archive, String installFile, String entryName)
+        private static async Task UpdateArchive(ZipArchive archive, string installFile, string entryName)
         {
-            String fileName = installFile;
+            string fileName = installFile;
             ZipArchiveEntry e = archive.CreateEntry(entryName);
 
             var file = FileData.GetFile(fileName);

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO.Compression.Test
+{
+    public partial class ZipTest : IDisposable
+    {
+        private const string DirPrefix = "ZipTests";
+
+        private readonly DirectoryInfo _rootTestDirectory;
+        private int _dirCount = 1;
+
+        public ZipTest()
+        {
+            _rootTestDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), 
+                DirPrefix + "Root_" + Guid.NewGuid().ToString("N")));
+            _rootTestDirectory.Create();
+        }
+
+        public void Dispose()
+        {
+            _rootTestDirectory.Delete(recursive: true);
+        }
+
+        private string GetTmpFilePath()
+        {
+            return Path.Combine(_rootTestDirectory.FullName, "tmp" + Guid.NewGuid().ToString("N"));
+        }
+
+        private string GetTmpDirPath(bool create = false)
+        {
+            string tempPath = Path.Combine(_rootTestDirectory.FullName, DirPrefix + _dirCount++);
+            if (create)
+            {
+                Directory.CreateDirectory(tempPath);
+            }
+            return tempPath;
+        }
+
+        private string CreateTempCopyFile(string path)
+        {
+            string newPath = GetTmpFilePath();
+            File.Copy(path, newPath, overwrite: false);
+            return newPath;
+        }
+    }
+}


### PR DESCRIPTION
The System.IO.Compression.ZipFile tests were leaving behind lots of temporary files and directories.  I've modified the tests to delete these when the tests completes.

As long as I was modifying the tests, I also boosted the code coverage of ZipFile and ZipFileExtensions to 100% (the library itself isn't at 100% because of the SR file and some unused code in a shared common file).

And I fixed up a few "String"=>"string"s I saw along the way.

Fixes #1927.