### PR TITLE
Fix potential AVs from poorly written HashAlgorithm usage

### DIFF
--- a/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -75,12 +75,8 @@ namespace Internal.Cryptography
                 Check(Interop.libcrypto.EVP_DigestInit_ex(_ctx, algorithmEvp, IntPtr.Zero));
             }
 
-            public sealed override unsafe void AppendHashData(byte[] data, int offset, int count)
+            public sealed override unsafe void AppendHashDataCore(byte[] data, int offset, int count)
             {
-                Debug.Assert(data != null);
-                Debug.Assert(offset >= 0 && count >= 0);
-                Debug.Assert((offset + count) >= 0 && (offset + count) <= data.Length);
-
                 fixed (byte* md = data)
                 {
                     Check(Interop.libcrypto.EVP_DigestUpdate(_ctx, md + offset, (IntPtr)count));
@@ -135,12 +131,8 @@ namespace Internal.Cryptography
                 }
             }
 
-            public sealed override unsafe void AppendHashData(byte[] data, int offset, int count)
+            public sealed override unsafe void AppendHashDataCore(byte[] data, int offset, int count)
             {
-                Debug.Assert(data != null);
-                Debug.Assert(offset >= 0 && count >= 0);
-                Debug.Assert((offset + count) >= 0 && (offset + count) <= data.Length);
-
                 fixed (byte* md = data)
                 {
                     Check(Interop.libcrypto.HMAC_Update(ref _hmacCtx, md + offset, count));

--- a/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -61,14 +61,11 @@ namespace Internal.Cryptography
                 return;
             }
 
-            public sealed override void AppendHashData(byte[] rgb, int ib, int cb)
+            public sealed override unsafe void AppendHashDataCore(byte[] data, int offset, int count)
             {
-                unsafe
+                fixed (byte* pRgb = data)
                 {
-                    fixed (byte* pRgb = rgb)
-                    {
-                        _hHash.BCryptHashData(pRgb + ib, cb);
-                    }
+                    _hHash.BCryptHashData(pRgb + offset, count);
                 }
             }
 

--- a/src/System.Security.Cryptography.Hashing.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/src/Resources/Strings.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
+  <data name="Argument_InvalidOffLen" xml:space="preserve">
+    <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
+  </data>
+  <data name="ArgumentNull_Buffer" xml:space="preserve">
+    <value>Buffer cannot be null.</value>
+  </data>
+</root>

--- a/src/System.Security.Cryptography.Hashing.Algorithms/tests/System.Security.Cryptography.Hashing.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/tests/System.Security.Cryptography.Hashing.Algorithms.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="ByteUtils.cs" />
     <Compile Include="HashAlgorithmTest.cs" />
+    <Compile Include="InvalidUsageTests.cs" />
     <Compile Include="HmacSha1Tests.cs" />
     <Compile Include="HmacSha256Tests.cs" />
     <Compile Include="HmacSha384Tests.cs" />

--- a/src/System.Security.Cryptography.Hashing/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Hashing/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -58,14 +58,10 @@ namespace System.Security.Cryptography
             // Default the buffer size to 4K.
             byte[] buffer = new byte[4096];
             int bytesRead;
-            do
+            while ((bytesRead = inputStream.Read(buffer, 0, buffer.Length)) > 0)
             {
-                bytesRead = inputStream.Read(buffer, 0, 4096);
-                if (bytesRead > 0)
-                {
-                    HashCore(buffer, 0, bytesRead);
-                }
-            } while (bytesRead > 0);
+                HashCore(buffer, 0, bytesRead);
+            }
             return CaptureHashCodeAndReinitialize();
         }
 


### PR DESCRIPTION
The implementation of HashCore in all of our HashAlgorithms on both Windows and Unix uses the buffer/offset/count in unsafe code without argument validation.  While most usage of HashCore comes from internal data that's constructed to be correct, there are two paths where externally supplied data can arrive to HashCore unverified:

1. A Stream passed to ComputeHash can return a number of bytes read that's larger than the buffer size.  This value will be passed as the count to HashCore.
2. A type can derive from one of the hashing algorithms and access HashCore directly, which is protected.

This PR adds argument validation to our Windows and Unix implementations prior to using unsafe code to process those arguments.

Fixes #1996