### PR TITLE
Remove SignAssembly=false from test assemblies

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Diagnostics.FileVersionInfo.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <ProjectGuid>{6DFDB760-CC88-48AE-BD81-C64844EA3CBC}</ProjectGuid>
     <NuGetPackageImportStamp>2fda0f27</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/System.IO.MemoryMappedFiles.Tests.csproj
@@ -26,7 +26,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <RootNamespace>f</RootNamespace>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/System.IO.MemoryMappedViewAccessor.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/System.IO.MemoryMappedViewAccessor.Tests.csproj
@@ -28,7 +28,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Dispose.cs" />

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream/System.IO.MemoryMappedViewStream.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream/System.IO.MemoryMappedViewStream.Tests.csproj
@@ -27,7 +27,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Dispose.cs" />

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.IO.Pipes.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <ProjectGuid>{142469EC-D665-4FE2-845A-FDA69F9CC557}</ProjectGuid>
     <NuGetPackageImportStamp>d2615b94</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -19,7 +19,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayHelpers.cs" />

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Linq.Parallel.Tests</RootNamespace>
     <AssemblyName>System.Linq.Parallel.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Runtime.Serialization.Json.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Serialization.Json.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <ProjectGuid>{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Runtime.Serialization.Xml.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Serialization.Xml.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Text.RegularExpressions.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/events/System.Xml.XDocument.Events.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/events/System.Xml.XDocument.Events.Tests.csproj
@@ -7,7 +7,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Events.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <ProjectGuid>{C560E194-5B14-4112-ABC6-3208491E53E6}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Xml.XmlSerializer.Tests</RootNamespace>
     <AssemblyName>System.Xml.XmlSerializer.Tests</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <ProjectGuid>{4050F1D1-1DD2-4B48-A17B-E3F90DD18C4B}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Setting SignAssembly to false breaks loading our test assemblies
in XUnit using the current folder structure we use.  It doesn't show
up in the open, because we always sign the assemblies, ignoring
this setting. But in our official drop environment, we respect the
property, and are unable to run these 12 tests.