### PR TITLE
Switch System.Runtime.Extensions to use BitConverter.cs in corefx

### DIFF
--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -136,7 +136,7 @@
     <value>The parameter '{0}' cannot be an empty string.</value>
   </data>
   <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
-    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+    <value>Array is not long enough. Check array index and length.</value>
   </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -21,12 +21,13 @@
 
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
-    <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
+    <Compile Include="System\BitConverter.cs" />
+    <Compile Include="System\IO\LowLevelTextWriter.cs" />
+    <Compile Include="System\IO\LowLevelStringWriter.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
     <Compile Include="System\Net\Configuration\UnicodeDecodingConformance.cs" />
     <Compile Include="System\Net\Configuration\UnicodeEncodingConformance.cs" />
-    <Compile Include="System\IO\LowLevelTextWriter.cs" />
-    <Compile Include="System\IO\LowLevelStringWriter.cs" />
+    <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Runtime.Extensions/src/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/src/System/BitConverter.cs
@@ -1,19 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-/*============================================================
-**
-** Class:  BitConverter
-**
-**
-** Purpose: Allows developers to view the base data types as 
-**          an arbitrary array of bits.
-**
-** 
-===========================================================*/
-
-using System;
-using System.Runtime.CompilerServices;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Security;
 
@@ -23,8 +11,6 @@ namespace System
     // converting an array of bytes to one of the base data 
     // types, as well as for converting a base data type to an
     // array of bytes.
-    // 
-    // Only statics, does not need to be marked with the serializable attribute
     public static class BitConverter
     {
         // This field indicates the "endianess" of the architecture.
@@ -36,7 +22,7 @@ namespace System
         public static readonly bool IsLittleEndian = true;
 #endif
 
-        // Converts a byte into an array of bytes with length one.
+        // Converts a Boolean into an array of bytes with length one.
         public static byte[] GetBytes(bool value)
         {
             Contract.Ensures(Contract.Result<byte[]>() != null);
@@ -157,19 +143,11 @@ namespace System
         public static char ToChar(byte[] value, int startIndex)
         {
             if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
-
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-            {
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
-            }
-
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 2)
-            {
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
-            }
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             return (char)ToInt16(value, startIndex);
@@ -180,37 +158,27 @@ namespace System
         public static unsafe short ToInt16(byte[] value, int startIndex)
         {
             if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
-
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-            {
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
-            }
-
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 2)
-            {
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
-            }
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             fixed (byte* pbyte = &value[startIndex])
             {
                 if (startIndex % 2 == 0)
-                { // data is aligned 
+                {
+                    // data is aligned 
                     return *((short*)pbyte);
+                }
+                else if (IsLittleEndian)
+                {
+                    return (short)((*pbyte) | (*(pbyte + 1) << 8));
                 }
                 else
                 {
-                    if (IsLittleEndian)
-                    {
-                        return (short)((*pbyte) | (*(pbyte + 1) << 8));
-                    }
-                    else
-                    {
-                        return (short)((*pbyte << 8) | (*(pbyte + 1)));
-                    }
+                    return (short)((*pbyte << 8) | (*(pbyte + 1)));
                 }
             }
         }
@@ -220,37 +188,27 @@ namespace System
         public static unsafe int ToInt32(byte[] value, int startIndex)
         {
             if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
-
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-            {
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
-            }
-
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 4)
-            {
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
-            }
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             fixed (byte* pbyte = &value[startIndex])
             {
                 if (startIndex % 4 == 0)
-                { // data is aligned 
+                {
+                    // data is aligned 
                     return *((int*)pbyte);
+                }
+                else if (IsLittleEndian)
+                {
+                    return (*pbyte) | (*(pbyte + 1) << 8) | (*(pbyte + 2) << 16) | (*(pbyte + 3) << 24);
                 }
                 else
                 {
-                    if (IsLittleEndian)
-                    {
-                        return (*pbyte) | (*(pbyte + 1) << 8) | (*(pbyte + 2) << 16) | (*(pbyte + 3) << 24);
-                    }
-                    else
-                    {
-                        return (*pbyte << 24) | (*(pbyte + 1) << 16) | (*(pbyte + 2) << 8) | (*(pbyte + 3));
-                    }
+                    return (*pbyte << 24) | (*(pbyte + 1) << 16) | (*(pbyte + 2) << 8) | (*(pbyte + 3));
                 }
             }
         }
@@ -260,41 +218,31 @@ namespace System
         public static unsafe long ToInt64(byte[] value, int startIndex)
         {
             if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
-
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-            {
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
-            }
-
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 8)
-            {
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
-            }
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             fixed (byte* pbyte = &value[startIndex])
             {
                 if (startIndex % 8 == 0)
-                { // data is aligned 
+                { 
+                    // data is aligned 
                     return *((long*)pbyte);
+                }
+                else if (IsLittleEndian)
+                {
+                    int i1 = (*pbyte) | (*(pbyte + 1) << 8) | (*(pbyte + 2) << 16) | (*(pbyte + 3) << 24);
+                    int i2 = (*(pbyte + 4)) | (*(pbyte + 5) << 8) | (*(pbyte + 6) << 16) | (*(pbyte + 7) << 24);
+                    return (uint)i1 | ((long)i2 << 32);
                 }
                 else
                 {
-                    if (IsLittleEndian)
-                    {
-                        int i1 = (*pbyte) | (*(pbyte + 1) << 8) | (*(pbyte + 2) << 16) | (*(pbyte + 3) << 24);
-                        int i2 = (*(pbyte + 4)) | (*(pbyte + 5) << 8) | (*(pbyte + 6) << 16) | (*(pbyte + 7) << 24);
-                        return (uint)i1 | ((long)i2 << 32);
-                    }
-                    else
-                    {
-                        int i1 = (*pbyte << 24) | (*(pbyte + 1) << 16) | (*(pbyte + 2) << 8) | (*(pbyte + 3));
-                        int i2 = (*(pbyte + 4) << 24) | (*(pbyte + 5) << 16) | (*(pbyte + 6) << 8) | (*(pbyte + 7));
-                        return (uint)i2 | ((long)i1 << 32);
-                    }
+                    int i1 = (*pbyte << 24) | (*(pbyte + 1) << 16) | (*(pbyte + 2) << 8) | (*(pbyte + 3));
+                    int i2 = (*(pbyte + 4) << 24) | (*(pbyte + 5) << 16) | (*(pbyte + 6) << 8) | (*(pbyte + 7));
+                    return (uint)i2 | ((long)i1 << 32);
                 }
             }
         }
@@ -306,11 +254,11 @@ namespace System
         public static ushort ToUInt16(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 2)
-                throw new ArgumentOutOfRangeException(SR.Arg_ArrayPlusOffTooSmall);
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             return (ushort)ToInt16(value, startIndex);
@@ -322,11 +270,11 @@ namespace System
         public static uint ToUInt32(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 4)
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             return (uint)ToInt32(value, startIndex);
@@ -338,11 +286,11 @@ namespace System
         public static ulong ToUInt64(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 8)
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             return (ulong)ToInt64(value, startIndex);
@@ -350,14 +298,14 @@ namespace System
 
         // Converts an array of bytes into a float.  
         [System.Security.SecuritySafeCritical]  // auto-generated
-        unsafe public static float ToSingle(byte[] value, int startIndex)
+        public unsafe static float ToSingle(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 4)
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             int val = ToInt32(value, startIndex);
@@ -366,14 +314,14 @@ namespace System
 
         // Converts an array of bytes into a double.  
         [System.Security.SecuritySafeCritical]  // auto-generated
-        unsafe public static double ToDouble(byte[] value, int startIndex)
+        public unsafe static double ToDouble(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                ThrowValueArgumentNull();
             if ((uint)startIndex >= value.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 8)
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             long val = ToInt64(value, startIndex);
@@ -382,7 +330,7 @@ namespace System
 
         private static char GetHexValue(int i)
         {
-            Contract.Assert(i >= 0 && i < 16, "i is out of range.");
+            Debug.Assert(i >= 0 && i < 16, "i is out of range.");
             if (i < 10)
             {
                 return (char)(i + '0');
@@ -392,27 +340,16 @@ namespace System
         }
 
         // Converts an array of bytes into a String.  
-        public static String ToString(byte[] value, int startIndex, int length)
+        public static string ToString(byte[] value, int startIndex, int length)
         {
             if (value == null)
-            {
-                throw new ArgumentNullException("byteArray");
-            }
-
+                ThrowValueArgumentNull();
             if (startIndex < 0 || startIndex >= value.Length && startIndex > 0)
-            {  // Don't throw for a 0 length array.
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_StartIndex);
-            }
-
+                ThrowStartIndexArgumentOutOfRange();
             if (length < 0)
-            {
                 throw new ArgumentOutOfRangeException("length", SR.ArgumentOutOfRange_GenericPositive);
-            }
-
             if (startIndex > value.Length - length)
-            {
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
-            }
+                ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
             if (length == 0)
@@ -420,10 +357,10 @@ namespace System
                 return string.Empty;
             }
 
-            if (length > (Int32.MaxValue / 3))
+            if (length > (int.MaxValue / 3))
             {
                 // (Int32.MaxValue / 3) == 715,827,882 Bytes == 699 MB
-                throw new ArgumentOutOfRangeException("length", SR.Format(SR.ArgumentOutOfRange_LengthTooLarge, (Int32.MaxValue / 3)));
+                throw new ArgumentOutOfRangeException("length", SR.Format(SR.ArgumentOutOfRange_LengthTooLarge, (int.MaxValue / 3)));
             }
 
             int chArrayLength = length * 3;
@@ -440,25 +377,25 @@ namespace System
             }
 
             // We don't need the last '-' character
-            return new String(chArray, 0, chArray.Length - 1);
+            return new string(chArray, 0, chArray.Length - 1);
         }
 
         // Converts an array of bytes into a String.  
-        public static String ToString(byte[] value)
+        public static string ToString(byte[] value)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
-            Contract.Ensures(Contract.Result<String>() != null);
+                ThrowValueArgumentNull();
+            Contract.Ensures(Contract.Result<string>() != null);
             Contract.EndContractBlock();
             return ToString(value, 0, value.Length);
         }
 
         // Converts an array of bytes into a String.  
-        public static String ToString(byte[] value, int startIndex)
+        public static string ToString(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
-            Contract.Ensures(Contract.Result<String>() != null);
+                ThrowValueArgumentNull();
+            Contract.Ensures(Contract.Result<string>() != null);
             Contract.EndContractBlock();
             return ToString(value, startIndex, value.Length - startIndex);
         }
@@ -475,14 +412,14 @@ namespace System
         public static bool ToBoolean(byte[] value, int startIndex)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                ThrowValueArgumentNull();
             if (startIndex < 0)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowStartIndexArgumentOutOfRange();
             if (startIndex > value.Length - 1)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                ThrowStartIndexArgumentOutOfRange(); // differs from other overloads, which throw base ArgumentException
             Contract.EndContractBlock();
 
-            return (value[startIndex] == 0) ? false : true;
+            return value[startIndex] != 0;
         }
 
         [SecuritySafeCritical]
@@ -493,7 +430,7 @@ namespace System
             // should be used by other programs on that processor, or for compatibility across multiple
             // formats.  Because this is ambiguous, we're excluding this from the Portable Library & Win8 Profile.
             // If we ever run on big endian machines, produce two versions where endianness is specified.
-            Contract.Assert(IsLittleEndian, "This method is implemented assuming little endian with an ambiguous spec.");
+            Debug.Assert(IsLittleEndian, "This method is implemented assuming little endian with an ambiguous spec.");
             return *((long*)&value);
         }
 
@@ -505,8 +442,23 @@ namespace System
             // should be used by other programs on that processor, or for compatibility across multiple
             // formats.  Because this is ambiguous, we're excluding this from the Portable Library & Win8 Profile.
             // If we ever run on big endian machines, produce two versions where endianness is specified.
-            Contract.Assert(IsLittleEndian, "This method is implemented assuming little endian with an ambiguous spec.");
+            Debug.Assert(IsLittleEndian, "This method is implemented assuming little endian with an ambiguous spec.");
             return *((double*)&value);
+        }
+
+        private static void ThrowValueArgumentNull()
+        {
+            throw new ArgumentNullException("value");
+        }
+
+        private static void ThrowStartIndexArgumentOutOfRange()
+        {
+            throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+        }
+
+        private static void ThrowValueArgumentTooSmall()
+        {
+            throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall, "value");
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>System.Runtime.Extensions.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -7,6 +7,101 @@ using Xunit;
 public static class BitConverterTests
 {
     [Fact]
+    public static unsafe void IsLittleEndian()
+    {
+        short s = 1;
+        Assert.Equal(BitConverter.IsLittleEndian, *((byte*)&s) == 1);
+    }
+
+    [Fact]
+    public static void ValueArgumentNull()
+    {
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToBoolean(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToChar(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToDouble(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt16(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt32(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt64(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToSingle(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt16(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt32(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt64(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null, 0));
+        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null, 0, 0));
+    }
+
+    [Fact]
+    public static void StartIndexBeyondLength()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], 1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], 2));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], 2));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], 3));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], 8));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], 9));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], 2));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], 3));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], 4));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], 5));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], 8));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], 9));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], 4));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], 5));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], 2));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], 3));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], 4));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], 5));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], 8));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], 9));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], -1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 1));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 2));
+
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], -1, 0));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 1, 0));
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 2, 0));
+
+        Assert.Throws<ArgumentOutOfRangeException>("length", () => BitConverter.ToString(new byte[1], 0, -1));
+    }
+
+    [Fact]
+    public static void StartIndexPlusNeededLengthTooLong()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[0], 0));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToChar(new byte[2], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToDouble(new byte[8], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt16(new byte[2], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt32(new byte[4], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt64(new byte[8], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToSingle(new byte[4], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt16(new byte[2], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt32(new byte[4], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt64(new byte[8], 1));
+        Assert.Throws<ArgumentException>("value", () => BitConverter.ToString(new byte[2], 1, 2));
+    }
+
+    [Fact]
     public static void DoubleToInt64Bits()
     {
         Double input = 123456.3234;
@@ -125,5 +220,11 @@ public static class BitConverterTests
 
         Assert.Equal(expectedBytes, bytes);
         Assert.Equal(input, convertBack(bytes, 0));
+
+        // Also try unaligned startIndex
+        byte[] longerBytes = new byte[bytes.Length + 1];
+        longerBytes[0] = 0;
+        Array.Copy(bytes, 0, longerBytes, 1, bytes.Length);
+        Assert.Equal(input, convertBack(longerBytes, 1));
     }
 }


### PR DESCRIPTION
The System.Runtime.Extensions.dll partial facade is currently forwarding to the System.BitConverter class in mscorlib.  This PR changes it to use the BitConverter.cs in corefx.  To help verify nothing broke in doing so, I increased the test coverage for BitConverter.  I also did a bit of code cleanup in the BitConverter.cs file, e.g. using Debug.Assert instead of Contract.Assert, using "string" instead of "String", eliminating some unnecessary branches, ensuring we're including a parameter name in ArgumentExceptions, consolidating how we throw exceptions (matching what's done in mscorlib), etc.