### PR TITLE
Fix overflowing key size in AesImplementation

### DIFF
--- a/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesImplementation.cs
+++ b/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesImplementation.cs
@@ -46,8 +46,12 @@ namespace Internal.Cryptography
             if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(this.LegalKeySizes))
                 throw new ArgumentException(SR.Cryptography_InvalidKeySize, "key");
 
-            if (rgbIV != null && rgbIV.Length * BitsPerByte != BlockSize)
-                throw new ArgumentException(SR.Cryptography_InvalidIVSize, "iv");
+            if (rgbIV != null)
+            {
+                long ivSize = rgbIV.Length * (long)BitsPerByte;
+                if (ivSize != BlockSize)
+                    throw new ArgumentException(SR.Cryptography_InvalidIVSize, "iv");
+            }
 
             if (encrypting)
                 return CreateEncryptor(Mode, Padding, rgbKey, rgbIV, BlockSize / BitsPerByte);

--- a/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesImplementation.cs
+++ b/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesImplementation.cs
@@ -41,11 +41,13 @@ namespace Internal.Cryptography
         {
             if (rgbKey == null)
                 throw new ArgumentNullException("key");
-            int keySize = rgbKey.Length * BitsPerByte;
-            if (!keySize.IsLegalSize(this.LegalKeySizes))
-                throw new ArgumentException(SR.Format(SR.Cryptography_InvalidKeySize, "key"));
+
+            long keySize = rgbKey.Length * (long)BitsPerByte;
+            if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(this.LegalKeySizes))
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, "key");
+
             if (rgbIV != null && rgbIV.Length * BitsPerByte != BlockSize)
-                throw new ArgumentException(SR.Format(SR.Cryptography_InvalidIVSize, "iv"));
+                throw new ArgumentException(SR.Cryptography_InvalidIVSize, "iv");
 
             if (encrypting)
                 return CreateEncryptor(Mode, Padding, rgbKey, rgbIV, BlockSize / BitsPerByte);

--- a/src/System.Security.Cryptography.Encryption.Aes/tests/AesContractTests.cs
+++ b/src/System.Security.Cryptography.Encryption.Aes/tests/AesContractTests.cs
@@ -86,6 +86,30 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             }
         }
 
+        [Theory]
+        [InlineData(64)]        // smaller than default BlockSize
+        [InlineData(129)]       // larger than default BlockSize
+        [InlineData(536870928)] // number of bits overflows and wraps around to default BlockSize
+        public static void InvalidIVSizes(int invalidIvSize)
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.GenerateKey();
+                byte[] key = aes.Key;
+                byte[] iv;
+                try
+                {
+                    iv = new byte[invalidIvSize];
+                }
+                catch (OutOfMemoryException) // in case there isn't enough memory at test-time to allocate the large array
+                {
+                    return;
+                }
+                Assert.Throws<ArgumentException>("iv", () => aes.CreateEncryptor(key, iv));
+                Assert.Throws<ArgumentException>("iv", () => aes.CreateDecryptor(key, iv));
+            }
+        }
+
         [Fact]
         public static void VerifyKeyGeneration_Default()
         {


### PR DESCRIPTION
Check that the key's size in bits doesn't overflow Int32.MaxValue, or else we could potentially be allowing in a gigantic key that happens to overflow to a valid key size.

Fixes #1981.