### PR TITLE
Optimize ImmutableSortedSet<T>.LeafToRootRefill

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1107,6 +1107,16 @@ namespace System.Collections.Immutable
             List<T> list;
             if (this.IsEmpty)
             {
+                // If the additional items enumerable list is known to be empty, too,
+                // then just return this empty instance.
+                int count;
+                if (addedItems.TryGetCount(out count) && count == 0)
+                {
+                    return this;
+                }
+
+                // Otherwise, construct a list from the items.  The Count could still
+                // be zero, in which case, again, just return this empty instance.
                 list = new List<T>(addedItems);
                 if (list.Count == 0)
                 {
@@ -1115,6 +1125,9 @@ namespace System.Collections.Immutable
             }
             else
             {
+                // Build the list from this set and then add the additional items.
+                // Even if the additional items is empty, this set isn't, so we know
+                // the resulting list will not be empty.
                 list = new List<T>(this);
                 list.AddRange(addedItems);
             }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1716,26 +1716,6 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
-            /// Creates a node tree from an existing (mutable) collection.
-            /// </summary>
-            /// <param name="collection">The collection.</param>
-            /// <returns>The root of the node tree.</returns>
-            [Pure]
-            internal static Node NodeTreeFromSortedSet(SortedSet<T> collection)
-            {
-                Requires.NotNull(collection, "collection");
-                Contract.Ensures(Contract.Result<Node>() != null);
-
-                if (collection.Count == 0)
-                {
-                    return EmptyNode;
-                }
-
-                var list = collection.AsOrderedCollection();
-                return NodeTreeFromList(list, 0, list.Count);
-            }
-
-            /// <summary>
             /// See the <see cref="ICollection{T}"/> interface.
             /// </summary>
             internal void CopyTo(T[] array, int arrayIndex)

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -121,11 +121,49 @@ namespace System.Collections.Immutable.Test
         }
 
         [Fact]
-        public void ToImmutableSortedSetTest()
+        public void ToImmutableSortedSetFromArrayTest()
         {
             var set = new[] { 1, 2, 2 }.ToImmutableSortedSet();
             Assert.Same(Comparer<int>.Default, set.KeyComparer);
             Assert.Equal(2, set.Count);
+        }
+
+        [Theory]
+        [InlineData(new int[] { }, new int[] { })]
+        [InlineData(new int[] { 1 }, new int[] { 1 })]
+        [InlineData(new int[] { 1, 1 }, new int[] { 1 })]
+        [InlineData(new int[] { 1, 1, 1 }, new int[] { 1 })]
+        [InlineData(new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 3, 2, 1 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 1, 1, 3 }, new int[] { 1, 3 })]
+        [InlineData(new int[] { 1, 2, 2 }, new int[] { 1, 2 })]
+        [InlineData(new int[] { 1, 2, 2, 3, 3, 3 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 1, 2, 3, 1, 2, 3 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 1, 1, 2, 2, 2, 3, 3, 3, 3 }, new int[] { 1, 2, 3 })]
+        public void ToImmutableSortedSetFromEnumerableTest(int[] input, int[] expectedOutput)
+        {
+            IEnumerable<int> enumerableInput = input.Select(i => i); // prevent querying for indexable interfaces
+            var set = enumerableInput.ToImmutableSortedSet();
+            Assert.Equal((IEnumerable<int>)expectedOutput, set.ToArray());
+        }
+
+        [Theory]
+        [InlineData(new int[] { }, new int[] { 1 })]
+        [InlineData(new int[] { 1 }, new int[] { 1 })]
+        [InlineData(new int[] { 1, 1 }, new int[] { 1 })]
+        [InlineData(new int[] { 1, 1, 1 }, new int[] { 1 })]
+        [InlineData(new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 3, 2, 1 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 1, 1, 3 }, new int[] { 1, 3 })]
+        [InlineData(new int[] { 1, 2, 2 }, new int[] { 1, 2 })]
+        [InlineData(new int[] { 1, 2, 2, 3, 3, 3 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 1, 2, 3, 1, 2, 3 }, new int[] { 1, 2, 3 })]
+        [InlineData(new int[] { 1, 1, 2, 2, 2, 3, 3, 3, 3 }, new int[] { 1, 2, 3 })]
+        public void UnionWithEnumerableTest(int[] input, int[] expectedOutput)
+        {
+            IEnumerable<int> enumerableInput = input.Select(i => i); // prevent querying for indexable interfaces
+            var set = ImmutableSortedSet.Create(1).Union(enumerableInput);
+            Assert.Equal((IEnumerable<int>)expectedOutput, set.ToArray());
         }
 
         [Fact]


### PR DESCRIPTION
Some basic microbenchmarks show that this can double throughput and halve garbage production, depending on the inputs.

Fixes #1943.