### PR TITLE
Optimize ImmutableArray<T>.RemoveRange for 0/1 items input

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -756,6 +756,11 @@ namespace System.Collections.Immutable
             Requires.Range(index >= 0 && index < self.Length, "index");
             Requires.Range(length >= 0 && index + length <= self.Length, "length");
 
+            if (length == 0)
+            {
+                return self;
+            }
+
             T[] tmp = new T[self.Length - length];
             Array.Copy(self.array, 0, tmp, 0, index);
             Array.Copy(self.array, index + length, tmp, index, self.Length - index - length);
@@ -817,7 +822,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableArray<T> RemoveRange(ImmutableArray<T> items)
         {
-            return this.RemoveRange(items.array);
+            return this.RemoveRange(items, EqualityComparer<T>.Default);
         }
 
         /// <summary>
@@ -833,7 +838,22 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, IEqualityComparer<T> equalityComparer)
         {
-            return this.RemoveRange(items.array, equalityComparer);
+            var self = this;
+            Requires.NotNull(items.array, "items");
+
+            if (items.IsEmpty)
+            {
+                self.ThrowNullRefIfNotInitialized();
+                return self;
+            }
+            else if (items.Length == 1)
+            {
+                return self.Remove(items[0], equalityComparer);
+            }
+            else
+            {
+                return self.RemoveRange(items.array, equalityComparer);
+            }
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -826,6 +826,8 @@ namespace System.Collections.Immutable.Test
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => s_empty.RemoveRange(0, 0));
             Assert.Throws<NullReferenceException>(() => s_emptyDefault.RemoveRange(0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => s_emptyDefault.RemoveRange(-1, 0));
+            Assert.Throws<NullReferenceException>(() => s_emptyDefault.RemoveRange(0, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_oneElement.RemoveRange(1, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_empty.RemoveRange(-1, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_oneElement.RemoveRange(0, 2));
@@ -911,6 +913,35 @@ namespace System.Collections.Immutable.Test
             Assert.Equal(new[] { 1, 2, 3 }, listWithDuplicates.RemoveRange(new[] { 2 }));
             Assert.Equal(new[] { 1, 3 }, listWithDuplicates.RemoveRange(new[] { 2, 2 }));
             Assert.Equal(new[] { 1, 3 }, listWithDuplicates.RemoveRange(new[] { 2, 2, 2 }));
+        }
+
+        [Fact]
+        public void RemoveRangeImmutableArrayTest()
+        {
+            var list = ImmutableArray.Create(1, 2, 3);
+
+            ImmutableArray<int> removed2 = list.RemoveRange(ImmutableArray.Create(2));
+            Assert.Equal(2, removed2.Length);
+            Assert.Equal(new[] { 1, 3 }, removed2);
+
+            ImmutableArray<int> removed13 = list.RemoveRange(ImmutableArray.Create(1, 3, 5));
+            Assert.Equal(1, removed13.Length);
+            Assert.Equal(new[] { 2 }, removed13);
+
+            Assert.Equal(new[] { 1, 3, 6, 8, 9 }, ImmutableArray.CreateRange(Enumerable.Range(1, 10)).RemoveRange(ImmutableArray.Create(2, 4, 5, 7, 10)));
+            Assert.Equal(new[] { 3, 6, 8, 9 }, ImmutableArray.CreateRange(Enumerable.Range(1, 10)).RemoveRange(ImmutableArray.Create(1, 2, 4, 5, 7, 10)));
+
+            Assert.Equal(list, list.RemoveRange(ImmutableArray.Create(5)));
+            Assert.Equal(ImmutableArray.Create<int>(), ImmutableArray.Create<int>().RemoveRange(ImmutableArray.Create(1)));
+
+            var listWithDuplicates = ImmutableArray.Create(1, 2, 2, 3);
+            Assert.Equal(new[] { 1, 2, 3 }, listWithDuplicates.RemoveRange(ImmutableArray.Create(2)));
+            Assert.Equal(new[] { 1, 3 }, listWithDuplicates.RemoveRange(ImmutableArray.Create(2, 2)));
+            Assert.Equal(new[] { 1, 3 }, listWithDuplicates.RemoveRange(ImmutableArray.Create(2, 2, 2)));
+
+            Assert.Equal(new[] { 2, 3 }, list.RemoveRange(ImmutableArray.Create(42), EverythingEqual<int>.Default));
+            Assert.Equal(new[] { 3 }, list.RemoveRange(ImmutableArray.Create(42, 42), EverythingEqual<int>.Default));
+            Assert.Equal(new int[0], list.RemoveRange(ImmutableArray.Create(42, 42, 42), EverythingEqual<int>.Default));
         }
 
         [Fact]


### PR DESCRIPTION
Adds an optimization for the RemoveRange(int,int) overload to not allocate if there are 0 items in the input range, and another for the RemoveRange(ImmutableArray<int>, ...) overloads to minimize allocations for when there are 0 or 1 items in the input array.

Prior to that, I also added some RemoveRange tests to improve the coverage for these different inputs; without the additional tests, which are basically copies of the RemoveRange(IEnumerable<T>) tests but with ImmutableArray<T> inputs, some of the new branches were uncovered.  I also added a few more argument validation tests, which highlight some inconsistencies in the exceptions that get thrown when various inputs are incorrect, but I didn't make any effort to change these.  The tests all pass before and after the subsequent commit of the optimizations.

Fixes #2029.