### PR TITLE
Separate BCryptGenRandom out of Cng.cs

### DIFF
--- a/src/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -129,14 +129,6 @@ namespace Internal.NativeCrypto
             }
         }
 
-        public static void BCryptGenRandom(byte[] buffer)
-        {
-            const int BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002;
-            NTSTATUS ntStatus = Interop.BCryptGenRandom(IntPtr.Zero, buffer, buffer.Length, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-            if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                throw CreateCryptographicException(ntStatus);
-        }
-
         public static SafeKeyHandle BCryptImportKey(this SafeAlgorithmHandle hAlg, byte[] key)
         {
             unsafe
@@ -309,9 +301,6 @@ namespace Internal.NativeCrypto
 
             [DllImport(CngDll, CharSet = CharSet.Unicode)]
             public static extern unsafe NTSTATUS BCryptSetProperty(SafeBCryptHandle hObject, String pszProperty, String pbInput, int cbInput, int dwFlags);
-
-            [DllImport(CngDll, CharSet = CharSet.Unicode)]
-            public static extern NTSTATUS BCryptGenRandom(IntPtr hAlgorithm, [In, Out] byte[] pbBuffer, int cbBuffer, int dwFlags);
 
             [DllImport(CngDll, CharSet = CharSet.Unicode)]
             public static extern NTSTATUS BCryptImportKey(SafeAlgorithmHandle hAlgorithm, IntPtr hImportKey, String pszBlobType, out SafeKeyHandle hKey, IntPtr pbKeyObject, int cbKeyObject, byte[] pbInput, int cbInput, int dwFlags);

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class BCrypt
+    {
+        internal static void BCryptGenRandom(byte[] buffer)
+        {
+            NTSTATUS ntStatus = BCryptGenRandom(IntPtr.Zero, buffer, buffer.Length, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+            if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                throw CreateCryptographicException(ntStatus);
+        }
+
+        private const int BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002;
+
+        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static extern NTSTATUS BCryptGenRandom(IntPtr hAlgorithm, [In, Out] byte[] pbBuffer, int cbBuffer, int dwFlags);
+    }
+}

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.NTSTATUS.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.NTSTATUS.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+
+internal partial class Interop
+{
+    internal partial class BCrypt
+    {
+        private enum NTSTATUS : uint
+        {
+            STATUS_SUCCESS = 0x0,
+            STATUS_NOT_FOUND = 0xc0000225,
+            STATUS_INVALID_PARAMETER = 0xc000000d,
+            STATUS_NO_MEMORY = 0xc0000017,
+        }
+
+        private static Exception CreateCryptographicException(NTSTATUS ntStatus)
+        {
+            int hr = ((int)ntStatus) | 0x01000000;
+            return new CryptographicException(hr);
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -5,6 +5,7 @@ internal static partial class Interop
 {
     private static class Libraries
     {
+        internal const string BCrypt = "BCrypt.dll";
         internal const string Console_L1 = "api-ms-win-core-console-l1-1-0.dll";
         internal const string Console_L2 = "api-ms-win-core-console-l2-1-0.dll";
         internal const string CoreFile_L1 = "api-ms-win-core-file-l1-1-0.dll";

--- a/src/System.Security.Cryptography.RandomNumberGenerator/src/System.Security.Cryptography.RandomNumberGenerator.csproj
+++ b/src/System.Security.Cryptography.RandomNumberGenerator/src/System.Security.Cryptography.RandomNumberGenerator.csproj
@@ -10,6 +10,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
+    <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU' " />
@@ -22,8 +23,14 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Cng.cs">
-      <Link>Common\Interop\Windows\BCrypt\Cng.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs">
+      <Link>Common\Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.NTSTATUS.cs">
+      <Link>Common\Interop\Windows\BCrypt\Interop.NTSTATUS.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Security.Cryptography.RandomNumberGenerator/src/System/Security/Cryptography/RNGCryptoServiceProvider.Windows.cs
+++ b/src/System.Security.Cryptography.RandomNumberGenerator/src/System/Security/Cryptography/RNGCryptoServiceProvider.Windows.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-
-using Internal.NativeCrypto;
-
 namespace System.Security.Cryptography
 {
     internal sealed class RNGCryptoServiceProvider : RandomNumberGenerator
@@ -14,9 +10,8 @@ namespace System.Security.Cryptography
             ValidateGetBytesArgs(data);
             if (data.Length > 0)
             {
-                Cng.BCryptGenRandom(data);
+                Interop.BCrypt.BCryptGenRandom(data);
             }
         }
     }
 }
-


### PR DESCRIPTION
As part of #1739, this commit begins to refactor Cng.cs, starting by pulling out the functionality needed for System.Security.Cryptography.RandomNumberGenerator.  The assembly was being filled with all of the Cng code, when in reality it only needed a very small amount of it.  And since the assembly doesn't have any string resources, I also modified the .csproj to suppress the buildtools inclusion of the common resources support.

As a result of the removals, this change boosts the code coverage number of System.Security.Cryptography.RandomNumberGenerator.dll from 13% to 96%.

(Note that there are still copies of the code in Interop.NTSTATUS.cs in Cng.cs, due to other dependencies in Cng.cs that I didn't want to change.  As we refactor Cng.cs further, we can remove those copies.)