### PR TITLE
Fix XPath tests to run on Desktop

### DIFF
--- a/src/Common/src/System/Xml/Ref.cs
+++ b/src/Common/src/System/Xml/Ref.cs
@@ -10,11 +10,8 @@ namespace System.Xml
     {
         public static bool Equal(string strA, string strB)
         {
-#if DEBUG
-            if (((object)strA != (object)strB) && string.Equals(strA, strB))
-                System.Diagnostics.Debug.Fail("Ref.Equal: Object comparison used for non-atomized string '" + strA + "'");
-#endif
-            return (object)strA == (object)strB;
+            // Active Issue: #2152
+            return strA == strB;
         }
 
         // Prevent typos. If someone uses Ref.Equals instead of Ref.Equal,

--- a/src/System.Xml.XPath.XDocument/tests/XDocument/NavigatorComparer.cs
+++ b/src/System.Xml.XPath.XDocument/tests/XDocument/NavigatorComparer.cs
@@ -29,8 +29,7 @@ namespace System.Xml.XPath.XDocument.Tests.XDocument
 
             if (AreComparableNodes(a.NodeType, b.NodeType))
             {
-                Assert.Equal(a.Value, b.Value);
-                Assert.Equal(a.Value, b.Value);
+                CompareValues(a, b);
                 Assert.Equal(a.Name, b.Name);
             }
 #endif
@@ -68,6 +67,15 @@ namespace System.Xml.XPath.XDocument.Tests.XDocument
             {
                 Assert.Equal(a, b);
             }
+        }
+        
+        private static void CompareValues(XPathNavigator a, XPathNavigator b)
+        {
+            // In order to account for Desktop vs CoreCLR difference in implementation of XmlDocument we need to normalize line endings to conform XML specification.
+            string sa = a.Value.Replace("\r\n", "\n").Replace("\r", "\n");
+            string sb = b.Value.Replace("\r\n", "\n").Replace("\r", "\n");
+
+            Assert.Equal(sa, sb);
         }
 
         public NavigatorComparer(XPathNavigator nav1, XPathNavigator nav2)
@@ -620,18 +628,16 @@ namespace System.Xml.XPath.XDocument.Tests.XDocument
         {
             get
             {
-                var r1 = _nav1.Value;
-                var r2 = _nav2.Value;
 #if CHECK_ATTRIBUTE_ORDER
-                Assert.Equal(r1, r2);
+                CompareValues(_nav1, _nav2);
 #else
                 CompareNodeTypes(_nav1.NodeType, _nav2.NodeType);
                 if (!IsNamespaceOrAttribute(_nav1.NodeType))
                 {
-                    Assert.Equal(r1, r2);
+                    CompareValues(_nav1, _nav2);
                 }
 #endif
-                return r1;
+                return _nav1.Value;
             }
         }
         public override object ValueAs(Type value)


### PR DESCRIPTION
Fixes 2 issues:
- New line endings issue - XmlDocument on Desktop is preserving \r\n while on CoreCLR it replaces it with \n (standard defines to replace it: http://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends ; Desktop needs to remain as is for compat reasons)
- References issues - workaround for a bug introduced during the split of System.Xml.dll into smaller libraries: More details here: https://github.com/dotnet/corefx/issues/2152