### PR TITLE
Fix RandomNumberGeneratorTest.ConcurrentAccess failures

### DIFF
--- a/src/System.Security.Cryptography.RandomNumberGenerator/tests/RandomNumberGeneratorTests.cs
+++ b/src/System.Security.Cryptography.RandomNumberGenerator/tests/RandomNumberGeneratorTests.cs
@@ -202,8 +202,10 @@ namespace System.Security.Cryptography.RNG.Tests
 
             // Over the long run there should be about as many 1s as 0s.
             // This isn't a guarantee, just a statistical observation.
-            // Allow a 3% tolerance band before considering it to have gotten out of hand.
-            Assert.True(bitDifference < 0.03);
+            // Allow a 7% tolerance band before considering it to have gotten out of hand.
+            const double AllowedTolerance = 0.07;
+            Assert.True(bitDifference < AllowedTolerance, 
+                "Expected bitDifference < " + AllowedTolerance + ", got " + bitDifference + ".");
         }
     }
 }


### PR DESCRIPTION
The ConcurrentAccess test is attempting to check statistical variance of the generated random values by verifying that the number of bits that are 0 is approximately the same as the number of bits that are 1.  The test is allowing for a 3% variance, but at that level the test has already failed in CI builds several times.  I ran the test locally hundreds of thousands of times, and it's failing 2-3% of all runs, on both Windows and Linux.  I changed it to allow for a 4% variance, and it still failed a handful.  At a million runs and 5% variance, it still failed a few.  At 6% variance, I couldn't get it to fail, so I've changed it to 7% to leave some further buffer.

(At some point we should probably do some slightly better test for the random distribution, such as a chi squared test.)

Fixes #1968.