### PR TITLE
Assign _safeProvHandle when importing public keys.

### DIFF
--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
@@ -308,6 +308,7 @@ namespace System.Security.Cryptography
                 SafeProvHandle safeProvHandleTemp = SafeProvHandle.InvalidHandle;
                 AcquireSafeProviderHandle(ref safeProvHandleTemp);
                 CapiHelper.ImportKeyBlob(safeProvHandleTemp, (CspProviderFlags)0, keyBlob, ref _safeKeyHandle);
+                _safeProvHandle = safeProvHandleTemp;
             }
             else
             {

--- a/src/System.Security.Cryptography.RSA/tests/SignVerify.cs
+++ b/src/System.Security.Cryptography.RSA/tests/SignVerify.cs
@@ -158,7 +158,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1888, PlatformID.Windows)]
         [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifySignature_SHA1_2048()
         {
@@ -202,7 +201,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1888, PlatformID.Windows)]
         [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifySignature_SHA256_1024()
         {
@@ -230,7 +228,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1888, PlatformID.Windows)]
         [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifySignature_SHA256_2048()
         {
@@ -494,7 +491,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1888, PlatformID.Windows)]
         [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifyHashSignature_SHA1_2048()
         {
@@ -545,7 +541,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1888, PlatformID.Windows)]
         [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifyHashSignature_SHA256_1024()
         {
@@ -580,7 +575,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1888, PlatformID.Windows)]
         [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifyHashSignature_SHA256_2048()
         {


### PR DESCRIPTION
Resolves #1888.