### PR TITLE
Improve performance of BigInteger.Pow/ModPow

### DIFF
--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -19,7 +19,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Numerics\BigIntegerCalculator.AddSub.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.BitsBuffer.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.DivRem.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.FastReducer.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.PowMod.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.SquMul.cs" />
     <Compile Include="System\Numerics\BigInteger.cs" />
     <Compile Include="System\Numerics\BigIntegerBuilder.cs" />

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
@@ -197,6 +197,7 @@ namespace System.Numerics
                 bits[i] = (uint)digit;
                 carry = digit >> 32;
             }
+
             Debug.Assert(carry == 0);
         }
 

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
@@ -1,0 +1,147 @@
+﻿using System.Diagnostics;
+using System.Security;
+
+namespace System.Numerics
+{
+    // ATTENTION: always pass BitsBuffer by reference,
+    // it's a structure for performance reasons. Furthermore
+    // it's a mutable one, so use it only with care!
+
+    internal static partial class BigIntegerCalculator
+    {
+        // To spare memory allocations a buffer helps reusing memory!
+        // We just create the target array twice and switch between every
+        // operation. In order to not compute unnecessarily with all those
+        // leading zeros we take care of the current actual length.
+
+        internal struct BitsBuffer
+        {
+            private uint[] _bits;
+            private int _length;
+
+            public BitsBuffer(int size, uint value)
+            {
+                Debug.Assert(size >= 1);
+
+                _bits = new uint[size];
+                _length = value != 0 ? 1 : 0;
+
+                _bits[0] = value;
+            }
+
+            public BitsBuffer(int size, uint[] value)
+            {
+                Debug.Assert(value != null);
+                Debug.Assert(size >= ActualLength(value));
+
+                _bits = new uint[size];
+                _length = ActualLength(value);
+
+                Array.Copy(value, 0, _bits, 0, _length);
+            }
+
+            [SecuritySafeCritical]
+            public unsafe void MultiplySelf(ref BitsBuffer value,
+                                            ref BitsBuffer temp)
+            {
+                Debug.Assert(temp._length == 0);
+                Debug.Assert(_length + value._length <= temp._bits.Length);
+
+                // Executes a multiplication for this and value, writes the
+                // result to temp. Switches this and temp arrays afterwards.
+
+                fixed (uint* b = _bits, v = value._bits, t = temp._bits)
+                {
+                    if (_length < value._length)
+                    {
+                        Multiply(v, value._length,
+                                 b, _length,
+                                 t, _length + value._length);
+                    }
+                    else
+                    {
+                        Multiply(b, _length,
+                                 v, value._length,
+                                 t, _length + value._length);
+                    }
+                }
+
+                Apply(ref temp, _length + value._length);
+            }
+
+            [SecuritySafeCritical]
+            public unsafe void SquareSelf(ref BitsBuffer temp)
+            {
+                Debug.Assert(temp._length == 0);
+                Debug.Assert(_length + _length <= temp._bits.Length);
+
+                // Executes a square for this, writes the result to temp.
+                // Switches this and temp arrays afterwards.
+
+                fixed (uint* b = _bits, t = temp._bits)
+                {
+                    Square(b, _length,
+                           t, _length + _length);
+                }
+
+                Apply(ref temp, _length + _length);
+            }
+
+            public void Reduce(ref FastReducer reducer)
+            {
+                // Executes a modulo operation using an optimized reducer.
+                // Thus, no need of any switching here, happens in-line.
+
+                _length = reducer.Reduce(_bits, _length);
+            }
+
+            [SecuritySafeCritical]
+            public unsafe void Reduce(uint[] modulus)
+            {
+                Debug.Assert(modulus != null);
+
+                // Executes a modulo operation using the divide operation.
+                // Thus, no need of any switching here, happens in-line.
+
+                if (_length >= modulus.Length)
+                {
+                    fixed (uint* b = _bits, m = modulus)
+                    {
+                        Divide(b, _length,
+                               m, modulus.Length,
+                               null, 0);
+                    }
+
+                    _length = ActualLength(_bits, modulus.Length);
+                }
+            }
+
+            public uint[] GetBits()
+            {
+                return _bits;
+            }
+
+            public int GetSize()
+            {
+                return _bits.Length;
+            }
+
+            private void Apply(ref BitsBuffer temp, int maxLength)
+            {
+                Debug.Assert(temp._length == 0);
+                Debug.Assert(maxLength <= temp._bits.Length);
+
+                // Resets this and switches this and temp afterwards.
+                // The caller assumed an empty temp, the next will too.
+
+                Array.Clear(_bits, 0, _length);
+
+                uint[] t = temp._bits;
+                temp._bits = _bits;
+                _bits = t;
+
+                _length = ActualLength(_bits, maxLength);
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -1,0 +1,148 @@
+﻿using System.Diagnostics;
+using System.Security;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        // If we need to reduce by a certain modulus again and again, it's much
+        // more efficient to do this with multiplication operations. This is
+        // possible, if we do some pre-computations first...
+
+        // see https://en.wikipedia.org/wiki/Barrett_reduction
+
+        internal struct FastReducer
+        {
+            private readonly uint[] _modulus;
+            private readonly uint[] _mu;
+            private readonly uint[] _q1;
+            private readonly uint[] _q2;
+
+            private readonly int _muLength;
+
+            public FastReducer(uint[] modulus)
+            {
+                Debug.Assert(modulus != null);
+
+                // Let r = 4^k, with 2^k > m
+                uint[] r = new uint[modulus.Length * 2 + 1];
+                r[r.Length - 1] = 1;
+
+                // Let mu = 4^k / m
+                _mu = Divide(r, modulus);
+                _modulus = modulus;
+
+                // Allocate memory for quotients once
+                _q1 = new uint[modulus.Length * 2 + 2];
+                _q2 = new uint[modulus.Length * 2 + 1];
+
+                _muLength = ActualLength(_mu);
+            }
+
+            public int Reduce(uint[] value, int length)
+            {
+                Debug.Assert(value != null);
+                Debug.Assert(length <= value.Length);
+                Debug.Assert(value.Length <= _modulus.Length * 2);
+
+                // trivial: value is shorter
+                if (length < _modulus.Length)
+                    return length;
+
+                // Let q1 = v/2^(k-1) * mu
+                int l1 = DivMul(value, length, _mu, _muLength,
+                                _q1, _modulus.Length - 1);
+
+                // Let q2 = q1/2^(k+1) * m
+                int l2 = DivMul(_q1, l1, _modulus, _modulus.Length,
+                                _q2, _modulus.Length + 1);
+
+                // Let v = (v - q2) % 2^(k+1) - i*m
+                return SubMod(value, length, _q2, l2,
+                              _modulus, _modulus.Length + 1);
+            }
+
+            [SecuritySafeCritical]
+            private unsafe static int DivMul(uint[] left, int leftLength,
+                                             uint[] right, int rightLength,
+                                             uint[] bits, int k)
+            {
+                Debug.Assert(left != null);
+                Debug.Assert(left.Length >= leftLength);
+                Debug.Assert(right != null);
+                Debug.Assert(right.Length >= rightLength);
+                Debug.Assert(bits != null);
+                Debug.Assert(bits.Length + k >= leftLength + rightLength);
+
+                // Executes the multiplication algorithm for left and right,
+                // but skips the first k limbs of left, which is equivalent to
+                // preceding division by 2^(32*k). To spare memory allocations
+                // we write the result to an already allocated memory.
+
+                Array.Clear(bits, 0, bits.Length);
+
+                if (leftLength > k)
+                {
+                    leftLength -= k;
+
+                    fixed (uint* l = left, r = right, b = bits)
+                    {
+                        if (leftLength < rightLength)
+                        {
+                            Multiply(r, rightLength,
+                                     l + k, leftLength,
+                                     b, leftLength + rightLength);
+                        }
+                        else
+                        {
+                            Multiply(l + k, leftLength,
+                                     r, rightLength,
+                                     b, leftLength + rightLength);
+                        }
+                    }
+
+                    return ActualLength(bits, leftLength + rightLength);
+                }
+
+                return 0;
+            }
+
+            [SecuritySafeCritical]
+            private unsafe static int SubMod(uint[] left, int leftLength,
+                                             uint[] right, int rightLength,
+                                             uint[] modulus, int k)
+            {
+                Debug.Assert(left != null);
+                Debug.Assert(left.Length >= leftLength);
+                Debug.Assert(right != null);
+                Debug.Assert(right.Length >= rightLength);
+
+                // Executes the subtraction algorithm for left and right,
+                // but considers only the first k limbs, which is equivalent to
+                // preceding reduction by 2^(32*k). Furthermore, if left is
+                // still greater than modulus, further subtractions are used.
+
+                if (leftLength > k)
+                    leftLength = k;
+                if (rightLength > k)
+                    rightLength = k;
+
+                fixed (uint* l = left, r = right, m = modulus)
+                {
+                    SubtractSelf(l, leftLength, r, rightLength);
+                    leftLength = ActualLength(left, leftLength);
+
+                    while (Compare(l, leftLength, m, modulus.Length) >= 0)
+                    {
+                        SubtractSelf(l, leftLength, m, modulus.Length);
+                        leftLength = ActualLength(left, leftLength);
+                    }
+                }
+
+                Array.Clear(left, leftLength, left.Length - leftLength);
+
+                return leftLength;
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
@@ -1,0 +1,401 @@
+﻿using System.Diagnostics;
+using System.Security;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        // Executes different exponentiation algorithms, which are
+        // basically based on the classic square-and-multiply method.
+
+        // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+
+        public static uint[] Pow(uint value, uint power)
+        {
+            // The basic pow method for a 32-bit integer.
+            // To spare memory allocations we first roughly
+            // estimate an upper bound for our buffers.
+
+            int size = PowBound(power, 1, 1);
+            BitsBuffer v = new BitsBuffer(size, value);
+            return PowCore(power, ref v);
+        }
+
+        public static uint[] Pow(uint[] value, uint power)
+        {
+            Debug.Assert(value != null);
+
+            // The basic pow method for a big integer.
+            // To spare memory allocations we first roughly
+            // estimate an upper bound for our buffers.
+
+            int size = PowBound(power, value.Length, 1);
+            BitsBuffer v = new BitsBuffer(size, value);
+            return PowCore(power, ref v);
+        }
+
+        private static uint[] PowCore(uint power, ref BitsBuffer value)
+        {
+            // Executes the basic pow algorithm.
+
+            int size = value.GetSize();
+
+            BitsBuffer temp = new BitsBuffer(size, 0);
+            BitsBuffer result = new BitsBuffer(size, 1);
+
+            PowCore(power, ref value, ref result, ref temp);
+
+            return result.GetBits();
+        }
+
+        private static int PowBound(uint power, int valueLength,
+                                    int resultLength)
+        {
+            // The basic pow algorithm, but instead of squaring
+            // and multiplying we just sum up the lengths.
+
+            while (power != 0)
+            {
+                if ((power & 1) == 1)
+                    resultLength += valueLength;
+                if (power != 1)
+                    valueLength += valueLength;
+                power = power >> 1;
+            }
+
+            return resultLength;
+        }
+
+        private static void PowCore(uint power, ref BitsBuffer value,
+                                    ref BitsBuffer result, ref BitsBuffer temp)
+        {
+            // The basic pow algorithm using square-and-multiply.
+
+            while (power != 0)
+            {
+                if ((power & 1) == 1)
+                    result.MultiplySelf(ref value, ref temp);
+                if (power != 1)
+                    value.SquareSelf(ref temp);
+                power = power >> 1;
+            }
+        }
+
+        public static uint Pow(uint value, uint power, uint modulus)
+        {
+            // The 32-bit modulus pow method for a 32-bit integer
+            // raised by a 32-bit integer...
+
+            return PowCore(power, modulus, value, 1);
+        }
+
+        public static uint Pow(uint[] value, uint power, uint modulus)
+        {
+            Debug.Assert(value != null);
+
+            // The 32-bit modulus pow method for a big integer
+            // raised by a 32-bit integer...
+
+            uint v = Remainder(value, modulus);
+            return PowCore(power, modulus, v, 1);
+        }
+
+        public static uint Pow(uint value, uint[] power, uint modulus)
+        {
+            Debug.Assert(power != null);
+
+            // The 32-bit modulus pow method for a 32-bit integer
+            // raised by a big integer...
+
+            return PowCore(power, modulus, value, 1);
+        }
+
+        public static uint Pow(uint[] value, uint[] power, uint modulus)
+        {
+            Debug.Assert(value != null);
+            Debug.Assert(power != null);
+
+            // The 32-bit modulus pow method for a big integer
+            // raised by a big integer...
+
+            uint v = Remainder(value, modulus);
+            return PowCore(power, modulus, v, 1);
+        }
+
+        private static uint PowCore(uint[] power, uint modulus,
+                                    ulong value, ulong result)
+        {
+            // The 32-bit modulus pow algorithm for all but
+            // the last power limb using square-and-multiply.
+
+            for (int i = 0; i < power.Length - 1; i++)
+            {
+                uint p = power[i];
+                for (int j = 0; j < 32; j++)
+                {
+                    if ((p & 1) == 1)
+                        result = (result * value) % modulus;
+                    value = (value * value) % modulus;
+                    p = p >> 1;
+                }
+            }
+
+            return PowCore(power[power.Length - 1], modulus, value, result);
+        }
+
+        private static uint PowCore(uint power, uint modulus,
+                                    ulong value, ulong result)
+        {
+            // The 32-bit modulus pow algorithm for the last or
+            // the only power limb using square-and-multiply.
+
+            while (power != 0)
+            {
+                if ((power & 1) == 1)
+                    result = (result * value) % modulus;
+                if (power != 1)
+                    value = (value * value) % modulus;
+                power = power >> 1;
+            }
+
+            return (uint)(result % modulus);
+        }
+
+        public static uint[] Pow(uint value, uint power, uint[] modulus)
+        {
+            Debug.Assert(modulus != null);
+
+            // The big modulus pow method for a 32-bit integer
+            // raised by a 32-bit integer...
+
+            int size = modulus.Length + modulus.Length;
+            BitsBuffer v = new BitsBuffer(size, value);
+            return PowCore(power, modulus, ref v);
+        }
+
+        public static uint[] Pow(uint[] value, uint power, uint[] modulus)
+        {
+            Debug.Assert(value != null);
+            Debug.Assert(modulus != null);
+
+            // The big modulus pow method for a big integer
+            // raised by a 32-bit integer...
+
+            if (value.Length > modulus.Length)
+                value = Remainder(value, modulus);
+
+            int size = modulus.Length + modulus.Length;
+            BitsBuffer v = new BitsBuffer(size, value);
+            return PowCore(power, modulus, ref v);
+        }
+
+        public static uint[] Pow(uint value, uint[] power, uint[] modulus)
+        {
+            Debug.Assert(power != null);
+            Debug.Assert(modulus != null);
+
+            // The big modulus pow method for a 32-bit integer
+            // raised by a big integer...
+
+            int size = modulus.Length + modulus.Length;
+            BitsBuffer v = new BitsBuffer(size, value);
+            return PowCore(power, modulus, ref v);
+        }
+
+        public static uint[] Pow(uint[] value, uint[] power, uint[] modulus)
+        {
+            Debug.Assert(value != null);
+            Debug.Assert(power != null);
+            Debug.Assert(modulus != null);
+
+            // The big modulus pow method for a big integer
+            // raised by a big integer...
+
+            if (value.Length > modulus.Length)
+                value = Remainder(value, modulus);
+
+            int size = modulus.Length + modulus.Length;
+            BitsBuffer v = new BitsBuffer(size, value);
+            return PowCore(power, modulus, ref v);
+        }
+
+        // Mutable for unit testing...
+        private static int ReducerThreshold = 32;
+
+        private static uint[] PowCore(uint[] power, uint[] modulus,
+                                      ref BitsBuffer value)
+        {
+            // Executes the big pow algorithm.
+
+            int size = value.GetSize();
+
+            BitsBuffer temp = new BitsBuffer(size, 0);
+            BitsBuffer result = new BitsBuffer(size, 1);
+
+            if (modulus.Length < ReducerThreshold)
+            {
+                PowCore(power, modulus, ref value, ref result, ref temp);
+            }
+            else
+            {
+                FastReducer reducer = new FastReducer(modulus);
+                PowCore(power, ref reducer, ref value, ref result, ref temp);
+            }
+
+            return result.GetBits();
+        }
+
+        private static uint[] PowCore(uint power, uint[] modulus,
+                                      ref BitsBuffer value)
+        {
+            // Executes the big pow algorithm.
+
+            int size = value.GetSize();
+
+            BitsBuffer temp = new BitsBuffer(size, 0);
+            BitsBuffer result = new BitsBuffer(size, 1);
+
+            if (modulus.Length < ReducerThreshold)
+            {
+                PowCore(power, modulus, ref value, ref result, ref temp);
+            }
+            else
+            {
+                FastReducer reducer = new FastReducer(modulus);
+                PowCore(power, ref reducer, ref value, ref result, ref temp);
+            }
+
+            return result.GetBits();
+        }
+
+        private static void PowCore(uint[] power, uint[] modulus,
+                                    ref BitsBuffer value, ref BitsBuffer result,
+                                    ref BitsBuffer temp)
+        {
+            // The big modulus pow algorithm for all but
+            // the last power limb using square-and-multiply.
+
+            // NOTE: we're using an ordinary remainder here,
+            // since the reducer overhead doesn't pay off.
+
+            for (int i = 0; i < power.Length - 1; i++)
+            {
+                uint p = power[i];
+                for (int j = 0; j < 32; j++)
+                {
+                    if ((p & 1) == 1)
+                    {
+                        result.MultiplySelf(ref value, ref temp);
+                        result.Reduce(modulus);
+                    }
+                    value.SquareSelf(ref temp);
+                    value.Reduce(modulus);
+                    p = p >> 1;
+                }
+            }
+
+            PowCore(power[power.Length - 1], modulus, ref value, ref result,
+                ref temp);
+        }
+
+        private static void PowCore(uint power, uint[] modulus,
+                                    ref BitsBuffer value, ref BitsBuffer result,
+                                    ref BitsBuffer temp)
+        {
+            // The big modulus pow algorithm for the last or
+            // the only power limb using square-and-multiply.
+
+            // NOTE: we're using an ordinary remainder here,
+            // since the reducer overhead doesn't pay off.
+
+            while (power != 0)
+            {
+                if ((power & 1) == 1)
+                {
+                    result.MultiplySelf(ref value, ref temp);
+                    result.Reduce(modulus);
+                }
+                if (power != 1)
+                {
+                    value.SquareSelf(ref temp);
+                    value.Reduce(modulus);
+                }
+                power = power >> 1;
+            }
+        }
+
+        private static void PowCore(uint[] power, ref FastReducer reducer,
+                                    ref BitsBuffer value, ref BitsBuffer result,
+                                    ref BitsBuffer temp)
+        {
+            // The big modulus pow algorithm for all but
+            // the last power limb using square-and-multiply.
+
+            // NOTE: we're using a special reducer here,
+            // since it's additional overhead does pay off.
+
+            for (int i = 0; i < power.Length - 1; i++)
+            {
+                uint p = power[i];
+                for (int j = 0; j < 32; j++)
+                {
+                    if ((p & 1) == 1)
+                    {
+                        result.MultiplySelf(ref value, ref temp);
+                        result.Reduce(ref reducer);
+                    }
+                    value.SquareSelf(ref temp);
+                    value.Reduce(ref reducer);
+                    p = p >> 1;
+                }
+            }
+
+            PowCore(power[power.Length - 1], ref reducer, ref value, ref result,
+                ref temp);
+        }
+
+        private static void PowCore(uint power, ref FastReducer reducer,
+                                    ref BitsBuffer value, ref BitsBuffer result,
+                                    ref BitsBuffer temp)
+        {
+            // The big modulus pow algorithm for the last or
+            // the only power limb using square-and-multiply.
+
+            // NOTE: we're using a special reducer here,
+            // since it's additional overhead does pay off.
+
+            while (power != 0)
+            {
+                if ((power & 1) == 1)
+                {
+                    result.MultiplySelf(ref value, ref temp);
+                    result.Reduce(ref reducer);
+                }
+                if (power != 1)
+                {
+                    value.SquareSelf(ref temp);
+                    value.Reduce(ref reducer);
+                }
+                power = power >> 1;
+            }
+        }
+
+        private static int ActualLength(uint[] value)
+        {
+            // Since we're reusing memory here, the actual length
+            // of a given value may be less then the array's length
+
+            return ActualLength(value, value.Length);
+        }
+
+        private static int ActualLength(uint[] value, int length)
+        {
+            Debug.Assert(value != null);
+            Debug.Assert(length <= value.Length);
+
+            while (length > 0 && value[length - 1] == 0)
+                --length;
+            return length;
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -24,11 +24,8 @@ namespace System.Numerics
             return bits;
         }
 
-#if DEBUG
-        private const int SquareThreshold = 8;
-#else
-        private const int SquareThreshold = 32;
-#endif
+        // Mutable for unit testing...
+        private static int SquareThreshold = 32;
 
         [SecuritySafeCritical]
         private unsafe static void Square(uint* value, int valueLength,
@@ -181,11 +178,8 @@ namespace System.Numerics
             return bits;
         }
 
-#if DEBUG
-        private const int MultiplyThreshold = 8;
-#else
-        private const int MultiplyThreshold = 32;
-#endif
+        // Mutable for unit testing...
+        private static int MultiplyThreshold = 32;
 
         [SecuritySafeCritical]
         private unsafe static void Multiply(uint* left, int leftLength,

--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntTools.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntTools.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Numerics;
+using System.Reflection;
 using System.Text;
 
 namespace BigIntTools
@@ -29,6 +31,27 @@ namespace BigIntTools
             else
             {
                 return randNum.ToString().Substring(0, numDigits);
+            }
+        }
+
+        private static readonly TypeInfo s_internalCalculator =
+            typeof(BigInteger).GetTypeInfo()
+                              .Assembly
+                              .GetType("System.Numerics.BigIntegerCalculator")
+                              .GetTypeInfo();
+
+        public static void RunWithFakeThreshold(string name, int value, Action action)
+        {
+            FieldInfo field = s_internalCalculator.GetDeclaredField(name);
+            int lastValue = (int)field.GetValue(null);
+            field.SetValue(null, value);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                field.SetValue(null, lastValue);
             }
         }
     }

--- a/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
@@ -17,10 +17,6 @@ namespace System.Numerics.Tests
             BigInteger result;
             bool b = BigInteger.TryParse("22", out result);
 
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
-
             // ModPow Method - with small numbers - valid
             for (int i = 1; i <= 1; i++)//-2
             {
@@ -40,9 +36,9 @@ namespace System.Numerics.Tests
         [Fact]
         public static void ModPowNegative()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+            byte[] tempByteArray3;
 
 
             // ModPow Method - with small numbers - invalid - zero modulus
@@ -102,9 +98,9 @@ namespace System.Numerics.Tests
         [Fact]
         public static void ModPow3SmallInt()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+            byte[] tempByteArray3;
             
             // ModPow Method - Three Small BigIntegers
             for (int i = 0; i < s_samples; i++)
@@ -119,9 +115,9 @@ namespace System.Numerics.Tests
         [Fact]
         public static void ModPow1Large2SmallInt()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+            byte[] tempByteArray3;
 
             // ModPow Method - One large and two small BigIntegers
             for (int i = 0; i < s_samples; i++)
@@ -144,11 +140,18 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void ModPow1Large2SmallInt_Threshold()
+        {
+            // Again, with lower threshold
+            BigIntTools.Utils.RunWithFakeThreshold("ReducerThreshold", 8, ModPow1Large2SmallInt);
+        }
+
+        [Fact]
         public static void ModPow2Large1SmallInt()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+            byte[] tempByteArray3;
 
             // ModPow Method - Two large and one small BigIntegers
             for (int i = 0; i < s_samples; i++)
@@ -161,11 +164,43 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void ModPow2Large1SmallInt_Threshold()
+        {
+            // Again, with lower threshold
+            BigIntTools.Utils.RunWithFakeThreshold("ReducerThreshold", 8, ModPow2Large1SmallInt);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void ModPow3LargeInt()
+        {
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+            byte[] tempByteArray3;
+
+            // ModPow Method - Three large BigIntegers
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = GetRandomPosByteArray(s_random);
+                tempByteArray3 = GetRandomByteArray(s_random);
+                VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow");
+            }
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void ModPow3LargeInt_Threshold()
+        {
+            // Again, with lower threshold
+            BigIntTools.Utils.RunWithFakeThreshold("ReducerThreshold", 8, ModPow3LargeInt);
+        }
+
+        [Fact]
         public static void ModPow0Power()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
             
             // ModPow Method - zero power
             for (int i = 0; i < s_samples; i++)
@@ -191,9 +226,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void ModPow0Base()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
             
             // ModPow Method - zero base
             for (int i = 0; i < s_samples; i++)
@@ -219,9 +253,9 @@ namespace System.Numerics.Tests
         [Fact]
         public static void ModPowAxiom()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+            byte[] tempByteArray3;
             
             // Axiom (x^y)%z = modpow(x,y,z)
             for (int i = 0; i < s_samples; i++)
@@ -239,10 +273,6 @@ namespace System.Numerics.Tests
         [Fact]
         public static void ModPowBoundary()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
-            byte[] tempByteArray3 = new byte[0];
-
             // Check interesting cases for boundary conditions
             // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0

--- a/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -35,6 +35,14 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void RunMultiply_TwoLargeBigIntegers_Threshold()
+        {
+            // Again, with lower threshold
+            BigIntTools.Utils.RunWithFakeThreshold("SquareThreshold", 8, RunMultiply_TwoLargeBigIntegers);
+            BigIntTools.Utils.RunWithFakeThreshold("MultiplyThreshold", 8, RunMultiply_TwoLargeBigIntegers);
+        }
+
+        [Fact]
         public static void RunMultiply_TwoSmallBigIntegers()
         {
             Random random = new Random(s_seed);


### PR DESCRIPTION
To introduce further performance tweaks, the exponentiation algorithms are ported to `BigIntegerCalculator`. Furthermore the newly introduced `FastReducer` triggers a bad corner case within the division algorithm, which gets fixed too.

A basic performance comparison based on [this code](https://gist.github.com/axelheer/3b701c91271b7c762586) unveils the following results:

**ModPow**

| # of bits | # of vals | before ms | after ms |
|----------:|----------:|----------:|---------:|
|        16 |   100,000 |        64 |       23 |
|        64 |    10,000 |       145 |      202 |
|       256 |     1,000 |       298 |      181 |
|     1,024 |       100 |     1,344 |      637 |
|     4,096 |        10 |     7,778 |    2,548 |
|    16,384 |         1 |    48,292 |    9,595 |

#1307