### PR TITLE
Remove usage of ArrayT<T>

### DIFF
--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -72,7 +72,7 @@ namespace System.Collections.Generic
                             newLength = count + 1;
                         }
 
-                        arr = ArrayT<T>.Resize(arr, newLength, count);
+                        Array.Resize(ref arr, newLength);
                     }
                     arr[count++] = item;
                 }

--- a/src/Common/src/System/Collections/Generic/LowLevelList.cs
+++ b/src/Common/src/System/Collections/Generic/LowLevelList.cs
@@ -137,14 +137,9 @@ namespace System.Collections.Generic
                 {
                     if (value > 0)
                     {
-#if TYPE_LOADER_IMPLEMENTATION
                         T[] newItems = new T[value];
-                        for (int i = 0; i < _size; i++)
-                            newItems[i] = _items[i];
+                        Array.Copy(_items, 0, newItems, 0, _size);
                         _items = newItems;
-#else
-                        _items = ArrayT<T>.Resize(_items, value, _size);
-#endif
                     }
                     else
                     {
@@ -237,7 +232,7 @@ namespace System.Collections.Generic
         {
             if (_size > 0)
             {
-                ArrayT<T>.Clear(_items, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
+                Array.Clear(_items, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
                 _size = 0;
             }
             _version++;
@@ -279,13 +274,13 @@ namespace System.Collections.Generic
             Contract.EndContractBlock();
 
             // Delegate rest of error checking to Array.Copy.
-            ArrayT<T>.Copy(_items, index, array, arrayIndex, count);
+            Array.Copy(_items, index, array, arrayIndex, count);
         }
 
         public void CopyTo(T[] array, int arrayIndex)
         {
             // Delegate rest of error checking to Array.Copy.
-            ArrayT<T>.Copy(_items, 0, array, arrayIndex, _size);
+            Array.Copy(_items, 0, array, arrayIndex, _size);
         }
 
         // Returns the index of the first occurrence of a given value in a range of
@@ -338,7 +333,7 @@ namespace System.Collections.Generic
             if (_size == _items.Length) EnsureCapacity(_size + 1);
             if (index < _size)
             {
-                ArrayT<T>.Copy(_items, index, _items, index + 1, _size - index);
+                Array.Copy(_items, index, _items, index + 1, _size - index);
             }
             _items[index] = item;
             _size++;
@@ -372,22 +367,22 @@ namespace System.Collections.Generic
                     EnsureCapacity(_size + count);
                     if (index < _size)
                     {
-                        ArrayT<T>.Copy(_items, index, _items, index + count, _size - index);
+                        Array.Copy(_items, index, _items, index + count, _size - index);
                     }
 
                     // If we're inserting a List into itself, we want to be able to deal with that.
                     if (this == c)
                     {
                         // Copy first part of _items to insert location
-                        ArrayT<T>.Copy(_items, 0, _items, index, index);
+                        Array.Copy(_items, 0, _items, index, index);
                         // Copy last part of _items back to inserted location
-                        ArrayT<T>.Copy(_items, index + count, _items, index * 2, _size - index);
+                        Array.Copy(_items, index + count, _items, index * 2, _size - index);
                     }
                     else
                     {
                         T[] itemsToInsert = new T[count];
                         c.CopyTo(itemsToInsert, 0);
-                        ArrayT<T>.Copy(itemsToInsert, 0, _items, index, count);
+                        Array.Copy(itemsToInsert, 0, _items, index, count);
                     }
                     _size += count;
                 }
@@ -451,7 +446,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            ArrayT<T>.Clear(_items, freeIndex, _size - freeIndex);
+            Array.Clear(_items, freeIndex, _size - freeIndex);
             int result = _size - freeIndex;
             _size = freeIndex;
             _version++;
@@ -471,7 +466,7 @@ namespace System.Collections.Generic
             _size--;
             if (index < _size)
             {
-                ArrayT<T>.Copy(_items, index + 1, _items, index, _size - index);
+                Array.Copy(_items, index + 1, _items, index, _size - index);
             }
             _items[_size] = default(T);
             _version++;
@@ -485,7 +480,7 @@ namespace System.Collections.Generic
             Contract.Ensures(Contract.Result<T[]>().Length == Count);
 
             T[] array = new T[_size];
-            ArrayT<T>.Copy(_items, 0, array, 0, _size);
+            Array.Copy(_items, 0, array, 0, _size);
             return array;
         }
 #endif

--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -30,11 +30,6 @@
     <Compile Include="System\Collections\Concurrent\PlatformHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1685,7 +1685,8 @@ namespace System.Collections.Concurrent
                 // Add more locks
                 if (_growLockArray && tables._locks.Length < MAX_LOCK_NUMBER)
                 {
-                    newLocks = ArrayT<object>.Resize(tables._locks, tables._locks.Length * 2, tables._locks.Length);
+                    newLocks = new object[tables._locks.Length * 2];
+                    Array.Copy(tables._locks, 0, newLocks, 0, tables._locks.Length);
                     for (int i = tables._locks.Length; i < newLocks.Length; i++)
                     {
                         newLocks[i] = new object();

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -665,7 +665,7 @@ namespace System.Collections.Concurrent
                     {
                         // adjust index and do the actual copy
                         actualNumElementsGrabbed = (endPos < _fillBufferSize) ? endPos : _fillBufferSize - beginPos;
-                        ArrayT<KeyValuePair<long, TSource>>.Copy(fillBufferLocalRef, beginPos, destArray, 0, actualNumElementsGrabbed);
+                        Array.Copy(fillBufferLocalRef, beginPos, destArray, 0, actualNumElementsGrabbed);
                     }
 
                     // let the record show we are no longer accessing the buffer

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -42,9 +42,6 @@
     <Compile Include="System\Collections\StructuralComparisons.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Collections\HashHelpers.cs">
       <Link>Common\System\Collections\HashHelpers.cs</Link>
     </Compile>

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -157,8 +157,8 @@ namespace System.Collections.Generic
 
                 // clear the elements so that the gc can reclaim the references.
                 // clear only up to _lastIndex for _slots 
-                ArrayT<Slot>.Clear(_slots, 0, _lastIndex);
-                ArrayT<int>.Clear(_buckets, 0, _buckets.Length);
+                Array.Clear(_slots, 0, _lastIndex);
+                Array.Clear(_buckets, 0, _buckets.Length);
                 _lastIndex = 0;
                 _count = 0;
                 _freeList = -1;
@@ -919,11 +919,11 @@ namespace System.Collections.Generic
 
             Debug.Assert(_buckets != null, "SetCapacity called on a set with no elements");
 
-            Slot[] newSlots;
-            if (_slots == null)
-                newSlots = new Slot[newSize];
-            else
-                newSlots = ArrayT<Slot>.Resize(_slots, newSize, _lastIndex);
+            Slot[] newSlots = new Slot[newSize];
+            if (_slots != null)
+            {
+                Array.Copy(_slots, 0, newSlots, 0, _lastIndex);
+            }
 
             if (forceNewHashCodes)
             {

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -102,11 +102,11 @@ namespace System.Collections.Generic
         public void Clear()
         {
             if (_head < _tail)
-                ArrayT<T>.Clear(_array, _head, _size);
+                Array.Clear(_array, _head, _size);
             else
             {
-                ArrayT<T>.Clear(_array, _head, _array.Length - _head);
-                ArrayT<T>.Clear(_array, 0, _tail);
+                Array.Clear(_array, _head, _array.Length - _head);
+                Array.Clear(_array, 0, _tail);
             }
 
             _head = 0;
@@ -141,11 +141,11 @@ namespace System.Collections.Generic
             if (numToCopy == 0) return;
 
             int firstPart = (_array.Length - _head < numToCopy) ? _array.Length - _head : numToCopy;
-            ArrayT<T>.Copy(_array, _head, array, arrayIndex, firstPart);
+            Array.Copy(_array, _head, array, arrayIndex, firstPart);
             numToCopy -= firstPart;
             if (numToCopy > 0)
             {
-                ArrayT<T>.Copy(_array, 0, array, arrayIndex + _array.Length - _head, numToCopy);
+                Array.Copy(_array, 0, array, arrayIndex + _array.Length - _head, numToCopy);
             }
         }
 
@@ -313,12 +313,12 @@ namespace System.Collections.Generic
 
             if (_head < _tail)
             {
-                ArrayT<T>.Copy(_array, _head, arr, 0, _size);
+                Array.Copy(_array, _head, arr, 0, _size);
             }
             else
             {
-                ArrayT<T>.Copy(_array, _head, arr, 0, _array.Length - _head);
-                ArrayT<T>.Copy(_array, 0, arr, _array.Length - _head, _tail);
+                Array.Copy(_array, _head, arr, 0, _array.Length - _head);
+                Array.Copy(_array, 0, arr, _array.Length - _head, _tail);
             }
 
             return arr;
@@ -334,12 +334,12 @@ namespace System.Collections.Generic
             {
                 if (_head < _tail)
                 {
-                    ArrayT<T>.Copy(_array, _head, newarray, 0, _size);
+                    Array.Copy(_array, _head, newarray, 0, _size);
                 }
                 else
                 {
-                    ArrayT<T>.Copy(_array, _head, newarray, 0, _array.Length - _head);
-                    ArrayT<T>.Copy(_array, 0, newarray, _array.Length - _head, _tail);
+                    Array.Copy(_array, _head, newarray, 0, _array.Length - _head);
+                    Array.Copy(_array, 0, newarray, _array.Length - _head, _tail);
                 }
             }
 

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -86,7 +86,7 @@ namespace System.Collections.Generic
         /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Clear"]/*' />
         public void Clear()
         {
-            ArrayT<T>.Clear(_array, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
+            Array.Clear(_array, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
             _size = 0;
             _version++;
         }
@@ -141,7 +141,7 @@ namespace System.Collections.Generic
             else
             {
                 // Legacy fallback in case we ever end up copying within the same array.
-                ArrayT<T>.Copy(_array, 0, array, arrayIndex, _size);
+                Array.Copy(_array, 0, array, arrayIndex, _size);
                 Array.Reverse(array, arrayIndex, _size);
             }
         }
@@ -208,8 +208,7 @@ namespace System.Collections.Generic
             int threshold = (int)(((double)_array.Length) * 0.9);
             if (_size < threshold)
             {
-                T[] newarray = ArrayT<T>.Resize(_array, _size, _size);
-                _array = newarray;
+                Array.Resize(ref _array, _size);
                 _version++;
             }
         }
@@ -244,8 +243,7 @@ namespace System.Collections.Generic
         {
             if (_size == _array.Length)
             {
-                T[] newArray = ArrayT<T>.Resize(_array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length, _size);
-                _array = newArray;
+                Array.Resize(ref _array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length);
             }
             _array[_size++] = item;
             _version++;

--- a/src/System.Linq.Parallel/src/System.Linq.Parallel.csproj
+++ b/src/System.Linq.Parallel/src/System.Linq.Parallel.csproj
@@ -158,9 +158,6 @@
   </ItemGroup>
   <!-- Common or Common-branched source files -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
   </ItemGroup>
   <!-- Resource files -->
   <ItemGroup>

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
@@ -114,7 +114,8 @@ namespace System.Linq.Parallel
         {
             int newSize = checked(_count * 2 + 1);
             int[] newBuckets = new int[newSize];
-            Slot[] newSlots = ArrayT<Slot>.Resize(_slots, newSize, _count);
+            Slot[] newSlots = new Slot[newSize];
+            Array.Copy(_slots, 0, newSlots, 0, _count);
             for (int i = 0; i < _count; i++)
             {
                 int bucket = newSlots[i].hashCode % newSize;

--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -16,9 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -2715,7 +2715,7 @@ namespace System.Linq
 
         void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
         {
-            ArrayT<TElement>.Copy(elements, 0, array, arrayIndex, count);
+            Array.Copy(elements, 0, array, arrayIndex, count);
         }
 
         bool ICollection<TElement>.Remove(TElement item)
@@ -2845,7 +2845,8 @@ namespace System.Linq
         {
             int newSize = checked(_count * 2 + 1);
             int[] newBuckets = new int[newSize];
-            Slot[] newSlots = ArrayT<Slot>.Resize(_slots, newSize, _count);
+            Slot[] newSlots = new Slot[newSize];
+            Array.Copy(_slots, 0, newSlots, 0, _count);
             for (int i = 0; i < _count; i++)
             {
                 int bucket = newSlots[i].hashCode % newSize;
@@ -3103,8 +3104,7 @@ namespace System.Linq
                     }
                     else if (items.Length == count)
                     {
-                        TElement[] newItems = ArrayT<TElement>.Resize(items, checked(count * 2), count);
-                        items = newItems;
+                        Array.Resize(ref items, checked(count * 2));
                     }
                     items[count] = item;
                     count++;
@@ -3119,7 +3119,9 @@ namespace System.Linq
             if (count == 0) return new TElement[0];
             if (items.Length == count) return items;
 
-            return ArrayT<TElement>.Resize(items, count, count);
+            var arr = new TElement[count];
+            Array.Copy(items, 0, arr, 0, count);
+            return arr;
         }
     }
 

--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -25,9 +25,6 @@
     <Compile Include="$(CommonPath)\System\Diagnostics\Debug.cs">
       <Link>Common\System\Diagnostics\Debug.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelDictionary.cs">
       <Link>Common\System\Collections\Generic\LowLevelDictionary.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -30,9 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelDictionary.cs">
       <Link>System\Collections\Generic\LowLevelDictionary.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -517,7 +517,7 @@ namespace System.Net
 
             if (decodedBytesCount < decodedBytes.Length)
             {
-                decodedBytes = ArrayT<byte>.Resize(decodedBytes, decodedBytesCount, decodedBytesCount);
+                Array.Resize(ref decodedBytes, decodedBytesCount);
             }
 
             return decodedBytes;

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -28,9 +28,6 @@
     <Compile Include="System\Security\Cryptography\OidGroup.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs">
       <Link>Common\System\Collections\Generic\LowLevelList.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.RSA/src/System.Security.Cryptography.RSA.csproj
+++ b/src/System.Security.Cryptography.RSA/src/System.Security.Cryptography.RSA.csproj
@@ -38,9 +38,6 @@
     <Compile Include="System\Security\Cryptography\RSAParameters.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs">
       <Link>Common\System\Collections\Generic\LowLevelList.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -19,9 +19,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="Internal\Cryptography\ICertificatePal.cs" />
-    <Compile Include="$(CommonPath)\System\ArrayT.cs">
-      <Link>Common\System\ArrayT.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs">
       <Link>Common\System\Collections\Generic\LowLevelList.cs</Link>
     </Compile>

--- a/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
+++ b/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
@@ -22,9 +22,6 @@
     <Compile Include="System\Xml\XPath\XNodeNavigator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -46,7 +46,6 @@
     <Compile Include="System\Xml\XPathNodeList.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\ArrayT.cs" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
```ArrayT<T>``` was a temporary workaround for some performance issues during the implementation of .NET Native.  Those performance issues have been fixed and the workaround is no longer needed.

This commit removes all usage of ```ArrayT<T>``` from the code currently on GitHub. The ArrayT.cs file itself is left to avoid breaking any libraries that haven't yet been ported to GitHub when the mirror moves these changes back internally.