### PR TITLE
ConcurrentBag performance improvements and new functions

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -48,6 +48,13 @@ namespace System.Collections.Concurrent
         // GlobalListsLock lock
         private bool _needSync;
 
+        // Approximate item count inside the bag. This is used to determine initial capacity for list copying operations.
+        // Note that this might not represent totally correct item count inside the bag.
+        private volatile int _approxCount;
+
+        // Count of the thread lists. This is used to determine initial capacity for the version lists
+        private volatile int _threadListCount;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentBag{T}"/>
         /// class.
@@ -84,14 +91,18 @@ namespace System.Collections.Concurrent
             _locals = new ThreadLocal<ThreadLocalList>();
 
             // Copy the collection to the bag
+            int count = 0;
             if (collection != null)
             {
                 ThreadLocalList list = GetThreadList(true);
                 foreach (T item in collection)
                 {
                     list.Add(item, false);
+                    count++;
                 }
             }
+
+            _approxCount = count;
         }
 
         /// <summary>
@@ -130,6 +141,9 @@ namespace System.Collections.Concurrent
                     Monitor.Enter(list, ref lockTaken);
                 }
                 list.Add(item, lockTaken);
+#pragma warning disable 0420
+                Interlocked.Increment(ref _approxCount);
+#pragma warning restore 0420
             }
             finally
             {
@@ -230,6 +244,10 @@ namespace System.Collections.Concurrent
                         }
                     }
                     list.Remove(out result);
+#pragma warning disable 0420
+                    Interlocked.Decrement(ref _approxCount);
+#pragma warning restore 0420
+                    return true;
                 }
                 else
                 {
@@ -274,6 +292,7 @@ namespace System.Collections.Concurrent
                         list = new ThreadLocalList(Environment.CurrentManagedThreadId);
                         _headList = list;
                         _tailList = list;
+                        _threadListCount++;
                     }
                     else
                     {
@@ -283,6 +302,7 @@ namespace System.Collections.Concurrent
                             list = new ThreadLocalList(Environment.CurrentManagedThreadId);
                             _tailList._nextList = list;
                             _tailList = list;
+                            _threadListCount++;
                         }
                     }
                     _locals.Value = list;
@@ -339,7 +359,7 @@ namespace System.Collections.Concurrent
 #endif
 
             bool loop;
-            List<int> versionsList = new List<int>(); // save the lists version
+            List<int> versionsList = new List<int>(_threadListCount); // save the lists version
             do
             {
                 versionsList.Clear(); //clear the list from the previous iteration
@@ -386,6 +406,12 @@ namespace System.Collections.Concurrent
                 if (CanSteal(list))
                 {
                     list.Steal(out result, take);
+                    if (take)
+                    {
+#pragma warning disable 0420
+                        Interlocked.Decrement(ref _approxCount);
+#pragma warning restore 0420
+                    }
                     return true;
                 }
                 result = default(T);
@@ -574,13 +600,245 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
+        /// Returns an enumerator that iterates through the <see cref="ConcurrentBag{T}"/>.
+        /// </summary>
+        /// <returns>An enumerator for the contents of the <see cref="ConcurrentBag{T}"/>.</returns>
+        /// <remarks>
+        /// The enumerator returned from the function is safe to use concurrently with
+        /// reads and writes to the bag, however it does not represent a moment-in-time snapshot
+        /// of the bag.  The contents exposed through the enumerator may contain modifications
+        /// made to the bag after <see cref="GetEnumerableSlim"/> was called. <see cref="GetEnumerableSlim"/>
+        /// does not copy the bag contents to a list as <see cref="GetEnumerator"/> does.
+        /// </remarks>
+        public IEnumerable<T> GetEnumerableSlim()
+        {
+            ThreadLocalList currentList = _headList;
+            while (currentList != null)
+            {
+                Node currentNode = currentList._head;
+                while (currentNode != null)
+                {
+                    yield return currentNode._value;
+                    currentNode = currentNode._next;
+                }
+                currentList = currentList._nextList;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="ConcurrentBag{T}"/> contains the specified item.
+        /// </summary>
+        /// <param name="item">The item to locate in the <see cref="ConcurrentBag{T}"/>.</param>
+        /// <returns>true if the <see cref="ConcurrentBag{T}"/> contains the specified item; 
+        /// otherwise, false.</returns>
+        /// <remarks>
+        /// The returned value represents a moment-in-time snapshot of the contents of the bag.
+        /// </remarks>
+        public bool Contains(T item)
+        {
+            // Short path if the bag is empty
+            if (_headList == null)
+                return false;
+
+            bool lockTaken = false;
+            try
+            {
+                FreezeBag(ref lockTaken);
+
+                EqualityComparer<T> comparer = EqualityComparer<T>.Default;
+                foreach (T bagItem in GetEnumerableSlim())
+                {
+                    if (comparer.Equals(bagItem, item))
+                        return true; // Item found
+                }
+                return false;
+            }
+            finally
+            {
+                UnfreezeBag(lockTaken);
+            }
+        }
+
+        /// <summary>
+        /// Searches for an element from <see cref="ConcurrentBag{T}"/> that matches the conditions defined by 
+        /// the specified predicate, and returns the first occurrence that matches the predicate.
+        /// </summary>
+        /// <param name="match">The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.</param>
+        /// <param name="item">When this method returns, <paramref name="item"/> contains the matched object from the
+        /// <see cref="ConcurrentBag{T}"/> or the default value of <typeparamref name="T"/> if there was no match.</param>
+        /// <returns>true if the <see cref="ConcurrentBag{T}"/> contains the matched item; 
+        /// otherwise, false.</returns>
+        /// <remarks>
+        /// The returned value represents a moment-in-time snapshot of the contents of the bag.
+        /// </remarks>
+        public bool Find(Predicate<T> match, out T item)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+
+            // Short path if the bag is empty
+            if (_headList == null)
+            {
+                item = default(T);
+                return false;
+            }
+
+            bool lockTaken = false;
+            try
+            {
+                FreezeBag(ref lockTaken);
+
+                foreach (T bagItem in GetEnumerableSlim())
+                {
+                    if (match(bagItem))
+                    {
+                        item = bagItem;
+                        return true; // Item found
+                    }
+                }
+                item = default(T);
+                return false;
+            }
+            finally
+            {
+                UnfreezeBag(lockTaken);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves all the elements from <see cref="ConcurrentBag{T}"/> that match 
+        /// the conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">The <see cref="Predicate{T}"/> delegate that defines the conditions of the elements to search for.</param>
+        /// <returns>A <see cref="List{T}"/> containing all the elements that match the conditions defined by the specified predicate, 
+        /// if found; otherwise, an empty <see cref="List{T}"/>.</returns>
+        /// <remarks>
+        /// The returned value represents a moment-in-time snapshot of the contents of the bag.
+        /// </remarks>
+        public List<T> FindAll(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+
+            // Short path if the bag is empty
+            if (_headList == null)
+                return new List<T>();
+
+            bool lockTaken = false;
+            try
+            {
+                FreezeBag(ref lockTaken);
+
+                List<T> matches = new List<T>();
+                foreach (T bagItem in GetEnumerableSlim())
+                {
+                    if (match(bagItem))
+                        matches.Add(bagItem);
+                }
+                return matches;
+            }
+            finally
+            {
+                UnfreezeBag(lockTaken);
+            }
+        }
+
+        /// <summary>
+        /// Searches for an element from <see cref="ConcurrentBag{T}"/> that matches the conditions defined by 
+        /// the specified predicate, and returns true if the match is found, otherwise false.
+        /// </summary>
+        /// <param name="match">The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.</param>
+        /// <returns>true if the <see cref="ConcurrentBag{T}"/> contains the matched item; 
+        /// otherwise, false.</returns>
+        /// <remarks>
+        /// The returned value represents a moment-in-time snapshot of the contents of the bag.
+        /// </remarks>
+        public bool Exists(Predicate<T> match)
+        {
+            T dummy = default(T);
+            return Find(match, out dummy);
+        }
+
+        /// <summary>
+        /// Determines whether every element in the <see cref="ConcurrentBag{T}"/> matches the 
+        /// conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">The <see cref="Predicate{T}"/> delegate that defines the conditions to check against the elements.</param>
+        /// <returns>true if every element in the <see cref="ConcurrentBag{T}"/> matches the conditions defined by the specified predicate; 
+        /// otherwise, false. If the list has no elements, the return value is true.</returns>
+        /// <remarks>
+        /// The returned value represents a moment-in-time snapshot of the contents of the bag.
+        /// </remarks>
+        public bool TrueForAll(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+
+            // Short path if the bag is empty
+            if (_headList == null)
+                return true;
+
+            bool lockTaken = false;
+            try
+            {
+                FreezeBag(ref lockTaken);
+
+                foreach (T bagItem in GetEnumerableSlim())
+                {
+                    if (!match(bagItem))
+                        return false;
+                }
+                return true;
+            }
+            finally
+            {
+                UnfreezeBag(lockTaken);
+            }
+        }
+
+        /// <summary>
+        /// Removes all items from the <see cref="ConcurrentBag{T}"/>.
+        /// </summary>
+        public void Clear()
+        {
+            // Short path if the bag is empty
+            if (_headList == null)
+                return;
+
+            bool lockTaken = false;
+            try
+            {
+                FreezeBag(ref lockTaken);
+
+                ThreadLocalList currentList = _headList;
+                while (currentList != null)
+                {
+                    currentList.Reset();
+                    currentList = currentList._nextList;
+                }
+
+                _approxCount = 0;
+            }
+            finally
+            {
+                UnfreezeBag(lockTaken);
+            }
+        }
+
+        /// <summary>
         /// Gets the number of elements contained in the <see cref="ConcurrentBag{T}"/>.
         /// </summary>
         /// <value>The number of elements contained in the <see cref="ConcurrentBag{T}"/>.</value>
         /// <remarks>
         /// The count returned represents a moment-in-time snapshot of the contents
-        /// of the bag.  It does not reflect any updates to the collection after 
-        /// <see cref="GetEnumerator"/> was called.
+        /// of the bag. It does not reflect any updates to the collection after 
+        /// <see cref="Count"/> was called.
         /// </remarks>
         public int Count
         {
@@ -666,7 +924,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         ///  A global lock object, used in two cases:
         ///  1- To  maintain the _tailList pointer for each new list addition process ( first time a thread called Add )
-        ///  2- To freeze the bag in GetEnumerator, CopyTo, ToArray and Count members
+        ///  2- To freeze the bag in GetEnumerator, CopyTo, ToArray, Contains, Clear and Count members
         /// </summary>
         private object GlobalListsLock
         {
@@ -815,7 +1073,11 @@ namespace System.Collections.Concurrent
         {
             Debug.Assert(Monitor.IsEntered(GlobalListsLock));
 
-            List<T> list = new List<T>();
+            int capacity = _approxCount;
+            if (capacity < 0) // Ensure capacity
+                capacity = 0;
+
+            List<T> list = new List<T>(capacity);
             ThreadLocalList currentList = _headList;
             while (currentList != null)
             {
@@ -984,6 +1246,15 @@ namespace System.Collections.Concurrent
                     _stealCount++;
                 }
                 result = tail._value;
+            }
+
+            internal void Reset()
+            {
+                _head = null;
+                _tail = null;
+                _count = 0;
+                _stealCount = 0;
+                _version = 0; // Reset version since the local list is empty again
             }
 
 

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -966,7 +966,7 @@ namespace System.Collections.Concurrent
                 _value = value;
             }
             public readonly T _value;
-            public Node _next;
+            public volatile Node _next;
             public Node _prev;
         }
 

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -1247,7 +1247,10 @@ namespace System.Collections.Concurrent
                 }
                 result = tail._value;
             }
-
+            
+            /// <summary>
+            /// Resets the local list
+            /// </summary>
             internal void Reset()
             {
                 _head = null;


### PR DESCRIPTION
-Improved ToList() performance by initializing the list with initial capacity
-Use initial capacity for bag version lists
-Added Clear function
-Added Contains/Find/FindAll/Exists/TrueForAll functions that avoid List
allocations. Functions represent moment-in-time state of the bag
-Added GetEnumerableSlim to avoid list allocation. Returned enumerable
does not represent moment-in-time state of the bag (which can be used when
moment-in-time representation is not enforced)

New functions can be used to avoid the list allocations which is
problematic with very large bags.