### PR TITLE
Use String.Equals instead of String.Compare for equality checks

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -578,12 +578,12 @@ namespace System.IO
 
             StringComparison pathComparison = PathInternal.GetComparison();
 
-            if (String.Compare(sourcePath, destPath, pathComparison) == 0)
+            if (String.Equals(sourcePath, destPath, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
             String sourceRoot = Path.GetPathRoot(sourcePath);
             String destinationRoot = Path.GetPathRoot(destPath);
-            if (String.Compare(sourceRoot, destinationRoot, pathComparison) != 0)
+            if (!String.Equals(sourceRoot, destinationRoot, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
             FileSystem.Current.MoveDirectory(fullsourceDirName, fulldestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -418,13 +418,13 @@ namespace System.IO
                 fullSourcePath = FullPath + PathHelpers.DirectorySeparatorCharAsString;
 
             StringComparison pathComparison = PathInternal.GetComparison();
-            if (String.Compare(fullSourcePath, fullDestDirName, pathComparison) == 0)
+            if (String.Equals(fullSourcePath, fullDestDirName, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
             String sourceRoot = Path.GetPathRoot(fullSourcePath);
             String destinationRoot = Path.GetPathRoot(fullDestDirName);
 
-            if (String.Compare(sourceRoot, destinationRoot, pathComparison) != 0)
+            if (!String.Equals(sourceRoot, destinationRoot, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
             FileSystem.Current.MoveDirectory(FullPath, fullDestDirName);

--- a/src/System.Net.Http/src/System/Net/Headers/AuthenticationHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/AuthenticationHeaderValue.cs
@@ -74,19 +74,19 @@ namespace System.Net.Http.Headers
 
             if (string.IsNullOrEmpty(_parameter) && string.IsNullOrEmpty(other._parameter))
             {
-                return (string.Compare(_scheme, other._scheme, StringComparison.OrdinalIgnoreCase) == 0);
+                return (string.Equals(_scheme, other._scheme, StringComparison.OrdinalIgnoreCase));
             }
             else
             {
                 // Since we can't parse the parameter, we use case-sensitive comparison.
-                return (string.Compare(_scheme, other._scheme, StringComparison.OrdinalIgnoreCase) == 0) &&
-                    (string.CompareOrdinal(_parameter, other._parameter) == 0);
+                return string.Equals(_scheme, other._scheme, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(_parameter, other._parameter, StringComparison.Ordinal);
             }
         }
 
         public override int GetHashCode()
         {
-            int result = _scheme.ToLowerInvariant().GetHashCode();
+            int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_scheme);
 
             if (!string.IsNullOrEmpty(_parameter))
             {

--- a/src/System.Net.Http/src/System/Net/Headers/CacheControlHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/CacheControlHeaderValue.cs
@@ -333,7 +333,7 @@ namespace System.Net.Http.Headers
             {
                 foreach (var noCacheHeader in _noCacheHeaders)
                 {
-                    result = result ^ noCacheHeader.ToLowerInvariant().GetHashCode();
+                    result = result ^ StringComparer.OrdinalIgnoreCase.GetHashCode(noCacheHeader);
                 }
             }
 
@@ -341,7 +341,7 @@ namespace System.Net.Http.Headers
             {
                 foreach (var privateHeader in _privateHeaders)
                 {
-                    result = result ^ privateHeader.ToLowerInvariant().GetHashCode();
+                    result = result ^ StringComparer.OrdinalIgnoreCase.GetHashCode(privateHeader);
                 }
             }
 

--- a/src/System.Net.Http/src/System/Net/Headers/ContentDispositionHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/ContentDispositionHeaderValue.cs
@@ -178,14 +178,14 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return (string.Compare(_dispositionType, other._dispositionType, StringComparison.OrdinalIgnoreCase) == 0) &&
+            return string.Equals(_dispositionType, other._dispositionType, StringComparison.OrdinalIgnoreCase) &&
                 HeaderUtilities.AreEqualCollections(_parameters, other._parameters);
         }
 
         public override int GetHashCode()
         {
             // The dispositionType string is case-insensitive.
-            return _dispositionType.ToLowerInvariant().GetHashCode() ^ NameValueHeaderValue.GetHashCode(_parameters);
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(_dispositionType) ^ NameValueHeaderValue.GetHashCode(_parameters);
         }
 
         // Implement ICloneable explicitly to allow derived types to "override" the implementation.

--- a/src/System.Net.Http/src/System/Net/Headers/ContentRangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/ContentRangeHeaderValue.cs
@@ -127,12 +127,12 @@ namespace System.Net.Http.Headers
             }
 
             return ((_from == other._from) && (_to == other._to) && (_length == other._length) &&
-                (string.Compare(_unit, other._unit, StringComparison.OrdinalIgnoreCase) == 0));
+                string.Equals(_unit, other._unit, StringComparison.OrdinalIgnoreCase));
         }
 
         public override int GetHashCode()
         {
-            int result = _unit.ToLowerInvariant().GetHashCode();
+            int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_unit);
 
             if (HasRange)
             {

--- a/src/System.Net.Http/src/System/Net/Headers/EntityTagHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/EntityTagHeaderValue.cs
@@ -92,7 +92,7 @@ namespace System.Net.Http.Headers
             }
 
             // Since the tag is a quoted-string we treat it case-sensitive.
-            return ((_isWeak == other._isWeak) && (string.CompareOrdinal(_tag, other._tag) == 0));
+            return ((_isWeak == other._isWeak) && string.Equals(_tag, other._tag, StringComparison.Ordinal));
         }
 
         public override int GetHashCode()

--- a/src/System.Net.Http/src/System/Net/Headers/MediaTypeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/MediaTypeHeaderValue.cs
@@ -113,14 +113,14 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return (string.Compare(_mediaType, other._mediaType, StringComparison.OrdinalIgnoreCase) == 0) &&
+            return string.Equals(_mediaType, other._mediaType, StringComparison.OrdinalIgnoreCase) &&
                 HeaderUtilities.AreEqualCollections(_parameters, other._parameters);
         }
 
         public override int GetHashCode()
         {
             // The media-type string is case-insensitive.
-            return _mediaType.ToLowerInvariant().GetHashCode() ^ NameValueHeaderValue.GetHashCode(_parameters);
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(_mediaType) ^ NameValueHeaderValue.GetHashCode(_parameters);
         }
 
         public static MediaTypeHeaderValue Parse(string input)

--- a/src/System.Net.Http/src/System/Net/Headers/NameValueHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/NameValueHeaderValue.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http.Headers
         {
             Debug.Assert(_name != null);
 
-            int nameHashCode = _name.ToLowerInvariant().GetHashCode();
+            int nameHashCode = StringComparer.OrdinalIgnoreCase.GetHashCode(_name);
 
             if (!string.IsNullOrEmpty(_value))
             {
@@ -73,7 +73,7 @@ namespace System.Net.Http.Headers
                     return nameHashCode ^ _value.GetHashCode();
                 }
 
-                return nameHashCode ^ _value.ToLowerInvariant().GetHashCode();
+                return nameHashCode ^ StringComparer.OrdinalIgnoreCase.GetHashCode(_value);
             }
 
             return nameHashCode;
@@ -88,7 +88,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            if (string.Compare(_name, other._name, StringComparison.OrdinalIgnoreCase) != 0)
+            if (!string.Equals(_name, other._name, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -105,11 +105,11 @@ namespace System.Net.Http.Headers
             if (_value[0] == '"')
             {
                 // We have a quoted string, so we need to do case-sensitive comparison.
-                return (string.CompareOrdinal(_value, other._value) == 0);
+                return string.Equals(_value, other._value, StringComparison.Ordinal);
             }
             else
             {
-                return (string.Compare(_value, other._value, StringComparison.OrdinalIgnoreCase) == 0);
+                return string.Equals(_value, other._value, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -307,7 +307,7 @@ namespace System.Net.Http.Headers
 
             foreach (var value in values)
             {
-                if (string.Compare(value.Name, name, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(value.Name, name, StringComparison.OrdinalIgnoreCase))
                 {
                     return value;
                 }

--- a/src/System.Net.Http/src/System/Net/Headers/ProductHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/ProductHeaderValue.cs
@@ -69,17 +69,17 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return (string.Compare(_name, other._name, StringComparison.OrdinalIgnoreCase) == 0) &&
-                (string.Compare(_version, other._version, StringComparison.OrdinalIgnoreCase) == 0);
+            return string.Equals(_name, other._name, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_version, other._version, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()
         {
-            int result = _name.ToLowerInvariant().GetHashCode();
+            int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_name);
 
             if (!string.IsNullOrEmpty(_version))
             {
-                result = result ^ _version.ToLowerInvariant().GetHashCode();
+                result = result ^ StringComparer.OrdinalIgnoreCase.GetHashCode(_version);
             }
 
             return result;

--- a/src/System.Net.Http/src/System/Net/Headers/ProductInfoHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/ProductInfoHeaderValue.cs
@@ -74,7 +74,7 @@ namespace System.Net.Http.Headers
             if (_product == null)
             {
                 // We compare comments using case-sensitive comparison.
-                return string.CompareOrdinal(_comment, other._comment) == 0;
+                return string.Equals(_comment, other._comment, StringComparison.Ordinal);
             }
 
             return _product.Equals(other._product);

--- a/src/System.Net.Http/src/System/Net/Headers/RangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/RangeHeaderValue.cs
@@ -95,13 +95,13 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return (string.Compare(_unit, other._unit, StringComparison.OrdinalIgnoreCase) == 0) &&
+            return string.Equals(_unit, other._unit, StringComparison.OrdinalIgnoreCase) &&
                 HeaderUtilities.AreEqualCollections(Ranges, other.Ranges);
         }
 
         public override int GetHashCode()
         {
-            int result = _unit.ToLowerInvariant().GetHashCode();
+            int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_unit);
 
             foreach (RangeItemHeaderValue range in Ranges)
             {

--- a/src/System.Net.Http/src/System/Net/Headers/StringWithQualityHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/StringWithQualityHeaderValue.cs
@@ -72,7 +72,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            if (string.Compare(_value, other._value, StringComparison.OrdinalIgnoreCase) != 0)
+            if (!string.Equals(_value, other._value, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -92,7 +92,7 @@ namespace System.Net.Http.Headers
 
         public override int GetHashCode()
         {
-            int result = _value.ToLowerInvariant().GetHashCode();
+            int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_value);
 
             if (_quality.HasValue)
             {

--- a/src/System.Net.Http/src/System/Net/Headers/TransferCodingHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/TransferCodingHeaderValue.cs
@@ -141,14 +141,14 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return (string.Compare(_value, other._value, StringComparison.OrdinalIgnoreCase) == 0) &&
+            return string.Equals(_value, other._value, StringComparison.OrdinalIgnoreCase) &&
                 HeaderUtilities.AreEqualCollections(_parameters, other._parameters);
         }
 
         public override int GetHashCode()
         {
             // The value string is case-insensitive.
-            return _value.ToLowerInvariant().GetHashCode() ^ NameValueHeaderValue.GetHashCode(_parameters);
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(_value) ^ NameValueHeaderValue.GetHashCode(_parameters);
         }
 
         // Implement ICloneable explicitly to allow derived types to "override" the implementation.

--- a/src/System.Net.Http/src/System/Net/Headers/ViaHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/ViaHeaderValue.cs
@@ -113,19 +113,20 @@ namespace System.Net.Http.Headers
 
             // Note that for token and host case-insensitive comparison is used. Comments are compared using case-
             // sensitive comparison.
-            return (string.Compare(_protocolVersion, other._protocolVersion, StringComparison.OrdinalIgnoreCase) == 0) &&
-                (string.Compare(_receivedBy, other._receivedBy, StringComparison.OrdinalIgnoreCase) == 0) &&
-                (string.Compare(_protocolName, other._protocolName, StringComparison.OrdinalIgnoreCase) == 0) &&
-                (string.CompareOrdinal(_comment, other._comment) == 0);
+            return string.Equals(_protocolVersion, other._protocolVersion, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_receivedBy, other._receivedBy, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_protocolName, other._protocolName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_comment, other._comment, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()
         {
-            int result = _protocolVersion.ToLowerInvariant().GetHashCode() ^ _receivedBy.ToLowerInvariant().GetHashCode();
+            int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_protocolVersion) ^
+                StringComparer.OrdinalIgnoreCase.GetHashCode(_receivedBy);
 
             if (!string.IsNullOrEmpty(_protocolName))
             {
-                result = result ^ _protocolName.ToLowerInvariant().GetHashCode();
+                result = result ^ StringComparer.OrdinalIgnoreCase.GetHashCode(_protocolName);
             }
 
             if (!string.IsNullOrEmpty(_comment))

--- a/src/System.Net.Http/src/System/Net/Headers/WarningHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Headers/WarningHeaderValue.cs
@@ -105,8 +105,8 @@ namespace System.Net.Http.Headers
 
             // 'agent' is a host/token, i.e. use case-insensitive comparison. Use case-sensitive comparison for 'text'
             // since it is a quoted string.
-            if ((_code != other._code) || (string.Compare(_agent, other._agent, StringComparison.OrdinalIgnoreCase) != 0) ||
-                (string.CompareOrdinal(_text, other._text) != 0))
+            if ((_code != other._code) || (!string.Equals(_agent, other._agent, StringComparison.OrdinalIgnoreCase)) ||
+                (!string.Equals(_text, other._text, StringComparison.Ordinal)))
             {
                 return false;
             }
@@ -123,7 +123,9 @@ namespace System.Net.Http.Headers
 
         public override int GetHashCode()
         {
-            int result = _code.GetHashCode() ^ _agent.ToLowerInvariant().GetHashCode() ^ _text.GetHashCode();
+            int result = _code.GetHashCode() ^
+                StringComparer.OrdinalIgnoreCase.GetHashCode(_agent) ^
+                _text.GetHashCode();
 
             if (_date.HasValue)
             {

--- a/src/System.Net.Http/src/System/Net/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/HttpMethod.cs
@@ -94,7 +94,7 @@ namespace System.Net.Http
                 return true;
             }
 
-            return (string.Compare(_method, other._method, StringComparison.OrdinalIgnoreCase) == 0);
+            return string.Equals(_method, other._method, StringComparison.OrdinalIgnoreCase);
         }
 
         #endregion
@@ -106,7 +106,7 @@ namespace System.Net.Http
 
         public override int GetHashCode()
         {
-            return _method.ToUpperInvariant().GetHashCode();
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(_method);
         }
 
         public override string ToString()

--- a/src/System.Net.Http/src/System/Net/HttpUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/HttpUtilities.cs
@@ -26,8 +26,8 @@ namespace System.Net.Http
             Debug.Assert(uri != null);
 
             string scheme = uri.Scheme;
-            return ((string.Compare("http", scheme, StringComparison.OrdinalIgnoreCase) == 0) ||
-                (string.Compare("https", scheme, StringComparison.OrdinalIgnoreCase) == 0));
+            return string.Equals("http", scheme, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals("https", scheme, StringComparison.OrdinalIgnoreCase);
         }
 
         // Returns true if the task was faulted or canceled and sets tcs accordingly.

--- a/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
@@ -1118,7 +1118,7 @@ namespace System.Net.Http.Unit.Tests
 
             foreach (var value in values)
             {
-                if (string.Compare(value.Name, name, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(value.Name, name, StringComparison.OrdinalIgnoreCase))
                 {
                     return value;
                 }

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -2139,7 +2139,7 @@ namespace System.Net.Http.Unit.Tests
 
                 if ((xs != null) && (ys != null))
                 {
-                    return string.Compare(xs, ys, StringComparison.OrdinalIgnoreCase) == 0;
+                    return string.Equals(xs, ys, StringComparison.OrdinalIgnoreCase);
                 }
 
                 return x.Equals(y);

--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/CapiHelper.cs
@@ -37,7 +37,7 @@ namespace Internal.NativeCrypto
         {
             string wszUpgrade = null;
             SafeProvHandle safeProvHandle = SafeProvHandle.InvalidHandle;
-            if (string.Compare(wszProvider, MS_DEF_DSS_DH_PROV) == 0)
+            if (string.Equals(wszProvider, MS_DEF_DSS_DH_PROV, StringComparison.Ordinal))
             {
                 // If this is the base DSS/DH provider, see if we can use the enhanced provider instead.
                 if (S_OK == AcquireCryptContext(ref safeProvHandle, null, MS_ENH_DSS_DH_PROV, dwProvType,
@@ -64,8 +64,8 @@ namespace Internal.NativeCrypto
         /// <returns>Returns upgrade CSP name</returns>
         public static string UpgradeRSA(int dwProvType, string wszProvider)
         {
-            bool requestedEnhanced = (string.Compare(wszProvider, MS_ENHANCED_PROV) == 0);
-            bool requestedBase = (string.Compare(wszProvider, MS_DEF_PROV) == 0);
+            bool requestedEnhanced = string.Equals(wszProvider, MS_ENHANCED_PROV, StringComparison.Ordinal);
+            bool requestedBase = string.Equals(wszProvider, MS_DEF_PROV, StringComparison.Ordinal);
             string wszUpgrade = null;
             SafeProvHandle safeProvHandle = SafeProvHandle.InvalidHandle;
             if (requestedBase || requestedEnhanced)

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.X509Certificates
                 String oidValue = new Oid(oid).Value;
                 foreach (X509Extension extension in _list)
                 {
-                    if (String.Compare(extension.Oid.Value, oidValue, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (String.Equals(extension.Oid.Value, oidValue, StringComparison.OrdinalIgnoreCase))
                         return extension;
                 }
                 return null;

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -2300,14 +2300,14 @@ namespace System.Xml
                 return _ps.encoding;
             }
 
-            if (0 == String.Compare(newEncodingName, "ucs-2", StringComparison.OrdinalIgnoreCase) ||
-                0 == String.Compare(newEncodingName, "utf-16", StringComparison.OrdinalIgnoreCase) ||
-                0 == String.Compare(newEncodingName, "iso-10646-ucs-2", StringComparison.OrdinalIgnoreCase) ||
-                0 == String.Compare(newEncodingName, "ucs-4", StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(newEncodingName, "ucs-2", StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(newEncodingName, "utf-16", StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(newEncodingName, "iso-10646-ucs-2", StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(newEncodingName, "ucs-4", StringComparison.OrdinalIgnoreCase))
             {
                 if (_ps.encoding.WebName != "utf-16BE" &&
                      _ps.encoding.WebName != "utf-16" &&
-                     0 != String.Compare(newEncodingName, "ucs-4", StringComparison.OrdinalIgnoreCase))
+                     !String.Equals(newEncodingName, "ucs-4", StringComparison.OrdinalIgnoreCase))
                 {
                     ThrowWithoutLineInfo(SR.Xml_MissingByteOrderMark);
                 }
@@ -2315,7 +2315,7 @@ namespace System.Xml
             }
 
             Encoding newEncoding = null;
-            if (0 == String.Compare(newEncodingName, "utf-8", StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(newEncodingName, "utf-8", StringComparison.OrdinalIgnoreCase))
             {
                 newEncoding = new UTF8Encoding(true, true);
             }
@@ -5030,7 +5030,7 @@ namespace System.Xml
             int nameEndPos = ParseName();
             string target = _nameTable.Add(_ps.chars, _ps.charPos, nameEndPos - _ps.charPos);
 
-            if (string.Compare(target, "xml", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(target, "xml", StringComparison.OrdinalIgnoreCase))
             {
                 Throw(target.Equals("xml") ? SR.Xml_XmlDeclNotFirst : SR.Xml_InvalidPIName, target);
             }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -3646,7 +3646,7 @@ namespace System.Xml
             int nameEndPos = await ParseNameAsync().ConfigureAwait(false);
             string target = _nameTable.Add(_ps.chars, _ps.charPos, nameEndPos - _ps.charPos);
 
-            if (string.Compare(target, "xml", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(target, "xml", StringComparison.OrdinalIgnoreCase))
             {
                 Throw(target.Equals("xml") ? SR.Xml_XmlDeclNotFirst : SR.Xml_InvalidPIName, target);
             }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplHelpers.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplHelpers.cs
@@ -726,7 +726,7 @@ namespace System.Xml
                     }
                 }
 
-                // string.Compare does reference euqality first for us, so we don't have to do it here
+                // string.Compare does reference equality first for us, so we don't have to do it here
                 int result = string.Compare(localName, localName2, StringComparison.Ordinal);
                 if (result != 0)
                 {

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriter.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriter.cs
@@ -954,7 +954,7 @@ namespace System.Xml
                 }
 
                 // xml declaration is a special case (not a processing instruction, but we allow WriteProcessingInstruction as a convenience)
-                if (name.Length == 3 && string.Compare(name, "xml", StringComparison.OrdinalIgnoreCase) == 0)
+                if (name.Length == 3 && string.Equals(name, "xml", StringComparison.OrdinalIgnoreCase))
                 {
                     if (_currentState != State.Start)
                     {

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriterAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriterAsync.cs
@@ -817,7 +817,7 @@ namespace System.Xml
                 }
 
                 // xml declaration is a special case (not a processing instruction, but we allow WriteProcessingInstruction as a convenience)
-                if (name.Length == 3 && string.Compare(name, "xml", StringComparison.OrdinalIgnoreCase) == 0)
+                if (name.Length == 3 && string.Equals(name, "xml", StringComparison.OrdinalIgnoreCase))
                 {
                     if (_currentState != State.Start)
                     {


### PR DESCRIPTION
This PR is a continuation of #298 for the more recently open-sourced libraries.

Per the [Best Practices for Using Strings in the .NET Framework](http://msdn.microsoft.com/en-us/library/dd465121(v=vs.110).aspx):

* Use an overload of the `String.Equals` method to test whether two strings are equal.
* Use the `String.Compare` and `String.CompareTo` methods to sort strings, **not to check for equality**.

Also, in `System.Net.Http` there were uses of `String.ToLowerInvariant().GetHashCode()` and `String.ToUpperInvariant().GetHashCode()` that have been changed to `StringComparer.OrdinalIgnoreCase.GetHashCode()` to avoid the unnecessary string allocation.

Also, in `System.Security.Cryptography.RSA` there were uses of `String.Compare` that didn't specify a `StringComparison`, which means it was doing a culture-sensitive comparison (the default behavior for `String.Compare`). I don't think a culture-sensitive comparison is what was intended here so I changed these to `String.Equals` with `StringComparison.Ordinal`. @bartonjs, let me know if this was intended to be culture-sensitive.

The PR is broken up into separate commits for each area to make it easier to review:

 * `System.IO.FileSystem` /cc @ericstj
 * `System.Net.Http` /cc @davidsh 
 * `System.Security.Cryptography.RSA` and `System.Security.Cryptography.X509Certificates` /cc @bartonjs
 * `System.Xml.ReaderWriter` /cc @krwq 

I can squash the commits after the review, if necessary.