### PR TITLE
Optimize array/list.Select(...).ToArray()

### DIFF
--- a/src/System.Linq/tests/ReverseTests.cs
+++ b/src/System.Linq/tests/ReverseTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq.Tests.Helpers;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class ReverseTests
+    {
+        [Fact]
+        public void InvalidArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => Enumerable.Reverse<string>(null));
+        }
+
+        [Theory]
+        [InlineData(new int[] { })]
+        [InlineData(new int[] { 1 })]
+        [InlineData(new int[] { 1, 3, 5 })]
+        [InlineData(new int[] { 2, 4, 6, 8 })]
+        public void ReverseMatches(int[] input)
+        {
+            int[] expectedResults = new int[input.Length];
+            for (int i = 0; i < input.Length; i++)
+            {
+                expectedResults[i] = input[input.Length - 1 - i];
+            }
+
+            Assert.NotSame(input, Enumerable.Reverse(input));
+
+            Assert.Equal(expectedResults, input.Reverse());
+            Assert.Equal(expectedResults, new TestCollection<int>(input).Reverse());
+            Assert.Equal(expectedResults, new TestEnumerable<int>(input).Reverse());
+            Assert.Equal(expectedResults, new TestReadOnlyCollection<int>(input).Reverse());
+
+            Assert.Equal(expectedResults.Select(i => i * 2), input.Select(i => i * 2).Reverse());
+            Assert.Equal(expectedResults.Where(i => true).Select(i => i * 2), input.Where(i => true).Select(i => i * 2).Reverse());
+            Assert.Equal(expectedResults.Where(i => false).Select(i => i * 2), input.Where(i => false).Select(i => i * 2).Reverse());
+        }
+    }
+}

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -35,6 +35,7 @@
     <Compile Include="RangeTests.cs" />
     <Compile Include="RepeatTests.cs" />
     <Compile Include="SumTests.cs" />
+    <Compile Include="ReverseTests.cs" />
     <Compile Include="WhereTests.cs" />
     <Compile Include="ToArrayTests.cs" />
     <Compile Include="ToDictionaryTests.cs" />

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -52,6 +52,10 @@ namespace System.Linq.Tests
 
             Assert.NotSame(sourceArray, resultArray);
             Assert.Equal(sourceArray, resultArray);
+
+            int[] emptySourceArray = Array.Empty<int>();
+            Assert.NotSame(emptySourceArray.ToArray(), emptySourceArray.ToArray());
+            Assert.NotSame(emptySourceArray.Select(i => i).ToArray(), emptySourceArray.Select(i => i).ToArray());
         }
 
 
@@ -153,5 +157,44 @@ namespace System.Linq.Tests
             var thrownException = Assert.ThrowsAny<Exception>(() => { largeSeq.ToArray(); });
             Assert.True(thrownException.GetType() == typeof(OverflowException) || thrownException.GetType() == typeof(OutOfMemoryException));
         }
+
+        [Theory]
+        [InlineData(new int[] { }, new string[] { })]
+        [InlineData(new int[] { 1 }, new string[] { "1" })]
+        [InlineData(new int[] { 1, 2, 3 }, new string[] { "1", "2", "3" })]
+        public void ToArray_ArrayWhereSelect(int[] sourceIntegers, string[] convertedStrings)
+        {
+            Assert.Equal(convertedStrings, sourceIntegers.Select(i => i.ToString()).ToArray());
+
+            Assert.Equal(sourceIntegers, sourceIntegers.Where(i => true).ToArray());
+            Assert.Equal(Array.Empty<int>(), sourceIntegers.Where(i => false).ToArray());
+
+            Assert.Equal(convertedStrings, sourceIntegers.Where(i => true).Select(i => i.ToString()).ToArray());
+            Assert.Equal(Array.Empty<string>(), sourceIntegers.Where(i => false).Select(i => i.ToString()).ToArray());
+
+            Assert.Equal(convertedStrings, sourceIntegers.Select(i => i.ToString()).Where(s => s != null).ToArray());
+            Assert.Equal(Array.Empty<string>(), sourceIntegers.Select(i => i.ToString()).Where(s => s == null).ToArray());
+        }
+
+        [Theory]
+        [InlineData(new int[] { }, new string[] { })]
+        [InlineData(new int[] { 1 }, new string[] { "1" })]
+        [InlineData(new int[] { 1, 2, 3 }, new string[] { "1", "2", "3" })]
+        public void ToArray_ListWhereSelect(int[] sourceIntegers, string[] convertedStrings)
+        {
+            var sourceList = new List<int>(sourceIntegers);
+
+            Assert.Equal(convertedStrings, sourceList.Select(i => i.ToString()).ToArray());
+            
+            Assert.Equal(sourceList, sourceList.Where(i => true).ToArray());
+            Assert.Equal(Array.Empty<int>(), sourceList.Where(i => false).ToArray());
+
+            Assert.Equal(convertedStrings, sourceList.Where(i => true).Select(i => i.ToString()).ToArray());
+            Assert.Equal(Array.Empty<string>(), sourceList.Where(i => false).Select(i => i.ToString()).ToArray());
+
+            Assert.Equal(convertedStrings, sourceList.Select(i => i.ToString()).Where(s => s != null).ToArray());
+            Assert.Equal(Array.Empty<string>(), sourceList.Select(i => i.ToString()).Where(s => s == null).ToArray());
+        }
+
     }
 }


### PR DESCRIPTION
LINQ already special-cases the very common case of using Select on input ```T[]```s and ```List<T>```s, but it doesn't take this to the next step of optimizing the case where that's then turned back into an array, a common pattern in its own right, e.g.
```C#
var names = people.Select(p => p.Name).ToArray();
```
This commit does so, modifying the internal Iterator type to support customization of ToArray, and updating the internal Buffer type to use it.  Changing Buffer not only helps ToArray but also Reverse and OrderBy, both of which convert the input sequence into an array internally.