### PR TITLE
Fix Exception type thrown in Vector<T> ctor and CopyTo methods

### DIFF
--- a/src/System.Numerics.Vectors/src/Resources/Strings.resx
+++ b/src/System.Numerics.Vectors/src/Resources/Strings.resx
@@ -126,6 +126,9 @@
   <data name="Arg_MultiDimArrayNotSupported" xml:space="preserve">
     <value>Only one-dimensional arrays are supported</value>
   </data>
+  <data name="Arg_NullArgumentNullRef" xml:space="preserve">
+    <value>The method was called with a null array argument.</value>
+  </data>
   <data name="Arg_RegisterLengthOfRangeException" xml:space="preserve">
     <value>length must be less than</value>
   </data>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
@@ -363,7 +363,8 @@ namespace System.Numerics
         {
             if (values == null)
             {
-                throw new ArgumentNullException("values");
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
             if (index < 0 || (values.Length - index) < Count)
             {
@@ -772,7 +773,8 @@ namespace System.Numerics
         {
             if (destination == null)
             {
-                throw new ArgumentNullException("values");
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
             if (startIndex < 0 || startIndex >= destination.Length)
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -175,7 +175,8 @@ namespace System.Numerics
         {
             if (values == null)
             {
-                throw new ArgumentNullException("values");
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
             if (index < 0 || (values.Length - index) < Count)
             {
@@ -292,7 +293,8 @@ namespace System.Numerics
         {
             if (destination == null)
             {
-                throw new ArgumentNullException("values");
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
             if (startIndex < 0 || startIndex >= destination.Length)
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs
@@ -64,11 +64,18 @@ namespace System.Numerics
         public void CopyTo(Single[] array, int index)
         {
             if (array == null)
-                throw new ArgumentNullException("values");
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
             if (index < 0 || index >= array.Length)
+            {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+            }
             if ((array.Length - index) < 2)
+            {
                 throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
+            }
             array[index] = X;
             array[index + 1] = Y;
         }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3_Intrinsics.cs
@@ -78,11 +78,18 @@ namespace System.Numerics
         public void CopyTo(Single[] array, int index)
         {
             if (array == null)
-                throw new ArgumentNullException("values");
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
             if (index < 0 || index >= array.Length)
+            {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+            }
             if ((array.Length - index) < 3)
+            {
                 throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
+            }
             array[index] = X;
             array[index + 1] = Y;
             array[index + 2] = Z;

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
@@ -106,11 +106,18 @@ namespace System.Numerics
         public void CopyTo(Single[] array, int index)
         {
             if (array == null)
-                throw new ArgumentNullException("values");
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
             if (index < 0 || index >= array.Length)
+            {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+            }
             if ((array.Length - index) < 4)
+            {
                 throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
+            }
             array[index] = X;
             array[index + 1] = Y;
             array[index + 2] = Z;

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -47,7 +47,7 @@ namespace System.Numerics.Tests
 
         private void TestConstructor<T>() where T : struct
         {
-            Assert.Throws<ArgumentNullException>(() => new Vector<T>((T[])null));
+            Assert.Throws<NullReferenceException>(() => new Vector<T>((T[])null));
 
             T[] values = GenerateRandomValuesForVector<T>();
             var vector = new Vector<T>(values);
@@ -81,7 +81,7 @@ namespace System.Numerics.Tests
         public void ConstructorWithOffsetDouble() { TestConstructorWithOffset<Double>(); }
         private void TestConstructorWithOffset<T>() where T : struct
         {
-            Assert.Throws<ArgumentNullException>(() => new Vector<T>((T[])null, 0));
+            Assert.Throws<NullReferenceException>(() => new Vector<T>((T[])null, 0));
 
             int offsetAmount = Util.GenerateSingleValue<int>(2, 250);
             T[] values = new T[offsetAmount].Concat(GenerateRandomValuesForVector<T>()).ToArray();
@@ -307,7 +307,7 @@ namespace System.Numerics.Tests
             var vector = new Vector<T>(initialValues);
             T[] array = new T[Vector<T>.Count];
 
-            Assert.Throws<ArgumentNullException>(() => vector.CopyTo(null, 0));
+            Assert.Throws<NullReferenceException>(() => vector.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => vector.CopyTo(array, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => vector.CopyTo(array, array.Length));
             Assert.Throws<ArgumentException>(() => vector.CopyTo(array, array.Length - 1));

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -41,7 +41,7 @@ namespace System.Numerics.Tests
 
         private void TestConstructor<T>() where T : struct
         {
-            Assert.Throws<ArgumentNullException>(() => new Vector<T>((T[])null));
+            Assert.Throws<NullReferenceException>(() => new Vector<T>((T[])null));
 
             T[] values = GenerateRandomValuesForVector<T>();
             var vector = new Vector<T>(values);
@@ -64,7 +64,7 @@ namespace System.Numerics.Tests
 #>
         private void TestConstructorWithOffset<T>() where T : struct
         {
-            Assert.Throws<ArgumentNullException>(() => new Vector<T>((T[])null, 0));
+            Assert.Throws<NullReferenceException>(() => new Vector<T>((T[])null, 0));
 
             int offsetAmount = Util.GenerateSingleValue<int>(2, 250);
             T[] values = new T[offsetAmount].Concat(GenerateRandomValuesForVector<T>()).ToArray();
@@ -213,7 +213,7 @@ namespace System.Numerics.Tests
             var vector = new Vector<T>(initialValues);
             T[] array = new T[Vector<T>.Count];
 
-            Assert.Throws<ArgumentNullException>(() => vector.CopyTo(null, 0));
+            Assert.Throws<NullReferenceException>(() => vector.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => vector.CopyTo(array, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => vector.CopyTo(array, array.Length));
             Assert.Throws<ArgumentException>(() => vector.CopyTo(array, array.Length - 1));

--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tests
             float[] a = new float[3];
             float[] b = new float[2];
 
-            Assert.Throws<ArgumentNullException>(() => v1.CopyTo(null, 0));
+            Assert.Throws<NullReferenceException>(() => v1.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, a.Length));
             Assert.Throws<ArgumentException>(() => v1.CopyTo(a, 2));

--- a/src/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tests
             float[] a = new float[4];
             float[] b = new float[3];
 
-            Assert.Throws<ArgumentNullException>(() => v1.CopyTo(null, 0));
+            Assert.Throws<NullReferenceException>(() => v1.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, a.Length));
             Assert.Throws<ArgumentException>(() => v1.CopyTo(a, a.Length - 2));

--- a/src/System.Numerics.Vectors/tests/Vector4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector4Tests.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tests
             float[] a = new float[5];
             float[] b = new float[4];
 
-            Assert.Throws<ArgumentNullException>(() => v1.CopyTo(null, 0));
+            Assert.Throws<NullReferenceException>(() => v1.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, a.Length));
             Assert.Throws<ArgumentException>(() => v1.CopyTo(a, a.Length - 2));


### PR DESCRIPTION
When the methods below are handled specially by the JIT, a NullReferenceException is produced, rather than the ArgumentNullException we are throwing in IL. Conceptually, it makes more sense to throw an ArgumentNullException here, but that would degrade the JIT's performance as, currently, the constructor is doing very little work (should be as simple as a load/store instruction for some cases).

* Vector\<T\>.ctor
* Vector\<T\>.CopyTo
* Vector2/3/4.CopyTo

To help diagnosability a bit, you will still get a reasonable exception message when using the IL version (so in Debug builds): "The method was called with a null array argument."

Thoughts on this? It is possible we could go the other way, and have the JIT throw the ArgumentNullException.

@CarolEidt , @nguerrera , @terrajobst 