### PR TITLE
Fix TaskExtensions.Unwrap stack dive

### DIFF
--- a/src/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -444,6 +444,24 @@ namespace System.Threading.Tasks.Tests
             }, CancellationToken.None, TaskCreationOptions.None, scheduler).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Test that a long chain of Unwraps can execute without overflowing the stack.
+        /// </summary>
+        [Fact]
+        public void RunStackGuardTests()
+        {
+            const int DiveDepth = 12000;
+
+            Func<int, Task<int>> func = null;
+            func = count =>
+                ++count < DiveDepth ?
+                    Task.Factory.StartNew(() => func(count), CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap() :
+                    Task.FromResult(count);
+
+            // This test will overflow if it fails.
+            Assert.Equal(DiveDepth, func(0).Result);
+        }
+
         /// <summary>Gets an enumerable of already completed non-generic tasks.</summary>
         public static IEnumerable<object[]> CompletedNonGenericTasks
         {


### PR DESCRIPTION
In strange but possible task configurations, it's possible to set up a series of Unwrap calls such that the continuations involved will form a very long chain of synchronously-executing calls.  In such cases, without extra measure, the implementation can overflow the stack.  The mscorlib Unwrap implementation takes precautions to avoid this, and ContinueWith (which was used in the previous, slower, standalone Unwrap implementation) has checks to avoid this as well, but currently await does not.  Since our new Unwrap implementation uses the await infrastructure, it's susceptible again.

This commit adds a check to the new Unwrap implementation to avoid the stack dive, as well as porting a test that triggers the stack dive prior to the fix.  Some local benchmarks show little-to-no impact from the additional checks, and it's very rare to hit the fallback path that triggers the async queueing: while the actual numbers will depend on the actual code being run, the size of stack frames, etc., in the test we only hit the fallback case ~8 times out of 12000 iterations, and that's in code trying very hard to force this condition.

Fixes #2208.