### PR TITLE
Restore packages in a single step, before building projects.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -20,7 +20,8 @@
   <Target Name="BatchRestorePackages">
     <Message Importance="High" Text="Restoring all packages..." />
     <!-- restore all project.jsons in one pass for perf & to avoid concurrency problems with dnu -->
-    <Exec Command="$(DnuRestoreCommand) &quot;$(MSBuildProjectDirectory)\src&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+    <!-- include ToolsDir to restore test-runtime\project.json as well -->
+    <Exec Command="$(DnuRestoreCommand) &quot;$(MSBuildProjectDirectory)\src&quot; &quot;$(ToolsDir)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
     <ItemGroup>
       <_allPackagesConfigs Include="$(MSBuildProjectDirectory)\src\**\packages.config"/>

--- a/build.proj
+++ b/build.proj
@@ -10,6 +10,27 @@
 
   <Import Project="dir.traversal.targets" />
 
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      BatchRestorePackages;
+      $(TraversalBuildDependsOn);
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="BatchRestorePackages">
+    <Message Importance="High" Text="Restoring all packages..." />
+    <!-- restore all project.jsons in one pass for perf & to avoid concurrency problems with dnu -->
+    <Exec Command="$(DnuRestoreCommand) &quot;$(MSBuildProjectDirectory)\src&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+
+    <ItemGroup>
+      <_allPackagesConfigs Include="$(MSBuildProjectDirectory)\src\**\packages.config"/>
+    </ItemGroup>
+    <Exec Condition="'@(_allPackagesConfigs)' != ''" Command="$(NugetRestoreCommand) &quot;%(_allPackagesConfigs.FullPath)&quot;" StandardOutputImportance="Low" />
+  </Target>
+
+  <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->
+  <Target Name="RestorePackages" DependsOnTargets="BatchRestorePackages" />
+
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="Clean">
     <RemoveDir Directories="$(BinDir)" />

--- a/dir.props
+++ b/dir.props
@@ -62,8 +62,14 @@
 
     <DnuRestoreCommand>"$(DnuToolPath)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
+    <DnuRestoreCommand>$(DnuRestoreCommand) --parallel</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/'))"</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">
+    <!-- When we do a traversal build we get all packages up front, don't restore them again -->
+    <RestorePackages>false</RestorePackages>
   </PropertyGroup>
 
   <!--

--- a/src/System.Diagnostics.Tools/tests/project.lock.json
+++ b/src/System.Diagnostics.Tools/tests/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {

--- a/src/System.IO/tests/project.lock.json
+++ b/src/System.IO/tests/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {


### PR DESCRIPTION
We've been hitting a number of concurrency issues on restore.  Avoid these by running restore as a single step at the start of the build.  We'll let DNX deal with concurrency via the --parallel switch.

/cc @JeremyKuhne @nguerrera @mmitche @Priya91