### PR TITLE
Remove some allocations from X509 library

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
 using System.Diagnostics;
 using System.Globalization;
-using System.Security.Cryptography;
 
 namespace Internal.Cryptography
 {
@@ -16,59 +14,54 @@ namespace Internal.Cryptography
             return (byte[])(src.Clone());
         }
 
-        // Encode a byte array as an upper case hex string.
-        public static String ToHexStringUpper(this byte[] bytes)
+        // Encode a byte array as an array of upper-case hex characters.
+        public static char[] ToHexArrayUpper(this byte[] bytes)
         {
-            StringBuilder sb = new StringBuilder(bytes.Length * 2);
+            char[] chars = new char[bytes.Length * 2];
+            int i = 0;
             foreach (byte b in bytes)
             {
-                sb.AppendFormat("{0:X2}", b);
+                chars[i++] = NibbleToHex((byte)(b >> 4));
+                chars[i++] = NibbleToHex((byte)(b & 0xF));
             }
-            return sb.ToString();
+            return chars;
+        }
+
+        // Encode a byte array as an upper case hex string.
+        public static string ToHexStringUpper(this byte[] bytes)
+        {
+            return new string(ToHexArrayUpper(bytes));
         }
 
         // Decode a hex string-encoded byte array passed to various X509 crypto api. The parsing rules are overly forgiving but for compat reasons,
         // they cannot be tightened.
         public static byte[] DecodeHexString(this String s)
         {
-            String hexString = DiscardWhiteSpaces(s);
-            uint cbHex = (uint)hexString.Length / 2;
+            int whitespaceCount = 0;
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                if (Char.IsWhiteSpace(s[i]))
+                    whitespaceCount++;
+            }
+
+            uint cbHex = (uint)(s.Length - whitespaceCount) / 2;
             byte[] hex = new byte[cbHex];
-            int i = 0;
-            for (int index = 0; index < cbHex; index++)
+
+            for (int index = 0, i = 0; index < cbHex; index++)
             {
-                hex[index] = (byte)((HexToByte(hexString[i]) << 4) | HexToByte(hexString[i + 1]));
-                i += 2;
+                if (Char.IsWhiteSpace(s[i]))
+                {
+                    i++;
+                }
+                else
+                {
+                    hex[index] = (byte)((HexToByte(s[i]) << 4) | HexToByte(s[i + 1]));
+                    i += 2;
+                }
             }
+
             return hex;
-        }
-
-        private static String DiscardWhiteSpaces(String inputBuffer)
-        {
-            return DiscardWhiteSpaces(inputBuffer, 0, inputBuffer.Length);
-        }
-
-        private static String DiscardWhiteSpaces(String inputBuffer, int inputOffset, int inputCount)
-        {
-            int i, iCount = 0;
-            for (i = 0; i < inputCount; i++)
-            {
-                if (Char.IsWhiteSpace(inputBuffer[inputOffset + i]))
-                {
-                    iCount++;
-                }
-            }
-
-            char[] rgbOut = new char[inputCount - iCount];
-            iCount = 0;
-            for (i = 0; i < inputCount; i++)
-            {
-                if (!Char.IsWhiteSpace(inputBuffer[inputOffset + i]))
-                {
-                    rgbOut[iCount++] = inputBuffer[inputOffset + i];
-                }
-            }
-            return new String(rgbOut);
         }
 
         private static byte HexToByte(char val)
@@ -81,6 +74,14 @@ namespace Internal.Cryptography
                 return (byte)((val - 'A') + 10);
             else
                 return 0xFF;
+        }
+
+        private static char NibbleToHex(byte b)
+        {
+            Debug.Assert(b >= 0 && b <= 15);
+            return (char)(b >= 0 && b <= 9 ? 
+                '0' + b : 
+                'A' + (b - 10));
         }
 
         public static bool ContentsEqual(this byte[] a1, byte[] a2)
@@ -115,5 +116,3 @@ namespace Internal.Cryptography
         }
     }
 }
-
-

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -35,13 +35,13 @@ namespace Internal.Cryptography
 
         // Decode a hex string-encoded byte array passed to various X509 crypto api. The parsing rules are overly forgiving but for compat reasons,
         // they cannot be tightened.
-        public static byte[] DecodeHexString(this String s)
+        public static byte[] DecodeHexString(this string s)
         {
             int whitespaceCount = 0;
 
             for (int i = 0; i < s.Length; i++)
             {
-                if (Char.IsWhiteSpace(s[i]))
+                if (char.IsWhiteSpace(s[i]))
                     whitespaceCount++;
             }
 
@@ -50,7 +50,7 @@ namespace Internal.Cryptography
 
             for (int index = 0, i = 0; index < cbHex; index++)
             {
-                if (Char.IsWhiteSpace(s[i]))
+                if (char.IsWhiteSpace(s[i]))
                 {
                     i++;
                 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -41,7 +41,7 @@ namespace Internal.Cryptography.Pal
                 // We never want to stomp over certificate private keys.
                 cspParameters.Flags |= CspProviderFlags.UseExistingKey;
 
-                int algId = OidInfo.FindOidInfo(CryptOidInfoKeyType.CRYPT_OID_INFO_OID_KEY, this.KeyAlgorithm, OidGroup.PublicKeyAlgorithm, fallBackToAllGroups: true).AlgId;
+                int algId = OidInfo.FindOidInfo(CryptOidInfoKeyType.CRYPT_OID_INFO_OID_KEY, KeyAlgorithm, OidGroup.PublicKeyAlgorithm, fallBackToAllGroups: true).AlgId;
                 switch (algId)
                 {
                     case AlgId.CALG_RSA_KEYX:

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -396,7 +396,7 @@ namespace Internal.Cryptography.Pal
             CspKeyContainerInfo cspKeyContainerInfo = null;
             try
             {
-                if (this.HasPrivateKey)
+                if (HasPrivateKey)
                 {
                     CspParameters parameters = GetPrivateKey();
                     cspKeyContainerInfo = new CspKeyContainerInfo(parameters);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Find.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Find.cs
@@ -449,7 +449,7 @@ namespace Internal.Cryptography.Pal
             for (int i = 1; i < len; i++)
             {
                 // ensure every character is either a digit or a dot
-                if (Char.IsDigit(keyValue[i]))
+                if (char.IsDigit(keyValue[i]))
                     continue;
                 if (keyValue[i] != '.' || keyValue[i + 1] == '.') // disallow double dots
                     throw new ArgumentException(SR.Argument_InvalidOidValue);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -18,8 +18,8 @@ namespace System.Security.Cryptography.X509Certificates
         public PublicKey(Oid oid, AsnEncodedData parameters, AsnEncodedData keyValue)
         {
             _oid = new Oid(oid);
-            this.EncodedParameters = new AsnEncodedData(parameters);
-            this.EncodedKeyValue = new AsnEncodedData(keyValue);
+            EncodedParameters = new AsnEncodedData(parameters);
+            EncodedKeyValue = new AsnEncodedData(keyValue);
             return;
         }
 
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 AsymmetricAlgorithm key = _lazyKey;
                 if (key == null)
-                    key = _lazyKey = X509Pal.Instance.DecodePublicKey(this.Oid, this.EncodedKeyValue.RawData, this.EncodedParameters.RawData);
+                    key = _lazyKey = X509Pal.Instance.DecodePublicKey(Oid, EncodedKeyValue.RawData, EncodedParameters.RawData);
                 return key;
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
@@ -58,12 +58,12 @@ namespace System.Security.Cryptography.X509Certificates
         public String Decode(X500DistinguishedNameFlags flag)
         {
             ThrowIfInvalid(flag);
-            return X509Pal.Instance.X500DistinguishedNameDecode(this.RawData, flag);
+            return X509Pal.Instance.X500DistinguishedNameDecode(RawData, flag);
         }
 
         public override String Format(bool multiLine)
         {
-            return X509Pal.Instance.X500DistinguishedNameFormat(this.RawData, multiLine);
+            return X509Pal.Instance.X500DistinguishedNameFormat(RawData, multiLine);
         }
 
         private static byte[] Encode(String distinguishedName, X500DistinguishedNameFlags flags)

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509BasicConstraintsExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509BasicConstraintsExtension.cs
@@ -82,9 +82,9 @@ namespace System.Security.Cryptography.X509Certificates
         private void DecodeExtension()
         {
             if (Oid.Value == Oids.BasicConstraints)
-                X509Pal.Instance.DecodeX509BasicConstraintsExtension(this.RawData, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
+                X509Pal.Instance.DecodeX509BasicConstraintsExtension(RawData, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
             else
-                X509Pal.Instance.DecodeX509BasicConstraints2Extension(this.RawData, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
+                X509Pal.Instance.DecodeX509BasicConstraints2Extension(RawData, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
 
             _decoded = true;
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -278,7 +278,8 @@ namespace System.Security.Cryptography.X509Certificates
             sb.Append("  ");
             byte[] serialNumber = this.GetSerialNumber();
             Array.Reverse(serialNumber);
-            sb.AppendLine(serialNumber.ToHexStringUpper());
+            sb.Append(serialNumber.ToHexArrayUpper());
+            sb.AppendLine();
 
             // NotBefore
             sb.AppendLine();
@@ -296,7 +297,8 @@ namespace System.Security.Cryptography.X509Certificates
             sb.AppendLine();
             sb.AppendLine("[Thumbprint]");
             sb.Append("  ");
-            sb.AppendLine(this.GetCertHash().ToHexStringUpper());
+            sb.Append(this.GetCertHash().ToHexArrayUpper());
+            sb.AppendLine();
 
             return sb.ToString();
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -125,7 +125,7 @@ namespace System.Security.Cryptography.X509Certificates
             X509Certificate other = obj as X509Certificate;
             if (other == null)
                 return false;
-            return this.Equals(other);
+            return Equals(other);
         }
 
         public virtual bool Equals(X509Certificate other)
@@ -133,13 +133,13 @@ namespace System.Security.Cryptography.X509Certificates
             if (other == null)
                 return false;
 
-            if (this.Pal == null)
+            if (Pal == null)
                 return other.Pal == null;
 
-            if (!this.Issuer.Equals(other.Issuer))
+            if (!Issuer.Equals(other.Issuer))
                 return false;
 
-            byte[] thisSerialNumber = this.GetSerialNumber();
+            byte[] thisSerialNumber = GetSerialNumber();
             byte[] otherSerialNumber = other.GetSerialNumber();
             if (thisSerialNumber.Length != otherSerialNumber.Length)
                 return false;
@@ -264,19 +264,19 @@ namespace System.Security.Cryptography.X509Certificates
             // Subject
             sb.AppendLine("[Subject]");
             sb.Append("  ");
-            sb.AppendLine(this.Subject);
+            sb.AppendLine(Subject);
 
             // Issuer
             sb.AppendLine();
             sb.AppendLine("[Issuer]");
             sb.Append("  ");
-            sb.AppendLine(this.Issuer);
+            sb.AppendLine(Issuer);
 
             // Serial Number
             sb.AppendLine();
             sb.AppendLine("[Serial Number]");
             sb.Append("  ");
-            byte[] serialNumber = this.GetSerialNumber();
+            byte[] serialNumber = GetSerialNumber();
             Array.Reverse(serialNumber);
             sb.Append(serialNumber.ToHexArrayUpper());
             sb.AppendLine();
@@ -285,19 +285,19 @@ namespace System.Security.Cryptography.X509Certificates
             sb.AppendLine();
             sb.AppendLine("[Not Before]");
             sb.Append("  ");
-            sb.AppendLine(FormatDate(this.GetNotBefore()));
+            sb.AppendLine(FormatDate(GetNotBefore()));
 
             // NotAfter
             sb.AppendLine();
             sb.AppendLine("[Not After]");
             sb.Append("  ");
-            sb.AppendLine(FormatDate(this.GetNotAfter()));
+            sb.AppendLine(FormatDate(GetNotAfter()));
 
             // Thumbprint
             sb.AppendLine();
             sb.AppendLine("[Thumbprint]");
             sb.Append("  ");
-            sb.Append(this.GetCertHash().ToHexArrayUpper());
+            sb.Append(GetCertHash().ToHexArrayUpper());
             sb.AppendLine();
 
             return sb.ToString();

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -262,32 +262,42 @@ namespace System.Security.Cryptography.X509Certificates
             StringBuilder sb = new StringBuilder();
 
             // Subject
-            sb.Append("[Subject]" + Environment.NewLine + "  ");
-            sb.Append(this.Subject);
+            sb.AppendLine("[Subject]");
+            sb.Append("  ");
+            sb.AppendLine(this.Subject);
 
             // Issuer
-            sb.Append(Environment.NewLine + Environment.NewLine + "[Issuer]" + Environment.NewLine + "  ");
-            sb.Append(this.Issuer);
+            sb.AppendLine();
+            sb.AppendLine("[Issuer]");
+            sb.Append("  ");
+            sb.AppendLine(this.Issuer);
 
             // Serial Number
-            sb.Append(Environment.NewLine + Environment.NewLine + "[Serial Number]" + Environment.NewLine + "  ");
+            sb.AppendLine();
+            sb.AppendLine("[Serial Number]");
+            sb.Append("  ");
             byte[] serialNumber = this.GetSerialNumber();
             Array.Reverse(serialNumber);
-            sb.Append(serialNumber.ToHexStringUpper());
+            sb.AppendLine(serialNumber.ToHexStringUpper());
 
             // NotBefore
-            sb.Append(Environment.NewLine + Environment.NewLine + "[Not Before]" + Environment.NewLine + "  ");
-            sb.Append(FormatDate(this.GetNotBefore()));
+            sb.AppendLine();
+            sb.AppendLine("[Not Before]");
+            sb.Append("  ");
+            sb.AppendLine(FormatDate(this.GetNotBefore()));
 
             // NotAfter
-            sb.Append(Environment.NewLine + Environment.NewLine + "[Not After]" + Environment.NewLine + "  ");
-            sb.Append(FormatDate(this.GetNotAfter()));
+            sb.AppendLine();
+            sb.AppendLine("[Not After]");
+            sb.Append("  ");
+            sb.AppendLine(FormatDate(this.GetNotAfter()));
 
             // Thumbprint
-            sb.Append(Environment.NewLine + Environment.NewLine + "[Thumbprint]" + Environment.NewLine + "  ");
-            sb.Append(this.GetCertHash().ToHexStringUpper());
+            sb.AppendLine();
+            sb.AppendLine("[Thumbprint]");
+            sb.Append("  ");
+            sb.AppendLine(this.GetCertHash().ToHexStringUpper());
 
-            sb.Append(Environment.NewLine);
             return sb.ToString();
         }
 
@@ -362,4 +372,3 @@ namespace System.Security.Cryptography.X509Certificates
         private const X509KeyStorageFlags KeyStorageFlagsAll = (X509KeyStorageFlags)0x1f;
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -307,146 +307,156 @@ namespace System.Security.Cryptography.X509Certificates
                 return ToString();
 
             StringBuilder sb = new StringBuilder();
-            String newLine = Environment.NewLine;
-            String newLine2 = newLine + newLine;
-            String newLinesp2 = newLine + "  ";
 
             // Version
-            sb.Append("[Version]");
-            sb.Append(newLinesp2);
-            sb.Append("V" + this.Version);
+            sb.AppendLine("[Version]");
+            sb.Append("  V");
+            sb.Append(this.Version);
 
             // Subject
-            sb.Append(newLine2);
-            sb.Append("[Subject]");
-            sb.Append(newLinesp2);
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("[Subject]");
+            sb.Append("  ");
             sb.Append(this.SubjectName.Name);
             String simpleName = GetNameInfo(X509NameType.SimpleName, false);
             if (simpleName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("Simple Name: ");
                 sb.Append(simpleName);
             }
             String emailName = GetNameInfo(X509NameType.EmailName, false);
             if (emailName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("Email Name: ");
                 sb.Append(emailName);
             }
             String upnName = GetNameInfo(X509NameType.UpnName, false);
             if (upnName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("UPN Name: ");
                 sb.Append(upnName);
             }
             String dnsName = GetNameInfo(X509NameType.DnsName, false);
             if (dnsName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("DNS Name: ");
                 sb.Append(dnsName);
             }
 
             // Issuer
-            sb.Append(newLine2);
-            sb.Append("[Issuer]");
-            sb.Append(newLinesp2);
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("[Issuer]");
+            sb.Append("  ");
             sb.Append(this.IssuerName.Name);
             simpleName = GetNameInfo(X509NameType.SimpleName, true);
             if (simpleName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("Simple Name: ");
                 sb.Append(simpleName);
             }
             emailName = GetNameInfo(X509NameType.EmailName, true);
             if (emailName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("Email Name: ");
                 sb.Append(emailName);
             }
             upnName = GetNameInfo(X509NameType.UpnName, true);
             if (upnName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("UPN Name: ");
                 sb.Append(upnName);
             }
             dnsName = GetNameInfo(X509NameType.DnsName, true);
             if (dnsName.Length > 0)
             {
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("DNS Name: ");
                 sb.Append(dnsName);
             }
 
             // Serial Number
-            sb.Append(newLine2);
-            sb.Append("[Serial Number]");
-            sb.Append(newLinesp2);
-            sb.Append(this.SerialNumber);
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("[Serial Number]");
+            sb.Append("  ");
+            sb.AppendLine(this.SerialNumber);
 
             // NotBefore
-            sb.Append(newLine2);
-            sb.Append("[Not Before]");
-            sb.Append(newLinesp2);
-            sb.Append(FormatDate(this.NotBefore));
+            sb.AppendLine();
+            sb.AppendLine("[Not Before]");
+            sb.Append("  ");
+            sb.AppendLine(FormatDate(this.NotBefore));
 
             // NotAfter
-            sb.Append(newLine2);
-            sb.Append("[Not After]");
-            sb.Append(newLinesp2);
-            sb.Append(FormatDate(this.NotAfter));
+            sb.AppendLine();
+            sb.AppendLine("[Not After]");
+            sb.Append("  ");
+            sb.AppendLine(FormatDate(this.NotAfter));
 
             // Thumbprint
-            sb.Append(newLine2);
-            sb.Append("[Thumbprint]");
-            sb.Append(newLinesp2);
-            sb.Append(this.Thumbprint);
+            sb.AppendLine();
+            sb.AppendLine("[Thumbprint]");
+            sb.Append("  ");
+            sb.AppendLine(this.Thumbprint);
 
             // Signature Algorithm
-            sb.Append(newLine2);
-            sb.Append("[Signature Algorithm]");
-            sb.Append(newLinesp2);
-            sb.Append(this.SignatureAlgorithm.FriendlyName + "(" + this.SignatureAlgorithm.Value + ")");
+            sb.AppendLine();
+            sb.AppendLine("[Signature Algorithm]");
+            sb.Append("  ");
+            sb.Append(this.SignatureAlgorithm.FriendlyName);
+            sb.Append('(');
+            sb.Append(this.SignatureAlgorithm.Value);
+            sb.AppendLine(")");
 
             // Public Key
-            sb.Append(newLine2);
+            sb.AppendLine();
             sb.Append("[Public Key]");
             // It could throw if it's some user-defined CryptoServiceProvider
             try
             {
                 PublicKey pubKey = this.PublicKey;
 
-                String temp = pubKey.Oid.FriendlyName;
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("Algorithm: ");
-                sb.Append(temp);
+                sb.Append(pubKey.Oid.FriendlyName);
                 // So far, we only support RSACryptoServiceProvider & DSACryptoServiceProvider Keys
                 try
                 {
-                    temp = pubKey.Key.KeySize.ToString();
-                    sb.Append(newLinesp2);
+                    sb.AppendLine();
+                    sb.Append("  ");
                     sb.Append("Length: ");
-                    sb.Append(temp);
+                    sb.Append(pubKey.Key.KeySize);
                 }
                 catch (NotSupportedException)
                 {
                 }
 
-                temp = pubKey.EncodedKeyValue.Format(true);
-                sb.Append(newLinesp2);
+                sb.AppendLine();
+                sb.Append("  ");
                 sb.Append("Key Blob: ");
-                sb.Append(temp);
+                sb.AppendLine(pubKey.EncodedKeyValue.Format(true));
 
-                temp = pubKey.EncodedParameters.Format(true);
-                sb.Append(newLinesp2);
+                sb.Append("  ");
                 sb.Append("Parameters: ");
-                sb.Append(temp);
+                sb.Append(pubKey.EncodedParameters.Format(true));
             }
             catch (CryptographicException)
             {
@@ -459,21 +469,23 @@ namespace System.Security.Cryptography.X509Certificates
             X509ExtensionCollection extensions = this.Extensions;
             if (extensions.Count > 0)
             {
-                sb.Append(newLine2);
+                sb.AppendLine();
+                sb.AppendLine();
                 sb.Append("[Extensions]");
-                String temp;
                 foreach (X509Extension extension in extensions)
                 {
                     try
                     {
-                        temp = extension.Oid.FriendlyName;
-                        sb.Append(newLine);
-                        sb.Append("* " + temp);
-                        sb.Append("(" + extension.Oid.Value + "):");
+                        sb.AppendLine();
+                        sb.Append("* ");
+                        sb.Append(extension.Oid.FriendlyName);
+                        sb.Append('(');
+                        sb.Append(extension.Oid.Value);
+                        sb.Append("):");
 
-                        temp = extension.Format(true);
-                        sb.Append(newLinesp2);
-                        sb.Append(temp);
+                        sb.AppendLine();
+                        sb.Append("  ");
+                        sb.Append(extension.Format(true));
                     }
                     catch (CryptographicException)
                     {
@@ -481,7 +493,7 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            sb.Append(newLine);
+            sb.AppendLine();
             return sb.ToString();
         }
 
@@ -518,4 +530,3 @@ namespace System.Security.Cryptography.X509Certificates
         private volatile X509ExtensionCollection _lazyExtensions;
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -157,7 +157,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
-                if (!this.HasPrivateKey)
+                if (!HasPrivateKey)
                     return null;
 
                 AsymmetricAlgorithm privateKey = _lazyPrivateKey;
@@ -170,7 +170,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
-                AsymmetricAlgorithm publicKey = this.PublicKey.Key;
+                AsymmetricAlgorithm publicKey = PublicKey.Key;
                 Pal.SetPrivateKey(value, publicKey);
                 _lazyPrivateKey = value;
             }
@@ -185,9 +185,9 @@ namespace System.Security.Cryptography.X509Certificates
                 PublicKey publicKey = _lazyPublicKey;
                 if (publicKey == null)
                 {
-                    String keyAlgorithmOid = this.GetKeyAlgorithm();
-                    byte[] parameters = this.GetKeyAlgorithmParameters();
-                    byte[] keyValue = this.GetPublicKey();
+                    String keyAlgorithmOid = GetKeyAlgorithm();
+                    byte[] parameters = GetKeyAlgorithmParameters();
+                    byte[] keyValue = GetPublicKey();
                     Oid oid = new Oid(keyAlgorithmOid);
                     publicKey = _lazyPublicKey = new PublicKey(oid, new AsnEncodedData(oid, parameters), new AsnEncodedData(oid, keyValue));
                 }
@@ -311,14 +311,14 @@ namespace System.Security.Cryptography.X509Certificates
             // Version
             sb.AppendLine("[Version]");
             sb.Append("  V");
-            sb.Append(this.Version);
+            sb.Append(Version);
 
             // Subject
             sb.AppendLine();
             sb.AppendLine();
             sb.AppendLine("[Subject]");
             sb.Append("  ");
-            sb.Append(this.SubjectName.Name);
+            sb.Append(SubjectName.Name);
             String simpleName = GetNameInfo(X509NameType.SimpleName, false);
             if (simpleName.Length > 0)
             {
@@ -357,7 +357,7 @@ namespace System.Security.Cryptography.X509Certificates
             sb.AppendLine();
             sb.AppendLine("[Issuer]");
             sb.Append("  ");
-            sb.Append(this.IssuerName.Name);
+            sb.Append(IssuerName.Name);
             simpleName = GetNameInfo(X509NameType.SimpleName, true);
             if (simpleName.Length > 0)
             {
@@ -396,33 +396,33 @@ namespace System.Security.Cryptography.X509Certificates
             sb.AppendLine();
             sb.AppendLine("[Serial Number]");
             sb.Append("  ");
-            sb.AppendLine(this.SerialNumber);
+            sb.AppendLine(SerialNumber);
 
             // NotBefore
             sb.AppendLine();
             sb.AppendLine("[Not Before]");
             sb.Append("  ");
-            sb.AppendLine(FormatDate(this.NotBefore));
+            sb.AppendLine(FormatDate(NotBefore));
 
             // NotAfter
             sb.AppendLine();
             sb.AppendLine("[Not After]");
             sb.Append("  ");
-            sb.AppendLine(FormatDate(this.NotAfter));
+            sb.AppendLine(FormatDate(NotAfter));
 
             // Thumbprint
             sb.AppendLine();
             sb.AppendLine("[Thumbprint]");
             sb.Append("  ");
-            sb.AppendLine(this.Thumbprint);
+            sb.AppendLine(Thumbprint);
 
             // Signature Algorithm
             sb.AppendLine();
             sb.AppendLine("[Signature Algorithm]");
             sb.Append("  ");
-            sb.Append(this.SignatureAlgorithm.FriendlyName);
+            sb.Append(SignatureAlgorithm.FriendlyName);
             sb.Append('(');
-            sb.Append(this.SignatureAlgorithm.Value);
+            sb.Append(SignatureAlgorithm.Value);
             sb.AppendLine(")");
 
             // Public Key
@@ -431,7 +431,7 @@ namespace System.Security.Cryptography.X509Certificates
             // It could throw if it's some user-defined CryptoServiceProvider
             try
             {
-                PublicKey pubKey = this.PublicKey;
+                PublicKey pubKey = PublicKey;
 
                 sb.AppendLine();
                 sb.Append("  ");
@@ -466,7 +466,7 @@ namespace System.Security.Cryptography.X509Certificates
             Pal.AppendPrivateKeyInfo(sb);
 
             // Extensions
-            X509ExtensionCollection extensions = this.Extensions;
+            X509ExtensionCollection extensions = Extensions;
             if (extensions.Count > 0)
             {
                 sb.AppendLine();

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -21,17 +21,17 @@ namespace System.Security.Cryptography.X509Certificates
 
         public X509Certificate2Collection(X509Certificate2 certificate)
         {
-            this.Add(certificate);
+            Add(certificate);
         }
 
         public X509Certificate2Collection(X509Certificate2[] certificates)
         {
-            this.AddRange(certificates);
+            AddRange(certificates);
         }
 
         public X509Certificate2Collection(X509Certificate2Collection certificates)
         {
-            this.AddRange(certificates);
+            AddRange(certificates);
         }
 
         public new X509Certificate2 this[int index]

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using Interlocked = System.Threading.Interlocked;
 
@@ -49,7 +50,11 @@ namespace System.Security.Cryptography.X509Certificates
         {
             get
             {
-                return Interlocked.CompareExchange(ref _syncRoot, new Object(), null);
+                if (_syncRoot == null)
+                {
+                    Interlocked.CompareExchange(ref _syncRoot, new object(), null);
+                }
+                return _syncRoot;
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
@@ -27,13 +27,13 @@ namespace System.Security.Cryptography.X509Certificates
         public X509CertificateCollection(X509Certificate[] value)
             : this()
         {
-            this.AddRange(value);
+            AddRange(value);
         }
 
         public X509CertificateCollection(X509CertificateCollection value)
             : this()
         {
-            this.AddRange(value);
+            AddRange(value);
         }
 
         public int Count
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             for (int i = 0; i < value.Length; i++)
             {
-                this.Add(value[i]);
+                Add(value[i]);
             }
         }
 
@@ -125,7 +125,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             for (int i = 0; i < value.Count; i++)
             {
-                this.Add(value[i]);
+                Add(value[i]);
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 Reset();
 
-                X509ChainPolicy chainPolicy = this.ChainPolicy;
+                X509ChainPolicy chainPolicy = ChainPolicy;
                 _pal = ChainPal.BuildChain(
                     false,
                     certificate.Pal,

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
@@ -58,10 +58,10 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
             if (index < 0 || index >= array.Length)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
-            if (index + this.Count > array.Length)
+            if (index + Count > array.Length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            for (int i = 0; i < this.Count; i++)
+            for (int i = 0; i < Count; i++)
             {
                 array.SetValue(this[i], index);
                 index++;

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (!_decoded)
                 {
-                    X509Pal.Instance.DecodeX509EnhancedKeyUsageExtension(this.RawData, out _enhancedKeyUsages);
+                    X509Pal.Instance.DecodeX509EnhancedKeyUsageExtension(RawData, out _enhancedKeyUsages);
                     _decoded = true;
                 }
                 return _enhancedKeyUsages;

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
@@ -83,10 +83,10 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
             if (index < 0 || index >= array.Length)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
-            if (index + this.Count > array.Length)
+            if (index + Count > array.Length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            for (int i = 0; i < this.Count; i++)
+            for (int i = 0; i < Count; i++)
             {
                 array.SetValue(this[i], index);
                 index++;

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (!_decoded)
                 {
-                    X509Pal.Instance.DecodeX509KeyUsageExtension(this.RawData, out _keyUsages);
+                    X509Pal.Instance.DecodeX509KeyUsageExtension(RawData, out _keyUsages);
                     _decoded = true;
                 }
                 return _keyUsages;

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -28,34 +28,34 @@ namespace System.Security.Cryptography.X509Certificates
             switch (storeName)
             {
                 case StoreName.AddressBook:
-                    this.Name = "AddressBook";
+                    Name = "AddressBook";
                     break;
                 case StoreName.AuthRoot:
-                    this.Name = "AuthRoot";
+                    Name = "AuthRoot";
                     break;
                 case StoreName.CertificateAuthority:
-                    this.Name = "CA";
+                    Name = "CA";
                     break;
                 case StoreName.Disallowed:
-                    this.Name = "Disallowed";
+                    Name = "Disallowed";
                     break;
                 case StoreName.My:
-                    this.Name = "My";
+                    Name = "My";
                     break;
                 case StoreName.Root:
-                    this.Name = "Root";
+                    Name = "Root";
                     break;
                 case StoreName.TrustedPeople:
-                    this.Name = "TrustedPeople";
+                    Name = "TrustedPeople";
                     break;
                 case StoreName.TrustedPublisher:
-                    this.Name = "TrustedPublisher";
+                    Name = "TrustedPublisher";
                     break;
                 default:
                     throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "storeName"));
             }
 
-            this.Location = storeLocation;
+            Location = storeLocation;
             return;
         }
 
@@ -64,8 +64,8 @@ namespace System.Security.Cryptography.X509Certificates
             if (storeLocation != StoreLocation.CurrentUser && storeLocation != StoreLocation.LocalMachine)
                 throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "storeLocation"));
 
-            this.Location = storeLocation;
-            this.Name = storeName;
+            Location = storeLocation;
+            Name = storeName;
             return;
         }
 
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.X509Certificates
         public void Open(OpenFlags flags)
         {
             Close();
-            _storePal = StorePal.FromSystemStore(this.Name, this.Location, flags);
+            _storePal = StorePal.FromSystemStore(Name, Location, flags);
             return;
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.X509Certificates
                 if (!_decoded)
                 {
                     byte[] subjectKeyIdentifierValue;
-                    X509Pal.Instance.DecodeX509SubjectKeyIdentifierExtension(this.RawData, out subjectKeyIdentifierValue);
+                    X509Pal.Instance.DecodeX509SubjectKeyIdentifierExtension(RawData, out subjectKeyIdentifierValue);
                     _subjectKeyIdentifier = subjectKeyIdentifierValue.ToHexStringUpper();
                     _decoded = true;
                 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -105,6 +105,30 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void X509CertEmptyToString()
+        {
+            using (var c = new X509Certificate())
+            {
+                string expectedResult = "System.Security.Cryptography.X509Certificates.X509Certificate";
+                Assert.Equal(expectedResult, c.ToString());
+                Assert.Equal(expectedResult, c.ToString(false));
+                Assert.Equal(expectedResult, c.ToString(true));
+            }
+        }
+
+        [Fact]
+        public static void X509Cert2EmptyToString()
+        {
+            using (var c2 = new X509Certificate2())
+            {
+                string expectedResult = "System.Security.Cryptography.X509Certificates.X509Certificate2";
+                Assert.Equal(expectedResult, c2.ToString());
+                Assert.Equal(expectedResult, c2.ToString(false));
+                Assert.Equal(expectedResult, c2.ToString(true));
+            }
+        }
+
+        [Fact]
         [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2ToStringVerbose()
         {
@@ -113,7 +137,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             foreach (X509Certificate2 c in store.Certificates)
             {
-                Assert.NotNull(c.ToString(true));
+                Assert.False(string.IsNullOrWhiteSpace(c.ToString(true)));
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -317,6 +317,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TestExportStore(X509ContentType.Pkcs7);
         }
 
+        [Fact]
+        public static void X509CertificateCollectionSyncRoot()
+        {
+            var cc = new X509CertificateCollection();
+            Assert.NotNull(((ICollection)cc).SyncRoot);
+            Assert.Same(((ICollection)cc).SyncRoot, ((ICollection)cc).SyncRoot);
+        }
+
         private static void TestExportSingleCert(X509ContentType ct)
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))


### PR DESCRIPTION
This addresses three of the items listed in https://github.com/dotnet/corefx/issues/1995, mostly related to reducing allocations:

1. "Internal.Cryptography.Helpers::DecodeHexString should skip whitespace, not use a string-allocating interior trim method"
2. "X509Certificate.ToString() and X509Certificate2.ToString() do a lot of allocations, try to reduce them"
3. "SyncRoot allocates a new object every call (which is thrown away on all calls aside from the first)"

The third one also addresses a bug: SyncRoot was returning null the first time it was accessed.