### PR TITLE
Fix exception message differences when deserializing empty string

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -96,10 +96,7 @@ namespace System.Xml
 
         static public XmlDictionaryReader CreateTextReader(Stream stream, XmlDictionaryReaderQuotas quotas)
         {
-            XmlReaderSettings readerSettings = new XmlReaderSettings();
-            readerSettings.CheckCharacters = false;
-            XmlReader reader = XmlReader.Create(stream, readerSettings);
-            return XmlDictionaryReader.CreateDictionaryReader(reader);
+            return CreateTextReader(stream, null, quotas, null);
         }
 
         static public XmlDictionaryReader CreateTextReader(Stream stream, Encoding encoding,

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1271,6 +1271,16 @@ public static class DataContractJsonSerializerTests
         Assert.True(output.OnDeserializedMethodInvoked, "output.OnDeserializedMethodInvoked is false");
     }
 
+    [Fact]
+    public static void DCJS_DeserializeEmptyString()
+    {
+        var serializer = new DataContractJsonSerializer(typeof (object));
+        Assert.Throws<SerializationException>(() =>
+        {
+            serializer.ReadObject(new MemoryStream());
+        });
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1703,6 +1703,16 @@ public static class DataContractSerializerTests
         Assert.StrictEqual(value.TestProperty, actual.TestProperty);
     }
 
+    [Fact]
+    public static void DCS_DeserializeEmptyString()
+    {
+        var serializer = new DataContractSerializer(typeof (object));
+        Assert.Throws<XmlException>(() =>
+        {
+            serializer.ReadObject(new MemoryStream());
+        });
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null)
     {
         DataContractSerializer dcs;


### PR DESCRIPTION
There is differences in the exception message when deserializing empty string using DataContractSerializer in NetCore/NetNative compared to Desktop.
This is due to XmlDictionaryReader uses different kind of XmlReader in one of the CreateTextReader overloads. This PR updates the overload to initialize to the same XmlUtf8TextReader.