### PR TITLE
Fix serialization for type which has DataMember with special Name values

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/BitFlagsGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/BitFlagsGenerator.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Security;
+
 namespace System.Runtime.Serialization
 {
-    using System;
-    using System.Reflection;
-    using System.Reflection.Emit;
-    using System.Security;
-
     internal class BitFlagsGenerator
     {
         private int _bitCount;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
@@ -33,7 +33,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getTypeFromHandle == null)
+                {
                     s_getTypeFromHandle = typeof(Type).GetMethod("GetTypeFromHandle");
+                    Debug.Assert(s_getTypeFromHandle != null);
+                }
                 return s_getTypeFromHandle;
             }
         }
@@ -54,7 +57,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_objectEquals == null)
+                {
                     s_objectEquals = Globals.TypeOfObject.GetMethod("Equals", BindingFlags.Public | BindingFlags.Static);
+                    Debug.Assert(s_objectEquals != null);
+                }
                 return s_objectEquals;
             }
         }
@@ -74,7 +80,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_arraySetValue == null)
+                {
                     s_arraySetValue = typeof(Array).GetMethod("SetValue", new Type[] { typeof(object), typeof(int) });
+                    Debug.Assert(s_arraySetValue != null);
+                }
                 return s_arraySetValue;
             }
         }
@@ -88,7 +97,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_objectToString == null)
+                {
                     s_objectToString = typeof(object).GetMethod("ToString", Array.Empty<Type>());
+                    Debug.Assert(s_objectToString != null);
+                }
                 return s_objectToString;
             }
         }
@@ -100,7 +112,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_stringFormat == null)
+                {
                     s_stringFormat = typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object[]) });
+                    Debug.Assert(s_stringFormat != null);
+                }
                 return s_stringFormat;
             }
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -74,7 +74,7 @@ namespace System.Runtime.Serialization
             Initialize(type, knownTypes, maxItemsInObjectGraph, ignoreExtensionDataObject, preserveObjectReferences, null, false);
         }
 #endif
-        
+
         public DataContractSerializer(Type type, XmlDictionaryString rootName, XmlDictionaryString rootNamespace,
             IEnumerable<Type> knownTypes,
             int maxItemsInObjectGraph,

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -125,6 +125,7 @@ namespace System.Runtime.Serialization
                 if (s_ienumeratorGetCurrentMethod == null)
                 {
                     s_ienumeratorGetCurrentMethod = typeof(IEnumerator).GetProperty("Current").GetGetMethod();
+                    Debug.Assert(s_ienumeratorGetCurrentMethod != null);
                 }
                 return s_ienumeratorGetCurrentMethod;
             }
@@ -137,6 +138,7 @@ namespace System.Runtime.Serialization
                 if (s_getItemContractMethod == null)
                 {
                     s_getItemContractMethod = typeof(CollectionDataContract).GetProperty("ItemContract", Globals.ScanAllMembers).GetGetMethod(true); // nonPublic
+                    Debug.Assert(s_getItemContractMethod != null);
                 }
                 return s_getItemContractMethod;
             }
@@ -149,6 +151,7 @@ namespace System.Runtime.Serialization
                 if (s_getJsonDataContractMethod == null)
                 {
                     s_getJsonDataContractMethod = typeof(JsonDataContract).GetMethod("GetJsonDataContract", Globals.ScanAllMembers);
+                    Debug.Assert(s_getJsonDataContractMethod != null);
                 }
                 return s_getJsonDataContractMethod;
             }
@@ -161,6 +164,7 @@ namespace System.Runtime.Serialization
                 if (s_getJsonMemberIndexMethod == null)
                 {
                     s_getJsonMemberIndexMethod = typeof(XmlObjectSerializerReadContextComplexJson).GetMethod("GetJsonMemberIndex", Globals.ScanAllMembers);
+                    Debug.Assert(s_getJsonMemberIndexMethod != null);
                 }
                 return s_getJsonMemberIndexMethod;
             }
@@ -173,6 +177,7 @@ namespace System.Runtime.Serialization
                 if (s_getRevisedItemContractMethod == null)
                 {
                     s_getRevisedItemContractMethod = typeof(XmlObjectSerializerWriteContextComplexJson).GetMethod("GetRevisedItemContract", Globals.ScanAllMembers);
+                    Debug.Assert(s_getRevisedItemContractMethod != null);
                 }
                 return s_getRevisedItemContractMethod;
             }
@@ -185,6 +190,7 @@ namespace System.Runtime.Serialization
                 if (s_getUninitializedObjectMethod == null)
                 {
                     s_getUninitializedObjectMethod = typeof(XmlFormatReaderGenerator).GetMethod("UnsafeGetUninitializedObject", Globals.ScanAllMembers, new Type[] { typeof(Type) });
+                    Debug.Assert(s_getUninitializedObjectMethod != null);
                 }
                 return s_getUninitializedObjectMethod;
             }
@@ -197,7 +203,8 @@ namespace System.Runtime.Serialization
             {
                 if (s_isStartElementMethod0 == null)
                 {
-                    s_isStartElementMethod0 = typeof (XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    Debug.Assert(s_isStartElementMethod0 != null);
                 }
                 return s_isStartElementMethod0;
             }
@@ -210,6 +217,7 @@ namespace System.Runtime.Serialization
                 if (s_isStartElementMethod2 == null)
                 {
                     s_isStartElementMethod2 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, new Type[] { typeof(XmlDictionaryString), typeof(XmlDictionaryString) });
+                    Debug.Assert(s_isStartElementMethod2 != null);
                 }
                 return s_isStartElementMethod2;
             }
@@ -222,6 +230,7 @@ namespace System.Runtime.Serialization
                 if (s_localNameProperty == null)
                 {
                     s_localNameProperty = typeof(XmlReaderDelegator).GetProperty("LocalName", Globals.ScanAllMembers);
+                    Debug.Assert(s_localNameProperty != null);
                 }
                 return s_localNameProperty;
             }
@@ -234,6 +243,7 @@ namespace System.Runtime.Serialization
                 if (s_namespaceProperty == null)
                 {
                     s_namespaceProperty = typeof(XmlReaderDelegator).GetProperty("NamespaceProperty", Globals.ScanAllMembers);
+                    Debug.Assert(s_namespaceProperty != null);
                 }
                 return s_namespaceProperty;
             }
@@ -246,6 +256,7 @@ namespace System.Runtime.Serialization
                 if (s_ienumeratorMoveNextMethod == null)
                 {
                     s_ienumeratorMoveNextMethod = typeof(IEnumerator).GetMethod("MoveNext");
+                    Debug.Assert(s_ienumeratorMoveNextMethod != null);
                 }
                 return s_ienumeratorMoveNextMethod;
             }
@@ -258,6 +269,7 @@ namespace System.Runtime.Serialization
                 if (s_moveToContentMethod == null)
                 {
                     s_moveToContentMethod = typeof(XmlReaderDelegator).GetMethod("MoveToContent", Globals.ScanAllMembers);
+                    Debug.Assert(s_moveToContentMethod != null);
                 }
                 return s_moveToContentMethod;
             }
@@ -270,6 +282,7 @@ namespace System.Runtime.Serialization
                 if (s_nodeTypeProperty == null)
                 {
                     s_nodeTypeProperty = typeof(XmlReaderDelegator).GetProperty("NodeType", Globals.ScanAllMembers);
+                    Debug.Assert(s_nodeTypeProperty != null);
                 }
                 return s_nodeTypeProperty;
             }
@@ -282,6 +295,7 @@ namespace System.Runtime.Serialization
                 if (s_readJsonValueMethod == null)
                 {
                     s_readJsonValueMethod = typeof(DataContractJsonSerializer).GetMethod("ReadJsonValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_readJsonValueMethod != null);
                 }
                 return s_readJsonValueMethod;
             }
@@ -306,6 +320,7 @@ namespace System.Runtime.Serialization
                 if (s_throwDuplicateMemberExceptionMethod == null)
                 {
                     s_throwDuplicateMemberExceptionMethod = typeof(XmlObjectSerializerReadContextComplexJson).GetMethod("ThrowDuplicateMemberException", Globals.ScanAllMembers);
+                    Debug.Assert(s_throwDuplicateMemberExceptionMethod != null);
                 }
                 return s_throwDuplicateMemberExceptionMethod;
             }
@@ -318,6 +333,7 @@ namespace System.Runtime.Serialization
                 if (s_throwMissingRequiredMembersMethod == null)
                 {
                     s_throwMissingRequiredMembersMethod = typeof(XmlObjectSerializerReadContextComplexJson).GetMethod("ThrowMissingRequiredMembers", Globals.ScanAllMembers);
+                    Debug.Assert(s_throwMissingRequiredMembersMethod != null);
                 }
                 return s_throwMissingRequiredMembersMethod;
             }
@@ -330,6 +346,7 @@ namespace System.Runtime.Serialization
                 if (s_typeHandleProperty == null)
                 {
                     s_typeHandleProperty = typeof(Type).GetProperty("TypeHandle");
+                    Debug.Assert(s_typeHandleProperty != null);
                 }
                 return s_typeHandleProperty;
             }
@@ -342,6 +359,7 @@ namespace System.Runtime.Serialization
                 if (s_useSimpleDictionaryFormatReadProperty == null)
                 {
                     s_useSimpleDictionaryFormatReadProperty = typeof(XmlObjectSerializerReadContextComplexJson).GetProperty("UseSimpleDictionaryFormat", Globals.ScanAllMembers);
+                    Debug.Assert(s_useSimpleDictionaryFormatReadProperty != null);
                 }
                 return s_useSimpleDictionaryFormatReadProperty;
             }
@@ -354,6 +372,7 @@ namespace System.Runtime.Serialization
                 if (s_useSimpleDictionaryFormatWriteProperty == null)
                 {
                     s_useSimpleDictionaryFormatWriteProperty = typeof(XmlObjectSerializerWriteContextComplexJson).GetProperty("UseSimpleDictionaryFormat", Globals.ScanAllMembers);
+                    Debug.Assert(s_useSimpleDictionaryFormatWriteProperty != null);
                 }
                 return s_useSimpleDictionaryFormatWriteProperty;
             }
@@ -366,6 +385,7 @@ namespace System.Runtime.Serialization
                 if (s_writeAttributeStringMethod == null)
                 {
                     s_writeAttributeStringMethod = typeof(XmlWriterDelegator).GetMethod("WriteAttributeString", Globals.ScanAllMembers, new Type[] { typeof(string), typeof(string), typeof(string), typeof(string) });
+                    Debug.Assert(s_writeAttributeStringMethod != null);
                 }
                 return s_writeAttributeStringMethod;
             }
@@ -378,6 +398,7 @@ namespace System.Runtime.Serialization
                 if (s_writeEndElementMethod == null)
                 {
                     s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    Debug.Assert(s_writeEndElementMethod != null);
                 }
                 return s_writeEndElementMethod;
             }
@@ -390,6 +411,7 @@ namespace System.Runtime.Serialization
                 if (s_writeJsonISerializableMethod == null)
                 {
                     s_writeJsonISerializableMethod = typeof(XmlObjectSerializerWriteContextComplexJson).GetMethod("WriteJsonISerializable", Globals.ScanAllMembers);
+                    Debug.Assert(s_writeJsonISerializableMethod != null);
                 }
                 return s_writeJsonISerializableMethod;
             }
@@ -402,6 +424,7 @@ namespace System.Runtime.Serialization
                 if (s_writeJsonNameWithMappingMethod == null)
                 {
                     s_writeJsonNameWithMappingMethod = typeof(XmlObjectSerializerWriteContextComplexJson).GetMethod("WriteJsonNameWithMapping", Globals.ScanAllMembers);
+                    Debug.Assert(s_writeJsonNameWithMappingMethod != null);
                 }
                 return s_writeJsonNameWithMappingMethod;
             }
@@ -414,6 +437,7 @@ namespace System.Runtime.Serialization
                 if (s_writeJsonValueMethod == null)
                 {
                     s_writeJsonValueMethod = typeof(DataContractJsonSerializer).GetMethod("WriteJsonValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_writeJsonValueMethod != null);
                 }
                 return s_writeJsonValueMethod;
             }
@@ -426,6 +450,7 @@ namespace System.Runtime.Serialization
                 if (s_writeStartElementMethod == null)
                 {
                     s_writeStartElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteStartElement", Globals.ScanAllMembers, new Type[] { typeof(XmlDictionaryString), typeof(XmlDictionaryString) });
+                    Debug.Assert(s_writeStartElementMethod != null);
                 }
                 return s_writeStartElementMethod;
             }
@@ -439,6 +464,7 @@ namespace System.Runtime.Serialization
                 if (s_writeStartElementStringMethod == null)
                 {
                     s_writeStartElementStringMethod = typeof(XmlWriterDelegator).GetMethod("WriteStartElement", Globals.ScanAllMembers, new Type[] { typeof(string), typeof(string) });
+                    Debug.Assert(s_writeStartElementStringMethod != null);
                 }
                 return s_writeStartElementStringMethod;
             }
@@ -465,6 +491,7 @@ namespace System.Runtime.Serialization
                 if (s_getJsonMemberNameMethod == null)
                 {
                     s_getJsonMemberNameMethod = typeof(XmlObjectSerializerReadContextComplexJson).GetMethod("GetJsonMemberName", Globals.ScanAllMembers, new Type[] { typeof(XmlReaderDelegator) });
+                    Debug.Assert(s_getJsonMemberNameMethod != null);
                 }
                 return s_getJsonMemberNameMethod;
             }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -326,6 +326,12 @@ namespace System.Runtime.Serialization.Json
                 scopedKnownTypes.Pop();
             }
         }
+
+        internal static void WriteJsonNameWithMapping(XmlWriterDelegator xmlWriter, XmlDictionaryString[] memberNames, int index)
+        {
+            xmlWriter.WriteStartElement("a", JsonGlobals.itemString, JsonGlobals.itemString);
+            xmlWriter.WriteAttributeString(null, JsonGlobals.itemString, null, memberNames[index].Value);
+        }
 #endif
 
         internal static void VerifyObjectCompatibilityWithInterface(DataContract contract, object graph, Type declaredType)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -28,7 +28,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeStartElementMethod2 == null)
+                {
                     s_writeStartElementMethod2 = typeof(XmlWriterDelegator).GetMethod("WriteStartElement", Globals.ScanAllMembers, new Type[] { typeof(XmlDictionaryString), typeof(XmlDictionaryString) });
+                    Debug.Assert(s_writeStartElementMethod2 != null);
+                }
                 return s_writeStartElementMethod2;
             }
         }
@@ -41,7 +44,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeStartElementMethod3 == null)
+                {
                     s_writeStartElementMethod3 = typeof(XmlWriterDelegator).GetMethod("WriteStartElement", Globals.ScanAllMembers, new Type[] { typeof(string), typeof(XmlDictionaryString), typeof(XmlDictionaryString) });
+                    Debug.Assert(s_writeStartElementMethod3 != null);
+                }
                 return s_writeStartElementMethod3;
             }
         }
@@ -54,7 +60,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeEndElementMethod == null)
+                {
                     s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    Debug.Assert(s_writeEndElementMethod != null);
+                }
                 return s_writeEndElementMethod;
             }
         }
@@ -67,7 +76,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeNamespaceDeclMethod == null)
+                {
                     s_writeNamespaceDeclMethod = typeof(XmlWriterDelegator).GetMethod("WriteNamespaceDecl", Globals.ScanAllMembers, new Type[] { typeof(XmlDictionaryString) });
+                    Debug.Assert(s_writeNamespaceDeclMethod != null);
+                }
                 return s_writeNamespaceDeclMethod;
             }
         }
@@ -94,7 +106,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_ienumeratorMoveNextMethod == null)
+                {
                     s_ienumeratorMoveNextMethod = typeof(IEnumerator).GetMethod("MoveNext");
+                    Debug.Assert(s_ienumeratorMoveNextMethod != null);
+                }
                 return s_ienumeratorMoveNextMethod;
             }
         }
@@ -107,7 +122,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_ienumeratorGetCurrentMethod == null)
+                {
                     s_ienumeratorGetCurrentMethod = typeof(IEnumerator).GetProperty("Current").GetMethod;
+                    Debug.Assert(s_ienumeratorGetCurrentMethod != null);
+                }
                 return s_ienumeratorGetCurrentMethod;
             }
         }
@@ -120,7 +138,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getItemContractMethod == null)
+                {
                     s_getItemContractMethod = typeof(CollectionDataContract).GetProperty("ItemContract", Globals.ScanAllMembers).GetMethod;
+                    Debug.Assert(s_getItemContractMethod != null);
+                }
                 return s_getItemContractMethod;
             }
         }
@@ -133,7 +154,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_isStartElementMethod2 == null)
+                {
                     s_isStartElementMethod2 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, new Type[] { typeof(XmlDictionaryString), typeof(XmlDictionaryString) });
+                    Debug.Assert(s_isStartElementMethod2 != null);
+                }
                 return s_isStartElementMethod2;
             }
         }
@@ -146,7 +170,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_isStartElementMethod0 == null)
+                {
                     s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    Debug.Assert(s_isStartElementMethod0 != null);
+                }
                 return s_isStartElementMethod0;
             }
         }
@@ -159,11 +186,13 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getUninitializedObjectMethod == null)
+                {
                     s_getUninitializedObjectMethod = typeof(XmlFormatReaderGenerator).GetMethod("UnsafeGetUninitializedObject", Globals.ScanAllMembers, new Type[] { typeof(int) });
+                    Debug.Assert(s_getUninitializedObjectMethod != null);
+                }
                 return s_getUninitializedObjectMethod;
             }
         }
-
 
         [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
@@ -173,13 +202,13 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_nodeTypeProperty == null)
+                {
                     s_nodeTypeProperty = typeof(XmlReaderDelegator).GetProperty("NodeType", Globals.ScanAllMembers);
+                    Debug.Assert(s_nodeTypeProperty != null);
+                }
                 return s_nodeTypeProperty;
             }
         }
-
-
-
 
         [SecurityCritical]
         private static ConstructorInfo s_hashtableCtor;
@@ -202,7 +231,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getStreamingContextMethod == null)
+                {
                     s_getStreamingContextMethod = typeof(XmlObjectSerializerContext).GetMethod("GetStreamingContext", Globals.ScanAllMembers);
+                    Debug.Assert(s_getStreamingContextMethod != null);
+                }
                 return s_getStreamingContextMethod;
             }
         }
@@ -215,7 +247,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getCollectionMemberMethod == null)
+                {
                     s_getCollectionMemberMethod = typeof(XmlObjectSerializerReadContext).GetMethod("GetCollectionMember", Globals.ScanAllMembers);
+                    Debug.Assert(s_getCollectionMemberMethod != null);
+                }
                 return s_getCollectionMemberMethod;
             }
         }
@@ -228,7 +263,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_storeCollectionMemberInfoMethod == null)
+                {
                     s_storeCollectionMemberInfoMethod = typeof(XmlObjectSerializerReadContext).GetMethod("StoreCollectionMemberInfo", Globals.ScanAllMembers, new Type[] { typeof(object) });
+                    Debug.Assert(s_storeCollectionMemberInfoMethod != null);
+                }
                 return s_storeCollectionMemberInfoMethod;
             }
         }
@@ -241,7 +279,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_storeIsGetOnlyCollectionMethod == null)
+                {
                     s_storeIsGetOnlyCollectionMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("StoreIsGetOnlyCollection", Globals.ScanAllMembers);
+                    Debug.Assert(s_storeIsGetOnlyCollectionMethod != null);
+                }
                 return s_storeIsGetOnlyCollectionMethod;
             }
         }
@@ -254,7 +295,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod == null)
+                {
                     s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ThrowNullValueReturnedForGetOnlyCollectionException", Globals.ScanAllMembers);
+                    Debug.Assert(s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod != null);
+                }
                 return s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod;
             }
         }
@@ -266,7 +310,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_throwArrayExceededSizeExceptionMethod == null)
+                {
                     s_throwArrayExceededSizeExceptionMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ThrowArrayExceededSizeException", Globals.ScanAllMembers);
+                    Debug.Assert(s_throwArrayExceededSizeExceptionMethod != null);
+                }
                 return s_throwArrayExceededSizeExceptionMethod;
             }
         }
@@ -279,7 +326,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_incrementItemCountMethod == null)
+                {
                     s_incrementItemCountMethod = typeof(XmlObjectSerializerContext).GetMethod("IncrementItemCount", Globals.ScanAllMembers);
+                    Debug.Assert(s_incrementItemCountMethod != null);
+                }
                 return s_incrementItemCountMethod;
             }
         }
@@ -293,7 +343,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_internalDeserializeMethod == null)
+                {
                     s_internalDeserializeMethod = typeof(XmlObjectSerializerReadContext).GetMethod("InternalDeserialize", Globals.ScanAllMembers, new Type[] { typeof(XmlReaderDelegator), typeof(int), typeof(RuntimeTypeHandle), typeof(string), typeof(string) });
+                    Debug.Assert(s_internalDeserializeMethod != null);
+                }
                 return s_internalDeserializeMethod;
             }
         }
@@ -306,7 +359,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_moveToNextElementMethod == null)
+                {
                     s_moveToNextElementMethod = typeof(XmlObjectSerializerReadContext).GetMethod("MoveToNextElement", Globals.ScanAllMembers);
+                    Debug.Assert(s_moveToNextElementMethod != null);
+                }
                 return s_moveToNextElementMethod;
             }
         }
@@ -319,7 +375,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getMemberIndexMethod == null)
+                {
                     s_getMemberIndexMethod = typeof(XmlObjectSerializerReadContext).GetMethod("GetMemberIndex", Globals.ScanAllMembers);
+                    Debug.Assert(s_getMemberIndexMethod != null);
+                }
                 return s_getMemberIndexMethod;
             }
         }
@@ -332,7 +391,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getMemberIndexWithRequiredMembersMethod == null)
+                {
                     s_getMemberIndexWithRequiredMembersMethod = typeof(XmlObjectSerializerReadContext).GetMethod("GetMemberIndexWithRequiredMembers", Globals.ScanAllMembers);
+                    Debug.Assert(s_getMemberIndexWithRequiredMembersMethod != null);
+                }
                 return s_getMemberIndexWithRequiredMembersMethod;
             }
         }
@@ -345,7 +407,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_throwRequiredMemberMissingExceptionMethod == null)
+                {
                     s_throwRequiredMemberMissingExceptionMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ThrowRequiredMemberMissingException", Globals.ScanAllMembers);
+                    Debug.Assert(s_throwRequiredMemberMissingExceptionMethod != null);
+                }
                 return s_throwRequiredMemberMissingExceptionMethod;
             }
         }
@@ -358,7 +423,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_skipUnknownElementMethod == null)
+                {
                     s_skipUnknownElementMethod = typeof(XmlObjectSerializerReadContext).GetMethod("SkipUnknownElement", Globals.ScanAllMembers);
+                    Debug.Assert(s_skipUnknownElementMethod != null);
+                }
                 return s_skipUnknownElementMethod;
             }
         }
@@ -371,7 +439,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_readIfNullOrRefMethod == null)
+                {
                     s_readIfNullOrRefMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ReadIfNullOrRef", Globals.ScanAllMembers, new Type[] { typeof(XmlReaderDelegator), typeof(Type), typeof(bool) });
+                    Debug.Assert(s_readIfNullOrRefMethod != null);
+                }
                 return s_readIfNullOrRefMethod;
             }
         }
@@ -384,7 +455,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_readAttributesMethod == null)
+                {
                     s_readAttributesMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ReadAttributes", Globals.ScanAllMembers);
+                    Debug.Assert(s_readAttributesMethod != null);
+                }
                 return s_readAttributesMethod;
             }
         }
@@ -397,7 +471,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_resetAttributesMethod == null)
+                {
                     s_resetAttributesMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ResetAttributes", Globals.ScanAllMembers);
+                    Debug.Assert(s_resetAttributesMethod != null);
+                }
                 return s_resetAttributesMethod;
             }
         }
@@ -410,7 +487,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getObjectIdMethod == null)
+                {
                     s_getObjectIdMethod = typeof(XmlObjectSerializerReadContext).GetMethod("GetObjectId", Globals.ScanAllMembers);
+                    Debug.Assert(s_getObjectIdMethod != null);
+                }
                 return s_getObjectIdMethod;
             }
         }
@@ -423,7 +503,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getArraySizeMethod == null)
+                {
                     s_getArraySizeMethod = typeof(XmlObjectSerializerReadContext).GetMethod("GetArraySize", Globals.ScanAllMembers);
+                    Debug.Assert(s_getArraySizeMethod != null);
+                }
                 return s_getArraySizeMethod;
             }
         }
@@ -436,7 +519,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_addNewObjectMethod == null)
+                {
                     s_addNewObjectMethod = typeof(XmlObjectSerializerReadContext).GetMethod("AddNewObject", Globals.ScanAllMembers);
+                    Debug.Assert(s_addNewObjectMethod != null);
+                }
                 return s_addNewObjectMethod;
             }
         }
@@ -449,7 +535,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_addNewObjectWithIdMethod == null)
+                {
                     s_addNewObjectWithIdMethod = typeof(XmlObjectSerializerReadContext).GetMethod("AddNewObjectWithId", Globals.ScanAllMembers);
+                    Debug.Assert(s_addNewObjectWithIdMethod != null);
+                }
                 return s_addNewObjectWithIdMethod;
             }
         }
@@ -462,7 +551,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getExistingObjectMethod == null)
+                {
                     s_getExistingObjectMethod = typeof(XmlObjectSerializerReadContext).GetMethod("GetExistingObject", Globals.ScanAllMembers);
+                    Debug.Assert(s_getExistingObjectMethod != null);
+                }
                 return s_getExistingObjectMethod;
             }
         }
@@ -475,7 +567,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_ensureArraySizeMethod == null)
+                {
                     s_ensureArraySizeMethod = typeof(XmlObjectSerializerReadContext).GetMethod("EnsureArraySize", Globals.ScanAllMembers);
+                    Debug.Assert(s_ensureArraySizeMethod != null);
+                }
                 return s_ensureArraySizeMethod;
             }
         }
@@ -488,7 +583,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_trimArraySizeMethod == null)
+                {
                     s_trimArraySizeMethod = typeof(XmlObjectSerializerReadContext).GetMethod("TrimArraySize", Globals.ScanAllMembers);
+                    Debug.Assert(s_trimArraySizeMethod != null);
+                }
                 return s_trimArraySizeMethod;
             }
         }
@@ -501,7 +599,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_checkEndOfArrayMethod == null)
+                {
                     s_checkEndOfArrayMethod = typeof(XmlObjectSerializerReadContext).GetMethod("CheckEndOfArray", Globals.ScanAllMembers);
+                    Debug.Assert(s_checkEndOfArrayMethod != null);
+                }
                 return s_checkEndOfArrayMethod;
             }
         }
@@ -515,7 +616,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getArrayLengthMethod == null)
+                {
                     s_getArrayLengthMethod = Globals.TypeOfArray.GetProperty("Length").GetMethod;
+                    Debug.Assert(s_getArrayLengthMethod != null);
+                }
                 return s_getArrayLengthMethod;
             }
         }
@@ -528,7 +632,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_createSerializationExceptionMethod == null)
+                {
                     s_createSerializationExceptionMethod = typeof(XmlObjectSerializerReadContext).GetMethod("CreateSerializationException", Globals.ScanAllMembers, new Type[] { typeof(string) });
+                    Debug.Assert(s_createSerializationExceptionMethod != null);
+                }
                 return s_createSerializationExceptionMethod;
             }
         }
@@ -541,7 +648,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_createUnexpectedStateExceptionMethod == null)
+                {
                     s_createUnexpectedStateExceptionMethod = typeof(XmlObjectSerializerReadContext).GetMethod("CreateUnexpectedStateException", Globals.ScanAllMembers, new Type[] { typeof(XmlNodeType), typeof(XmlReaderDelegator) });
+                    Debug.Assert(s_createUnexpectedStateExceptionMethod != null);
+                }
                 return s_createUnexpectedStateExceptionMethod;
             }
         }
@@ -554,7 +664,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_internalSerializeReferenceMethod == null)
+                {
                     s_internalSerializeReferenceMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("InternalSerializeReference", Globals.ScanAllMembers);
+                    Debug.Assert(s_internalSerializeReferenceMethod != null);
+                }
                 return s_internalSerializeReferenceMethod;
             }
         }
@@ -567,7 +680,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_internalSerializeMethod == null)
+                {
                     s_internalSerializeMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("InternalSerialize", Globals.ScanAllMembers);
+                    Debug.Assert(s_internalSerializeMethod != null);
+                }
                 return s_internalSerializeMethod;
             }
         }
@@ -580,7 +696,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeNullMethod == null)
+                {
                     s_writeNullMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("WriteNull", Globals.ScanAllMembers, new Type[] { typeof(XmlWriterDelegator), typeof(Type), typeof(bool) });
+                    Debug.Assert(s_writeNullMethod != null);
+                }
                 return s_writeNullMethod;
             }
         }
@@ -593,7 +712,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_incrementArrayCountMethod == null)
+                {
                     s_incrementArrayCountMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("IncrementArrayCount", Globals.ScanAllMembers);
+                    Debug.Assert(s_incrementArrayCountMethod != null);
+                }
                 return s_incrementArrayCountMethod;
             }
         }
@@ -606,7 +728,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_incrementCollectionCountMethod == null)
+                {
                     s_incrementCollectionCountMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("IncrementCollectionCount", Globals.ScanAllMembers, new Type[] { typeof(XmlWriterDelegator), typeof(ICollection) });
+                    Debug.Assert(s_incrementCollectionCountMethod != null);
+                }
                 return s_incrementCollectionCountMethod;
             }
         }
@@ -619,7 +744,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_incrementCollectionCountGenericMethod == null)
+                {
                     s_incrementCollectionCountGenericMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("IncrementCollectionCountGeneric", Globals.ScanAllMembers);
+                    Debug.Assert(s_incrementCollectionCountGenericMethod != null);
+                }
                 return s_incrementCollectionCountGenericMethod;
             }
         }
@@ -632,7 +760,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getDefaultValueMethod == null)
+                {
                     s_getDefaultValueMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("GetDefaultValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_getDefaultValueMethod != null);
+                }
                 return s_getDefaultValueMethod;
             }
         }
@@ -645,7 +776,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getNullableValueMethod == null)
+                {
                     s_getNullableValueMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("GetNullableValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_getNullableValueMethod != null);
+                }
                 return s_getNullableValueMethod;
             }
         }
@@ -658,7 +792,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_throwRequiredMemberMustBeEmittedMethod == null)
+                {
                     s_throwRequiredMemberMustBeEmittedMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("ThrowRequiredMemberMustBeEmitted", Globals.ScanAllMembers);
+                    Debug.Assert(s_throwRequiredMemberMustBeEmittedMethod != null);
+                }
                 return s_throwRequiredMemberMustBeEmittedMethod;
             }
         }
@@ -671,7 +808,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getHasValueMethod == null)
+                {
                     s_getHasValueMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("GetHasValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_getHasValueMethod != null);
+                }
                 return s_getHasValueMethod;
             }
         }
@@ -686,7 +826,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_isMemberTypeSameAsMemberValue == null)
+                {
                     s_isMemberTypeSameAsMemberValue = typeof(XmlObjectSerializerWriteContext).GetMethod("IsMemberTypeSameAsMemberValue", Globals.ScanAllMembers, new Type[] { typeof(object), typeof(Type) });
+                    Debug.Assert(s_isMemberTypeSameAsMemberValue != null);
+                }
                 return s_isMemberTypeSameAsMemberValue;
             }
         }
@@ -699,7 +842,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeXmlValueMethod == null)
+                {
                     s_writeXmlValueMethod = typeof(DataContract).GetMethod("WriteXmlValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_writeXmlValueMethod != null);
+                }
                 return s_writeXmlValueMethod;
             }
         }
@@ -712,7 +858,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_readXmlValueMethod == null)
+                {
                     s_readXmlValueMethod = typeof(DataContract).GetMethod("ReadXmlValue", Globals.ScanAllMembers);
+                    Debug.Assert(s_readXmlValueMethod != null);
+                }
                 return s_readXmlValueMethod;
             }
         }
@@ -725,7 +874,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_namespaceProperty == null)
+                {
                     s_namespaceProperty = typeof(DataContract).GetProperty("Namespace", Globals.ScanAllMembers);
+                    Debug.Assert(s_namespaceProperty != null);
+                }
                 return s_namespaceProperty;
             }
         }
@@ -738,7 +890,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_contractNamespacesField == null)
+                {
                     s_contractNamespacesField = typeof(ClassDataContract).GetField("ContractNamespaces", Globals.ScanAllMembers);
+                    Debug.Assert(s_contractNamespacesField != null);
+                }
                 return s_contractNamespacesField;
             }
         }
@@ -751,11 +906,13 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_memberNamesField == null)
+                {
                     s_memberNamesField = typeof(ClassDataContract).GetField("MemberNames", Globals.ScanAllMembers);
+                    Debug.Assert(s_memberNamesField != null);
+                }
                 return s_memberNamesField;
             }
         }
-
 
         [SecurityCritical]
         private static PropertyInfo s_childElementNamespacesProperty;
@@ -765,7 +922,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_childElementNamespacesProperty == null)
+                {
                     s_childElementNamespacesProperty = typeof(ClassDataContract).GetProperty("ChildElementNamespaces", Globals.ScanAllMembers);
+                    Debug.Assert(s_childElementNamespacesProperty != null);
+                }
                 return s_childElementNamespacesProperty;
             }
         }
@@ -778,7 +938,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_collectionItemNameProperty == null)
+                {
                     s_collectionItemNameProperty = typeof(CollectionDataContract).GetProperty("CollectionItemName", Globals.ScanAllMembers);
+                    Debug.Assert(s_collectionItemNameProperty != null);
+                }
                 return s_collectionItemNameProperty;
             }
         }
@@ -791,7 +954,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_childElementNamespaceProperty == null)
+                {
                     s_childElementNamespaceProperty = typeof(CollectionDataContract).GetProperty("ChildElementNamespace", Globals.ScanAllMembers);
+                    Debug.Assert(s_childElementNamespaceProperty != null);
+                }
                 return s_childElementNamespaceProperty;
             }
         }
@@ -804,7 +970,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getDateTimeOffsetMethod == null)
+                {
                     s_getDateTimeOffsetMethod = typeof(DateTimeOffsetAdapter).GetMethod("GetDateTimeOffset", Globals.ScanAllMembers);
+                    Debug.Assert(s_getDateTimeOffsetMethod != null);
+                }
                 return s_getDateTimeOffsetMethod;
             }
         }
@@ -817,7 +986,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_getDateTimeOffsetAdapterMethod == null)
+                {
                     s_getDateTimeOffsetAdapterMethod = typeof(DateTimeOffsetAdapter).GetMethod("GetDateTimeOffsetAdapter", Globals.ScanAllMembers);
+                    Debug.Assert(s_getDateTimeOffsetAdapterMethod != null);
+                }
                 return s_getDateTimeOffsetAdapterMethod;
             }
         }
@@ -859,7 +1031,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_throwInvalidDataContractExceptionMethod == null)
+                {
                     s_throwInvalidDataContractExceptionMethod = typeof(DataContract).GetMethod("ThrowInvalidDataContractException", Globals.ScanAllMembers, new Type[] { typeof(string), typeof(Type) });
+                    Debug.Assert(s_throwInvalidDataContractExceptionMethod != null);
+                }
                 return s_throwInvalidDataContractExceptionMethod;
             }
         }
@@ -872,7 +1047,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_serializeReadOnlyTypesProperty == null)
+                {
                     s_serializeReadOnlyTypesProperty = typeof(XmlObjectSerializerWriteContext).GetProperty("SerializeReadOnlyTypes", Globals.ScanAllMembers);
+                    Debug.Assert(s_serializeReadOnlyTypesProperty != null);
+                }
                 return s_serializeReadOnlyTypesProperty;
             }
         }
@@ -885,7 +1063,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_classSerializationExceptionMessageProperty == null)
+                {
                     s_classSerializationExceptionMessageProperty = typeof(ClassDataContract).GetProperty("SerializationExceptionMessage", Globals.ScanAllMembers);
+                    Debug.Assert(s_classSerializationExceptionMessageProperty != null);
+                }
                 return s_classSerializationExceptionMessageProperty;
             }
         }
@@ -898,7 +1079,10 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_collectionSerializationExceptionMessageProperty == null)
+                {
                     s_collectionSerializationExceptionMessageProperty = typeof(CollectionDataContract).GetProperty("SerializationExceptionMessage", Globals.ScanAllMembers);
+                    Debug.Assert(s_collectionSerializationExceptionMessageProperty != null);
+                }
                 return s_collectionSerializationExceptionMessageProperty;
             }
         }

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1296,6 +1296,19 @@ public static class DataContractJsonSerializerTests
         Assert.StrictEqual(dict["key2"], deserialized["key2"]);
     }
 
+    [Fact]
+    public static void DCJS_DataMemberNames()
+    {
+        var obj = new AppEnvironment()
+        {
+            ScreenDpi = 440,
+            ScreenOrientation = "horizontal"
+        };
+        var actual = SerializeAndDeserialize(obj, @"{""screen_dpi(x:y)"":440,""screen:orientation"":""horizontal""}");
+        Assert.StrictEqual(obj.ScreenDpi, actual.ScreenDpi);
+        Assert.StrictEqual(obj.ScreenOrientation, actual.ScreenOrientation);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2119,3 +2119,13 @@ public class TypeWithNonParameterlessConstructor
         StringProperty = value;
     }
 }
+
+[DataContract]
+public class AppEnvironment
+{
+    [DataMember(Name = "screen:orientation")]
+    public string ScreenOrientation { get; set; }
+
+    [DataMember(Name = "screen_dpi(x:y)")]
+    public int ScreenDpi { get; set; }
+}


### PR DESCRIPTION
This issue happens only for DCJS and affecting both NetCore and NetNative, due to missing method from recent merging of DCJS.

cc: @SGuyGe @shmao @zhenlan 