### PR TITLE
Implement basic System.Diagnostics.Process.Modules support on Linux

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -85,7 +85,11 @@ namespace System.Diagnostics
         /// <summary>Gets the main module for the associated process.</summary>
         public ProcessModule MainModule
         {
-            get { throw new PlatformNotSupportedException(); }
+            get
+            {
+                ProcessModuleCollection pmc = Modules;
+                return pmc.Count > 0 ? pmc[0] : null;
+            }
         }
 
         /// <summary>Checks whether the process has exited and updates state accordingly.</summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -70,6 +70,15 @@ namespace System.Diagnostics
             return procInfo;
         }
 
+        /// <summary>Gets an array of module infos for the specified process.</summary>
+        /// <param name="processId">The ID of the process whose modules should be enumerated.</param>
+        /// <returns>The array of modules.</returns>
+        internal static ModuleInfo[] GetModuleInfos(int processId)
+        {
+            // We currently don't provide support for modules on OS X.
+            return Array.Empty<ModuleInfo>();
+        }
+
         // ----------------------------------
         // ---- Unix PAL layer ends here ----
         // ----------------------------------

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -77,17 +77,6 @@ namespace System.Diagnostics
             return (int)processHandle.DangerousGetHandle(); // not actually dangerous; just wraps a process ID
         }
 
-        /// <summary>Gets an array of module infos for the specified process.</summary>
-        /// <param name="processId">The ID of the process whose modules should be enumerated.</param>
-        /// <returns>The array of modules.</returns>
-        public static ModuleInfo[] GetModuleInfos(int processId)
-        {
-            // Not currently supported, but we can simply return an empty array rather than throwing.
-            // Could potentially be done via /proc/pid/maps and some heuristics to determine
-            // which entries correspond to modules.
-            return Array.Empty<ModuleInfo>();
-        }
-
         /// <summary>Gets whether the named machine is remote or local.</summary>
         /// <param name="machineName">The machine name.</param>
         /// <returns>true if the machine is remote; false if it's local.</returns>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -229,14 +229,11 @@ namespace System.Diagnostics.ProcessTests
         public void Process_MainModule()
         {
             // Get MainModule property from a Process object
-            ProcessModule mainModule = null;
-            if (global::Interop.IsWindows)
+            ProcessModule mainModule = _process.MainModule;
+
+            if (!global::Interop.IsOSX) // OS X doesn't currently implement modules support
             {
-                mainModule = _process.MainModule;
-            }
-            else
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => _process.MainModule);
+                Assert.NotNull(mainModule);
             }
 
             if (mainModule != null)
@@ -320,11 +317,13 @@ namespace System.Diagnostics.ProcessTests
             {
                 // Validated that we can get a value for each of the following.
                 Assert.NotNull(pModule);
-                Assert.NotNull(pModule.BaseAddress);
-                Assert.NotNull(pModule.EntryPointAddress);
+                Assert.NotEqual(IntPtr.Zero, pModule.BaseAddress);
                 Assert.NotNull(pModule.FileName);
-                int memSize = pModule.ModuleMemorySize;
                 Assert.NotNull(pModule.ModuleName);
+
+                // Just make sure these don't throw
+                IntPtr addr = pModule.EntryPointAddress;
+                int memSize = pModule.ModuleMemorySize;
             }
         }
 


### PR DESCRIPTION
I'd previously left a comment in the implementation that we could potentially implement Process.Modules support by enumerating the contents of the procfs /procs/[pid]/maps file.  This commit does that.  It uses the heuristic that if the pathname isn't empty and the mapped region has both read and execute permissions, then the entry should be considered a module.  We can tweak this logic over time as needed, and potentially augment the results with a different data source if we find an appropriate one.

#1727