### PR TITLE
Updating a broken link in the top-level readme.md.

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -4,7 +4,7 @@ Documents Index
 Learn about .NET Core
 ====================
 
-- [Brief Intro to .NET Core](https://github.com/dotnet/coreclr/blob/master/Documentation/dotnetcore-intro.md)
+- [Brief Intro to .NET Core](https://github.com/dotnet/coreclr/blob/master/Documentation/README.md)
 - [[WIP] Official .NET Core Docs](http://dotnet.readthedocs.org)
 
 Get .NET Core


### PR DESCRIPTION
The first link in the top-level readme.md is broken. Changing the link to point to the top-level CoreCLR documentation.

cc: @terrajobst 