### PR TITLE
Disable several FileSystemWatcher tests failing on OSX

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
@@ -9,6 +9,7 @@ using Xunit;
 public partial class FileSystemWatcher_4000_Tests
 {
     [Fact]
+    [ActiveIssue(2011, PlatformID.OSX)]
     public static void FileSystemWatcher_Changed_LastWrite_File()
     {
         using (var file = Utility.CreateTestFile())
@@ -26,6 +27,7 @@ public partial class FileSystemWatcher_4000_Tests
     }
 
     [Fact]
+    [ActiveIssue(2011, PlatformID.OSX)]
     public static void FileSystemWatcher_Changed_LastWrite_Directory()
     {
         using (var dir = Utility.CreateTestDirectory())

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -45,6 +45,7 @@ public partial class FileSystemWatcher_4000_Tests
     }
 
     [Fact]
+    [ActiveIssue(2011, PlatformID.OSX)]
     public static void FileSystemWatcher_Created_MoveDirectory()
     {
         // create two test directories


### PR DESCRIPTION
Opened #2011 to track.