### PR TITLE
Add FreeBSD support to System.IO.Compression.ZipFile

### DIFF
--- a/src/System.IO.Compression.ZipFile/System.IO.Compression.ZipFile.sln
+++ b/src/System.IO.Compression.ZipFile/System.IO.Compression.ZipFile.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.ZipFi
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		FreeBSD_Debug|Any CPU = FreeBSD_Debug|Any CPU
+		FreeBSD_Release|Any CPU = FreeBSD_Release|Any CPU
 		Linux_Debug|Any CPU = Linux_Debug|Any CPU
 		Linux_Release|Any CPU = Linux_Release|Any CPU
 		OSX_Debug|Any CPU = OSX_Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.FreeBSD_Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.FreeBSD_Debug|Any CPU.Build.0 = Release|Any CPU
+		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.FreeBSD_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.FreeBSD_Release|Any CPU.Build.0 = Release|Any CPU
 		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Linux_Debug|Any CPU.ActiveCfg = Release|Any CPU
 		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Linux_Debug|Any CPU.Build.0 = Release|Any CPU
 		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -29,6 +35,10 @@ Global
 		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Windows_Debug|Any CPU.Build.0 = Release|Any CPU
 		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
+		{ED453083-A80F-480C-AD25-5B8618E8A303}.FreeBSD_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED453083-A80F-480C-AD25-5B8618E8A303}.FreeBSD_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED453083-A80F-480C-AD25-5B8618E8A303}.FreeBSD_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED453083-A80F-480C-AD25-5B8618E8A303}.FreeBSD_Release|Any CPU.Build.0 = Release|Any CPU
 		{ED453083-A80F-480C-AD25-5B8618E8A303}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED453083-A80F-480C-AD25-5B8618E8A303}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED453083-A80F-480C-AD25-5B8618E8A303}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -10,6 +10,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
@@ -33,6 +35,12 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- FreeBSD -->
+  <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true'">
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitive.cs">
+      <Link>Common\System\IO\PathInternal.CaseSensitive.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Linux -->


### PR DESCRIPTION
Adding support for FreeBSD to System.IO.Compression.ZipFile. PathInternal is identical to Linux, as they share the same file system requirements (paths are case sensitive and can contain all Unicode characters except NULL).

/cc @josteink @stephentoub 