### PR TITLE
Makes a static field used by multiple tests ThreadStatic

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.genclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.genclass.cs
@@ -29,6 +29,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.genclas
 
     public class MemberClass<T>
     {
+        [ThreadStatic]
         public static int Status;
         public bool? this[string p1, float p2, short[] p3]
         {
@@ -238,6 +239,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.genclas
     public class MemberClassWithClassConstraint<T>
         where T : class
     {
+        [ThreadStatic]
         public static int Status;
         public int this[int x]
         {
@@ -271,6 +273,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.genclas
     public class MemberClassWithNewConstraint<T>
         where T : new()
     {
+        [ThreadStatic]
         public static int Status;
         public dynamic this[T t]
         {

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.genclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.genclass.cs
@@ -236,7 +236,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.genclas
     public class MemberClassWithAnotherTypeConstraint<T, U>
         where T : U
     {
-        public static int Status;
         public static implicit operator MyStruct[] (MemberClassWithAnotherTypeConstraint<T, U> p1)
         {
             return new MyStruct[]


### PR DESCRIPTION
If tests run concurrently we could have random failures.

Fixes #1544