### PR TITLE
Fix DNU restore on Unix

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -60,12 +60,13 @@
 
   <!-- list of nuget package sources passed to dnu -->
   <ItemGroup>
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-core/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-coreclr/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-corefx/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-corefxtestdata/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-buildtools/" />
-    <DnuSourceList Include="https://www.nuget.org/api/v2/" />
+    <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-coreclr/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
+    <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
MSBuild on Unix normalizes double forward slashes to a single slash.
Escape to avoid the issue with URLs.

Fixes #2157
@akoeplinger, @jhendrixMSFT, @weshaggard, @stephentoub  