### PR TITLE
Exclude injected SR functions from code coverage

### DIFF
--- a/src/Common/src/System/SR.cs
+++ b/src/Common/src/System/SR.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Resources;
+using System.Resources.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System
@@ -12,6 +13,7 @@ namespace System
 
         private static ResourceManager ResourceManager
         {
+            [ExcludeFromCodeCoverage]
             get
             {
                 if (SR.s_resourceManager == null)
@@ -23,13 +25,15 @@ namespace System
         }
 
         // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format. 
-        // by default it returns false.
+        // It is hardcoded to return false, but on some platforms an IL transform may rewrite it to instead return true.
+        [ExcludeFromCodeCoverage]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool UsingResourceKeys()
         {
             return false;
         }
 
+        [ExcludeFromCodeCoverage]
         internal static string GetResourceString(string resourceKey, string defaultString)
         {
             string resourceString = null;
@@ -44,6 +48,7 @@ namespace System
             return resourceString;
         }
 
+        [ExcludeFromCodeCoverage]
         internal static string Format(string resourceFormat, params object[] args)
         {
             if (args != null)
@@ -59,6 +64,7 @@ namespace System
             return resourceFormat;
         }
 
+        [ExcludeFromCodeCoverage]
         internal static string Format(string resourceFormat, object p1)
         {
             if (UsingResourceKeys())
@@ -69,6 +75,7 @@ namespace System
             return String.Format(resourceFormat, p1);
         }
 
+        [ExcludeFromCodeCoverage]
         internal static string Format(string resourceFormat, object p1, object p2)
         {
             if (UsingResourceKeys())
@@ -79,6 +86,7 @@ namespace System
             return String.Format(resourceFormat, p1, p2);
         }
 
+        [ExcludeFromCodeCoverage]
         internal static string Format(string resourceFormat, object p1, object p2, object p3)
         {
             if (UsingResourceKeys())
@@ -87,5 +95,22 @@ namespace System
             }
             return String.Format(resourceFormat, p1, p2, p3);
         }
+    }
+}
+
+namespace System.Resources.Diagnostics
+{
+    [AttributeUsage(AttributeTargets.All)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class ExcludeFromCodeCoverageAttribute : Attribute
+    {
+        // The code in the partial SR above is injected into all assemblies with resources, regardless of
+        // whether those assemblies use this functionality.  As such, it should be excluded from code coverage.
+        // The code coverage tools are configured to ignore any code attributed with an attribute
+        // named ExcludeFromCodeCoverage, regardless of its namespace.  We have it in a specialized namespace
+        // so as to avoid conflicts with other ExcludeFromCodeCoverageAttribute types used elsewhere in corefx.
+        // It's applied to the individual members in SR rather than to SR as a whole because we still
+        // want code coverage to include the individual resource keys; doing so helps to highlight whether
+        // we're exercising all error paths, whether any resource strings are stale and can be removed, etc.
     }
 }

--- a/src/Common/src/System/SR.vb
+++ b/src/Common/src/System/SR.vb
@@ -8,6 +8,7 @@
 '
 
 Imports System.Resources
+Imports System.Resources.Diagnostics
 Imports System.Text
 
 Namespace System
@@ -15,9 +16,13 @@ Namespace System
     Friend Class SR
 
         Private Shared s_resourceManager As ResourceManager
+
+        <ExcludeFromCodeCoverage>
         Private Sub New()
         End Sub
+
         Private Shared ReadOnly Property ResourceManager As ResourceManager
+            <ExcludeFromCodeCoverage>
             Get
 
                 If SR.s_resourceManager Is Nothing Then
@@ -33,11 +38,13 @@ Namespace System
         ' This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format. 
         ' by default it returns false. We overwrite the implementation of this method to return true through IL transformer 
         ' when compiling ProjectN app as retail build. 
+        <ExcludeFromCodeCoverage>
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
         Public Shared Function UsingResourceKeys() As Boolean
             Return False
         End Function
 
+        <ExcludeFromCodeCoverage>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, ByVal defaultString As String) As String
 
             Dim resourceString As String = Nothing
@@ -55,6 +62,7 @@ Namespace System
             Return resourceString
         End Function
 
+        <ExcludeFromCodeCoverage>
         Friend Shared Function Format(ByVal resourceFormat As String, ParamArray args() As Object) As String
             If args IsNot Nothing Then
                 If (UsingResourceKeys()) Then
@@ -65,6 +73,7 @@ Namespace System
             Return resourceFormat
         End Function
 
+        <ExcludeFromCodeCoverage>
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
         Friend Shared Function Format(ByVal resourceFormat As String, p1 As Object) As String
             If (UsingResourceKeys()) Then
@@ -74,6 +83,7 @@ Namespace System
             Return String.Format(resourceFormat, p1)
         End Function
 
+        <ExcludeFromCodeCoverage>
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
         Friend Shared Function Format(ByVal resourceFormat As String, p1 As Object, p2 As Object) As String
             If (UsingResourceKeys()) Then
@@ -83,6 +93,7 @@ Namespace System
             Return String.Format(resourceFormat, p1, p2)
         End Function
 
+        <ExcludeFromCodeCoverage>
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
         Friend Shared Function Format(ByVal resourceFormat As String, p1 As Object, p2 As Object, p3 As Object) As String
             If (UsingResourceKeys()) Then
@@ -91,4 +102,24 @@ Namespace System
             Return String.Format(resourceFormat, p1, p2, p3)
         End Function
     End Class
+End Namespace
+
+Namespace System.Resources.Diagnostics
+
+    <AttributeUsage(AttributeTargets.All)>
+    <ExcludeFromCodeCoverage>
+    Friend Class ExcludeFromCodeCoverageAttribute
+        Inherits Attribute
+
+        ' The code in the partial SR above is injected into all assemblies with resources, regardless of
+        ' whether those assemblies use this functionality.  As such, it should be excluded from code coverage.
+        ' The code coverage tools are configured to ignore any code attributed with an attribute
+        ' named ExcludeFromCodeCoverage, regardless of its namespace.  We have it in a specialized namespace
+        ' so as to avoid conflicts with other ExcludeFromCodeCoverageAttribute types used elsewhere in corefx.
+        ' It's applied to the individual members in SR rather than to SR as a whole because we still
+        ' want code coverage to include the individual resource keys; doing so helps to highlight whether
+        ' we're exercising all error paths, whether any resource strings are stale and can be removed, etc.
+
+    End Class
+
 End Namespace


### PR DESCRIPTION
Build tools inject resource helper functions into any library that has resource strings.  These should be excluded from code coverage.

We already have an ExcludeFromCodeCoverage attribute in our Common folder, but I copied it here to be in the same file as SR.cs/vb so that build tools didn't need to inject yet another file dependency; I put the copy in a different namespace to avoid any conflicts.