### PR TITLE
Add CompareInfo tests

### DIFF
--- a/src/System.Globalization/tests/CompareInfo.TestData.cs
+++ b/src/System.Globalization/tests/CompareInfo.TestData.cs
@@ -1,0 +1,323 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+public partial class CompareInfoTests
+{    
+    public static IEnumerable<object[]> CompareToData
+    {
+        get
+        {
+            yield return new object[] { "", null, "Test's", -1, CompareOptions.None };
+            yield return new object[] { "", "Test's", null, 1, CompareOptions.None };
+            yield return new object[] { "", null, null, 0, CompareOptions.None };
+            yield return new object[] { "", "\u3042", "\u30A1", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3042", "\u30A2", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3042", "\uFF71", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u304D\u3083", "\u30AD\u30E3", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u304D\u3083", "\u30AD\u3083", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u304D \u3083", "\u30AD\u3083", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3044", "I", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "a", "A", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "a", "\uFF41", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "\uFF21\uFF22\uFF23\uFF24\uFF25", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "\uFF21\uFF22\uFF23D\uFF25", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "a\uFF22\uFF23D\uFF25", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "\uFF41\uFF42\uFF23D\uFF25", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u6FA4", "\u6CA2", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u30D6\u30D9\u30DC", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\u30DC", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\uFF8E\uFF9E", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\uFF8E\uFF9E", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u3079\uFF8E\uFF9E", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D6", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3071\u3074\u30D7\u307A", "\uFF8B\uFF9F\uFF8C\uFF9F", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u3070\uFF8E\uFF9E\u30D6", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C\u3079\u307C", "\u3079\uFF8E\uFF9E", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3070\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D6", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABDDE", "D", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "\uFF43D\uFF25", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "\uFF43D", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "c", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3060", "\u305F", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3060", "\uFF80\uFF9E", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3060", "\u30C0", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30C7\u30BF\u30D9\u30B9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E\uFF7D", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30C7", "\uFF83\uFF9E", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30C7\u30BF", "\uFF83\uFF9E\uFF80", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30C7\u30BF\u30D9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30BF", "\uFF80", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\uFF83\uFF9E\uFF70\uFF80\uFF8D\uFF9E\uFF70\uFF7D", "\u3067\u30FC\u305F\u3079\u30FC\u3059", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u68EE\u9D0E\u5916", "\u68EE\u9DD7\u5916", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u68EE\u9DD7\u5916", "\u68EE\u9DD7\u5916", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u2019\u2019\u2019\u2019", "''''", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u2019", "'", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "", "'", -1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u4E00", "\uFF11", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u2160", "\uFF11", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "0", "\uFF10", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "10", "1\uFF10", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "1\uFF10", "1\uFF10", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "9999\uFF1910", "1\uFF10", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "9999\uFF191010", "1\uFF10", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "'\u3000'", "' '", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "'\u3000'", "''", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\uFF1B", ";", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\uFF08", "(", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30FC", "\uFF70", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30FC", "\uFF0D", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30FC", "\u30FC", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30FC", "\u2015", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u30FC", "\u2010", 1, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "/", "\uFF0F", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "'", "\uFF07", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\"", "\uFF02", 0, CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "\u3042", "\u30A1", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3042", "\u30A2", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3042", "\uFF71", 1, CompareOptions.None };
+            yield return new object[] { "", "\u304D\u3083", "\u30AD\u30E3", 1, CompareOptions.None };
+            yield return new object[] { "", "\u304D\u3083", "\u30AD\u3083", 1, CompareOptions.None };
+            yield return new object[] { "", "\u304D \u3083", "\u30AD\u3083", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3044", "I", 1, CompareOptions.None };
+            yield return new object[] { "", "a", "A", -1, CompareOptions.None };
+            yield return new object[] { "", "a", "\uFF41", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "\uFF21\uFF22\uFF23\uFF24\uFF25", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "\uFF21\uFF22\uFF23D\uFF25", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "a\uFF22\uFF23D\uFF25", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "\uFF41\uFF42\uFF23D\uFF25", 1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "\uFF41\uFF42\uFF23\uFF24\uFF25", 1, CompareOptions.IgnoreWidth };
+            yield return new object[] { "", "ABCDE", "\uFF41\uFF42\uFF23\uFF24\uFF25", 0, CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase };
+            yield return new object[] { "", "\u6FA4", "\u6CA2", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u30D6\u30D9\u30DC", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\u30DC", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\uFF8E\uFF9E", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\uFF8E\uFF9E", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u3079\uFF8E\uFF9E", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D6", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3071\u3074\u30D7\u307A", "\uFF8B\uFF9F\uFF8C\uFF9F", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u3070\uFF8E\uFF9E\u30D6", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C\u3079\u307C", "\u3079\uFF8E\uFF9E", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3070\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D6", -1, CompareOptions.None };
+            yield return new object[] { "", "ABDDE", "D", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "\uFF43D\uFF25", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "\uFF43D", -1, CompareOptions.None };
+            yield return new object[] { "", "ABCDE", "c", -1, CompareOptions.None };
+            yield return new object[] { "", "\u3060", "\u305F", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3060", "\uFF80\uFF9E", 1, CompareOptions.None };
+            yield return new object[] { "", "\u3060", "\u30C0", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30C7\u30BF\u30D9\u30B9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E\uFF7D", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30C7", "\uFF83\uFF9E", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30C7\u30BF", "\uFF83\uFF9E\uFF80", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30C7\u30BF\u30D9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30BF", "\uFF80", 1, CompareOptions.None };
+            yield return new object[] { "", "\uFF83\uFF9E\uFF70\uFF80\uFF8D\uFF9E\uFF70\uFF7D", "\u3067\u30FC\u305F\u3079\u30FC\u3059", -1, CompareOptions.None };
+            yield return new object[] { "", "\u68EE\u9D0E\u5916", "\u68EE\u9DD7\u5916", -1, CompareOptions.None };
+            yield return new object[] { "", "\u68EE\u9DD7\u5916", "\u68EE\u9DD7\u5916", 0, CompareOptions.None };
+            yield return new object[] { "", "\u2019\u2019\u2019\u2019", "''''", 1, CompareOptions.None };
+            yield return new object[] { "", "\u2019", "'", 1, CompareOptions.None };
+            yield return new object[] { "", "", "'", -1, CompareOptions.None };
+            yield return new object[] { "", "\u4E00", "\uFF11", 1, CompareOptions.None };
+            yield return new object[] { "", "\u2160", "\uFF11", 1, CompareOptions.None };
+            yield return new object[] { "", "0", "\uFF10", -1, CompareOptions.None };
+            yield return new object[] { "", "10", "1\uFF10", -1, CompareOptions.None };
+            yield return new object[] { "", "1\uFF10", "1\uFF10", 0, CompareOptions.None };
+            yield return new object[] { "", "9999\uFF1910", "1\uFF10", 1, CompareOptions.None };
+            yield return new object[] { "", "9999\uFF191010", "1\uFF10", 1, CompareOptions.None };
+            yield return new object[] { "", "'\u3000'", "' '", 1, CompareOptions.None };
+            yield return new object[] { "", "'\u3000'", "''", 1, CompareOptions.None };
+            yield return new object[] { "", "\uFF1B", ";", 1, CompareOptions.None };
+            yield return new object[] { "", "\uFF08", "(", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30FC", "\uFF70", 0, CompareOptions.None };
+            yield return new object[] { "", "\u30FC", "\uFF0D", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30FC", "\u30FC", 0, CompareOptions.None };
+            yield return new object[] { "", "\u30FC", "\u2015", 1, CompareOptions.None };
+            yield return new object[] { "", "\u30FC", "\u2010", 1, CompareOptions.None };
+            yield return new object[] { "", "/", "\uFF0F", -1, CompareOptions.None };
+            yield return new object[] { "", "'", "\uFF07", -1, CompareOptions.None };
+            yield return new object[] { "", "\"", "\uFF02", -1, CompareOptions.None };
+            yield return new object[] { "hu-HU", "dzsdzs", "ddzs", 0, CompareOptions.None };
+            yield return new object[] { "hu-HU", "dzsdzs", "ddzs", 1, CompareOptions.Ordinal };
+            yield return new object[] { "", "dzsdzs", "ddzs", 1, CompareOptions.None };
+            yield return new object[] { "", "dzsdzs", "ddzs", 1, CompareOptions.Ordinal };
+            yield return new object[] { "tr-TR", "i", "I", 1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "i", "I", 0, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "i", "\u0130", 0, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "i", "\u0130", -1, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "i", "I", 1, CompareOptions.None };
+            yield return new object[] { "", "i", "I", -1, CompareOptions.None };
+            yield return new object[] { "tr-TR", "i", "\u0130", -1, CompareOptions.None };
+            yield return new object[] { "", "i", "\u0130", -1, CompareOptions.None };
+            yield return new object[] { "", "\u00C0", "A\u0300", 0, CompareOptions.None };
+            yield return new object[] { "", "\u00C0", "A\u0300", 1, CompareOptions.Ordinal };
+            yield return new object[] { "", "\u00C0", "a\u0300", 0, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "\u00C0", "a\u0300", 1, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "", "\u00C0", "a\u0300", 1, CompareOptions.None };
+            yield return new object[] { "", "\u00C0", "a\u0300", 1, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.None };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "FooBA\u0300R", "Foo\u0400B\u00C0R", -1, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "Test's", "Tests", 0, CompareOptions.IgnoreSymbols };
+            yield return new object[] { "", "Test's", "Tests", 1, CompareOptions.None };
+            yield return new object[] { "", "Test's", "Tests", -1, CompareOptions.StringSort };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5555), 0, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5555) + "b", -1, CompareOptions.None };
+        }
+    }
+
+    public static IEnumerable<object[]> IndexOfData
+    {
+        get
+        {
+            yield return new object[] { "", "foo", "", 0, CompareOptions.None };
+            yield return new object[] { "", "", "", 0, CompareOptions.None };
+            yield return new object[] { "", new string('b', 100) + new string('a', 5555), "aaaaaaaaaaaaaaa", 100, CompareOptions.None };
+            yield return new object[] { "", new string('b', 101) + new string('a', 5555), new string('a', 5000), 101, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5000) + "b", -1, CompareOptions.None };
+            yield return new object[] { "hu-HU", "foobardzsdzs", "rddzs", 5, CompareOptions.None };
+            yield return new object[] { "hu-HU", "foobardzsdzs", "rddzs", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "foobardzsdzs", "rddzs", -1, CompareOptions.None };
+            yield return new object[] { "", "foobardzsdzs", "rddzs", -1, CompareOptions.Ordinal };
+            yield return new object[] { "tr-TR", "Hi", "I", -1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "I", 1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "I", 1, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "tr-TR", "Hi", "\u0130", 1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "\u0130", -1, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "Hi", "I", -1, CompareOptions.None };
+            yield return new object[] { "", "Hi", "I", -1, CompareOptions.None };
+            yield return new object[] { "tr-TR", "Hi", "\u0130", -1, CompareOptions.None };
+            yield return new object[] { "", "Hi", "\u0130", -1, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "A\u0300", 8, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "A\u0300", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", 8, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", -1, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", -1, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.None };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "~FooBar", "Foo\u0400Bar", -1, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "TestFooBA\u0300R", "Foo\u0400B\u00C0R", -1, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "More Test's", "Tests", 5, CompareOptions.IgnoreSymbols };
+            yield return new object[] { "", "More Test's", "Tests", -1, CompareOptions.None };
+            yield return new object[] { "", "cbabababdbaba", "ab", 2, CompareOptions.None };
+        }
+    }
+
+    public static IEnumerable<object[]> LastIndexOfData
+    {
+        get
+        {
+            yield return new object[] { "", "foo", "", 2, CompareOptions.None };
+            yield return new object[] { "", "", "", 0, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555) + new string('b', 100), "aaaaaaaaaaaaaaa", 5540, CompareOptions.None };
+            yield return new object[] { "", new string('b', 101) + new string('a', 5555), new string('a', 5000), 656, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5000) + "b", -1, CompareOptions.None };
+            yield return new object[] { "hu-HU", "foobardzsdzs", "rddzs", 5, CompareOptions.None };
+            yield return new object[] { "hu-HU", "foobardzsdzs", "rddzs", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "foobardzsdzs", "rddzs", -1, CompareOptions.None };
+            yield return new object[] { "", "foobardzsdzs", "rddzs", -1, CompareOptions.Ordinal };
+            yield return new object[] { "tr-TR", "Hi", "I", -1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "I", 1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "I", 1, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "tr-TR", "Hi", "\u0130", 1, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "\u0130", -1, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "Hi", "I", -1, CompareOptions.None };
+            yield return new object[] { "", "Hi", "I", -1, CompareOptions.None };
+            yield return new object[] { "tr-TR", "Hi", "\u0130", -1, CompareOptions.None };
+            yield return new object[] { "", "Hi", "\u0130", -1, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "A\u0300", 8, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "A\u0300", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", 8, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", -1, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", -1, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.None };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", -1, CompareOptions.Ordinal };
+            yield return new object[] { "", "~FooBar", "Foo\u0400Bar", -1, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "TestFooBA\u0300R", "Foo\u0400B\u00C0R", -1, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "More Test's", "Tests", 5, CompareOptions.IgnoreSymbols };
+            yield return new object[] { "", "More Test's", "Tests", -1, CompareOptions.None };
+            yield return new object[] { "", "cbabababdbaba", "ab", 10, CompareOptions.None };
+        }
+    }
+
+    public static IEnumerable<object[]> IsPrefixData
+    {
+        get
+        {
+            yield return new object[] { "", new string('a', 5555), "aaaaaaaaaaaaaaa", true, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5000), true, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5000) + "b", false, CompareOptions.None };
+            yield return new object[] { "", "foo", "", true, CompareOptions.None };
+            yield return new object[] { "", "", "", true, CompareOptions.None };
+            yield return new object[] { "hu-HU", "dzsdzsfoobar", "ddzsf", true, CompareOptions.None };
+            yield return new object[] { "hu-HU", "dzsdzsfoobar", "ddzsf", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "dzsdzsfoobar", "ddzsf", false, CompareOptions.None };
+            yield return new object[] { "", "dzsdzsfoobar", "ddzsf", false, CompareOptions.Ordinal };
+            yield return new object[] { "tr-TR", "interesting", "I", false, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "interesting", "I", true, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "interesting", "\u0130", true, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "interesting", "\u0130", false, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "interesting", "I", false, CompareOptions.None };
+            yield return new object[] { "", "interesting", "I", false, CompareOptions.None };
+            yield return new object[] { "tr-TR", "interesting", "\u0130", false, CompareOptions.None };
+            yield return new object[] { "", "interesting", "\u0130", false, CompareOptions.None };
+            yield return new object[] { "", "\u00C0nimal", "A\u0300", true, CompareOptions.None };
+            yield return new object[] { "", "\u00C0nimal", "A\u0300", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "\u00C0nimal", "a\u0300", true, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "\u00C0nimal", "a\u0300", false, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "", "\u00C0nimal", "a\u0300", false, CompareOptions.None };
+            yield return new object[] { "", "\u00C0nimal", "a\u0300", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", false, CompareOptions.None };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", false, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "FooBA\u0300R", "Foo\u0400B\u00C0R", false, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "Test's can be interesting", "Tests", true, CompareOptions.IgnoreSymbols };
+            yield return new object[] { "", "Test's can be interesting", "Tests", false, CompareOptions.None };
+        }
+    }
+
+    public static IEnumerable<object[]> IsSuffixData
+    {
+        get
+        {
+            yield return new object[] { "", new string('a', 5555), "aaaaaaaaaaaaaaa", true, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5000), true, CompareOptions.None };
+            yield return new object[] { "", new string('a', 5555), new string('a', 5000) + "b", false, CompareOptions.None };
+            yield return new object[] { "", "foo", "", true, CompareOptions.None };
+            yield return new object[] { "", "", "", true, CompareOptions.None };
+            yield return new object[] { "hu-HU", "foobardzsdzs", "rddzs", true, CompareOptions.None };
+            yield return new object[] { "hu-HU", "foobardzsdzs", "rddzs", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "foobardzsdzs", "rddzs", false, CompareOptions.None };
+            yield return new object[] { "", "foobardzsdzs", "rddzs", false, CompareOptions.Ordinal };
+            yield return new object[] { "tr-TR", "Hi", "I", false, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "I", true, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "Hi", "\u0130", true, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Hi", "\u0130", false, CompareOptions.IgnoreCase };
+            yield return new object[] { "tr-TR", "Hi", "I", false, CompareOptions.None };
+            yield return new object[] { "", "Hi", "I", false, CompareOptions.None };
+            yield return new object[] { "tr-TR", "Hi", "\u0130", false, CompareOptions.None };
+            yield return new object[] { "", "Hi", "\u0130", false, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "A\u0300", true, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "A\u0300", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", true, CompareOptions.IgnoreCase };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", false, CompareOptions.OrdinalIgnoreCase };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", false, CompareOptions.None };
+            yield return new object[] { "", "Exhibit \u00C0", "a\u0300", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", false, CompareOptions.None };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", false, CompareOptions.Ordinal };
+            yield return new object[] { "", "FooBar", "Foo\u0400Bar", false, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "FooBA\u0300R", "Foo\u0400B\u00C0R", false, CompareOptions.IgnoreNonSpace };
+            yield return new object[] { "", "More Test's", "Tests", true, CompareOptions.IgnoreSymbols };
+            yield return new object[] { "", "More Test's", "Tests", false, CompareOptions.None };
+        }
+    }
+}
+

--- a/src/System.Globalization/tests/CompareInfo.cs
+++ b/src/System.Globalization/tests/CompareInfo.cs
@@ -1,0 +1,424 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using Xunit;
+
+public partial class CompareInfoTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("en")]
+    [InlineData("en-US")]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void GetCompareInfo(string localeName)
+    {
+        CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
+
+        Assert.Equal(localeName, ci.Name);
+    }
+
+    [Fact]
+    public static void GetCompareInfoBadCompareType()
+    {
+        Assert.Throws<ArgumentNullException>(() => CompareInfo.GetCompareInfo(null));
+    }
+
+    [Theory]
+    [MemberData("CompareToData")]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void Compare(string localeName, string left, string right, int expected, CompareOptions options)
+    {
+        CompareInfo ci = CompareInfo.GetCompareInfo(localeName);        
+        
+        Assert.Equal(expected, Math.Sign(ci.Compare(left, right, options)));
+
+        if (options == CompareOptions.None)
+        {
+            Assert.Equal(expected, Math.Sign(ci.Compare(left, right)));
+        }
+    }
+
+    [Theory]
+    [InlineData(null, -1)]
+    [InlineData("", -1)]
+    [InlineData("abc", -1)]
+    [InlineData("abc", 4)]
+    public static void CompareArgumentOutOfRangeIndex(string badString, int badOffset)
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare("good", 0, badString, badOffset));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare(badString, badOffset, "good", 0));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare("good", 0, badString, badOffset, CompareOptions.None));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare(badString, badOffset, "good", 0, CompareOptions.None));
+    }
+
+    [Theory]
+    [InlineData(null, 0, -1)]
+    [InlineData(null, -1, 0)]
+    [InlineData(null, -1, -1)]
+    [InlineData("", 0, -1)]
+    [InlineData("", -1, 0)]
+    [InlineData("", -1, -1)]
+    [InlineData("abc", 0, 4)]
+    [InlineData("abc", 4, 0)]
+    [InlineData("abc", 0, -1)]
+    [InlineData("abc", -1, 3)]
+    [InlineData("abc", 2, 2)]
+    public static void CompareArgumentOutOfRangeIndexAndCount(string badString, int badOffset, int badCount)
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare("good", 0, 4, badString, badOffset, badCount));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare(badString, badOffset, badCount, "good", 0, 4));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare("good", 0, 4, badString, badOffset, badCount, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.Compare(badString, badOffset, badCount, "good", 0, 4, CompareOptions.Ordinal));
+    }
+
+    [Fact]
+    public static void CompareBadCompareOptions()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentException>(() => ci.Compare("a", "b", CompareOptions.Ordinal | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.Compare("a", "b", CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.Compare("a", "b", (CompareOptions)(-1)));
+    }
+
+    [Theory]
+    [MemberData("IndexOfData")]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void IndexOf(string localeName, string source, string value, int expectedResult, CompareOptions options)
+    {
+        CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
+
+        Assert.Equal(expectedResult, ci.IndexOf(source, value, options));
+
+        if (value.Length == 1)
+        {
+            Assert.Equal(expectedResult, ci.IndexOf(source, value[0], options));
+        }
+
+        if (options == CompareOptions.None)
+        {
+            Assert.Equal(expectedResult, ci.IndexOf(source, value));
+        }
+
+        if (value.Length == 1 && options == CompareOptions.None)
+        {
+            Assert.Equal(expectedResult, ci.IndexOf(source, value[0]));
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void IndexOfMinusOneCompatability()
+    {
+        CompareInfo ci  = CultureInfo.InvariantCulture.CompareInfo;
+
+        // This behavior was for .NET Framework 1.1 compatability.  We early outed for empty source strings
+        // even with invalid offsets.
+
+        Assert.Equal(0, ci.IndexOf("", "", -1, CompareOptions.None));
+        Assert.Equal(-1, ci.IndexOf("", "a", -1, CompareOptions.None));
+    }
+
+    [Theory]
+    [InlineData("", 'a', 1)]
+    [InlineData("abc", 'a', -1)]
+    [InlineData("abc", 'a', 4)]
+    public static void IndexOfArgumentOutOfRangeIndex(string source, char value, int badStartIndex)
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+        string valueAsString = value.ToString();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.IndexOf(source, value, badStartIndex, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.IndexOf(source, valueAsString, badStartIndex, CompareOptions.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("abc", 'a', 0, -1)]
+    [InlineData("abc", 'a', 0, 4)]
+    [InlineData("abc", 'a', 2, 2)]
+    [InlineData("abc", 'a', 4, 0)]
+    [InlineData("abc", 'a', 4, -1)]
+    public static void IndexOfArgumentOutOfRangeIndexAndCount(string source, char value, int badStartIndex, int badCount)
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+        string valueAsString = value.ToString();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.IndexOf(source, value, badStartIndex, badCount));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.IndexOf(source, value, badStartIndex, badCount, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.IndexOf(source, valueAsString, badStartIndex, badCount));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.IndexOf(source, valueAsString, badStartIndex, badCount, CompareOptions.Ordinal));
+    }
+
+    [Fact]
+    public static void IndexOfArgumentNullException()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, 'a'));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, "a"));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf("a", null));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, 'a', CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, "a", CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf("a", null, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, 'a', 0, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, "a", 0, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf("a", null, 0, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, 'a', 0, 1));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, "a", 0, 1));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf("a", null, 0, 1));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, 'a', 0, 1, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf(null, "a", 0, 1, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.IndexOf("a", null, 0, 1, CompareOptions.Ordinal));
+    }
+
+    [Fact]
+    public static void IndexOfBadCompareOptions()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentException>(() => ci.IndexOf("abc", "a", CompareOptions.Ordinal | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.IndexOf("abc", "a", CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.IndexOf("abc", "a", (CompareOptions)(-1)));
+        Assert.Throws<ArgumentException>(() => ci.IndexOf("abc", "a", CompareOptions.StringSort));
+    }
+
+    [Theory]
+    [MemberData("LastIndexOfData")]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void LastIndexOf(string localeName, string source, string value, int expectedResult, CompareOptions options)
+    {
+        CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
+
+        Assert.Equal(expectedResult, ci.LastIndexOf(source, value, options));
+
+        if (value.Length == 1)
+        {
+            Assert.Equal(expectedResult, ci.LastIndexOf(source, value[0], options));
+        }
+
+        if (options == CompareOptions.None)
+        {
+            Assert.Equal(expectedResult, ci.LastIndexOf(source, value));
+        }
+
+        if (value.Length == 1 && options == CompareOptions.None)
+        {
+            Assert.Equal(expectedResult, ci.LastIndexOf(source, value[0]));
+        }
+    }
+
+    [Theory]
+    [InlineData("", 'a', 1)]
+    [InlineData("abc", 'a', -1)]
+    [InlineData("abc", 'a', 4)]
+    public static void LastIndexOfArgumentOutOfRangeIndex(string source, char value, int badStartIndex)
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+        string valueAsString = value.ToString();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.LastIndexOf(source, value, badStartIndex, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.LastIndexOf(source, valueAsString, badStartIndex, CompareOptions.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("abc", 'a', 2, -1)]
+    [InlineData("abc", 'a', 2, 4)]
+    [InlineData("abc", 'a', 1, 3)]
+    [InlineData("abc", 'a', 4, 0)]
+    [InlineData("abc", 'a', 4, -1)]
+    public static void LastIndexOfArgumentOutOfRangeIndexAndCount(string source, char value, int badStartIndex, int badCount)
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+        string valueAsString = value.ToString();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.LastIndexOf(source, value, badStartIndex, badCount));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.LastIndexOf(source, value, badStartIndex, badCount, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.LastIndexOf(source, valueAsString, badStartIndex, badCount));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ci.LastIndexOf(source, valueAsString, badStartIndex, badCount, CompareOptions.Ordinal));
+    }
+
+    [Fact]
+    public static void LastIndexOfArgumentNullException()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, 'a'));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, "a"));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf("a", null));
+
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, 'a', CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, "a", CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf("a", null, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, 'a', 1, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, "a", 1, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf("a", null, 1, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, 'a', 1, 1));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, "a", 1, 1));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf("a", null, 1, 1));
+
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, 'a', 1, 1, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf(null, "a", 1, 1, CompareOptions.Ordinal));
+        Assert.Throws<ArgumentNullException>(() => ci.LastIndexOf("a", null, 1, 1, CompareOptions.Ordinal));
+    }
+
+    [Fact]
+    public static void LastIndexOfBadCompareOptions()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentException>(() => ci.LastIndexOf("abc", "a", CompareOptions.Ordinal | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.LastIndexOf("abc", "a", CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.LastIndexOf("abc", "a", (CompareOptions)(-1)));
+        Assert.Throws<ArgumentException>(() => ci.LastIndexOf("abc", "a", CompareOptions.StringSort));
+    }
+
+    [Theory]
+    [MemberData("IsPrefixData")]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void IsPrefix(string localeName, string source, string prefix, bool expectedResult, CompareOptions options)
+    {
+        CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
+
+        Assert.Equal(expectedResult, ci.IsPrefix(source, prefix, options));
+    }
+
+    [Fact]
+    public static void IsPrefixBadCompareOptions()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentException>(() => ci.IsPrefix("aaa", "a", CompareOptions.Ordinal | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.IsPrefix("aaa", "a", CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.IsPrefix("aaa", "a", CompareOptions.StringSort));
+        Assert.Throws<ArgumentException>(() => ci.IsPrefix("aaa", "a", (CompareOptions)(-1)));
+    }
+
+    [Fact]
+    public static void IsPrefixArgumentNullException()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentNullException>(() => ci.IsPrefix(null, ""));
+        Assert.Throws<ArgumentNullException>(() => ci.IsPrefix(null, "", CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IsPrefix("", null));
+        Assert.Throws<ArgumentNullException>(() => ci.IsPrefix("", null, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IsPrefix(null, null));
+        Assert.Throws<ArgumentNullException>(() => ci.IsPrefix(null, null, CompareOptions.Ordinal));
+    }
+
+    [Theory]
+    [MemberData("IsSuffixData")]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void IsSuffix(string localeName, string source, string suffix, bool expectedResult, CompareOptions options)
+    {
+        CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
+
+        Assert.Equal(expectedResult, ci.IsSuffix(source, suffix, options));
+    }
+
+    [Fact]
+    public static void IsSuffixBadCompareOptions()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentException>(() => ci.IsSuffix("aaa", "a", CompareOptions.Ordinal | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.IsSuffix("aaa", "a", CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreWidth));
+        Assert.Throws<ArgumentException>(() => ci.IsSuffix("aaa", "a", CompareOptions.StringSort));
+        Assert.Throws<ArgumentException>(() => ci.IsSuffix("aaa", "a", (CompareOptions)(-1)));
+    }
+
+    [Fact]
+    public static void IsSuffixArgumentNullException()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentNullException>(() => ci.IsSuffix(null, ""));
+        Assert.Throws<ArgumentNullException>(() => ci.IsSuffix(null, "", CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IsSuffix("", null));
+        Assert.Throws<ArgumentNullException>(() => ci.IsSuffix("", null, CompareOptions.Ordinal));
+
+        Assert.Throws<ArgumentNullException>(() => ci.IsSuffix(null, null));
+        Assert.Throws<ArgumentNullException>(() => ci.IsSuffix(null, null, CompareOptions.Ordinal));
+    }
+
+    [Fact]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void EqualsAndHashCode()
+    {
+        CompareInfo ciInvariantFromCultureInfo = CultureInfo.InvariantCulture.CompareInfo;
+        CompareInfo ciInvariantFromFactory = CompareInfo.GetCompareInfo("");
+        CompareInfo ciEnUs = CompareInfo.GetCompareInfo("en-US");
+
+        Assert.True(ciInvariantFromCultureInfo.Equals(ciInvariantFromFactory));
+        Assert.False(ciEnUs.Equals(ciInvariantFromCultureInfo));
+        Assert.False(ciEnUs.Equals(new object()));
+
+        Assert.Equal(ciInvariantFromCultureInfo.GetHashCode(), ciInvariantFromFactory.GetHashCode());
+    }
+
+    [Fact]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void GetHashCodeOfString()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Equal("abc".GetHashCode(), ci.GetHashCode("abc", CompareOptions.Ordinal));
+
+        Assert.Equal(ci.GetHashCode("abc", CompareOptions.OrdinalIgnoreCase), ci.GetHashCode("ABC", CompareOptions.OrdinalIgnoreCase));
+
+        // This behavior of the empty string is specical cased today.
+        Assert.Equal(0, ci.GetHashCode("", CompareOptions.None));
+
+        // Not much we can assert about the hashcode of a string itself, but we can assume that computing it twice yeilds the same value.
+        int hashCode1 = ci.GetHashCode("abc", CompareOptions.None);
+        int hashCode2 = ci.GetHashCode("abc", CompareOptions.None);
+
+        Assert.Equal(hashCode1, hashCode2);
+    }
+
+    [Fact]
+    public static void GetHashCodeOfStringNullSource()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentNullException>(() => ci.GetHashCode(null, CompareOptions.None));
+    }
+
+    [Fact]
+    public static void GetHashCodeOfStringBadCompareOptions()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.Throws<ArgumentException>(() => ci.GetHashCode("", CompareOptions.StringSort));
+        Assert.Throws<ArgumentException>(() => ci.GetHashCode("", CompareOptions.Ordinal | CompareOptions.IgnoreSymbols));
+        Assert.Throws<ArgumentException>(() => ci.GetHashCode("", (CompareOptions)(-1)));
+    }
+
+    [Fact]
+    public static void ToStringReturnsNonNullNonEmpty()
+    {
+        CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;
+
+        Assert.NotNull(ci.ToString());
+        Assert.NotEqual("", ci.ToString());
+    }
+}

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -16,6 +16,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CompareInfo.cs" />
+    <Compile Include="CompareInfo.TestData.cs" />
     <Compile Include="TextInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
An initial set of tests, based on the coverage we have internally in our
conformance tests, but rewritten in idomatic xunit style.

In addition, I have added some more tests to bring up the code coverage
numbers of the Windows implementation of globalization.