### PR TITLE
Disabling System.Diagnostics.Process.MainModule test against Issue#1896

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -225,6 +225,7 @@ namespace System.Diagnostics.ProcessTests
         }
 
         [Fact]
+        [ActiveIssue(1896, PlatformID.Windows)]
         public void Process_MainModule()
         {
             // Get MainModule property from a Process object


### PR DESCRIPTION
Process class uses Win32 API EnumProcessModules to get the process's MainModule. This API is a best effort API which may not work in certain scenarios. I am debating over whether we should remove this dependency completely so for now, I am simply disabling the test against Issue#1896 while I gather more data.