### PR TITLE
Fix Matrix/Plane/Quaternion field offset tests, Issue #1002

### DIFF
--- a/src/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
@@ -1009,19 +1009,22 @@ namespace System.Numerics.Tests
 
         // A test to make sure the fields are laid out how we expect
         [Fact]
-        [ActiveIssue(1002)]
         public unsafe void Matrix3x2FieldOffsetTest()
         {
-            Matrix3x2* ptr = (Matrix3x2*)0;
+            Matrix3x2 mat = new Matrix3x2();
+            float* basePtr = &mat.M11; // Take address of first element
+            Matrix3x2* matPtr = &mat; // Take address of whole matrix
 
-            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->M11));
-            Assert.Equal(new IntPtr(4), new IntPtr(&ptr->M12));
+            Assert.Equal(new IntPtr(basePtr), new IntPtr(matPtr));
 
-            Assert.Equal(new IntPtr(8), new IntPtr(&ptr->M21));
-            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->M22));
+            Assert.Equal(new IntPtr(basePtr + 0), new IntPtr(&mat.M11));
+            Assert.Equal(new IntPtr(basePtr + 1), new IntPtr(&mat.M12));
 
-            Assert.Equal(new IntPtr(16), new IntPtr(&ptr->M31));
-            Assert.Equal(new IntPtr(20), new IntPtr(&ptr->M32));
+            Assert.Equal(new IntPtr(basePtr + 2), new IntPtr(&mat.M21));
+            Assert.Equal(new IntPtr(basePtr + 3), new IntPtr(&mat.M22));
+
+            Assert.Equal(new IntPtr(basePtr + 4), new IntPtr(&mat.M31));
+            Assert.Equal(new IntPtr(basePtr + 5), new IntPtr(&mat.M32));
         }
     }
 }

--- a/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -2485,30 +2485,34 @@ namespace System.Numerics.Tests
 
         // A test to make sure the fields are laid out how we expect
         [Fact]
-        [ActiveIssue(1002)]
         public unsafe void Matrix4x4FieldOffsetTest()
         {
-            Matrix4x4* ptr = (Matrix4x4*)0;
+            Matrix4x4 mat = new Matrix4x4();
 
-            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->M11));
-            Assert.Equal(new IntPtr(4), new IntPtr(&ptr->M12));
-            Assert.Equal(new IntPtr(8), new IntPtr(&ptr->M13));
-            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->M14));
+            float* basePtr = &mat.M11; // Take address of first element
+            Matrix4x4* matPtr = &mat; // Take address of whole matrix
 
-            Assert.Equal(new IntPtr(16), new IntPtr(&ptr->M21));
-            Assert.Equal(new IntPtr(20), new IntPtr(&ptr->M22));
-            Assert.Equal(new IntPtr(24), new IntPtr(&ptr->M23));
-            Assert.Equal(new IntPtr(28), new IntPtr(&ptr->M24));
+            Assert.Equal(new IntPtr(basePtr), new IntPtr(matPtr));
 
-            Assert.Equal(new IntPtr(32), new IntPtr(&ptr->M31));
-            Assert.Equal(new IntPtr(36), new IntPtr(&ptr->M32));
-            Assert.Equal(new IntPtr(40), new IntPtr(&ptr->M33));
-            Assert.Equal(new IntPtr(44), new IntPtr(&ptr->M34));
+            Assert.Equal(new IntPtr(basePtr + 0), new IntPtr(&mat.M11));
+            Assert.Equal(new IntPtr(basePtr + 1), new IntPtr(&mat.M12));
+            Assert.Equal(new IntPtr(basePtr + 2), new IntPtr(&mat.M13));
+            Assert.Equal(new IntPtr(basePtr + 3), new IntPtr(&mat.M14));
 
-            Assert.Equal(new IntPtr(48), new IntPtr(&ptr->M41));
-            Assert.Equal(new IntPtr(52), new IntPtr(&ptr->M42));
-            Assert.Equal(new IntPtr(56), new IntPtr(&ptr->M43));
-            Assert.Equal(new IntPtr(60), new IntPtr(&ptr->M44));
+            Assert.Equal(new IntPtr(basePtr + 4), new IntPtr(&mat.M21));
+            Assert.Equal(new IntPtr(basePtr + 5), new IntPtr(&mat.M22));
+            Assert.Equal(new IntPtr(basePtr + 6), new IntPtr(&mat.M23));
+            Assert.Equal(new IntPtr(basePtr + 7), new IntPtr(&mat.M24));
+
+            Assert.Equal(new IntPtr(basePtr + 8), new IntPtr(&mat.M31));
+            Assert.Equal(new IntPtr(basePtr + 9), new IntPtr(&mat.M32));
+            Assert.Equal(new IntPtr(basePtr + 10), new IntPtr(&mat.M33));
+            Assert.Equal(new IntPtr(basePtr + 11), new IntPtr(&mat.M34));
+
+            Assert.Equal(new IntPtr(basePtr + 12), new IntPtr(&mat.M41));
+            Assert.Equal(new IntPtr(basePtr + 13), new IntPtr(&mat.M42));
+            Assert.Equal(new IntPtr(basePtr + 14), new IntPtr(&mat.M43));
+            Assert.Equal(new IntPtr(basePtr + 15), new IntPtr(&mat.M44));
         }
     }
 }

--- a/src/System.Numerics.Vectors/tests/PlaneTests.cs
+++ b/src/System.Numerics.Vectors/tests/PlaneTests.cs
@@ -363,13 +363,17 @@ namespace System.Numerics.Tests
 
         // A test to make sure the fields are laid out how we expect
         [Fact]
-        [ActiveIssue(1002)]
         public unsafe void PlaneFieldOffsetTest()
         {
-            Plane* ptr = (Plane*)0;
+            Plane plane = new Plane();
 
-            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->Normal));
-            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->D));
+            float* basePtr = &plane.Normal.X; // Take address of first element
+            Plane* planePtr = &plane; // Take address of whole Plane
+
+            Assert.Equal(new IntPtr(basePtr), new IntPtr(planePtr));
+
+            Assert.Equal(new IntPtr(basePtr + 0), new IntPtr(&plane.Normal));
+            Assert.Equal(new IntPtr(basePtr + 3), new IntPtr(&plane.D));
         }
     }
 }

--- a/src/System.Numerics.Vectors/tests/QuaternionTests.cs
+++ b/src/System.Numerics.Vectors/tests/QuaternionTests.cs
@@ -967,15 +967,19 @@ namespace System.Numerics.Tests
 
         // A test to make sure the fields are laid out how we expect
         [Fact]
-        [ActiveIssue(1002)]
         public unsafe void QuaternionFieldOffsetTest()
         {
-            Quaternion* ptr = (Quaternion*)0;
+            Quaternion quat = new Quaternion();
 
-            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->X));
-            Assert.Equal(new IntPtr(4), new IntPtr(&ptr->Y));
-            Assert.Equal(new IntPtr(8), new IntPtr(&ptr->Z));
-            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->W));
+            float* basePtr = &quat.X; // Take address of first element
+            Quaternion* quatPtr = &quat; // Take address of whole Quaternion
+
+            Assert.Equal(new IntPtr(basePtr), new IntPtr(quatPtr));
+
+            Assert.Equal(new IntPtr(basePtr + 0), new IntPtr(&quat.X));
+            Assert.Equal(new IntPtr(basePtr + 1), new IntPtr(&quat.Y));
+            Assert.Equal(new IntPtr(basePtr + 2), new IntPtr(&quat.Z));
+            Assert.Equal(new IntPtr(basePtr + 3), new IntPtr(&quat.W));
         }
     }
 }


### PR DESCRIPTION
This fixes #1002. For some reason these tests work fine on x86, but doing these pointer accesses on x64 fails (understandably). I've re-worked the tests so they do roughly the same thing as before but in a less-strange manner.