### PR TITLE
Small optimization in BigInteger

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -432,10 +432,11 @@ namespace System.Numerics
             Int32 i = number.scale;
             Int32 cur = 0;
 
+            BigInteger ten = 10;
             value = 0;
             while (--i >= 0)
             {
-                value *= 10;
+                value *= ten;
                 if (number.digits[cur] != '\0')
                 {
                     value += (Int32)(number.digits[cur++] - '0');


### PR DESCRIPTION
While debugging something, I noticed that we run same BigInteger ctor repeatedly in a loop.
This change runs the ctor once and caches the constant value to be used inside the loop.