### PR TITLE
Avoid unnecessary allocations related to X509ChainElementCollection

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IChainPal.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Win32.SafeHandles;
@@ -16,7 +15,7 @@ namespace Internal.Cryptography.Pal
         /// </summary>
         bool? Verify(X509VerificationFlags flags, out Exception exception);
 
-        IEnumerable<X509ChainElement> ChainElements { get; }
+        X509ChainElement[] ChainElements { get; }
         X509ChainStatus[] ChainStatus { get; }
         SafeX509ChainHandle SafeHandle { get; }
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Win32.SafeHandles;
@@ -18,7 +20,7 @@ namespace Internal.Cryptography.Pal
             return null;
         }
 
-        public IEnumerable<X509ChainElement> ChainElements
+        public X509ChainElement[] ChainElements
         {
             get { throw new NotImplementedException(); }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.cs
@@ -2,21 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
-using System.Diagnostics;
-using System.Globalization;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 
-using Internal.NativeCrypto;
-using Internal.Cryptography;
 using Internal.Cryptography.Pal.Native;
 
-using System.Security.Cryptography;
-
-using FILETIME = Internal.Cryptography.Pal.Native.FILETIME;
-using SafeX509ChainHandle = Microsoft.Win32.SafeHandles.SafeX509ChainHandle;
-using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
 {
@@ -49,7 +41,7 @@ namespace Internal.Cryptography.Pal
             return status.dwError == 0;
         }
 
-        public IEnumerable<X509ChainElement> ChainElements
+        public X509ChainElement[] ChainElements
         {
             get
             {
@@ -58,7 +50,7 @@ namespace Internal.Cryptography.Pal
                     CERT_CHAIN_CONTEXT* pCertChainContext = (CERT_CHAIN_CONTEXT*)(_chain.DangerousGetHandle());
                     CERT_SIMPLE_CHAIN* pCertSimpleChain = pCertChainContext->rgpChain[0];
 
-                    LowLevelListWithIList<X509ChainElement> chainElements = new LowLevelListWithIList<X509ChainElement>();
+                    X509ChainElement[] chainElements = new X509ChainElement[pCertSimpleChain->cElement];
                     for (int i = 0; i < pCertSimpleChain->cElement; i++)
                     {
                         CERT_CHAIN_ELEMENT* pChainElement = pCertSimpleChain->rgpElement[i];
@@ -68,7 +60,7 @@ namespace Internal.Cryptography.Pal
                         String information = Marshal.PtrToStringUni(pChainElement->pwszExtendedErrorInfo);
 
                         X509ChainElement chainElement = new X509ChainElement(certificate, chainElementStatus, information);
-                        chainElements.Add(chainElement);
+                        chainElements[i] = chainElement;
                     }
 
                     GC.KeepAlive(this);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
@@ -1,21 +1,26 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
 using System.Collections;
 using System.Diagnostics;
-using System.Globalization;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
 
 namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class X509ChainElementCollection : ICollection, IEnumerable
     {
+        private readonly X509ChainElement[] _elements;
+
+        internal X509ChainElementCollection()
+        {
+            _elements = Array.Empty<X509ChainElement>();
+        }
+
+        internal X509ChainElementCollection(X509ChainElement[] chainElements)
+        {
+            Debug.Assert(chainElements != null, "chainElements != null");
+            _elements = chainElements;
+        }
+
         public int Count
         {
             get { return _elements.Length; }
@@ -26,7 +31,7 @@ namespace System.Security.Cryptography.X509Certificates
             get { return false; }
         }
 
-        public Object SyncRoot
+        public object SyncRoot
         {
             get { return this; }
         }
@@ -79,21 +84,5 @@ namespace System.Security.Cryptography.X509Certificates
         {
             return new X509ChainElementEnumerator(this);
         }
-
-        internal X509ChainElementCollection()
-        {
-            _elements = new X509ChainElement[0];
-            return;
-        }
-
-        internal X509ChainElementCollection(IEnumerable<X509ChainElement> chainElements)
-        {
-            _elements = new LowLevelList<X509ChainElement>(chainElements).ToArray();
-            return;
-        }
-
-
-        private X509ChainElement[] _elements;
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementEnumerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementEnumerator.cs
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
 using System.Collections;
-using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
 
 namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class X509ChainElementEnumerator : IEnumerator
     {
+        private readonly X509ChainElementCollection _chainElements;
+        private int _current;
+
+        internal X509ChainElementEnumerator(X509ChainElementCollection chainElements)
+        {
+            _chainElements = chainElements;
+            _current = -1;
+        }
+
         public X509ChainElement Current
         {
             get
@@ -23,11 +24,11 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        Object IEnumerator.Current
+        object IEnumerator.Current
         {
             get
             {
-                return _chainElements[_current];
+                return Current;
             }
         }
 
@@ -43,15 +44,5 @@ namespace System.Security.Cryptography.X509Certificates
         {
             _current = -1;
         }
-
-        internal X509ChainElementEnumerator(X509ChainElementCollection chainElements)
-        {
-            _chainElements = chainElements;
-            _current = -1;
-        }
-
-        private X509ChainElementCollection _chainElements;
-        private int _current;
     }
 }
-


### PR DESCRIPTION
- Avoid intermediate `LowLevelList<T>`, `Array`, and `Enumerator` allocations.
- Minor cleanup.

/cc @bartonjs