### PR TITLE
Fix incorrect MethodSpec signature header check

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -254,7 +254,7 @@ namespace System.Reflection.Metadata.Decoding
         public static ImmutableArray<TType> DecodeMethodSpecificationSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
         {
             SignatureHeader header = blobReader.ReadSignatureHeader();
-            if (header.RawValue != (byte)SignatureAttributes.Generic)
+            if (header.Kind != SignatureKind.MethodSpecification)
             {
                 throw new BadImageFormatException();
             }


### PR DESCRIPTION
There was some confusion in untested code around ELEMENTTYPE_GENERICINST vs. CALLCONV_GENERICINST

cc @tmat