### PR TITLE
Add FreeBSD to System.Private.Uri

### DIFF
--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -14,6 +14,8 @@
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU' " />
@@ -138,6 +140,15 @@
     </Compile>
   </ItemGroup>
 
+  <!-- FreeBSD -->
+  <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\FreeBSD\Interop.Errors.cs">
+      <Link>Common\Interop\FreeBSD\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\FreeBSD\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\FreeBSD\Interop.OpenFlags.cs</Link>
+    </Compile>
+  </ItemGroup>
   <!-- Linux -->
   <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Errors.cs">


### PR DESCRIPTION
Add FreeBSD to the System.Private.Uri.CoreCLR.csproj file. This commit depends on the Interop bits from PR#2031.