### PR TITLE
Avoid InvalidCastException from the IList implementation of ImmutableArray<T>

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -173,7 +173,7 @@ namespace System.Collections.Immutable
         public static ImmutableArray<T> Create<T>(T[] items, int start, int length)
         {
             Requires.NotNull(items, "items");
-            Requires.Range(start >= 0 && start < items.Length, "start");
+            Requires.Range(start >= 0 && start <= items.Length, "start");
             Requires.Range(length >= 0 && start + length <= items.Length, "length");
 
             if (length == 0)
@@ -205,7 +205,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length)
         {
-            Requires.Range(start >= 0 && start < items.Length, "start");
+            Requires.Range(start >= 0 && start <= items.Length, "start");
             Requires.Range(length >= 0 && start + length <= items.Length, "length");
 
             if (length == 0)
@@ -271,7 +271,7 @@ namespace System.Collections.Immutable
         {
             int itemsLength = items.Length;
 
-            Requires.Range(start >= 0 && start < itemsLength, "start");
+            Requires.Range(start >= 0 && start <= itemsLength, "start");
             Requires.Range(length >= 0 && start + length <= itemsLength, "length");
             Requires.NotNull(selector, "selector");
 
@@ -339,7 +339,7 @@ namespace System.Collections.Immutable
         {
             int itemsLength = items.Length;
 
-            Requires.Range(start >= 0 && start < itemsLength, "start");
+            Requires.Range(start >= 0 && start <= itemsLength, "start");
             Requires.Range(length >= 0 && start + length <= itemsLength, "length");
             Requires.NotNull(selector, "selector");
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -173,7 +173,7 @@ namespace System.Collections.Immutable
         public static ImmutableArray<T> Create<T>(T[] items, int start, int length)
         {
             Requires.NotNull(items, "items");
-            Requires.Range(start >= 0 && start <= items.Length, "start");
+            Requires.Range(start >= 0 && start < items.Length, "start");
             Requires.Range(length >= 0 && start + length <= items.Length, "length");
 
             if (length == 0)
@@ -205,7 +205,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length)
         {
-            Requires.Range(start >= 0 && start <= items.Length, "start");
+            Requires.Range(start >= 0 && start < items.Length, "start");
             Requires.Range(length >= 0 && start + length <= items.Length, "length");
 
             if (length == 0)
@@ -271,7 +271,7 @@ namespace System.Collections.Immutable
         {
             int itemsLength = items.Length;
 
-            Requires.Range(start >= 0 && start <= itemsLength, "start");
+            Requires.Range(start >= 0 && start < itemsLength, "start");
             Requires.Range(length >= 0 && start + length <= itemsLength, "length");
             Requires.NotNull(selector, "selector");
 
@@ -339,7 +339,7 @@ namespace System.Collections.Immutable
         {
             int itemsLength = items.Length;
 
-            Requires.Range(start >= 0 && start <= itemsLength, "start");
+            Requires.Range(start >= 0 && start < itemsLength, "start");
             Requires.Range(length >= 0 && start + length <= itemsLength, "length");
             Requires.NotNull(selector, "selector");
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -793,24 +793,18 @@ namespace System.Collections.Immutable
             Requires.NotNull(items, "items");
             Requires.NotNull(equalityComparer, "equalityComparer");
 
-            List<int> indexesToRemove = null;
-            for (int i = 0; i < self.Length; i++)
+            var indexesToRemove = new SortedSet<int>();
+            foreach (var item in items)
             {
-                foreach (var item in items)
+                int index = self.IndexOf(item, equalityComparer);
+                while (index >= 0 && !indexesToRemove.Add(index) && index + 1 < self.Length)
                 {
-                    T elem = self.array[i];
-                    if (equalityComparer.Equals(item, elem))
-                    {
-                        indexesToRemove = indexesToRemove ?? new List<int>();
-                        indexesToRemove.Add(i);
-                        break;
-                    }
+                    // This is a duplicate of one we've found. Try hard to find another instance in the list to remove.
+                    index = self.IndexOf(item, index + 1, equalityComparer);
                 }
             }
 
-            return indexesToRemove != null ?
-                self.RemoveAtRange(indexesToRemove) :
-                self;
+            return self.RemoveAtRange(indexesToRemove);
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1286,6 +1286,13 @@ namespace System.Collections.Immutable
             return self.Replace(oldValue, newValue, equalityComparer);
         }
 
+        private static bool IsCompatibleObject(object value)
+        {
+            // Non-null values are fine.  Only accept nulls if T is a class or Nullable<U>.
+            // Note that default(T) is not equal to null for value types except when T is Nullable<U>. 
+            return ((value is T) || (value == null && default(T) == null));
+        }
+
         /// <summary>
         /// Adds an item to the <see cref="IList"/>.
         /// </summary>
@@ -1322,7 +1329,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowInvalidOperationIfNotInitialized();
-            return value is T && self.Contains((T)value);
+            return IsCompatibleObject(value) && self.Contains((T)value);
         }
 
         /// <summary>
@@ -1337,7 +1344,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowInvalidOperationIfNotInitialized();
-            return value is T ? self.IndexOf((T)value) : -1;
+            return IsCompatibleObject(value) ? self.IndexOf((T)value) : -1;
         }
 
         /// <summary>


### PR DESCRIPTION
1. Crib the IsCompatibleObject predicate from List
2. Make IList.Contains and IList.Index call IsCompatibleObject to decide
whether the value to search for is compatible with T
3. Fix typos in comments