### PR TITLE
Add more tests for System.Console

### DIFF
--- a/src/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.cs
@@ -1,35 +1,23 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Globalization;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace System.IO
 {
     internal sealed class SyncTextReader : TextReader
     {
-        internal TextReader _in;
+        private readonly TextReader _in;
         private readonly object _methodLock = new object();
 
-        public static TextReader GetSynchronizedTextReader(TextReader reader)
+        public static SyncTextReader GetSynchronizedTextReader(TextReader reader)
         {
-            if (reader == null)
-                throw new ArgumentNullException("reader");
-            Contract.Ensures(Contract.Result<TextReader>() != null);
-            Contract.EndContractBlock();
-
-            if (reader is SyncTextReader)
-                return reader;
-
-            return new SyncTextReader(reader);
+            Debug.Assert(reader != null);
+            return reader as SyncTextReader ?? 
+                new SyncTextReader(reader);
         }
 
         internal SyncTextReader(TextReader t)

--- a/src/System.Console/src/System/IO/SyncTextWriter.cs
+++ b/src/System.Console/src/System/IO/SyncTextWriter.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
+using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,15 +12,10 @@ namespace System.IO
         private readonly object _methodLock = new object();
         internal readonly TextWriter _out;
 
-        internal static TextWriter GetSynchronizedTextWriter(TextWriter writer)
+        internal static SyncTextWriter GetSynchronizedTextWriter(TextWriter writer)
         {
-            if (writer == null)
-                throw new ArgumentNullException("writer");
-            Contract.Ensures(Contract.Result<TextWriter>() != null);
-            Contract.EndContractBlock();
-
-            return writer is SyncTextWriter ?
-                writer :
+            Debug.Assert(writer != null);
+            return writer as SyncTextWriter ?? 
                 new SyncTextWriter(writer);
         }
 

--- a/src/System.Console/src/System/Text/ConsoleEncoding.cs
+++ b/src/System.Console/src/System/Text/ConsoleEncoding.cs
@@ -22,6 +22,21 @@ namespace System.Text
             return Array.Empty<byte>();
         }
 
+        public override int CodePage
+        {
+            get { return _encoding.CodePage; }
+        }
+
+        public override bool IsSingleByte
+        {
+            get { return _encoding.IsSingleByte; }
+        }
+
+        public override string EncodingName
+        {
+            get { return _encoding.EncodingName; }
+        }
+
         public override string WebName
         {
             get { return _encoding.WebName; }
@@ -32,6 +47,11 @@ namespace System.Text
             return _encoding.GetByteCount(chars);
         }
 
+        public override unsafe int GetByteCount(char* chars, int count)
+        {
+            return _encoding.GetByteCount(chars, count);
+        }
+
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return _encoding.GetByteCount(chars, index, count);
@@ -40,6 +60,11 @@ namespace System.Text
         public override int GetByteCount(string s)
         {
             return _encoding.GetByteCount(s);
+        }
+
+        public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
+        {
+            return _encoding.GetBytes(chars, charCount, bytes, byteCount);
         }
 
         public override byte[] GetBytes(char[] chars)
@@ -67,6 +92,11 @@ namespace System.Text
             return _encoding.GetBytes(s, charIndex, charCount, bytes, byteIndex);
         }
 
+        public override unsafe int GetCharCount(byte* bytes, int count)
+        {
+            return _encoding.GetCharCount(bytes, count);
+        }
+
         public override int GetCharCount(byte[] bytes)
         {
             return _encoding.GetCharCount(bytes);
@@ -75,6 +105,11 @@ namespace System.Text
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return _encoding.GetCharCount(bytes, index, count);
+        }
+
+        public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
+        {
+            return _encoding.GetChars(bytes, byteCount, chars, charCount);
         }
 
         public override char[] GetChars(byte[] bytes)
@@ -110,6 +145,11 @@ namespace System.Text
         public override int GetMaxCharCount(int byteCount)
         {
             return _encoding.GetMaxCharCount(byteCount);
+        }
+
+        public override string GetString(byte[] bytes)
+        {
+            return _encoding.GetString(bytes);
         }
 
         public override string GetString(byte[] bytes, int index, int count)

--- a/src/System.Console/tests/CancelKeyPress.cs
+++ b/src/System.Console/tests/CancelKeyPress.cs
@@ -2,23 +2,66 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
+using System.Threading;
 using Xunit;
 
 public class CancelKeyPress
 {
+    private const int WaitFailTestTimeoutSeconds = 30;
+
     [Fact]
     public static void CanAddAndRemoveHandler()
     {
-        ConsoleCancelEventHandler handler = new ConsoleCancelEventHandler(Console_CancelKeyPress);
-
+        ConsoleCancelEventHandler handler = (sender, e) =>
+        {
+            // We don't actually want to do anything here.  This will only get called on the off chance
+            // that someone CTRL+C's the test run while the handler is hooked up.  This is just used to 
+            // validate that we can add and remove a handler, we don't care about exercising it.
+        };
         Console.CancelKeyPress += handler;
         Console.CancelKeyPress -= handler;
     }
 
-    static void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    [Fact]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public static void InvokingCancelKeyPressHandler()
     {
-        // We don't actually want to do anything here.  This will only get called on the off chance
-        // that someone CTRL+C's the test run while the handler is hooked up.  This is just used to 
-        // validate that we can add and remove a handler, we don't care about exercising it.
+        // On Windows we could use GenerateConsoleCtrlEvent to send a ctrl-C to the process,
+        // however that'll apply to all processes associated with the same group, which will
+        // include processes like the code coverage tool when doing code coverage runs, causing
+        // those other processes to exit.  As such, we test this only on Unix, where we can
+        // send a SIGINT signal to this specific process only.
+
+        using (var mres = new ManualResetEventSlim())
+        {
+            ConsoleCancelEventHandler handler = (sender, e) => {
+                e.Cancel = true;
+                mres.Set();
+            };
+
+            Console.CancelKeyPress += handler;
+            try
+            {
+                Assert.Equal(0, kill(getpid(), SIGINT));
+                Assert.True(mres.Wait(WaitFailTestTimeoutSeconds));
+            }
+            finally
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
     }
+
+    #region Unix Imports
+    // P/Invokes included here rather than being pulled from Interop\Unix
+    // to avoid platform-dependent includes in csproj
+    [DllImport("libc", SetLastError = true)]
+    private static extern int kill(int pid, int sig);
+
+    [DllImport("libc")]
+    private static extern int getpid();
+
+    private const int SIGINT = 2;
+    #endregion
 }

--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -10,6 +10,32 @@ using Xunit;
 public class Color
 {
     [Fact]
+    public static void InvalidColors()
+    {
+        Assert.Throws<ArgumentException>(() => Console.BackgroundColor = (ConsoleColor)42);
+        Assert.Throws<ArgumentException>(() => Console.ForegroundColor = (ConsoleColor)42);
+    }
+
+    [Fact]
+    public static void RoundtrippingColor()
+    {
+        if (Interop.IsWindows)
+        {
+            Console.BackgroundColor = Console.BackgroundColor;
+            Console.ForegroundColor = Console.ForegroundColor;
+            // Changing color on Windows doesn't have effect in some testing environments
+            // when there is no associated console, such as when run under a profiler like 
+            // our code coverage tools, so we don't assert that the change took place and 
+            // simple ensure that getting/setting doesn't throw.
+        }
+        else
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor);
+            Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor);
+        }
+    }
+
+    [Fact]
     [PlatformSpecific(PlatformID.AnyUnix)]
     public static void RedirectedOutputDoesNotUseAnsiSequences()
     {

--- a/src/System.Console/tests/Helpers.cs
+++ b/src/System.Console/tests/Helpers.cs
@@ -11,7 +11,9 @@ class Helpers
     {
         const string TestString = "Test";
 
-        TextWriter oldErrorToRestore = getHelper();
+        TextWriter oldWriterToRestore = getHelper();
+        Assert.NotNull(oldWriterToRestore);
+
         try
         {
             using (MemoryStream memStream = new MemoryStream())
@@ -40,7 +42,7 @@ class Helpers
         }
         finally
         {
-            setHelper(oldErrorToRestore);
+            setHelper(oldWriterToRestore);
         }
     }
 }

--- a/src/System.Console/tests/ReadAndWrite.cs
+++ b/src/System.Console/tests/ReadAndWrite.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 public class ReadAndWrite
@@ -97,6 +97,11 @@ public class ReadAndWrite
 
     private static void WriteLineCore()
     {
+        Assert.Equal(Environment.NewLine, Console.Out.NewLine);
+        Console.Out.NewLine = "abcd";
+        Assert.Equal("abcd", Console.Out.NewLine);
+        Console.Out.NewLine = Environment.NewLine;
+
         // We just want to ensure none of these throw exceptions, we don't actually validate 
         // what was written.
 
@@ -124,6 +129,133 @@ public class ReadAndWrite
         Console.WriteLine(50UL);
         Console.WriteLine(new object());
         Console.WriteLine("Hello World");
+    }
+
+    [Fact]
+    public static async Task OutWriteAndWriteLineOverloads()
+    {
+        TextWriter savedStandardOutput = Console.Out;
+        try
+        {
+            using (var sw = new StreamWriter(new MemoryStream()))
+            {
+                Console.SetOut(sw);
+                TextWriter writer = Console.Out;
+                Assert.NotNull(writer);
+                Assert.NotEqual(writer, sw); // the writer we provide gets wrapped
+
+                // We just want to ensure none of these throw exceptions, we don't actually validate 
+                // what was written.
+
+                writer.Write("{0}", 32);
+                writer.Write("{0} {1}", 32, "Hello");
+                writer.Write("{0} {1} {2}", 32, "Hello", (uint)50);
+                writer.Write("{0} {1} {2} {3}", 32, "Hello", (uint)50, (ulong)5);
+                writer.Write("{0} {1} {2} {3} {4}", 32, "Hello", (uint)50, (ulong)5, 'a');
+                writer.Write(true);
+                writer.Write('a');
+                writer.Write(new char[] { 'a', 'b', 'c', 'd', });
+                writer.Write(new char[] { 'a', 'b', 'c', 'd', }, 1, 2);
+                writer.Write(1.23d);
+                writer.Write(123.456M);
+                writer.Write(1.234f);
+                writer.Write(39);
+                writer.Write(50u);
+                writer.Write(50L);
+                writer.Write(50UL);
+                writer.Write(new object());
+                writer.Write("Hello World");
+
+                writer.Flush();
+
+                await writer.WriteAsync('c');
+                await writer.WriteAsync(new char[] { 'a', 'b', 'c', 'd' });
+                await writer.WriteAsync(new char[] { 'a', 'b', 'c', 'd' }, 1, 2);
+                await writer.WriteAsync("Hello World");
+
+                await writer.WriteLineAsync('c');
+                await writer.WriteLineAsync(new char[] { 'a', 'b', 'c', 'd' });
+                await writer.WriteLineAsync(new char[] { 'a', 'b', 'c', 'd' }, 1, 2);
+                await writer.WriteLineAsync("Hello World");
+
+                await writer.FlushAsync();
+            }
+        }
+        finally
+        {
+            Console.SetOut(savedStandardOutput);
+        }
+    }
+
+    [Fact]
+    public static unsafe void ValidateConsoleEncoding()
+    {
+        Assert.Same(Console.Out, Console.Out);
+
+        Encoding encoding = Console.Out.Encoding;
+        Assert.NotNull(encoding);
+        Assert.Same(encoding, Console.Out.Encoding);
+
+        // The primary purpose of ConsoleEncoding is to return an empty preamble.
+        Assert.Equal(Array.Empty<byte>(), encoding.GetPreamble());
+
+        // There's not much validation we can do, but we can at least invoke members
+        // to ensure they don't throw exceptions as they delegate to the underlying
+        // encoding wrapped by ConsoleEncoding.
+
+        Assert.False(string.IsNullOrWhiteSpace(encoding.EncodingName));
+        Assert.False(string.IsNullOrWhiteSpace(encoding.WebName));
+        Assert.True(encoding.CodePage >= 0);
+        bool ignored = encoding.IsSingleByte;
+
+        // And we can validate that the encoding is self-consistent by roundtripping
+        // data between chars and bytes.
+
+        string str = "This is the input string.";
+        char[] strAsChars = str.ToCharArray();
+        byte[] strAsBytes = encoding.GetBytes(str);
+        Assert.Equal(strAsBytes.Length, encoding.GetByteCount(str));
+        Assert.True(encoding.GetMaxByteCount(str.Length) >= strAsBytes.Length);
+
+        Assert.Equal(str, encoding.GetString(strAsBytes));
+        Assert.Equal(str, encoding.GetString(strAsBytes, 0, strAsBytes.Length));
+        Assert.Equal(str, new string(encoding.GetChars(strAsBytes)));
+        Assert.Equal(str, new string(encoding.GetChars(strAsBytes, 0, strAsBytes.Length)));
+        fixed (byte* bytesPtr = strAsBytes)
+        {
+            char[] outputArr = new char[encoding.GetMaxCharCount(strAsBytes.Length)];
+
+            int len = encoding.GetChars(strAsBytes, 0, strAsBytes.Length, outputArr, 0);
+            Assert.Equal(str, new string(outputArr, 0, len));
+            Assert.Equal(len, encoding.GetCharCount(strAsBytes));
+            Assert.Equal(len, encoding.GetCharCount(strAsBytes, 0, strAsBytes.Length));
+
+            fixed (char* charsPtr = outputArr)
+            {
+                len = encoding.GetChars(bytesPtr, strAsBytes.Length, charsPtr, outputArr.Length);
+                Assert.Equal(str, new string(charsPtr, 0, len));
+                Assert.Equal(len, encoding.GetCharCount(bytesPtr, strAsBytes.Length));
+            }
+
+            Assert.Equal(str, encoding.GetString(bytesPtr, strAsBytes.Length));
+        }
+
+        Assert.Equal(strAsBytes, encoding.GetBytes(strAsChars));
+        Assert.Equal(strAsBytes, encoding.GetBytes(strAsChars, 0, strAsChars.Length));
+        Assert.Equal(strAsBytes.Length, encoding.GetByteCount(strAsChars));
+        Assert.Equal(strAsBytes.Length, encoding.GetByteCount(strAsChars, 0, strAsChars.Length));
+        fixed (char* charsPtr = strAsChars)
+        {
+            Assert.Equal(strAsBytes.Length, encoding.GetByteCount(charsPtr, strAsChars.Length));
+
+            byte[] outputArr = new byte[encoding.GetMaxByteCount(strAsChars.Length)];
+            Assert.Equal(strAsBytes.Length, encoding.GetBytes(strAsChars, 0, strAsChars.Length, outputArr, 0));
+            fixed (byte* bytesPtr = outputArr)
+            {
+                Assert.Equal(strAsBytes.Length, encoding.GetBytes(charsPtr, strAsChars.Length, bytesPtr, outputArr.Length));
+            }
+            Assert.Equal(strAsBytes.Length, encoding.GetBytes(str, 0, str.Length, outputArr, 0));
+        }
     }
 
     static readonly string[] s_testLines = new string[] {

--- a/src/System.Console/tests/SyncTextReader.cs
+++ b/src/System.Console/tests/SyncTextReader.cs
@@ -66,8 +66,13 @@ public class SyncTextReader
         }
         finally
         {
+            TextWriter oldWriter = Console.Out;
             Console.SetOut(savedStandardOutput);
+            oldWriter.Dispose();
+
+            TextReader oldReader = Console.In;
             Console.SetIn(savedStandardInput);
+            oldReader.Dispose();
         }
     }
 
@@ -163,6 +168,12 @@ public class SyncTextReader
             Assert.Equal(5, result);
             Assert.Equal(expected, buffer);
             Assert.Equal(-1, Console.Read()); // We should be at EOF now. 
+
+            // Invalid args
+            Assert.Throws<ArgumentNullException>(() => { Console.In.ReadBlockAsync(null, 0, 0); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Console.In.ReadBlockAsync(new char[1], -1, 0); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Console.In.ReadBlockAsync(new char[1], 0, -1); });
+            Assert.Throws<ArgumentException>(() => { Console.In.ReadBlockAsync(new char[1], 1, 1); });
         });
     }
 
@@ -181,6 +192,12 @@ public class SyncTextReader
             Assert.Equal(5, result);
             Assert.Equal(expected, buffer);
             Assert.Equal(-1, Console.Read()); // We should be at EOF now.
+
+            // Invalid args
+            Assert.Throws<ArgumentNullException>(() => { Console.In.ReadAsync(null, 0, 0); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Console.In.ReadAsync(new char[1], -1, 0); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Console.In.ReadAsync(new char[1], 0, -1); });
+            Assert.Throws<ArgumentException>(() => { Console.In.ReadAsync(new char[1], 1, 1); });
         });
     }
 

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -8,12 +8,11 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Console.Tests</AssemblyName>
     <RootNamespace>System.Console.Tests</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="CancelKeyPress.cs" />
     <Compile Include="Helpers.cs" />
@@ -27,6 +26,7 @@
     <Compile Include="Timeout.cs" />
     <Compile Include="ThreadSafety.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Console.csproj">


### PR DESCRIPTION
This improves code coverage as much as we can reasonably, given the difficulty in automating certain console-related functionality in inner loop testing, e.g. allowing ctrl-c to take down the testing process.

As part of this, I removed a bit of dead code, but also added some more overrides to ConsoleEncoding, which was missing some that should have been delegating to the wrapped encoding (some of the new tests failed without these).

Fixes #923.