### PR TITLE
Fix config file headline comment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
-# EditorConfig is awesome:
-http://EditorConfig.org
+# editorconfig.org
 
 # top-most EditorConfig file
 root = true


### PR DESCRIPTION
This is a small PR corrects unwanted line break added to original
EditorConfig example content headline: http://editorconfig.org/#example-file

Thanks!
