### PR TITLE
Add missing null-argument check to System.Linq.Parallel.Cast().

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
@@ -5363,6 +5363,8 @@ namespace System.Linq
         /// </exception>
         public static ParallelQuery<TResult> Cast<TResult>(this ParallelQuery source)
         {
+            if (source == null) throw new ArgumentNullException("source");
+
             return source.Cast<TResult>();
         }
 

--- a/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
@@ -118,10 +118,9 @@ namespace Test
         }
 
         [Fact]
-        public static void Cast_NullReferenceException()
+        public static void Cast_ArgumentNullException()
         {
-            // Everything else throws ArgumentNullException, but Cast is missing the check that would do so.
-            Assert.Throws<NullReferenceException>(() => ((ParallelQuery<object>)null).Cast<int>());
+            Assert.Throws<ArgumentNullException>(() => ((ParallelQuery<object>)null).Cast<int>());
         }
 
         private class Castable


### PR DESCRIPTION
Add missing null-argument check.
Update tests as necessary.
This makes Cast act the same as the other extension methods, and follow its documented behavior.