### PR TITLE
Fix Jit assert failure in struct serialization tests due to missing cast

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -2483,9 +2483,9 @@ namespace System.Xml.Serialization
                   );
             ilg.Ldc(type);
             ilg.Call(Activator_CreateInstance);
+            ilg.MarkLabel(labelReturn);
             if (cast != null)
                 ilg.ConvertValue(Activator_CreateInstance.ReturnType, cast);
-            ilg.MarkLabel(labelReturn);
         }
 
         internal void WriteLocalDecl(string variableName, SourceInfo initValue)


### PR DESCRIPTION
This change fixes 3 struct serialization test Jit assert failures due to missing cast in IL generated code.

cc: @zhenlan @SGuyGe @shmao 