### PR TITLE
Fix and enable RSA and X509Certificates tests on Unix

### DIFF
--- a/src/System.Security.Cryptography.RSA/src/Internal/Cryptography/RsaOpenSsl.cs
+++ b/src/System.Security.Cryptography.RSA/src/Internal/Cryptography/RsaOpenSsl.cs
@@ -145,6 +145,8 @@ namespace Internal.Cryptography
         
         public override unsafe void ImportParameters(RSAParameters parameters)
         {
+            ValidateParameters(ref parameters);
+
             SafeRsaHandle key = Interop.libcrypto.RSA_new();
             bool imported = false;
 
@@ -205,6 +207,35 @@ namespace Internal.Cryptography
                 if (handle != null)
                 {
                     handle.Dispose();
+                }
+            }
+        }
+
+        private static void ValidateParameters(ref RSAParameters parameters)
+        {
+            if (parameters.Modulus == null || parameters.Exponent == null)
+                throw new CryptographicException(SR.Argument_InvalidValue);
+
+            if (parameters.D == null)
+            {
+                if (parameters.P != null ||
+                    parameters.DP != null ||
+                    parameters.Q != null ||
+                    parameters.DQ != null ||
+                    parameters.InverseQ != null)
+                {
+                    throw new CryptographicException(SR.Argument_InvalidValue);
+                }
+            }
+            else
+            {
+                if (parameters.P == null ||
+                    parameters.DP == null ||
+                    parameters.Q == null ||
+                    parameters.DQ == null ||
+                    parameters.InverseQ == null)
+                {
+                    throw new CryptographicException(SR.Argument_InvalidValue);
                 }
             }
         }

--- a/src/System.Security.Cryptography.RSA/tests/System.Security.Cryptography.RSA.Tests.csproj
+++ b/src/System.Security.Cryptography.RSA/tests/System.Security.Cryptography.RSA.Tests.csproj
@@ -8,8 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.RSA.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Rsa.Tests</RootNamespace>
-	<!-- Disabled on Linux/OSX (Issue 1986) -->
-	<UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Security.Cryptography.RSA.csproj">

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -58,7 +58,7 @@ namespace Internal.Cryptography.Pal
 
         public IntPtr Handle
         {
-            get { return IntPtr.Zero; }
+            get { return _cert == null ? IntPtr.Zero : _cert.DangerousGetHandle(); }
         }
 
         public string Issuer

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -140,7 +140,12 @@ namespace Internal.Cryptography.Pal
             get
             {
                 IntPtr serialNumberPtr = Interop.libcrypto.X509_get_serialNumber(_cert);
-                return Interop.NativeCrypto.GetAsn1StringBytes(serialNumberPtr);
+                byte[] serial = Interop.NativeCrypto.GetAsn1StringBytes(serialNumberPtr);
+
+                // Windows returns this in BigInteger Little-Endian,
+                // OpenSSL returns this in BigInteger Big-Endian.
+                Array.Reverse(serial);
+                return serial;
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -30,6 +30,11 @@ namespace Internal.Cryptography.Pal
 
                 _cert = Interop.libcrypto.d2i_X509(IntPtr.Zero, ppData, data.Length);
 
+                if (_cert.IsInvalid)
+                {
+                    throw new CryptographicException();
+                }
+
                 // X509_check_purpose has the effect of populating the sha1_hash value,
                 // and other "initialize" type things.
                 bool init = Interop.libcrypto.X509_check_purpose(_cert, -1, 0);

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -81,6 +81,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         /// This test is for excerising X509Store and X509Chain code without actually installing any certificate 
         /// </summary>
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509CertStoreChain()
         {
             X509Store store = new X509Store("My", StoreLocation.LocalMachine);
@@ -104,6 +105,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2ToStringVerbose()
         {
             X509Store store = new X509Store("My", StoreLocation.CurrentUser);

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -154,6 +154,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportPfx()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -175,6 +176,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportStoreSavedAsCerData()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -196,6 +198,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportStoreSavedAsSerializedCerData()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -217,6 +220,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportStoreSavedAsSerializedStoreData()
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
@@ -241,6 +245,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportStoreSavedAsPfxData()
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
@@ -285,24 +290,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportCert()
         {
             TestExportSingleCert(X509ContentType.Cert);
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportSerializedCert()
         {
             TestExportSingleCert(X509ContentType.SerializedCert);
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportSerializedStore()
         {
             TestExportStore(X509ContentType.SerializedStore);
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportPkcs7()
         {
             TestExportStore(X509ContentType.Pkcs7);

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -71,6 +71,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Fact]
         public static void TestNullConstructorArguments()
         {
             Assert.Throws<ArgumentException>(() => new X509Certificate2((byte[])null, (String)null));
@@ -97,6 +98,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.Throws<CryptographicException>(() => c.GetCertHash());
                 }
             }
+        }
+
+        [Fact]
+        public static void InvalidCertificateBlob()
+        {
+            Assert.Throws<CryptographicException>(() => new X509Certificate2(new byte[] { 0x01, 0x02, 0x03 }));
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
@@ -8,6 +8,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ExportTests
     {
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsCert()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -19,6 +20,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsSerializedCert()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -36,6 +38,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsPfx()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -52,6 +55,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsPfxWithPassword()
         {
             const string password = "Cotton";
@@ -70,6 +74,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsPfxVerifyPassword()
         {
             const string password = "Cotton";

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -129,60 +129,70 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_CrlSign()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.CrlSign, false, "03020102".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_DataEncipherment()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.DataEncipherment, false, "03020410".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_DecipherOnly()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.DecipherOnly, false, "0303070080".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_DigitalSignature()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false, "03020780".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_EncipherOnly()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.EncipherOnly, false, "03020001".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_KeyAgreement()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.KeyAgreement, false, "03020308".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_KeyCertSign()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.KeyCertSign, false, "03020204".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_KeyEncipherment()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.KeyEncipherment, false, "03020520".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_None()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.None, false, "030100".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void KeyUsageExtension_NonRepudiation()
         {
             TestKeyUsageExtension(X509KeyUsageFlags.NonRepudiation, false, "03020640".HexToByteArray());
@@ -204,30 +214,35 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void BasicConstraintsExtension_Leaf()
         {
             TestBasicConstraintsExtension(false, false, 0, false, "3000".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void BasicConstraintsExtension_CA_NoLength()
         {
             TestBasicConstraintsExtension(true, false, 0, false, "30030101ff".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void BasicConstraintsExtension_Leaf_Length0()
         {
             TestBasicConstraintsExtension(false, true, 0, false, "3003020100".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void BasicConstraintsExtension_LeafLongPath()
         {
             TestBasicConstraintsExtension(false, true, 7654321, false, "3005020374cbb1".HexToByteArray());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void BasicConstraintsExtension_CA_559()
         {
             TestBasicConstraintsExtension(true, true, 559, false, "30070101ff0202022f".HexToByteArray());
@@ -248,6 +263,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void EnhancedKeyUsageExtension_Empty()
         {
             OidCollection usages = new OidCollection();
@@ -255,6 +271,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void EnhancedKeyUsageExtension_2Oids()
         {
             Oid oid1 = Oid.FromOidValue("1.3.6.1.5.5.7.3.1", OidGroup.EnhancedKeyUsage);
@@ -282,6 +299,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_Bytes()
         {
             byte[] sk = { 1, 2, 3, 4 };
@@ -296,6 +314,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_String()
         {
             string sk = "01ABcd";
@@ -310,6 +329,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKey()
         {
             PublicKey pk = new X509Certificate2(TestData.MsCertificate).PublicKey;
@@ -324,6 +344,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKeySha1()
         {
             TestSubjectKeyIdentifierExtension(
@@ -335,6 +356,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKeyShortSha1()
         {
             TestSubjectKeyIdentifierExtension(
@@ -346,6 +368,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKeyCapiSha1()
         {
             TestSubjectKeyIdentifierExtension(

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -96,24 +96,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void FindByNullName()
         {
             RunExceptionTest<ArgumentNullException>(X509FindType.FindBySubjectName, null);
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void FindByThumbprint_Object()
         {
             RunExceptionTest<CryptographicException>(X509FindType.FindByThumbprint, new object());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void FindByInvalidThumbprint()
         {
             RunZeroMatchTest(X509FindType.FindByThumbprint, "Nothing");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void FindByValidThumbprint()
         {
             RunTest(
@@ -128,36 +132,42 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSubjectName_Object()
         {
             RunExceptionTest<CryptographicException>(X509FindType.FindBySubjectName, new object());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSubjectName_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindBySubjectName, "Nothing");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSubjectName_Match()
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectName, "Microsoft Corporation");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestDistinguishedSubjectName_Object()
         {
             RunExceptionTest<CryptographicException>(X509FindType.FindBySubjectDistinguishedName, new object());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestDistinguishedSubjectName_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindBySubjectDistinguishedName, "Nothing");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestDistinguishedSubjectName_Match()
         {
             RunSingleMatchTest_MsCer(
@@ -166,12 +176,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTimeValid_Object()
         {
             RunExceptionTest<CryptographicException>(X509FindType.FindByTimeValid, new object());
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTimeValid_Before()
         {
             RunTest(
@@ -189,6 +201,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTimeValid_After()
         {
             RunTest(
@@ -206,6 +219,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTimeValid_Between()
         {
             RunTest(
@@ -232,6 +246,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTimeValid_Match()
         {
             RunTest(
@@ -246,6 +261,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_Decimal()
         {
             // Decimal string is an allowed input format.
@@ -255,6 +271,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_DecimalLeadingZeros()
         {
             // Checking that leading zeros are ignored.
@@ -264,6 +281,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_DecimalNegative()
         {
             // This serial number has the high bit on which means that it's easier to misinterpret as a negative number.
@@ -274,6 +292,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_Hex()
         {
             // Hex string is also an allowed input format.
@@ -283,6 +302,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_HexIgnoreCase()
         {
             // Hex string is also an allowed input format and case-blind
@@ -292,6 +312,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_HexLeadingZeros()
         {
             // Checking that leading zeros are ignored.
@@ -301,6 +322,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_NoMatch()
         {
             RunZeroMatchTest(
@@ -309,30 +331,35 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByExtension_FriendlyName()
         {
             RunSingleMatchTest_MsCer(X509FindType.FindByExtension, "Enhanced Key Usage");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByExtension_OidValue()
         {
             RunSingleMatchTest_MsCer(X509FindType.FindByExtension, "2.5.29.37");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByExtension_UnknownFriendlyName()
         {
             RunExceptionTest<ArgumentException>(X509FindType.FindByExtension, "BOGUS");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByExtension_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindByExtension, "2.9");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySubjectKeyIdentifier_MatchA()
         {
             RunSingleMatchTest_PfxCer(
@@ -341,6 +368,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySubjectKeyIdentifier_MatchB()
         {
             RunSingleMatchTest_MsCer(
@@ -349,12 +377,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestBySubjectKeyIdentifier_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindBySubjectKeyIdentifier, "");
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByApplicationPolicy_MatchAll()
         {
             RunTest(
@@ -376,6 +406,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByApplicationPolicy_NoPolicyAlwaysMatches()
         {
             // PfxCer doesn't have any application policies which means it's good for all usages (even nonsensical ones.)
@@ -383,6 +414,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByApplicationPolicy_NoMatch()
         {
             RunTest(
@@ -399,6 +431,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByCertificatePolicies_MatchA()
         {
             using (var policyCert = new X509Certificate2(TestData.CertWithPolicies))
@@ -412,6 +445,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByCertificatePolicies_MatchB()
         {
             using (var policyCert = new X509Certificate2(TestData.CertWithPolicies))
@@ -425,6 +459,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByCertificatePolicies_NoMatch()
         {
             using (var policyCert = new X509Certificate2(TestData.CertWithPolicies))
@@ -437,6 +472,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTemplate_MatchA()
         {
             using (var templatedCert = new X509Certificate2(TestData.CertWithTemplateData))
@@ -450,6 +486,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTemplate_MatchB()
         {
             using (var templatedCert = new X509Certificate2(TestData.CertWithTemplateData))
@@ -463,6 +500,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByTemplate_NoMatch()
         {
             using (var templatedCert = new X509Certificate2(TestData.CertWithTemplateData))

--- a/src/System.Security.Cryptography.X509Certificates/tests/InteropTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/InteropTests.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class InteropTests
     {
         [Fact]
-        [ActiveIssue(0, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)]
         public static void TestHandle()
         {
             //
@@ -41,6 +41,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public static void TestHandleCtor()
         {
             IntPtr pCertContext = IntPtr.Zero;

--- a/src/System.Security.Cryptography.X509Certificates/tests/NameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/NameTests.cs
@@ -8,6 +8,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class NameTests
     {
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestEncode()
         {
             byte[] expectedEncoding = "300e310c300a06035504031303466f6f".HexToByteArray();
@@ -32,6 +33,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestFormat()
         {
             byte[] encoding = "300e310c300a06035504031303466f6f".HexToByteArray();

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class PfxTests
     {
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestConstructor()
         {
             byte[] expectedThumbprint = "71cb4e2b02738ad44f8b382c93bd17ba665f9914".HexToByteArray();
@@ -23,6 +24,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestRawData()
         {
             byte[] expectedRawData = (
@@ -56,6 +58,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestPrivateKey()
         {
             using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -72,6 +75,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSetPrivateKey()
         {
             X509Certificate2 current;

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -174,6 +174,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestContentType()
         {
             X509ContentType ct = X509Certificate2.GetCertContentType(TestData.MsCertificate);
@@ -181,6 +182,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestArchive()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -196,6 +198,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestFriendlyName()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    TestData.NormalizeX500String("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
                     c.Issuer);
             }
         }
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    TestData.NormalizeX500String("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
                     c.Subject);
             }
         }
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    TestData.NormalizeX500String("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
                     c.SubjectName.Name);
             }
         }
@@ -227,7 +227,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    TestData.NormalizeX500String("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
                     c.IssuerName.Name);
 
             }

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -31,6 +31,9 @@
     <Compile Include="PropsTests.cs" />
     <Compile Include="PublicKeyTests.cs" />
     <Compile Include="TestData.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -9,8 +9,6 @@
     <AssemblyName>System.Security.Cryptography.X509Certificates.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.X509Certificates.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Disabled on Linux/OSX (Issue 1986) -->
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Security.Cryptography.X509Certificates.csproj">

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
@@ -373,7 +373,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         internal static string NormalizeX500String(string expected)
         {
-            if (StringComparer.Ordinal.Equals("Windows_NT", Environment.GetEnvironmentVariable("OS")))
+            if (Interop.IsWindows)
             {
                 return expected;
             }

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
@@ -370,5 +370,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             "29008DE8B851E2C30B6BF73F219BCE651E5972E62D651BA171D1DA9831A449D99" +
             "AF4E2F4B9EE3FD0991EF305ADDA633C44EB5E4979751280B3F54F9CCD561AC27D" +
             "3426BC6FF32E8E1AAF9F7C0150A726B").HexToByteArray();
+
+        internal static string NormalizeX500String(string expected)
+        {
+            if (StringComparer.Ordinal.Equals("Windows_NT", Environment.GetEnvironmentVariable("OS")))
+            {
+                return expected;
+            }
+
+            // Windows calls OID(2.5.4.8) "S", which matches ITU X.520.
+            // OpenSSL calls it "ST", because RFC1327 calls "S" surname.
+            // 
+            // This provides a test mitigation for issue 1985, allowing the
+            // thrust of the test to proceed with this one known problem.
+            return expected.Replace(" S=", " ST=");
+        }
     }
 }


### PR DESCRIPTION
Resolves #1986.