### PR TITLE
Add TaskExtensions.Unwrap tests

### DIFF
--- a/src/System.Threading.Tasks/System.Threading.Tasks.sln
+++ b/src/System.Threading.Tasks/System.Threading.Tasks.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Tasks.CoreCLR", "src\System.Threading.Tasks.CoreCLR.csproj", "{3BCAEAA6-3A29-49EC-B334-6E7BE8BE9ABA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Tasks.Tests", "tests\System.Threading.Tasks.Tests.csproj", "{B6C09633-D161-499A-8FE1-46B2D53A16E7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{3BCAEAA6-3A29-49EC-B334-6E7BE8BE9ABA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BCAEAA6-3A29-49EC-B334-6E7BE8BE9ABA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BCAEAA6-3A29-49EC-B334-6E7BE8BE9ABA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6C09633-D161-499A-8FE1-46B2D53A16E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6C09633-D161-499A-8FE1-46B2D53A16E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6C09633-D161-499A-8FE1-46B2D53A16E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6C09633-D161-499A-8FE1-46B2D53A16E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Threading.Tasks.Tests</AssemblyName>
+    <ProjectGuid>{B6C09633-D161-499A-8FE1-46B2D53A16E7}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <Compile Include="UnwrapTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the System.Runtime contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="..\src\System.Threading.Tasks.CoreCLR.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -1,0 +1,550 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    public class UnwrapTests
+    {
+        /// <summary>Tests unwrap argument validation.</summary>
+        [Fact]
+        public void ArgumentValidation()
+        {
+            Assert.Throws<ArgumentNullException>(() => { ((Task<Task>)null).Unwrap(); });
+            Assert.Throws<ArgumentNullException>(() => { ((Task<Task<int>>)null).Unwrap(); });
+            Assert.Throws<ArgumentNullException>(() => { ((Task<Task<string>>)null).Unwrap(); });
+        }
+
+        /// <summary>
+        /// Tests Unwrap when both the outer task and non-generic inner task have completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="inner">Will be run with a RanToCompletion, Faulted, and Canceled task.</param>
+        [Theory]
+        [MemberData("CompletedNonGenericTasks")]
+        public void NonGeneric_Completed_Completed(Task inner) 
+        {
+            Task<Task> outer = Task.FromResult(inner);
+            Task unwrappedInner = outer.Unwrap();
+            // Assert.True(unwrappedInner.IsCompleted); // TODO: uncomment once we have implementation with this optimization
+            // Assert.Same(inner, unwrappedInner); // TODO: uncomment once we have implementation with this optimization
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when both the outer task and generic inner task have completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="inner">The inner task.</param>
+        [Theory]
+        [MemberData("CompletedStringTasks")]
+        public void Generic_Completed_Completed(Task<string> inner)
+        {
+            Task<Task<string>> outer = Task.FromResult(inner);
+            Task<string> unwrappedInner = outer.Unwrap();
+            // Assert.True(unwrappedInner.IsCompleted); // TODO: uncomment once we have implementation with this optimization
+            // Assert.Same(inner, unwrappedInner); // TODO: uncomment once we have implementation with this optimization
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when the non-generic inner task has completed but the outer task has not completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="inner">The inner task.</param>
+        [Theory]
+        [MemberData("CompletedNonGenericTasks")]
+        public void NonGeneric_NotCompleted_Completed(Task inner) 
+        {
+            var outerTcs = new TaskCompletionSource<Task>();
+            Task<Task> outer = outerTcs.Task;
+
+            Task unwrappedInner = outer.Unwrap();
+            Assert.False(unwrappedInner.IsCompleted);
+
+            outerTcs.SetResult(inner);
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when the generic inner task has completed but the outer task has not completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="inner">The inner task.</param>
+        [Theory]
+        [MemberData("CompletedStringTasks")]
+        public void Generic_NotCompleted_Completed(Task<string> inner)
+        {
+            var outerTcs = new TaskCompletionSource<Task<string>>();
+            Task<Task<string>> outer = outerTcs.Task;
+
+            Task<string> unwrappedInner = outer.Unwrap();
+            Assert.False(unwrappedInner.IsCompleted);
+
+            outerTcs.SetResult(inner);
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when the non-generic inner task has not yet completed but the outer task has completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="innerStatus">How the inner task should be completed.</param>
+        [Theory]
+        [InlineData(TaskStatus.RanToCompletion)]
+        [InlineData(TaskStatus.Faulted)]
+        [InlineData(TaskStatus.Canceled)]
+        public void NonGeneric_Completed_NotCompleted(TaskStatus innerStatus) 
+        {
+            var innerTcs = new TaskCompletionSource<bool>();
+            Task inner = innerTcs.Task;
+
+            Task<Task> outer = Task.FromResult(inner);
+            Task unwrappedInner = outer.Unwrap();
+            Assert.False(unwrappedInner.IsCompleted);
+
+            switch (innerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    innerTcs.SetResult(true);
+                    break;
+                case TaskStatus.Faulted:
+                    innerTcs.SetException(new InvalidProgramException());
+                    break;
+                case TaskStatus.Canceled:
+                    innerTcs.SetCanceled();
+                    break;
+            }
+
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when the non-generic inner task has not yet completed but the outer task has completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="innerStatus">How the inner task should be completed.</param>
+        [Theory]
+        [InlineData(TaskStatus.RanToCompletion)]
+        [InlineData(TaskStatus.Faulted)]
+        [InlineData(TaskStatus.Canceled)]
+        public void Generic_Completed_NotCompleted(TaskStatus innerStatus)
+        {
+            var innerTcs = new TaskCompletionSource<int>();
+            Task<int> inner = innerTcs.Task;
+
+            Task<Task<int>> outer = Task.FromResult(inner);
+            Task<int> unwrappedInner = outer.Unwrap();
+            Assert.False(unwrappedInner.IsCompleted);
+
+            switch (innerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    innerTcs.SetResult(42);
+                    break;
+                case TaskStatus.Faulted:
+                    innerTcs.SetException(new InvalidProgramException());
+                    break;
+                case TaskStatus.Canceled:
+                    innerTcs.SetCanceled();
+                    break;
+            }
+
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when neither the non-generic inner task nor the outer task has completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="outerCompletesFirst">Whether the outer task or the inner task completes first.</param>
+        /// <param name="innerStatus">How the inner task should be completed.</param>
+        [Theory]
+        [InlineData(true, TaskStatus.RanToCompletion)]
+        [InlineData(true, TaskStatus.Canceled)]
+        [InlineData(true, TaskStatus.Faulted)]
+        [InlineData(false, TaskStatus.RanToCompletion)]
+        [InlineData(false, TaskStatus.Canceled)]
+        [InlineData(false, TaskStatus.Faulted)]
+        public void NonGeneric_NotCompleted_NotCompleted(bool outerCompletesFirst, TaskStatus innerStatus) 
+        {
+            var innerTcs = new TaskCompletionSource<bool>();
+            Task inner = innerTcs.Task;
+
+            var outerTcs = new TaskCompletionSource<Task>();
+            Task<Task> outer = outerTcs.Task;
+
+            Task unwrappedInner = outer.Unwrap();
+            Assert.False(unwrappedInner.IsCompleted);
+
+            if (outerCompletesFirst)
+            {
+                outerTcs.SetResult(inner);
+                Assert.False(unwrappedInner.IsCompleted);
+            }
+
+            switch (innerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    innerTcs.SetResult(true);
+                    break;
+                case TaskStatus.Faulted:
+                    innerTcs.SetException(new InvalidOperationException());
+                    break;
+                case TaskStatus.Canceled:
+                    innerTcs.TrySetCanceled(CreateCanceledToken());
+                    break;
+            }
+            
+            if (!outerCompletesFirst)
+            {
+                Assert.False(unwrappedInner.IsCompleted);
+                outerTcs.SetResult(inner);
+            }
+
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when neither the generic inner task nor the outer task has completed by the time Unwrap is called.
+        /// </summary>
+        /// <param name="outerCompletesFirst">Whether the outer task or the inner task completes first.</param>
+        /// <param name="innerStatus">How the inner task should be completed.</param>
+        [Theory]
+        [InlineData(true, TaskStatus.RanToCompletion)]
+        [InlineData(true, TaskStatus.Canceled)]
+        [InlineData(true, TaskStatus.Faulted)]
+        [InlineData(false, TaskStatus.RanToCompletion)]
+        [InlineData(false, TaskStatus.Canceled)]
+        [InlineData(false, TaskStatus.Faulted)]
+        public void Generic_NotCompleted_NotCompleted(bool outerCompletesFirst, TaskStatus innerStatus)
+        {
+            var innerTcs = new TaskCompletionSource<int>();
+            Task<int> inner = innerTcs.Task;
+
+            var outerTcs = new TaskCompletionSource<Task<int>>();
+            Task<Task<int>> outer = outerTcs.Task;
+
+            Task<int> unwrappedInner = outer.Unwrap();
+            Assert.False(unwrappedInner.IsCompleted);
+
+            if (outerCompletesFirst)
+            {
+                outerTcs.SetResult(inner);
+                Assert.False(unwrappedInner.IsCompleted);
+            }
+
+            switch (innerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    innerTcs.SetResult(42);
+                    break;
+                case TaskStatus.Faulted:
+                    innerTcs.SetException(new InvalidOperationException());
+                    break;
+                case TaskStatus.Canceled:
+                    innerTcs.TrySetCanceled(CreateCanceledToken());
+                    break;
+            }
+
+            if (!outerCompletesFirst)
+            {
+                Assert.False(unwrappedInner.IsCompleted);
+                outerTcs.SetResult(inner);
+            }
+
+            AssertTasksAreEqual(inner, unwrappedInner);
+        }
+
+        /// <summary>
+        /// Tests Unwrap when the outer task for a non-generic inner fails in some way.
+        /// </summary>
+        /// <param name="outerCompletesFirst">Whether the outer task completes before Unwrap is called.</param>
+        /// <param name="outerStatus">How the outer task should be completed (RanToCompletion means returning null).</param>
+        [Theory]
+        [InlineData(true, TaskStatus.RanToCompletion)]
+        [InlineData(true, TaskStatus.Faulted)]
+        [InlineData(true, TaskStatus.Canceled)]
+        [InlineData(false, TaskStatus.RanToCompletion)]
+        [InlineData(false, TaskStatus.Faulted)]
+        [InlineData(false, TaskStatus.Canceled)]
+        public void NonGeneric_UnsuccessfulOuter(bool outerCompletesBeforeUnwrap, TaskStatus outerStatus)
+        {
+            var outerTcs = new TaskCompletionSource<Task>();
+            Task<Task> outer = outerTcs.Task;
+
+            Task unwrappedInner = null;
+
+            if (!outerCompletesBeforeUnwrap)
+                unwrappedInner = outer.Unwrap();
+
+            switch (outerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    outerTcs.SetResult(null);
+                    break;
+                case TaskStatus.Canceled:
+                    outerTcs.TrySetCanceled(CreateCanceledToken());
+                    break;
+                case TaskStatus.Faulted:
+                    outerTcs.SetException(new InvalidCastException());
+                    break;
+            }
+
+            if (outerCompletesBeforeUnwrap)
+                unwrappedInner = outer.Unwrap();
+
+            WaitNoThrow(unwrappedInner);
+
+            switch (outerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    Assert.True(unwrappedInner.IsCanceled);
+                    break;
+                default:
+                    AssertTasksAreEqual(outer, unwrappedInner);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Tests Unwrap when the outer task for a generic inner fails in some way.
+        /// </summary>
+        /// <param name="outerCompletesFirst">Whether the outer task completes before Unwrap is called.</param>
+        /// <param name="outerStatus">How the outer task should be completed (RanToCompletion means returning null).</param>
+        [Theory]
+        [InlineData(true, TaskStatus.RanToCompletion)]
+        [InlineData(true, TaskStatus.Faulted)]
+        [InlineData(true, TaskStatus.Canceled)]
+        [InlineData(false, TaskStatus.RanToCompletion)]
+        [InlineData(false, TaskStatus.Faulted)]
+        [InlineData(false, TaskStatus.Canceled)]
+        public void Generic_UnsuccessfulOuter(bool outerCompletesBeforeUnwrap, TaskStatus outerStatus)
+        {
+            var outerTcs = new TaskCompletionSource<Task<int>>();
+            Task<Task<int>> outer = outerTcs.Task;
+
+            Task<int> unwrappedInner = null;
+
+            if (!outerCompletesBeforeUnwrap)
+                unwrappedInner = outer.Unwrap();
+
+            switch (outerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    outerTcs.SetResult(null); // cancellation
+                    break;
+                case TaskStatus.Canceled:
+                    outerTcs.TrySetCanceled(CreateCanceledToken());
+                    break;
+                case TaskStatus.Faulted:
+                    outerTcs.SetException(new InvalidCastException());
+                    break;
+            }
+
+            if (outerCompletesBeforeUnwrap)
+                unwrappedInner = outer.Unwrap();
+
+            WaitNoThrow(unwrappedInner);
+
+            switch (outerStatus)
+            {
+                case TaskStatus.RanToCompletion:
+                    Assert.True(unwrappedInner.IsCanceled);
+                    break;
+                default:
+                    AssertTasksAreEqual(outer, unwrappedInner);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Test Unwrap when the outer task for a non-generic inner task is marked as AttachedToParent.
+        /// </summary>
+        [Fact]
+        public void NonGeneric_AttachedToParent()
+        {
+            Exception error = new InvalidTimeZoneException();
+            Task parent = Task.Factory.StartNew(() =>
+            {
+                var outerTcs = new TaskCompletionSource<Task>(TaskCreationOptions.AttachedToParent);
+                Task<Task> outer = outerTcs.Task;
+
+                Task inner = Task.FromException(error);
+
+                Task unwrappedInner = outer.Unwrap();
+                Assert.Equal(TaskCreationOptions.AttachedToParent, unwrappedInner.CreationOptions);
+
+                outerTcs.SetResult(inner);
+                AssertTasksAreEqual(inner, unwrappedInner);
+            }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            WaitNoThrow(parent);
+            Assert.Equal(TaskStatus.Faulted, parent.Status);
+            Assert.Same(error, parent.Exception.Flatten().InnerException);
+        }
+
+        /// <summary>
+        /// Test Unwrap when the outer task for a generic inner task is marked as AttachedToParent.
+        /// </summary>
+        [Fact]
+        public void Generic_AttachedToParent()
+        {
+            Exception error = new InvalidTimeZoneException();
+            Task parent = Task.Factory.StartNew(() =>
+            {
+                var outerTcs = new TaskCompletionSource<Task<object>>(TaskCreationOptions.AttachedToParent);
+                Task<Task<object>> outer = outerTcs.Task;
+
+                Task<object> inner = Task.FromException<object>(error);
+
+                Task<object> unwrappedInner = outer.Unwrap();
+                Assert.Equal(TaskCreationOptions.AttachedToParent, unwrappedInner.CreationOptions);
+
+                outerTcs.SetResult(inner);
+                AssertTasksAreEqual(inner, unwrappedInner);
+            }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            WaitNoThrow(parent);
+            Assert.Equal(TaskStatus.Faulted, parent.Status);
+            Assert.Same(error, parent.Exception.Flatten().InnerException);
+        }
+
+        /// <summary>
+        /// Test that Unwrap with a non-generic task doesn't use TaskScheduler.Current.
+        /// </summary>
+        // [Fact] // TODO: Uncomment once new implementation matches mscorlib behavior and guarantees TaskScheduler.Default is used
+        public void NonGeneric_DefaultSchedulerUsed()
+        {
+            var scheduler = new CountingScheduler();
+            Task.Factory.StartNew(() =>
+            {
+                int initialCallCount = scheduler.QueueTaskCalls;
+
+                Task<Task> outer = Task.Factory.StartNew(() => Task.Run(() => { }),
+                    CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+                Task unwrappedInner = outer.Unwrap();
+                unwrappedInner.Wait();
+
+                Assert.Equal(initialCallCount, scheduler.QueueTaskCalls);
+            }, CancellationToken.None, TaskCreationOptions.None, scheduler).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Test that Unwrap with a generic task doesn't use TaskScheduler.Current.
+        /// </summary>
+        // [Fact] // TODO: Uncomment once new implementation matches mscorlib behavior and guarantees TaskScheduler.Default is used
+        public void Generic_DefaultSchedulerUsed()
+        {
+            var scheduler = new CountingScheduler();
+            Task.Factory.StartNew(() =>
+            {
+                int initialCallCount = scheduler.QueueTaskCalls;
+
+                Task<Task<int>> outer = Task.Factory.StartNew(() => Task.Run(() => 42),
+                    CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+                Task<int> unwrappedInner = outer.Unwrap();
+                unwrappedInner.Wait();
+
+                Assert.Equal(initialCallCount, scheduler.QueueTaskCalls);
+            }, CancellationToken.None, TaskCreationOptions.None, scheduler).GetAwaiter().GetResult();
+        }
+
+        /// <summary>Gets an enumerable of already completed non-generic tasks.</summary>
+        public static IEnumerable<object[]> CompletedNonGenericTasks
+        {
+            get
+            {
+                yield return new object[] { Task.CompletedTask };
+                yield return new object[] { Task.FromCanceled(CreateCanceledToken()) };
+                yield return new object[] { Task.FromException(new FormatException()) };
+            }
+        }
+
+        /// <summary>Gets an enumerable of already completed generic tasks.</summary>
+        public static IEnumerable<object[]> CompletedStringTasks
+        {
+            get
+            {
+                yield return new object[] { Task.FromResult("Tasks") };
+                yield return new object[] { Task.FromCanceled<string>(CreateCanceledToken()) };
+                yield return new object[] { Task.FromException<string>(new FormatException()) };
+            }
+        }
+
+        /// <summary>Asserts that two non-generic tasks are logically equal with regards to completion status.</summary>
+        private static void AssertTasksAreEqual(Task expected, Task actual)
+        {
+            Assert.NotNull(actual);
+            WaitNoThrow(actual);
+
+            Assert.Equal(expected.Status, actual.Status);
+            switch (expected.Status)
+            {
+                case TaskStatus.Faulted:
+                    Assert.Equal((IEnumerable<Exception>)expected.Exception.InnerExceptions, actual.Exception.InnerExceptions);
+                    break;
+                case TaskStatus.Canceled:
+                    // TODO: Uncomment once we have new implementation that guarantees this
+                    //Assert.Equal(GetCanceledTaskToken(expected), GetCanceledTaskToken(actual));
+                    break;
+            }
+        }
+
+        /// <summary>Asserts that two non-generic tasks are logically equal with regards to completion status.</summary>
+        private static void AssertTasksAreEqual<T>(Task<T> expected, Task<T> actual)
+        {
+            AssertTasksAreEqual((Task)expected, actual);
+            if (expected.Status == TaskStatus.RanToCompletion)
+            {
+                if (typeof(T).GetTypeInfo().IsValueType)
+                    Assert.Equal(expected.Result, actual.Result);
+                else
+                    Assert.Same(expected.Result, actual.Result);
+            }
+        }
+
+        /// <summary>Creates an already canceled token.</summary>
+        private static CancellationToken CreateCanceledToken()
+        {
+            // Create an already canceled token.  We construct a new CTS rather than
+            // just using CT's Boolean ctor in order to better validate the right
+            // token ends up in the resulting unwrapped task.
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            return cts.Token;
+        }
+
+        /// <summary>Waits for a task to complete without throwing any exceptions.</summary>
+        private static void WaitNoThrow(Task task)
+        {
+            ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+        }
+
+        /// <summary>Extracts the CancellationToken associated with a task.</summary>
+        private static CancellationToken GetCanceledTaskToken(Task task)
+        {
+            Assert.True(task.IsCanceled);
+            try
+            {
+                task.GetAwaiter().GetResult();
+                Assert.False(true, "Canceled task should have thrown from GetResult");
+                return default(CancellationToken);
+            }
+            catch (OperationCanceledException oce)
+            {
+                return oce.CancellationToken;
+            }
+        }
+
+        private sealed class CountingScheduler : TaskScheduler
+        {
+            public volatile int QueueTaskCalls = 0;
+
+            protected override void QueueTask(Task task)
+            {
+                Interlocked.Increment(ref QueueTaskCalls);
+                Task.Run(() => TryExecuteTask(task));
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) { return false; }
+
+            protected override IEnumerable<Task> GetScheduledTasks() { return null; }
+        }
+
+    }
+}

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -1,0 +1,23 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-*",
+    "System.Diagnostics.Debug": "4.0.10-beta-*",
+    "System.Diagnostics.Tracing": "4.0.20-beta-*",
+    "System.Globalization": "4.0.10-beta-*",
+    "System.Reflection": "4.0.10-beta-*",
+    "System.Runtime": "4.0.20-beta-*",
+    "System.Runtime.Extensions": "4.0.10-beta-*",
+    "System.Runtime.InteropServices": "4.0.20-beta-*",
+    "System.Threading": "4.0.10-beta-*",
+    "System.Threading.Tasks": "4.0.10-beta-*",
+    "xunit": "2.0.0-beta5-build2785",
+    "xunit.abstractions.netcore": "1.0.0-prerelease",
+    "xunit.assert": "2.0.0-beta5-build2785",
+    "xunit.core.netcore": "1.0.1-prerelease",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Threading.Tasks/tests/project.lock.json
+++ b/src/System.Threading.Tasks/tests/project.lock.json
@@ -1,0 +1,715 @@
+{
+  "locked": true,
+  "version": -9997,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Collections.dll"
+        ]
+      },
+      "System.Console/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23008",
+          "System.Runtime.InteropServices": "4.0.20-beta-23008",
+          "System.Resources.ResourceManager": "4.0.0-beta-23008",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23008",
+          "System.IO": "4.0.10-beta-23008",
+          "System.Threading.Tasks": "4.0.10-beta-23008",
+          "System.Text.Encoding": "4.0.10-beta-23008",
+          "System.Threading": "4.0.10-beta-23008",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Console.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Console.dll"
+        ]
+      },
+      "System.Diagnostics.Debug/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Debug.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Debug.dll"
+        ]
+      },
+      "System.Diagnostics.Tracing/4.0.20-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tracing.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll"
+        ]
+      },
+      "System.Globalization/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Globalization.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Globalization.dll"
+        ]
+      },
+      "System.IO/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23008",
+          "System.Text.Encoding": "4.0.0-beta-23008",
+          "System.Threading.Tasks": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.IO.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.IO.dll"
+        ]
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/any/System.IO.FileSystem.Primitives.dll"
+        ]
+      },
+      "System.Linq/4.0.0-beta-22816": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-22816",
+          "System.Runtime": "4.0.20-beta-22816"
+        },
+        "compile": [
+          "lib/contract/System.Linq.dll"
+        ],
+        "runtime": [
+          "lib/aspnetcore50/System.Linq.dll"
+        ]
+      },
+      "System.Private.Uri/4.0.0-beta-23008": {
+        "runtime": [
+          "lib/DNXCore50/System.Private.Uri.dll"
+        ]
+      },
+      "System.Reflection/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23008",
+          "System.IO": "4.0.0-beta-23008",
+          "System.Reflection.Primitives": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Reflection.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.dll"
+        ]
+      },
+      "System.Reflection.Primitives/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.Primitives.dll"
+        ]
+      },
+      "System.Resources.ResourceManager/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008",
+          "System.Reflection": "4.0.0-beta-23008",
+          "System.Globalization": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Resources.ResourceManager.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Resources.ResourceManager.dll"
+        ]
+      },
+      "System.Runtime/4.0.20-beta-23008": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Runtime.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.dll"
+        ]
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.Extensions.dll"
+        ]
+      },
+      "System.Runtime.Handles/4.0.0-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Handles.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.Handles.dll"
+        ]
+      },
+      "System.Runtime.InteropServices/4.0.20-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008",
+          "System.Reflection": "4.0.0-beta-23008",
+          "System.Reflection.Primitives": "4.0.0-beta-23008",
+          "System.Runtime.Handles": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Runtime.InteropServices.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.InteropServices.dll"
+        ]
+      },
+      "System.Text.Encoding/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Text.Encoding.dll"
+        ]
+      },
+      "System.Text.Encoding.Extensions/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008",
+          "System.Text.Encoding": "4.0.10-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll"
+        ]
+      },
+      "System.Threading/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008",
+          "System.Threading.Tasks": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Threading.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.dll"
+        ]
+      },
+      "System.Threading.Tasks/4.0.10-beta-23008": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23008"
+        },
+        "compile": [
+          "ref/any/System.Threading.Tasks.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Tasks.dll"
+        ]
+      },
+      "xunit/2.0.0-beta5-build2785": {
+        "dependencies": {
+          "xunit.core": "[2.0.0-beta5-build2785]",
+          "xunit.assert": "[2.0.0-beta5-build2785]"
+        }
+      },
+      "xunit.abstractions/2.0.0-beta5-build2785": {
+        "compile": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.abstractions.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.abstractions.dll"
+        ]
+      },
+      "xunit.abstractions.netcore/1.0.0-prerelease": {
+        "compile": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll"
+        ]
+      },
+      "xunit.assert/2.0.0-beta5-build2785": {
+        "compile": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.dll"
+        ]
+      },
+      "xunit.core/2.0.0-beta5-build2785": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0-beta5-build2785]"
+        },
+        "compile": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.dll"
+        ]
+      },
+      "xunit.core.netcore/1.0.1-prerelease": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0-beta5-build2785]"
+        },
+        "compile": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
+        ]
+      },
+      "xunit.netcore.extensions/1.0.0-prerelease-00053": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-22703",
+          "System.IO": "4.0.10-beta-22703",
+          "System.Linq": "4.0.0-beta-22703",
+          "System.Reflection": "4.0.10-beta-22703",
+          "System.Reflection.Primitives": "4.0.0-beta-22703",
+          "System.Runtime": "4.0.20-beta-22703",
+          "System.Runtime.Extensions": "4.0.10-beta-22703",
+          "System.Runtime.Handles": "4.0.0-beta-22703",
+          "System.Runtime.InteropServices": "4.0.20-beta-22703",
+          "System.Text.Encoding": "4.0.10-beta-22703",
+          "System.Threading": "4.0.10-beta-22703",
+          "System.Threading.Tasks": "4.0.10-beta-22703",
+          "xunit.abstractions.netcore": "1.0.0-prerelease",
+          "xunit.core.netcore": "1.0.0-prerelease"
+        },
+        "compile": [
+          "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
+        ]
+      }
+    }
+  },
+  "libraries": {
+    "System.Collections/4.0.0-beta-23008": {
+      "sha512": "GbHBy1NvO92u+/+9opTcYpfxqhIWgiAuogAj2ag3drWcpSl1VlWgPyTH9Tzy26jhM3FDRyyhtzHn7LWsDzFTLg==",
+      "files": [
+        "License.rtf",
+        "System.Collections.4.0.0-beta-23008.nupkg",
+        "System.Collections.4.0.0-beta-23008.nupkg.sha512",
+        "System.Collections.nuspec",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "ref/any/System.Collections.dll",
+        "ref/net45/_._",
+        "ref/win8/_._"
+      ]
+    },
+    "System.Console/4.0.0-beta-23008": {
+      "sha512": "tYqFB6jTTA5/aCFigf3rb2fIIKLXmwamC5xTD6VuQGdxgbORAw6hw6GCMCKiwkgk59FeH/yhedgVNNmgr6xBYg==",
+      "files": [
+        "System.Console.4.0.0-beta-23008.nupkg",
+        "System.Console.4.0.0-beta-23008.nupkg.sha512",
+        "System.Console.nuspec",
+        "lib/DNXCore50/System.Console.dll",
+        "lib/net46/System.Console.dll",
+        "ref/any/System.Console.dll",
+        "ref/net46/System.Console.dll"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10-beta-23008": {
+      "sha512": "nJDxh4LmuRPM/GKdWMX6kqpR2GHTWoIy1U8rOKMsBd7z+SjPyZn9F5IQjjRpi/ClOc88kNAtVgvWn4iCYU26Nw==",
+      "files": [
+        "System.Diagnostics.Debug.4.0.10-beta-23008.nupkg",
+        "System.Diagnostics.Debug.4.0.10-beta-23008.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/any/System.Diagnostics.Debug.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.20-beta-23008": {
+      "sha512": "m6irlhgmoh4p0pfR3cGFprlvXy4Gx9WQRTMdFA5/qIBwaD66Ul01cJAuTlJAvn9q2joqBWYr+meaAl7VoDZIpQ==",
+      "files": [
+        "System.Diagnostics.Tracing.4.0.20-beta-23008.nupkg",
+        "System.Diagnostics.Tracing.4.0.20-beta-23008.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Tracing.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/any/System.Diagnostics.Tracing.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
+      ]
+    },
+    "System.Globalization/4.0.10-beta-23008": {
+      "sha512": "JBUTXW1KzjXantOJhPZQUTyoQ+AVtIVDW8nqyv0YfPjDnSAds51uvIW+tYiDM6yXFhjeXjNT/RcKBR6OtUmbTg==",
+      "files": [
+        "System.Globalization.4.0.10-beta-23008.nupkg",
+        "System.Globalization.4.0.10-beta-23008.nupkg.sha512",
+        "System.Globalization.nuspec",
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
+        "ref/any/System.Globalization.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
+      ]
+    },
+    "System.IO/4.0.10-beta-23008": {
+      "sha512": "NrvoHRUhZUAILWNGPFayAlezxqo4R2qX7RZ/wwJ2PjSY/4svgDuaB4VJRTnuOPx1wRQasPLXI5sEl+dXPvfTnQ==",
+      "files": [
+        "System.IO.4.0.10-beta-23008.nupkg",
+        "System.IO.4.0.10-beta-23008.nupkg.sha512",
+        "System.IO.nuspec",
+        "lib/DNXCore50/System.IO.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "ref/any/System.IO.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0-beta-23008": {
+      "sha512": "pW1z4Lk7GtKHqgoI2DG9Alhjp9TK46DIwjM/61H++RtVi0xKQ519ho2t9Mx3dFCpq0YQmjbApvzjOES4xmjvUw==",
+      "files": [
+        "System.IO.FileSystem.Primitives.4.0.0-beta-23008.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-23008.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec",
+        "lib/any/System.IO.FileSystem.Primitives.dll",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/any/System.IO.FileSystem.Primitives.dll",
+        "ref/net46/System.IO.FileSystem.Primitives.dll"
+      ]
+    },
+    "System.Linq/4.0.0-beta-22816": {
+      "sha512": "QlwRD8FTiYAZ7BxEjB5u9vjKaAHZ6KvuZYm+4tjYduTIWpFI3o34UjowJXCaPlLwc8USRshAXLgnsQ3iaOjv8Q==",
+      "files": [
+        "License.rtf",
+        "System.Linq.4.0.0-beta-22816.nupkg",
+        "System.Linq.4.0.0-beta-22816.nupkg.sha512",
+        "System.Linq.nuspec",
+        "lib/aspnetcore50/System.Linq.dll",
+        "lib/contract/System.Linq.dll",
+        "lib/net45/System.Linq.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Linq.dll"
+      ]
+    },
+    "System.Private.Uri/4.0.0-beta-23008": {
+      "sha512": "q2VlKvy9ufHawdI5abrNKXvUIgFZYnBYMtPqK8gy1kEVhaQ1LWR7WLprwgI11mk7Ef18+P5mj08gCuXbl/rINw==",
+      "files": [
+        "System.Private.Uri.4.0.0-beta-23008.nupkg",
+        "System.Private.Uri.4.0.0-beta-23008.nupkg.sha512",
+        "System.Private.Uri.nuspec",
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
+      ]
+    },
+    "System.Reflection/4.0.10-beta-23008": {
+      "sha512": "1189taPg0slhVhsstTmIlvzAdCQfLLr5Wd187fZHO3NPNMxrO7VLkI+t8G33HBCVtRfFzkNbpk3sTHtqA3yqAw==",
+      "files": [
+        "System.Reflection.4.0.10-beta-23008.nupkg",
+        "System.Reflection.4.0.10-beta-23008.nupkg.sha512",
+        "System.Reflection.nuspec",
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
+        "ref/any/System.Reflection.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0-beta-23008": {
+      "sha512": "eI0lHFHEQZcLM3iHj0nj6GbbY9wSrC70usIZ7qryR8xSExmJANVy34+Z8dquXx3wscYFAhyhFBCBOAle1a2HXw==",
+      "files": [
+        "System.Reflection.Primitives.4.0.0-beta-23008.nupkg",
+        "System.Reflection.Primitives.4.0.0-beta-23008.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "ref/any/System.Reflection.Primitives.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0-beta-23008": {
+      "sha512": "6lqlZBtUl2Fo2rZjWO4lKO6n59RKrfwCwB2i1kLEiYthOVQ3/neeGkpErpOBkabXq6lk5SMgJpp3jC/AfPsmAA==",
+      "files": [
+        "System.Resources.ResourceManager.4.0.0-beta-23008.nupkg",
+        "System.Resources.ResourceManager.4.0.0-beta-23008.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec",
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "ref/any/System.Resources.ResourceManager.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-23008": {
+      "sha512": "YX9/7Q6EHadgTLjH4Sa5zKHGMTMrwiMynAlQxMSQLGYCyJX6Z4/hejrBR7cNxrRddXnzxs5OALdEZqdU80zwxw==",
+      "files": [
+        "System.Runtime.4.0.20-beta-23008.nupkg",
+        "System.Runtime.4.0.20-beta-23008.nupkg.sha512",
+        "System.Runtime.nuspec",
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "ref/any/System.Runtime.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10-beta-23008": {
+      "sha512": "488ce5N/0JQ2EbMzolr3CiIwqY64HEtxh3bIRDZ87p1eY2hQ79pROseFjQQ5n9q7aG+xs1D5CWVzuXcps976tA==",
+      "files": [
+        "System.Runtime.Extensions.4.0.10-beta-23008.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-23008.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/any/System.Runtime.Extensions.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0-beta-23008": {
+      "sha512": "MC+Xc6KdYugsDK3xBefREfzPgzwhM1nDAF/nbaGLllx/huXsIvoBjFXRpxtbXfKrShYZBvInsfaElCpx28b1Rg==",
+      "files": [
+        "System.Runtime.Handles.4.0.0-beta-23008.nupkg",
+        "System.Runtime.Handles.4.0.0-beta-23008.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "ref/any/System.Runtime.Handles.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20-beta-23008": {
+      "sha512": "aEI0FSdMvSv71yf+992rXOr5O3lJg+7SBN47p1C9Vmup/33IYqdAHoerV7WZ8y0s7KOtAwhKQBH5AokJgRGSiQ==",
+      "files": [
+        "System.Runtime.InteropServices.4.0.20-beta-23008.nupkg",
+        "System.Runtime.InteropServices.4.0.20-beta-23008.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/any/System.Runtime.InteropServices.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
+      ]
+    },
+    "System.Text.Encoding/4.0.10-beta-23008": {
+      "sha512": "dDcnfqdj6stUj1o1mNZIxEDTI0er7TVER+CVcng+6rEejErS5HQjIEsuEepQSiAF3VDiZu8ZI89RAUuQbCSjEw==",
+      "files": [
+        "System.Text.Encoding.4.0.10-beta-23008.nupkg",
+        "System.Text.Encoding.4.0.10-beta-23008.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "ref/any/System.Text.Encoding.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.10-beta-23008": {
+      "sha512": "prdF3DGvtjlD0/YKpJGtWIZWCGfIj/ym4MKHOKVu6JsxKpykNu2w4M0Ox42CAxlEFRk9FoHARLPiENgm7bdySw==",
+      "files": [
+        "System.Text.Encoding.Extensions.4.0.10-beta-23008.nupkg",
+        "System.Text.Encoding.Extensions.4.0.10-beta-23008.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/any/System.Text.Encoding.Extensions.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
+      ]
+    },
+    "System.Threading/4.0.10-beta-23008": {
+      "sha512": "RzNbZAUcR5Kkl/vj+7tqdHzmYFR+y7a2vW6rZPWOPnQaRsyxPVZxlyOgDseHTcRC3rAK8CmmmFwgo9LzjZlZUg==",
+      "files": [
+        "System.Threading.4.0.10-beta-23008.nupkg",
+        "System.Threading.4.0.10-beta-23008.nupkg.sha512",
+        "System.Threading.nuspec",
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "ref/any/System.Threading.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10-beta-23008": {
+      "sha512": "G47/e2ZxNzYmfAXgHA7UwxdTGVJPD4bLmG/v1pxyPTyTsPzNA3CjqHVId27PsDdfo/L3w2Cl+oZM1s+pHfXXRw==",
+      "files": [
+        "System.Threading.Tasks.4.0.10-beta-23008.nupkg",
+        "System.Threading.Tasks.4.0.10-beta-23008.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "ref/any/System.Threading.Tasks.dll",
+        "ref/net46/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
+      ]
+    },
+    "xunit/2.0.0-beta5-build2785": {
+      "sha512": "bNycxZe/83M7o7j0IbGp3/daiPLi17hZgYZB6xttgCVDnxgAuw/TP1zetiUTW1yVUPASnAjlkBeJayv/G2Crsw==",
+      "files": [
+        "xunit.2.0.0-beta5-build2785.nupkg",
+        "xunit.2.0.0-beta5-build2785.nupkg.sha512",
+        "xunit.nuspec"
+      ]
+    },
+    "xunit.abstractions/2.0.0-beta5-build2785": {
+      "sha512": "b2RCnV2/wilCH1dsh7bAF82Ou+Vs+WfYLEItzRUUbD3YHNODx0ncpQwLz1JYjL/voBFc5mQh77hxIbgCGmyxKA==",
+      "files": [
+        "xunit.abstractions.2.0.0-beta5-build2785.nupkg",
+        "xunit.abstractions.2.0.0-beta5-build2785.nupkg.sha512",
+        "xunit.abstractions.nuspec",
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.abstractions.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.abstractions.xml"
+      ]
+    },
+    "xunit.abstractions.netcore/1.0.0-prerelease": {
+      "sha512": "fajSAvVztuUVSb/o1GxYM5I33Ikvx6CNNscpOnDAl6AnDAKqhOeu3iPTL0VzDhzXiXyOKbRi4iewv4hAWTgeuw==",
+      "files": [
+        "xunit.abstractions.netcore.1.0.0-prerelease.nupkg",
+        "xunit.abstractions.netcore.1.0.0-prerelease.nupkg.sha512",
+        "xunit.abstractions.netcore.nuspec",
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml"
+      ]
+    },
+    "xunit.assert/2.0.0-beta5-build2785": {
+      "sha512": "1PTLrP+jLzSIhqO3JzzgPcMPmSyBlFadpFH6v3d2Vm08x/bIYHnF78h20qt6wk/t3wMu7smOsyoNcUFeP2ZnGg==",
+      "files": [
+        "xunit.assert.2.0.0-beta5-build2785.nupkg",
+        "xunit.assert.2.0.0-beta5-build2785.nupkg.sha512",
+        "xunit.assert.nuspec",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.pdb",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.xml"
+      ]
+    },
+    "xunit.core/2.0.0-beta5-build2785": {
+      "sha512": "3rDhbyvCS1iA20A7uXxYvw3LLa4MtyXUX9Y6i3QjY/dRhIHEZcSxBjBfGP3MjPm900WnsBx2H0ryQo2RWABhhg==",
+      "files": [
+        "xunit.core.2.0.0-beta5-build2785.nupkg",
+        "xunit.core.2.0.0-beta5-build2785.nupkg.sha512",
+        "xunit.core.nuspec",
+        "build/monoandroid/xunit.core.props",
+        "build/monoandroid/xunit.execution.dll",
+        "build/monotouch/xunit.core.props",
+        "build/monotouch/xunit.execution.dll",
+        "build/portable-net45+win+wpa81+wp80+monotouch+monoandroid/xunit.core.props",
+        "build/portable-net45+win+wpa81+wp80+monotouch+monoandroid/xunit.execution.dll",
+        "build/win8/xunit.core.props",
+        "build/win8/xunit.core.targets",
+        "build/win8/xunit.execution.dll",
+        "build/win8/device/xunit.execution.dll",
+        "build/wp8/xunit.core.props",
+        "build/wp8/xunit.core.targets",
+        "build/wp8/xunit.execution.dll",
+        "build/wp8/device/xunit.execution.dll",
+        "build/wpa81/xunit.core.props",
+        "build/wpa81/xunit.core.targets",
+        "build/wpa81/xunit.execution.dll",
+        "build/wpa81/device/xunit.execution.dll",
+        "build/wpa81/device/xunit.execution.pri",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.dll.tdnet",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.pdb",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.xml",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.runner.tdnet.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.runner.utility.dll"
+      ]
+    },
+    "xunit.core.netcore/1.0.1-prerelease": {
+      "sha512": "iy2u6WUx6CxSn7ahvJrBOrrpsLphtu1kjDGmyJKOiCmoCPczZEHjPOVL1OCt4V3EWCwS0zypWV8uVSqn1/UM8g==",
+      "files": [
+        "xunit.core.netcore.1.0.1-prerelease.nupkg",
+        "xunit.core.netcore.1.0.1-prerelease.nupkg.sha512",
+        "xunit.core.netcore.nuspec",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.pdb",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.xml",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.dll",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.pdb",
+        "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
+      ]
+    },
+    "xunit.netcore.extensions/1.0.0-prerelease-00053": {
+      "sha512": "Nr3usfWn6O4WWWJyIN9wgMENawbcGuZ0wjlVkBFxbC+O0KRc2K+F8sWNJ7mN6RN8wlczI3tizEcve83m/MvqtQ==",
+      "files": [
+        "xunit.netcore.extensions.1.0.0-prerelease-00053.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00053.nupkg.sha512",
+        "xunit.netcore.extensions.nuspec",
+        "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Collections >= 4.0.0-beta-*",
+      "System.Console >= 4.0.0-beta-*",
+      "System.Diagnostics.Debug >= 4.0.10-beta-*",
+      "System.Diagnostics.Tracing >= 4.0.20-beta-*",
+      "System.Globalization >= 4.0.10-beta-*",
+      "System.Reflection >= 4.0.10-beta-*",
+      "System.Runtime >= 4.0.20-beta-*",
+      "System.Runtime.Extensions >= 4.0.10-beta-*",
+      "System.Runtime.InteropServices >= 4.0.20-beta-*",
+      "System.Threading >= 4.0.10-beta-*",
+      "System.Threading.Tasks >= 4.0.10-beta-*",
+      "xunit >= 2.0.0-beta5-build2785",
+      "xunit.abstractions.netcore >= 1.0.0-prerelease",
+      "xunit.assert >= 2.0.0-beta5-build2785",
+      "xunit.core.netcore >= 1.0.1-prerelease",
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}


### PR DESCRIPTION
This commit provides a System.Threading.Tasks.Tests project that doesn't include all of the tests that @mellinoe is porting (#702).  However, it does include a new set of tests written from scratch for TaskExtensions.Unwrap, which is the portion of System.Threading.Tasks whose source lives in corefx rather than in coreclr.  

These new tests are meant to be the primary unit testing for Unwrap, as the existing tests only superficially exercise the functionality. Once these are committed, #1589 can be validated against them (and the TODOs in the tests can be uncommented, as they're addressed by the new implementation).