### PR TITLE
Remove unnecessary SafeHandle allocations in X509Certificates library

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeHandleCache.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeHandleCache.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    /// <summary>Provides a cache for special instances of SafeHandles.</summary>
+    /// <typeparam name="T">Specifies the type of SafeHandle.</typeparam>
+    internal static class SafeHandleCache<T> where T : SafeHandle
+    {
+        private static T s_invalidHandle;
+
+        /// <summary>
+        /// Gets a cached, invalid handle.  As the instance is cached, it should either never be Disposed
+        /// or it should override <see cref="SafeHandle.Dispose(bool)"/> to prevent disposal when the
+        /// instance is the <see cref="InvalidHandle"/>.
+        /// </summary>
+        internal static T GetInvalidHandle(Func<T> invalidHandleFactory)
+        {
+            T currentHandle = Volatile.Read(ref s_invalidHandle);
+            if (currentHandle == null)
+            {
+                T newHandle = invalidHandleFactory();
+                currentHandle = Interlocked.CompareExchange(ref s_invalidHandle, newHandle, null);
+                if (currentHandle == null)
+                {
+                    GC.SuppressFinalize(newHandle);
+                    currentHandle = newHandle;
+                }
+                else
+                {
+                    newHandle.Dispose();
+                }
+            }
+            Debug.Assert(currentHandle.IsInvalid);
+            return currentHandle;
+        }
+
+        /// <summary>Gets whether the specified handle is <see cref="InvalidHandle"/>.</summary>
+        /// <param name="handle">The handle to compare.</param>
+        /// <returns>true if <paramref name="handle"/> is <see cref="InvalidHandle"/>; otherwise, false.</returns>
+        internal static bool IsCachedInvalidHandle(SafeHandle handle)
+        {
+            Debug.Assert(handle != null);
+            bool isCachedInvalidHandle = ReferenceEquals(handle, Volatile.Read(ref s_invalidHandle));
+            Debug.Assert(!isCachedInvalidHandle || handle.IsInvalid, "The cached invalid handle must still be invalid.");
+            return isCachedInvalidHandle;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.Import.cs
@@ -137,7 +137,7 @@ namespace Internal.Cryptography.Pal
                     certInfo.SerialNumber.pbData = pCmsgSignerInfo->SerialNumber.pbData;
                 }
 
-                SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
+                SafeCertContextHandle pCertContext = null;
                 if (!Interop.crypt32.CertFindCertificateInStore(hCertStore, CertFindType.CERT_FIND_SUBJECT_CERT, &certInfo, ref pCertContext))
                     throw new CryptographicException(Marshal.GetHRForLastWin32Error());
 
@@ -147,7 +147,7 @@ namespace Internal.Cryptography.Pal
 
         private static SafeCertContextHandle FilterPFXStore(byte[] rawData, String password, PfxCertStoreFlags pfxCertStoreFlags)
         {
-            SafeCertStoreHandle hStore = SafeCertStoreHandle.InvalidHandle;
+            SafeCertStoreHandle hStore;
             unsafe
             {
                 fixed (byte* pbRawData = rawData)
@@ -164,7 +164,7 @@ namespace Internal.Cryptography.Pal
                 // Find the first cert with private key. If none, then simply take the very first cert. Along the way, delete the keycontainers
                 // of any cert we don't accept.
                 SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
-                SafeCertContextHandle pEnumContext = SafeCertContextHandle.InvalidHandle;
+                SafeCertContextHandle pEnumContext = null;
                 while (Interop.crypt32.CertEnumCertificatesInStore(hStore, ref pEnumContext))
                 {
                     if (pEnumContext.ContainsPrivateKey)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
@@ -23,11 +23,10 @@ namespace Internal.Cryptography.Pal.Native
         /// </summary>
         public static SafeHandle ToLpstrArray(this OidCollection oids, out int numOids)
         {
-            SafeLocalAllocHandle safeLocalAllocHandle = SafeLocalAllocHandle.InvalidHandle;
             if (oids == null || oids.Count == 0)
             {
                 numOids = 0;
-                return safeLocalAllocHandle;
+                return SafeLocalAllocHandle.InvalidHandle;
             }
 
             // Copy the oid strings to a local list to prevent a security race condition where
@@ -52,7 +51,7 @@ namespace Internal.Cryptography.Pal.Native
                     }
                 }
 
-                safeLocalAllocHandle = SafeLocalAllocHandle.Create(allocationSize);
+                SafeLocalAllocHandle safeLocalAllocHandle = SafeLocalAllocHandle.Create(allocationSize);
                 byte** pOidPointers = (byte**)(safeLocalAllocHandle.DangerousGetHandle());
                 byte* pOidContents = (byte*)(pOidPointers + numOids);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -104,15 +104,15 @@ namespace Internal.Cryptography.Pal.Native
             /// <summary>
             /// A less error-prone wrapper for CertEnumCertificatesInStore().
             /// 
-            /// To begin the enumeration, set pCertContext to SafeCertStoreHandle.InvalidHandle. Each iteration replaces pCertContext with
-            /// the next certificate in the iteration. The final call sets pCertContext back to SafeCertStoreHandle.InvalidHandle and returns "false"
-            /// to indicate the the end of the store has been reached.
+            /// To begin the enumeration, set pCertContext to null. Each iteration replaces pCertContext with
+            /// the next certificate in the iteration. The final call sets pCertContext to an invalid SafeCertStoreHandle 
+            /// and returns "false" to indicate the the end of the store has been reached.
             /// </summary>
             public static bool CertEnumCertificatesInStore(SafeCertStoreHandle hCertStore, ref SafeCertContextHandle pCertContext)
             {
                 unsafe
                 {
-                    CERT_CONTEXT* pPrevCertContext = pCertContext.Disconnect();
+                    CERT_CONTEXT* pPrevCertContext = pCertContext == null ? null : pCertContext.Disconnect();
                     pCertContext = CertEnumCertificatesInStore(hCertStore, pPrevCertContext);
                     return !pCertContext.IsInvalid;
                 }
@@ -226,13 +226,13 @@ namespace Internal.Cryptography.Pal.Native
             /// <summary>
             /// A less error-prone wrapper for CertEnumCertificatesInStore().
             /// 
-            /// To begin the enumeration, set pCertContext to SafeCertStoreHandle.InvalidHandle. Each iteration replaces pCertContext with
-            /// the next certificate in the iteration. The final call sets pCertContext back to SafeCertStoreHandle.InvalidHandle and returns "false"
-            /// to indicate the the end of the store has been reached.
+            /// To begin the enumeration, set pCertContext to null. Each iteration replaces pCertContext with
+            /// the next certificate in the iteration. The final call sets pCertContext to an invalid SafeCertStoreHandle 
+            /// and returns "false" to indicate the the end of the store has been reached.
             /// </summary>
             public static unsafe bool CertFindCertificateInStore(SafeCertStoreHandle hCertStore, CertFindType dwFindType, void* pvFindPara, ref SafeCertContextHandle pCertContext)
             {
-                CERT_CONTEXT* pPrevCertContext = pCertContext.Disconnect();
+                CERT_CONTEXT* pPrevCertContext = pCertContext == null ? null : pCertContext.Disconnect();
                 pCertContext = CertFindCertificateInStore(hCertStore, CertEncodingType.All, CertFindFlags.None, dwFindType, pvFindPara, pPrevCertContext);
                 return !pCertContext.IsInvalid;
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Export.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Export.cs
@@ -27,7 +27,7 @@ namespace Internal.Cryptography.Pal
             {
                 case X509ContentType.Cert:
                     {
-                        SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
+                        SafeCertContextHandle pCertContext = null;
                         if (!Interop.crypt32.CertEnumCertificatesInStore(_certStore, ref pCertContext))
                             return null;
                         try
@@ -48,7 +48,7 @@ namespace Internal.Cryptography.Pal
 
                 case X509ContentType.SerializedCert:
                     {
-                        SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
+                        SafeCertContextHandle pCertContext = null;
                         if (!Interop.crypt32.CertEnumCertificatesInStore(_certStore, ref pCertContext))
                             return null;
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Find.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Find.cs
@@ -478,7 +478,7 @@ namespace Internal.Cryptography.Pal
             if (findResults.IsInvalid)
                 throw new CryptographicException(Marshal.GetHRForLastWin32Error());
 
-            SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
+            SafeCertContextHandle pCertContext = null;
             while (Interop.crypt32.CertFindCertificateInStore(_certStore, dwFindType, pvFindPara, ref pCertContext))
             {
                 if (filter != null && !filter(pCertContext))

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
@@ -48,7 +48,7 @@ namespace Internal.Cryptography.Pal
                         void* pvObject = fromFile ? (void*)pFileName : (void*)&blob;
 
                         ContentType contentType;
-                        SafeCertStoreHandle certStore = SafeCertStoreHandle.InvalidHandle;
+                        SafeCertStoreHandle certStore;
                         if (!Interop.crypt32.CryptQueryObject(
                             fromFile ? CertQueryObjectType.CERT_QUERY_OBJECT_FILE : CertQueryObjectType.CERT_QUERY_OBJECT_BLOB,
                             pvObject,
@@ -86,7 +86,7 @@ namespace Internal.Cryptography.Pal
 
                         if (!persistKeySet)
                         {
-                            SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
+                            SafeCertContextHandle pCertContext = null;
                             while (Interop.crypt32.CertEnumCertificatesInStore(certStore, ref pCertContext))
                             {
                                 CRYPTOAPI_BLOB nullBlob = new CRYPTOAPI_BLOB(0, null);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.cs
@@ -27,7 +27,7 @@ namespace Internal.Cryptography.Pal
             {
                 LowLevelListWithIList<X509Certificate2> certificates = new LowLevelListWithIList<X509Certificate2>();
 
-                SafeCertContextHandle pCertContext = SafeCertContextHandle.InvalidHandle;
+                SafeCertContextHandle pCertContext = null;
                 while (Interop.crypt32.CertEnumCertificatesInStore(_certStore, ref pCertContext))
                 {
                     X509Certificate2 cert = new X509Certificate2(pCertContext.DangerousGetHandle());
@@ -49,7 +49,7 @@ namespace Internal.Cryptography.Pal
             unsafe
             {
                 SafeCertContextHandle existingCertContext = ((CertificatePal)certificate).CertContext;
-                SafeCertContextHandle enumCertContext = SafeCertContextHandle.InvalidHandle;
+                SafeCertContextHandle enumCertContext = null;
                 CERT_CONTEXT* pCertContext = existingCertContext.CertContext;
                 if (!Interop.crypt32.CertFindCertificateInStore(_certStore, CertFindType.CERT_FIND_EXISTING, pCertContext, ref enumCertContext))
                     return; // The certificate is not present in the store, simply return.

--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafeX509ChainHandle.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafeX509ChainHandle.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
-using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
 using Internal.Cryptography.Pal;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -25,15 +20,22 @@ namespace Microsoft.Win32.SafeHandles
             get { return handle == IntPtr.Zero; }
         }
 
+        public static SafeX509ChainHandle InvalidHandle
+        {
+            get { return SafeHandleCache<SafeX509ChainHandle>.GetInvalidHandle(() => new SafeX509ChainHandle()); }
+        }
+
         protected override bool ReleaseHandle()
         {
             return ChainPal.ReleaseSafeX509ChainHandle(handle);
         }
 
-        internal static SafeX509ChainHandle InvalidHandle
+        protected override void Dispose(bool disposing)
         {
-            get { return new SafeX509ChainHandle(); }
+            if (!SafeHandleCache<SafeX509ChainHandle>.IsCachedInvalidHandle(this))
+            {
+                base.Dispose(disposing);
+            }
         }
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -22,6 +22,9 @@
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs">
       <Link>Common\System\Collections\Generic\LowLevelList.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
+    </Compile>
     <Compile Include="Internal\Cryptography\ErrorCode.cs" />
     <Compile Include="Internal\Cryptography\Helpers.cs" />
     <Compile Include="Internal\Cryptography\Oids.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -90,6 +90,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             if (store.Certificates.Count > 0)
             {
                 X509Chain chain = new X509Chain();
+                Assert.NotNull(chain.SafeHandle);
+                Assert.Same(chain.SafeHandle, chain.SafeHandle);
+                Assert.True(chain.SafeHandle.IsInvalid);
+
                 foreach (X509Certificate2 c in store.Certificates)
                 {
                     // can't guarantee success, so no Assert 


### PR DESCRIPTION
Several related issues:
- The custom SafeHandle types expose an InvalidHandle property.  As a property, one typically expects that each call to the property returns the same instance, but each call to these properties is manufacturing a new SafeHandle instance.
- Lots of the accesses to InvalidHandle are to get an initially "null" handle to pass to a native function that expects a null handle on the first invocation.  This means that we're allocating a finalizable object only to then throw it away.
- In some cases, we were completely ignoring the allocated handle, e.g. initializing a handle to InvalidHandle and then immediately using that variable as an out argument.
- etc.

This commit addresses these issues, such that the number of allocated handles noticeably decreases.  As an example, during the execution of the System.Security.Cryptography.X509Certificates.Tests as they currently exist, prior to this change 1661 SafePointerHandles were being allocated; after this change, that number drops to 1410, for a 15% reduction.

Contributes to #1995.