### PR TITLE
Update build instructions to include FreeBSD.

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -45,7 +45,7 @@ Coding Guidelines
 Building from Source
 ====================
 
-- [Building on Linux](linux-instructions.md)
+- [Building CoreFX on FreeBSD, Linux and OS X](unix-instructions.md)
 - [Code Coverage](code-coverage.md)
 
 Other Information

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -8,11 +8,12 @@ Building the repository
 
 The CoreFX repo can be built from a regular, non-admin command prompt. The build produces multiple managed binaries that make up the CoreFX libraries and the accompanying tests. The repo can be built for the following platforms, using the provided instructions.
 
-| Chip  | Windows | Linux | OS X |
-| :---- | :-----: | :---: | :--: |
-| x64   | &#x25CF;| &#x25D2;| &#x25D2; |		  
-| x86   | &#x25EF;| &#x25EF;| &#x25EF;|
-| ARM32 | &#x25EF; | &#x25EF;| &#x25EF; |
-|       | [Instructions](windows-instructions.md) | [Instructions](linux-instructions.md) | |  
+| Chip  | Windows | Linux | OS X | FreeBSD |
+| :---- | :-----: | :---: | :--: | :--: |
+| x64   | &#x25CF;| &#x25D2;| &#x25D2;| &#x25D2;|
+| x86   | &#x25EF;| &#x25EF;| &#x25EF;| &#x25EF;|
+| ARM32 | &#x25EF;| &#x25EF;| &#x25EF;| &#x25EF;|
+|       | [Instructions](windows-instructions.md) | [Instructions](unix-instructions.md) | [Instructions](unix-instructions.md) | [Instructions](unix-instructions.md) |
+
 
 The CoreFX build and test suite is a work in progress, as are the [building and testing instructions](README.md). The .NET Core team and the community are improving Linux and OS X support on a daily basis are and adding more tests for all platforms. See [CoreFX Issues](https://github.com/dotnet/corefx/issues) to find out about specific work items or report issues.

--- a/Documentation/unix-instructions.md
+++ b/Documentation/unix-instructions.md
@@ -1,5 +1,5 @@
-Building CoreFX on Linux
-========================
+Building CoreFX on FreeBSD, Linux and OS X
+==========================================
 
 CoreFx can be built on top of current [Mono CI builds](#installing-mono-packages) or a direct [build/install of Mono](http://www.mono-project.com/docs/compiling-mono/). It builds using MSBuild and Roslyn and requires changes that have not yet made it to official released builds.
 
@@ -76,3 +76,5 @@ System.Diagnostics.FileVersionInfo.Tests.csproj does not build on Unix. https://
 System.Diagnostics.Debug.Tests does not build on Unix. https://github.com/dotnet/corefx/issues/1609
 
 Mono fails when trying to get custom attributes on CoreFx assemblies. https://bugzilla.xamarin.com/show_bug.cgi?id=29679
+
+Some third party dependencies may incorrectly assume that `bash` is always installed in `/bin/`. This can manifest itself in errors like `corefx/packages/dnx-mono.1.0.0-beta5-11760/bin/dnu: not found`. The simplest way to get around this until fixed upstream is simply making the assumption correct: `sudo ln -s /usr/local/bin/bash /bin/bash`.

--- a/Documentation/windows-instructions.md
+++ b/Documentation/windows-instructions.md
@@ -21,7 +21,7 @@ the core tests for the project. Visual Studio Solution (.sln) files exist for
 related groups of libraries. These can be loaded to build, debug and test inside
 the Visual Studio IDE.
 
-[Building On Linux](linux-instructions.md)
+[Building CoreFX on FreeBSD, Linux and OS X](unix-instructions.md)
 ## Tests
 
 We use the OSS testing framework [xunit](http://xunit.github.io/)

--- a/build.sh
+++ b/build.sh
@@ -21,12 +21,12 @@ __referenceassemblyroot=$__monoroot/lib/mono/xbuild-frameworks
 __monoversion=$(mono --version | grep "version 4.[1-9]")
 
 if [ $? -ne 0 ]; then
-    echo "Mono 4.1 or later is required to build corefx. Please see https://github.com/dotnet/corefx/blob/master/Documentation/linux-instructions.md for more details."
+    echo "Mono 4.1 or later is required to build corefx. Please see https://github.com/dotnet/corefx/blob/master/Documentation/unix-instructions.md for more details."
     exit 1
 fi
 
 if [ ! -e "$__referenceassemblyroot/.NETPortable" ]; then
-    echo "PCL reference assemblies not found. Please see https://github.com/dotnet/corefx/blob/master/Documentation/linux-instructions.md for more details."
+    echo "PCL reference assemblies not found. Please see https://github.com/dotnet/corefx/blob/master/Documentation/unix-instructions.md for more details."
     exit 1
 fi
 
@@ -37,7 +37,7 @@ __buildlog=$__scriptpath/msbuild.log
 if [ ! -e "$__nugetpath" ]; then
     which curl wget > /dev/null 2> /dev/null
     if [ $? -ne 0 -a $? -ne 1 ]; then
-        echo "cURL or wget is required to build corefx. Please see https://github.com/dotnet/corefx/blob/master/Documentation/linux-instructions.md for more details."
+        echo "cURL or wget is required to build corefx. Please see https://github.com/dotnet/corefx/blob/master/Documentation/unix-instructions.md for more details."
         exit 1
     fi
     echo "Restoring NuGet.exe..."


### PR DESCRIPTION
These instructions presume that that https://github.com/dotnet/corefx/pull/2030 is committed and merged.

They also correct the error where build on all Unixes is referred to as building on Linux.

CC: @janhenke 