### PR TITLE
Enable file-load tests for X509Certificates

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -10,13 +10,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class CertTests
     {
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509CertTest()
         {
             const string CertSubject =
                 @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
 
-            using (X509Certificate cert = new X509Certificate("microsoft.cer"))
+            using (X509Certificate cert = new X509Certificate("TestData\\microsoft.cer"))
             {
                 Assert.Equal(CertSubject, cert.Subject);
                 Assert.Equal(CertSubject, cert.Issuer);
@@ -50,13 +50,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2Test()
         {
             const string CertName =
                 @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US";
 
-            using (X509Certificate2 cert2 = new X509Certificate2("test.cer"))
+            using (X509Certificate2 cert2 = new X509Certificate2("TestData\\test.cer"))
             {
                 Assert.Equal(CertName, cert2.IssuerName.Name);
                 Assert.Equal(CertName, cert2.SubjectName.Name);
@@ -118,10 +118,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2CreateFromPfxFile()
         {
-            using (X509Certificate2 cert2 = new X509Certificate2("DummyTcpServer.pfx"))
+            using (X509Certificate2 cert2 = new X509Certificate2("TestData\\DummyTcpServer.pfx"))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());
@@ -129,10 +129,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2CreateFromPfxWithPassword()
         {
-            using (X509Certificate2 cert2 = new X509Certificate2("test.pfx", "test"))
+            using (X509Certificate2 cert2 = new X509Certificate2("TestData\\test.pfx", "test"))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Text;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -16,7 +15,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             const string CertSubject =
                 @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
 
-            using (X509Certificate cert = new X509Certificate("TestData\\microsoft.cer"))
+            using (X509Certificate cert = new X509Certificate(Path.Combine("TestData", "microsoft.cer")))
             {
                 Assert.Equal(CertSubject, cert.Subject);
                 Assert.Equal(CertSubject, cert.Issuer);
@@ -56,7 +55,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             const string CertName =
                 @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US";
 
-            using (X509Certificate2 cert2 = new X509Certificate2("TestData\\test.cer"))
+            DateTime notBefore = new DateTime(1999, 7, 12, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
+            DateTime notAfter = new DateTime(2009, 7, 9, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
+
+            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.cer")))
             {
                 Assert.Equal(CertName, cert2.IssuerName.Name);
                 Assert.Equal(CertName, cert2.SubjectName.Name);
@@ -67,8 +69,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.True(pubKey.Key is RSACryptoServiceProvider);
                 Assert.Equal("RSA", pubKey.Oid.FriendlyName);
 
-                Assert.Equal(new DateTime(2009, 7, 9, 10, 33, 53), cert2.NotAfter);
-                Assert.Equal(new DateTime(1999, 7, 12, 10, 33, 53), cert2.NotBefore);
+                Assert.Equal(notAfter, cert2.NotAfter);
+                Assert.Equal(notBefore, cert2.NotBefore);
 
                 Assert.Equal("00D01E4090000046520000000100000004", cert2.SerialNumber);
                 Assert.Equal("1.2.840.113549.1.1.5", cert2.SignatureAlgorithm.Value);
@@ -121,7 +123,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2CreateFromPfxFile()
         {
-            using (X509Certificate2 cert2 = new X509Certificate2("TestData\\DummyTcpServer.pfx"))
+            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "DummyTcpServer.pfx")))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());
@@ -132,7 +134,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2CreateFromPfxWithPassword()
         {
-            using (X509Certificate2 cert2 = new X509Certificate2("TestData\\test.pfx", "test"))
+            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.pfx"), "test"))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -3,7 +3,7 @@
 
 using System.Linq;
 using System.Collections;
-
+using System.IO;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -274,7 +274,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             {
                 X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(@"TestData\My.pfx", TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet);
+                cc2.Import(Path.Combine("TestData" ,"My.pfx"), TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet);
                 int count = cc2.Count;
                 Assert.Equal(1, count);
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -268,7 +268,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportFromFileTests()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class LoadFromFileTests
     {
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestIssuer()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSubject()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSerial()
         {
             byte[] expectedSerial = "b00000000100dd9f3bd08b0aaf11b000000033".HexToByteArray();
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestThumbprint()
         {
             byte[] expectedThumbPrint = "108e2ba23632620c427c570b6d9db51ac31387fe".HexToByteArray();
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetFormat()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetKeyAlgorithm()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetKeyAlgorithmParameters()
         {
             string expected = "0500";
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetPublicKey()
         {
             byte[] expectedPublicKey = (
@@ -123,7 +123,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestLoadSignedFile()
         {
             // X509Certificate2 can also extract the certificate from a signed file.

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -128,7 +128,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             // X509Certificate2 can also extract the certificate from a signed file.
 
-            string path = @"TestData\Windows6.1-KB3004361-x64.msu";
+            string path = Path.Combine("TestData", "Windows6.1-KB3004361-x64.msu");
             if (!File.Exists(path))
                 throw new Exception(string.Format("Test infrastructure failure: Expected to find file \"{0}\".", path));
 
@@ -152,9 +152,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         private static X509Certificate2 LoadCertificateFromFile()
         {
-            string path = @"TestData\Ms.cer";
+            string path = Path.Combine("TestData", "Ms.cer");
             if (!File.Exists(path))
-                throw new Exception(String.Format("Test infrastructure failure: Expected to find file \"{0}\".", path));
+                throw new Exception(string.Format("Test infrastructure failure: Expected to find file \"{0}\".", path));
             byte[] data = File.ReadAllBytes(path);
             Assert.Equal(TestData.MsCertificate, data);
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -121,7 +121,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestContentType()
         {
-            String fileName = @"TestData\My.pfx";
+            string fileName = Path.Combine("TestData", "My.pfx");
             if (!File.Exists(fileName))
                 throw new Exception("Test infrastructure failure: Expected to find file: \"" + fileName + "\".");
             X509ContentType ct = X509Certificate2.GetCertContentType(fileName);

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1977, PlatformID.Any)]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestContentType()
         {
             String fileName = @"TestData\My.pfx";

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -39,4 +39,19 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Temporary until we have new work in build tools to
+       deploy content from nuget packages -->
+  <Target Name="CopyX509TestDataToTestDirectory" AfterTargets="CopyTestToTestDirectory" Inputs="$(PackagesDir)$(X509TestPackage)\content" Outputs="$(TestPath)%(TestTargetFramework.Folder)\*.*">
+    <PropertyGroup>
+      <X509TestPackage>System.Security.Cryptography.X509Certificates.TestData\1.0.0-prerelease</X509TestPackage>
+      <TestTargetFrameworkFolder>%(TestTargetFramework.Folder)</TestTargetFrameworkFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <X509TestDataSrc Include="$(PackagesDir)$(X509TestPackage)\content\**\*.*" />
+      <X509TestDataDest Include="@(X509TestDataSrc->'$(TestPath)$(TestTargetFrameworkFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(X509TestDataSrc)" DestinationFiles="@(X509TestDataDest)" SkipUnchangedFiles="$(SkipCopyUnchangedFiles)" OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)" Retries="$(CopyRetryCount)" RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -8,6 +8,7 @@
     "System.Security.Cryptography.Encoding": "4.0.0-beta-*",
     "System.Security.Cryptography.Encryption": "4.0.0-beta-*",
     "System.Security.Cryptography.RSA": "4.0.0-beta-*",
+    "System.Security.Cryptography.X509Certificates.TestData": "1.0.0-prerelease",
     "xunit": "2.0.0-beta5-build2785",
     "xunit.abstractions.netcore": "1.0.0-prerelease",
     "xunit.assert": "2.0.0-beta5-build2785",

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.lock.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.lock.json
@@ -313,6 +313,7 @@
           "lib/DNXCore50/System.Security.Cryptography.RSA.dll"
         ]
       },
+      "System.Security.Cryptography.X509Certificates.TestData/1.0.0-prerelease": {},
       "System.Text.Encoding/4.0.10-beta-23008": {
         "dependencies": {
           "System.Runtime": "4.0.0-beta-23008"
@@ -757,6 +758,22 @@
         "ref/net46/System.Security.Cryptography.RSA.dll"
       ]
     },
+    "System.Security.Cryptography.X509Certificates.TestData/1.0.0-prerelease": {
+      "sha512": "UbpXPyovZcwfKhYg/O85pLjFEO3hkrEjCLGus7P9y45Peoqrfc8XKzdCW5k5WIDCtLw9M1PJHGlOFV/U0D1tkg==",
+      "files": [
+        "System.Security.Cryptography.X509Certificates.TestData.1.0.0-prerelease.nupkg",
+        "System.Security.Cryptography.X509Certificates.TestData.1.0.0-prerelease.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.TestData.nuspec",
+        "content/TestData/DummyTcpServer.pfx",
+        "content/TestData/microsoft.cer",
+        "content/TestData/MS.cer",
+        "content/TestData/My.cer",
+        "content/TestData/My.pfx",
+        "content/TestData/test.cer",
+        "content/TestData/test.pfx",
+        "content/TestData/Windows6.1-KB3004361-x64.msu"
+      ]
+    },
     "System.Text.Encoding/4.0.10-beta-23008": {
       "sha512": "dDcnfqdj6stUj1o1mNZIxEDTI0er7TVER+CVcng+6rEejErS5HQjIEsuEepQSiAF3VDiZu8ZI89RAUuQbCSjEw==",
       "files": [
@@ -952,6 +969,7 @@
       "System.Security.Cryptography.Encoding >= 4.0.0-beta-*",
       "System.Security.Cryptography.Encryption >= 4.0.0-beta-*",
       "System.Security.Cryptography.RSA >= 4.0.0-beta-*",
+      "System.Security.Cryptography.X509Certificates.TestData >= 1.0.0-prerelease",
       "xunit >= 2.0.0-beta5-build2785",
       "xunit.abstractions.netcore >= 1.0.0-prerelease",
       "xunit.assert >= 2.0.0-beta5-build2785",


### PR DESCRIPTION
For the Unix implementation the removal of the 1977 ActiveIssue required adding the 1993 ActiveIssue, since file-load is not yet implemented for the Unix builds.

Borrowed the package unpack/copy target from the System.IO.Compression tests.