### PR TITLE
Made System.Linq.Expressions and System.Dynamic.Runtime conditionally…

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/Common/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -10,7 +10,7 @@ using System.Dynamic.Utils;
 using System.Runtime.CompilerServices;
 using System.Reflection;
 
-#if FEATURE_REFEMIT
+#if !FEATURE_DYNAMIC_DELEGATE
 using System.Reflection.Emit;
 #endif
 
@@ -29,7 +29,7 @@ namespace System.Dynamic.Utils
 
         internal static Delegate CreateObjectArrayDelegate(Type delegateType, System.Func<object[], object> handler)
         {
-#if FEATURE_REFEMIT
+#if !FEATURE_DYNAMIC_DELEGATE
             return CreateObjectArrayDelegateRefEmit(delegateType, handler);
 #else
             return Internal.Runtime.Augments.DynamicDelegateAugments.CreateObjectArrayDelegate(delegateType, handler);
@@ -37,7 +37,7 @@ namespace System.Dynamic.Utils
         }
 
 
-#if FEATURE_REFEMIT
+#if !FEATURE_DYNAMIC_DELEGATE
 
         // We will generate the following code:
         //  
@@ -157,7 +157,7 @@ namespace System.Dynamic.Utils
             return (t.IsPointer) ? typeof(IntPtr) : t;
         }
 
-#endif // FEATURE_REFEMIT
+#endif
 
     }
 }

--- a/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
+++ b/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
@@ -7,9 +7,9 @@
     <ProjectGuid>{C4E89B8C-07DB-40CA-8C99-82A23E8F5F39}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Dynamic.Runtime</AssemblyName>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
-    <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
     <RootNamespace>System.Dynamic.Runtime</RootNamespace>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' " >$(DefineConstants);FEATURE_CORECLR</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -71,12 +71,6 @@
     <Compile Include="$(CommonPath)\System\Runtime\CompilerServices\TrueReadOnlyCollection.cs">
       <Link>Common\System\Runtime\CompilerServices\TrueReadOnlyCollection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Dynamic\Utils\CollectionExtensions.Map.cs">
-      <Link>Common\System\Dynamic\Utils\CollectionExtensions.Map.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Linq\Expressions\Compiler\AssemblyGen.cs">
-      <Link>Common\System\Linq\Expressions\Compiler\AssemblyGen.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -119,8 +113,22 @@
     <Compile Include="System\Runtime\CompilerServices\RuleCache.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(IsInterpreting)' != 'true' ">
+    <Compile Include="$(CommonPath)\System\Dynamic\Utils\CollectionExtensions.Map.cs">
+      <Link>Common\System\Dynamic\Utils\CollectionExtensions.Map.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Linq\Expressions\Compiler\AssemblyGen.cs">
+      <Link>Common\System\Linq\Expressions\Compiler\AssemblyGen.cs</Link>
+    </Compile>
+
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(IsInterpreting)' == 'true' ">
+    <Compile Include="$(CommonPath)\System\Dynamic\Utils\DelegateHelpers.cs">
+      <Link>Common\System\Dynamic\Utils\DelegateHelpers.cs</Link>
+    </Compile>
+
+    <None Include="projectInterpreting.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Dynamic.Runtime/src/project.json
+++ b/src/System.Dynamic.Runtime/src/project.json
@@ -12,6 +12,7 @@
     "System.Reflection": "4.0.10-beta-*",
     "System.Reflection.Emit": "4.0.0-beta-*",
     "System.Reflection.Emit.ILGeneration": "4.0.0-beta-*",
+    "System.Reflection.Emit.Lightweight": "4.0.0-beta-*",
     "System.Reflection.Primitives": "4.0.0-beta-*",
     "System.Reflection.TypeExtensions": "4.0.0-beta-*",
     "System.Resources.ResourceManager": "4.0.0-beta-*",

--- a/src/System.Dynamic.Runtime/src/project.lock.json
+++ b/src/System.Dynamic.Runtime/src/project.lock.json
@@ -172,6 +172,20 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll"
         ]
       },
+      "System.Reflection.Emit.Lightweight/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23008",
+          "System.Reflection.Primitives": "4.0.0-beta-23008",
+          "System.Runtime": "4.0.0-beta-23008",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Emit.Lightweight.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll"
+        ]
+      },
       "System.Reflection.Extensions/4.0.0-beta-23008": {
         "dependencies": {
           "System.Runtime": "4.0.0-beta-23008",
@@ -461,6 +475,19 @@
         "ref/net45/_._"
       ]
     },
+    "System.Reflection.Emit.Lightweight/4.0.0-beta-23008": {
+      "sha512": "A+ftyIU9ZtHd9FC74eZNuT7UJynSR50noEmVAhuDKn0a0CFlEznEO9u34qPD4egQFZ2FMfCqhGzQ/gvO/V18xg==",
+      "files": [
+        "System.Reflection.Emit.Lightweight.4.0.0-beta-23008.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.0-beta-23008.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.nuspec",
+        "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
+        "ref/any/System.Reflection.Emit.Lightweight.dll",
+        "ref/net45/_._"
+      ]
+    },
     "System.Reflection.Extensions/4.0.0-beta-23008": {
       "sha512": "btrHhR/58LNjwl0OTjWKj4+gYffoNcl/E5V+x1piHFNIvnf7EzLwTkhJ74QnqlycICHz3ZqHmdUT3OsfmcPRSA==",
       "files": [
@@ -608,6 +635,7 @@
       "System.Reflection >= 4.0.10-beta-*",
       "System.Reflection.Emit >= 4.0.0-beta-*",
       "System.Reflection.Emit.ILGeneration >= 4.0.0-beta-*",
+      "System.Reflection.Emit.Lightweight >= 4.0.0-beta-*",
       "System.Reflection.Primitives >= 4.0.0-beta-*",
       "System.Reflection.TypeExtensions >= 4.0.0-beta-*",
       "System.Resources.ResourceManager >= 4.0.0-beta-*",

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
-    <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
+    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_CORECLR</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -20,9 +20,6 @@
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\CacheDict.cs">
       <Link>Common\System\Dynamic\Utils\CacheDict.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Dynamic\Utils\CollectionExtensions.AddFirst.cs">
-      <Link>Common\System\Dynamic\Utils\CollectionExtensions.AddFirst.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\CollectionExtensions.cs">
       <Link>Common\System\Dynamic\Utils\CollectionExtensions.cs</Link>
     </Compile>
@@ -31,9 +28,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\ContractUtils.cs">
       <Link>Common\System\Dynamic\Utils\ContractUtils.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs">
-      <Link>Common\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\EmptyReadOnlyCollection.cs">
       <Link>Common\System\Dynamic\Utils\EmptyReadOnlyCollection.cs</Link>
@@ -59,9 +53,6 @@
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\TypeUtils.cs">
       <Link>Common\System\Dynamic\Utils\TypeUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Linq\Expressions\Compiler\AssemblyGen.cs">
-      <Link>Common\System\Linq\Expressions\Compiler\AssemblyGen.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Linq\Expressions\Compiler\DelegateHelpers.cs">
       <Link>Common\System\Linq\Expressions\Compiler\DelegateHelpers.cs</Link>
     </Compile>
@@ -78,38 +69,14 @@
       <Link>Common\System\Runtime\CompilerServices\TrueReadOnlyCollection.cs</Link>
     </Compile>
     <Compile Include="System\Dynamic\Utils\CollectionExtensions.cs" />
-    <Compile Include="System\Dynamic\Utils\Helpers.cs" />
-    <Compile Include="System\Dynamic\Utils\ReferenceEqualityComparer.cs" />
+
     <Compile Include="System\Dynamic\Utils\TypeExtensions.cs" />
     <Compile Include="System\Dynamic\Utils\TypeUtils.cs" />
+
     <Compile Include="System\Linq\Expressions\BinaryExpression.cs" />
     <Compile Include="System\Linq\Expressions\BlockExpression.cs" />
     <Compile Include="System\Linq\Expressions\CatchBlock.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\AnalyzedTree.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\BoundConstants.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\CompilerScope.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\CompilerScope.Storage.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\ConstantCheck.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.Generated.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\HoistedLocals.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\ILGen.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\KeyedQueue.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LabelInfo.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Address.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Binary.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.ControlFlow.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Expressions.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Generated.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Lambda.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Logical.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Statements.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Unary.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.Bindings.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.Generated.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.Temps.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\VariableBinder.cs" />
+
     <Compile Include="System\Linq\Expressions\ConditionalExpression.cs" />
     <Compile Include="System\Linq\Expressions\ConstantExpression.cs" />
     <Compile Include="System\Linq\Expressions\DebugInfoExpression.cs" />
@@ -152,13 +119,97 @@
     <Compile Include="System\Linq\Expressions\TypeBinaryExpression.cs" />
     <Compile Include="System\Linq\Expressions\UnaryExpression.cs" />
     <Compile Include="System\Linq\IQueryable.cs" />
-    <Compile Include="System\Runtime\CompilerServices\Closure.cs" />
+
     <Compile Include="System\Runtime\CompilerServices\IRuntimeVariables.cs" />
+    <None Include="project.json"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsInterpreting)' != 'true' ">
+    <Compile Include="$(CommonPath)\System\Dynamic\Utils\CollectionExtensions.AddFirst.cs">
+      <Link>Common\System\Dynamic\Utils\CollectionExtensions.AddFirst.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs">
+      <Link>Common\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Linq\Expressions\Compiler\AssemblyGen.cs">
+      <Link>Common\System\Linq\Expressions\Compiler\AssemblyGen.cs</Link>
+    </Compile>
+
+    <Compile Include="System\Dynamic\Utils\Helpers.cs" />
+    <Compile Include="System\Dynamic\Utils\ReferenceEqualityComparer.cs" />
+
+    <Compile Include="System\Linq\Expressions\Compiler\AnalyzedTree.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\BoundConstants.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\CompilerScope.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\CompilerScope.Storage.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\ConstantCheck.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\HoistedLocals.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\ILGen.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\KeyedQueue.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LabelInfo.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Address.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Binary.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.ControlFlow.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Expressions.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Lambda.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Logical.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Statements.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\LambdaCompiler.Unary.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.Bindings.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\StackSpiller.Temps.cs" />
+    <Compile Include="System\Linq\Expressions\Compiler\VariableBinder.cs" />
+
+    <Compile Include="System\Runtime\CompilerServices\Closure.cs" />
+
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.ExpressionQuoter.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.RuntimeVariableList.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
+
+  <ItemGroup Condition=" '$(IsInterpreting)' == 'true' ">
+    <Compile Include="$(CommonPath)\System\Dynamic\Utils\DelegateHelpers.cs">
+      <Link>Common\System\Dynamic\Utils\DelegateHelpers.cs</Link>
+    </Compile>
+
+    <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.Generated.cs" />
+
+    <Compile Include="System\Linq\Expressions\Interpreter\AddInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ArrayOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\BranchLabel.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\CallInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\CallInstruction.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ConstantCheck.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ControlFlowInstructions.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\DivInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\EqualInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\FieldOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\GreaterThanInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ILightCallSiteBinder.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\Instruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\InstructionList.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\InterpretedFrame.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\Interpreter.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LabelInfo.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LessThanInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightCompiler.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightDelegateCreator.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightLambda.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightLambda.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LocalAccess.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LocalVariables.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\MulInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NotEqualInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NumericConvertInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\RuntimeVariables.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\StackOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\SubInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\TypeOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\Utilities.cs" />
   </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
… buildable in Interpreter mode

To build in interpreting mode, compile with /p:IsInterpreting=true
In particular building System.Linq.Expressions.Tests with     /p:IsInterpreting /t:BuildAndTest  will build the library in interpreting mode and will run tests on it.

Currently all System.Linq.Expressions.Tests tests are passing.
System.Dynamic.Runtime needs some fixing though.