### PR TITLE
Simplify Any<TSource>() boolean logic

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1425,9 +1425,8 @@ namespace System.Linq
             if (source == null) throw Error.ArgumentNull("source");
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (e.MoveNext()) return true;
+                return e.MoveNext();
             }
-            return false;
         }
 
         public static bool Any<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)


### PR DESCRIPTION
For some reason, `Any<TSource>()` used to look like this:

    if (e.MoveNext())
        return true;
    return false;

It has been remodeled to `return e.MoveNext()`.