### PR TITLE
Remove <AllowUnsafeBlocks/> from various test projects

### DIFF
--- a/src/Common/src/Interop/Interop.PlatformDetection.cs
+++ b/src/Common/src/Interop/Interop.PlatformDetection.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Runtime.InteropServices;
 
-// TODO: This implementation is temporary until Environment.OSVersion is officially exposed,
-//       at which point that should be used instead.
+// TODO: This implementation is temporary until System.Runtime.InteropServices.RuntimeInformation
+//       is available, at which point that should be used instead.
 
 internal static partial class Interop
 {
@@ -39,22 +39,27 @@ internal static partial class Interop
         {
             if (Environment.NewLine != "\r\n")
             {
-                unsafe
+                IntPtr buffer = Marshal.AllocHGlobal(8192); // the size of the uname struct is platform-specific; this should be large enough for any OS
+                try
                 {
-                    byte* buffer = stackalloc byte[8192]; // the size use with uname is platform specific; this should be large enough for any OS
                     if (uname(buffer) == 0)
                     {
-                        return Marshal.PtrToStringAnsi((IntPtr)buffer) == "Darwin" ?
-                            OperatingSystem.OSX :
-                            OperatingSystem.Linux;
+                        switch (Marshal.PtrToStringAnsi((IntPtr)buffer))
+                        {
+                            case "Darwin":
+                                return OperatingSystem.OSX;
+                            default:
+                                return OperatingSystem.Linux;
+                        }
                     }
                 }
+                finally { Marshal.FreeHGlobal(buffer); }
             }
             return OperatingSystem.Windows;
         });
 
         // not in src\Interop\Unix to avoiding pulling platform-dependent files into all projects
         [DllImport("libc")]
-        private static extern unsafe uint uname(byte* buf); 
+        private static extern uint uname(IntPtr buf); 
     }
 }

--- a/src/System.Diagnostics.Contracts/tests/System.Diagnostics.Contracts.Tests.csproj
+++ b/src/System.Diagnostics.Contracts/tests/System.Diagnostics.Contracts.Tests.csproj
@@ -7,7 +7,6 @@
     <ProjectGuid>{0C4E7FF1-54C6-49B7-9700-18F5F3EB8E65}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Diagnostics.Contracts.Tests</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Diagnostics.FileVersionInfo.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{6DFDB760-CC88-48AE-BD81-C64844EA3CBC}</ProjectGuid>
     <NuGetPackageImportStamp>2fda0f27</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>System.Diagnostics.Process.Tests</RootNamespace>
     <AssemblyName>System.Diagnostics.Process.Tests</AssemblyName>
     <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -7,7 +7,6 @@
     <ProjectGuid>{ED453083-A80F-480C-AD25-5B8618E8A303}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Compression.ZipFile.Tests</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -7,7 +7,6 @@
     <ProjectGuid>{BC2E1649-291D-412E-9529-EDDA94FA7AD6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Compression.Tests</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -8,7 +8,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Watcher.Tests</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.IO.FileSystem.Watcher.csproj">

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -7,7 +7,6 @@
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/System.IO.MemoryMappedFiles.Tests.csproj
@@ -9,7 +9,6 @@
     <FileAlignment>512</FileAlignment>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{9D6F6254-B5A3-40FF-8925-68AA8D1CE933}</ProjectGuid>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/System.IO.MemoryMappedViewAccessor.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/System.IO.MemoryMappedViewAccessor.Tests.csproj
@@ -11,7 +11,6 @@
     <FileAlignment>512</FileAlignment>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{F26FBD53-C04A-4FFC-90C9-AA804285A7AD}</ProjectGuid>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream/System.IO.MemoryMappedViewStream.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream/System.IO.MemoryMappedViewStream.Tests.csproj
@@ -10,7 +10,6 @@
     <FileAlignment>512</FileAlignment>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{688496E1-A7B3-41AE-9E32-C6F1A1127F91}</ProjectGuid>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -11,7 +11,6 @@
     <SignAssembly>false</SignAssembly>
     <ProjectGuid>{142469EC-D665-4FE2-845A-FDA69F9CC557}</ProjectGuid>
     <NuGetPackageImportStamp>d2615b94</NuGetPackageImportStamp>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -11,7 +11,6 @@
     <RootNamespace>System.Linq.Parallel.Tests</RootNamespace>
     <AssemblyName>System.Linq.Parallel.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>System.Runtime.Extensions.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>System.Runtime.Serialization.Json.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Serialization.Json.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>System.Runtime.Serialization.Xml.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Serialization.Xml.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Text.RegularExpressions.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>System.Xml.XmlSerializer.Tests</RootNamespace>
     <AssemblyName>System.Xml.XmlSerializer.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{4050F1D1-1DD2-4B48-A17B-E3F90DD18C4B}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Most test projects don't need unsafe code, but many were forced to allow unsafe blocks due to Interop.PlatformDetection.cs using pointers, and others were allowing it for no apparent reason.  I've modified Interop.PlatformDetection.cs to not use unsafe code, and updated the relevant test projects accordingly. (Eventually we'll switch it over to using the new RuntimeInformation assembly, anyway.)