### PR TITLE
Fixes bug 1958

### DIFF
--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -21,17 +21,6 @@ namespace Microsoft.Framework.WebEncoders
         private static readonly UTF8Encoding _utf8EncodingThrowOnInvalidBytes = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
         [Fact]
-        public void GetDefinedCharacterBitmap_ReturnsSingletonInstance()
-        {
-            // Act
-            uint[] retVal1 = UnicodeHelpers.GetDefinedCharacterBitmap();
-            uint[] retVal2 = UnicodeHelpers.GetDefinedCharacterBitmap();
-
-            // Assert
-            Assert.Same(retVal1, retVal2);
-        }
-
-        [Fact]
         public void GetScalarValueFromUtf16()
         {
             // TODO: [ActiveIssue(846, PlatformID.AnyUnix)]


### PR DESCRIPTION
Another remaining test for sameness that we agreed to remove (i.e. cost to synchronize too high
in comparison to the benefit)

There are a few other tests like that (they all test sameness of codepointfilter creation).
I will review them as a separate workitem as they are probably also not very reliable. But for now,
I am removing this test as it is actually failing during runs.