### PR TITLE
Fix Process bugs on OSX

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.libproc.cs
+++ b/src/Common/src/Interop/OSX/Interop.libproc.cs
@@ -25,7 +25,7 @@ internal static partial class Interop
         private const int PROC_PIDPATHINFO_MAXSIZE = 4 * MAXPATHLEN;
         private static int PROC_PIDLISTFD_SIZE = Marshal.SizeOf<proc_fdinfo>();
         private static int PROC_PIDLISTTHREADS_SIZE = (Marshal.SizeOf<uint>() * 2);
-        
+
         // Constants from sys\resource.h
         private const int RUSAGE_SELF = 0;
 
@@ -364,6 +364,7 @@ internal static partial class Interop
             int result = 0;
             int size = 20; // start assuming 20 threads is enough
             ulong[] threadIds = null;
+            var threads = new List<KeyValuePair<ulong, proc_threadinfo?>>();
 
             // We have no way of knowning how many threads the process has (and therefore how big our buffer should be)
             // so while the return value of the function is the same as our buffer size (meaning it completely filled
@@ -378,7 +379,10 @@ internal static partial class Interop
 
                 if (result <= 0)
                 {
-                    throw new Win32Exception();
+                    // If we were unable to access the information, just return the empty list.  
+                    // This is likely to happen for privileged processes, if the process went away
+                    // by the time we tried to query it, etc.
+                    return threads;
                 }
                 else
                 {
@@ -394,7 +398,7 @@ internal static partial class Interop
 
             // Loop over each thread and get the thread info
             int count = (int)(result / Marshal.SizeOf<ulong>());
-            List<KeyValuePair<ulong, proc_threadinfo?>> threads = new List<KeyValuePair<ulong, proc_threadinfo?>>(count);
+            threads.Capacity = count;
             for (int i = 0; i < count; i++)
             {        
                 threads.Add(new KeyValuePair<ulong, proc_threadinfo?>(threadIds[i], GetThreadInfoById(pid, threadIds[i])));
@@ -406,7 +410,7 @@ internal static partial class Interop
         /// <summary>
         /// Retrieves the number of open file descriptors for the specified pid
         /// </summary>
-        /// <returns>Returns an array of open File Descriptors for this process</returns>
+        /// <returns>A count of file descriptors for this process.</returns>
         /// <remarks>
         /// This function doesn't use the helper since it seems to allow passing NULL
         /// values in to the buffer and length parameters to get back an estimation 
@@ -426,11 +430,14 @@ internal static partial class Interop
             int result = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, (proc_fdinfo*)null, 0);
             if (result <= 0)
             {
-                throw new Win32Exception();
+                // If we were unable to access the information, just return the empty list.  
+                // This is likely to happen for privileged processes, if the process went away
+                // by the time we tried to query it, etc.
+                return 0;
             }
 
             proc_fdinfo[] fds;
-            int size = (int)(result / Marshal.SizeOf<proc_fdinfo>());
+            int size = (int)(result / Marshal.SizeOf<proc_fdinfo>()) + 1;
 
             // Just in case the app opened a ton of handles between when we asked and now,
             // make sure we retry if our buffer is filled
@@ -444,7 +451,10 @@ internal static partial class Interop
 
                 if (result <= 0)
                 {
-                    throw new Win32Exception();
+                    // If we were unable to access the information, just return the empty list.  
+                    // This is likely to happen for privileged processes, if the process went away
+                    // by the time we tried to query it, etc.
+                    return 0;
                 }
                 else
                 {

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -79,7 +79,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.Equal(priority, _process.BasePriority);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_BasePriority()
         {
             ProcessPriorityClass originalPriority = _process.PriorityClass;
@@ -119,7 +119,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.True(p.WaitForExit(WaitInMS));
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_EnableRaiseEvents()
         {
             {
@@ -156,7 +156,7 @@ namespace System.Diagnostics.ProcessTests
             }
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_ExitCode()
         {
             {
@@ -261,11 +261,17 @@ namespace System.Diagnostics.ProcessTests
             }
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_MaxWorkingSet()
         {
-            IntPtr min, max;
-            uint flags;
+            using (Process p = Process.GetCurrentProcess())
+            {
+                Assert.True((long)p.MaxWorkingSet > 0);
+                Assert.True((long)p.MinWorkingSet >= 0);
+            }
+
+            if (global::Interop.IsOSX)
+                return; // doesn't support getting/setting working set for other processes
 
             long curValue = (long)_process.MaxWorkingSet;
             Assert.True(curValue >= 0);
@@ -275,6 +281,9 @@ namespace System.Diagnostics.ProcessTests
                 try
                 {
                     _process.MaxWorkingSet = (IntPtr)((int)curValue + 1024);
+
+                    IntPtr min, max;
+                    uint flags;
                     Interop.GetProcessWorkingSetSizeEx(_process.SafeHandle, out min, out max, out flags);
                     curValue = (int)max;
                     _process.Refresh();
@@ -287,9 +296,18 @@ namespace System.Diagnostics.ProcessTests
             }
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_MinWorkingSet()
         {
+            using (Process p = Process.GetCurrentProcess())
+            {
+                Assert.True((long)p.MaxWorkingSet > 0);
+                Assert.True((long)p.MinWorkingSet >= 0);
+            }
+
+            if (global::Interop.IsOSX)
+                return; // doesn't support getting/setting working set for other processes
+
             long curValue = (long)_process.MinWorkingSet;
             Assert.True(curValue >= 0);
 
@@ -341,57 +359,59 @@ namespace System.Diagnostics.ProcessTests
             }
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_NonpagedSystemMemorySize64()
         {
             AssertNonZeroWindowsZeroUnix(_process.NonpagedSystemMemorySize64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_PagedMemorySize64()
         {
             AssertNonZeroWindowsZeroUnix(_process.PagedMemorySize64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_PagedSystemMemorySize64()
         {
             AssertNonZeroWindowsZeroUnix(_process.PagedSystemMemorySize64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_PeakPagedMemorySize64()
         {
             AssertNonZeroWindowsZeroUnix(_process.PeakPagedMemorySize64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_PeakVirtualMemorySize64()
         {
             AssertNonZeroWindowsZeroUnix(_process.PeakVirtualMemorySize64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_PeakWorkingSet64()
         {
             AssertNonZeroWindowsZeroUnix(_process.PeakWorkingSet64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_PrivateMemorySize64()
         {
             AssertNonZeroWindowsZeroUnix(_process.PrivateMemorySize64);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
-        public void Process_PrivilegedProcessorTime()
+        [Fact]
+        [ActiveIssue(2184, PlatformID.OSX)]
+        public void Process_ProcessorTime()
         {
             Assert.True(_process.UserProcessorTime.TotalSeconds >= 0);
             Assert.True(_process.PrivilegedProcessorTime.TotalSeconds >= 0);
             Assert.True(_process.TotalProcessorTime.TotalSeconds >= 0);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
+        [PlatformSpecific(~PlatformID.OSX)] // getting/setting affinity not supported on OSX
         public void Process_ProcessorAffinity()
         {
             IntPtr curProcessorAffinity = _process.ProcessorAffinity;
@@ -449,7 +469,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.Throws<ArgumentException>(() => { p.PriorityClass = ProcessPriorityClass.Normal | ProcessPriorityClass.Idle; });
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void ProcessProcessName()
         {
             Assert.Equal(_process.ProcessName, CoreRunName, StringComparer.OrdinalIgnoreCase);
@@ -462,7 +482,7 @@ namespace System.Diagnostics.ProcessTests
         [DllImport("libc")]
         internal static extern int getpid();
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_GetCurrentProcess()
         {
             Process current = Process.GetCurrentProcess();
@@ -476,7 +496,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.Equal(Process.GetProcessById(currentProcessId).ProcessName, Process.GetCurrentProcess().ProcessName);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_GetProcesses()
         {
             // Get all the processes running on the machine.
@@ -494,7 +514,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.True(foundCurrentProcess, "Process_GetProcesses002 failed");
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_GetProcessesByName()
         {
             // Get the current process using its name
@@ -757,6 +777,26 @@ namespace System.Diagnostics.ProcessTests
 
                 Assert.True(p.WaitForExit(WaitInMS));
                 Assert.Equal(SuccessExitCode, p.ExitCode);
+            }
+        }
+
+        [Fact]
+        public void ThreadCount()
+        {
+            Assert.True(_process.Threads.Count > 0);
+            using (Process p = Process.GetCurrentProcess())
+            {
+                Assert.True(p.Threads.Count > 0);
+            }
+        }
+
+        // [Fact] // uncomment for diagnostic purposes to list processes to console
+        public void ConsoleWriteLineProcesses()
+        {
+            foreach (var p in Process.GetProcesses().OrderBy(p => p.Id))
+            {
+                Console.WriteLine("{0} : \"{1}\" (Threads: {2})", p.Id, p.ProcessName, p.Threads.Count);
+                p.Dispose();
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Diagnostics.ProcessTests
@@ -23,7 +22,7 @@ namespace System.Diagnostics.ProcessTests
 
         private const int s_ConsoleEncoding = 437;
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_EncodingBeforeProvider()
         {
             Action<int> run = expectedCodePage =>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics.ProcessTests
             return CreateProcess("byteAtATime");
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_SyncErrorStream()
         {
             Process p = CreateProcessError();
@@ -42,7 +42,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.True(p.WaitForExit(WaitInMS));
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_AsyncErrorStream()
         {
             for (int i = 0; i < 2; ++i)
@@ -69,7 +69,7 @@ namespace System.Diagnostics.ProcessTests
             }
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_SyncOutputStream()
         {
             Process p = CreateProcessStream();
@@ -80,7 +80,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.Equal(TestExeName + " started" + Environment.NewLine + TestExeName + " closed" + Environment.NewLine, s);
         }
 
-        [Fact, ActiveIssue(1538, PlatformID.OSX)]
+        [Fact]
         public void Process_AsyncOutputStream()
         {
             for (int i = 0; i < 2; ++i)


### PR DESCRIPTION
Fixes a few issues in System.Diagnostics.Process on OSX and reenables most of the previously disabled tests.

Fixes #1538.