### PR TITLE
Check for state before fetching threadID

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -100,7 +100,7 @@ namespace System.Linq
 
             public IEnumerator<TSource> GetEnumerator()
             {
-                if (_threadId == Environment.CurrentManagedThreadId && state == 0)
+                if (state == 0 && _threadId == Environment.CurrentManagedThreadId)
                 {
                     state = 1;
                     return this;


### PR DESCRIPTION
It is unlikely that fetching CurrentManagedThreadId is cheaper than fetching an int field, so lets check the state first.