### PR TITLE
Fix NuGet.exe package restore on systems where wget fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,12 +50,13 @@ if [ ! -e "$__nugetpath" ]; then
     fi
     echo "Restoring NuGet.exe..."
 
-    which wget > /dev/null 2> /dev/null
+    # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
+    which curl > /dev/null 2> /dev/null
     if [ $? -ne 0 ]; then
-       curl -sSL --create-dirs -o $__nugetpath https://api.nuget.org/downloads/nuget.exe
-    else
        mkdir -p $__packageroot
        wget -q -O $__nugetpath https://api.nuget.org/downloads/nuget.exe
+    else
+       curl -sSL --create-dirs -o $__nugetpath https://api.nuget.org/downloads/nuget.exe
     fi
 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
`wget` often fails because of missing CA-trust.

Trying to run `build.sh` on a clean FreeBSD-system will fail because NuGet.exe isn't downloaded
correctly.

````
/usr/home/josteink/build/corefx $ wget https://api.nuget.org/downloads/nuget.exe
--2015-06-21 05:43:58-- https://api.nuget.org/downloads/nuget.exe
Resolving api.nuget.org (api.nuget.org)...
185.31.18.64 Connecting to api.nuget.org (api.nuget.org)|185.31.18.64|:443... connected.
ERROR: cannot verify api.nuget.org's certificate, issued by ‘CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US’:
 Unable to locally verify the issuer's authority.
To connect to api.nuget.org insecurely, use `--no-check-certificate'.
/usr/home/josteink/build/corefx $
````

This is the case on a default FreeBSD 10.1 installation, and the same behaviour with `wget` failing on HTTPS trust-issues can very often be observed in the wild across several OSes and projects, not just FreeBSD and corefx.

(For FreeBSD, a workaround for this issue is to install the `/usr/ports/security/ca_root_nss`, but this package is not installed by default.)

After this error has (silently) happened, a zero-byte `NuGet.exe` is left on disk, causing all subsequent builds to fail on the `MSbuild`-restore stage.

However downloading with `curl` doesn't fail, so default to trying `curl` instead of `wget` first solves this issue.

CC: @akoeplinger