### PR TITLE
Properly reset HashAlgorithm objects using OpenSSL.

### DIFF
--- a/src/Common/src/Interop/OSX/libcrypto/Interop.HMAC.cs
+++ b/src/Common/src/Interop/OSX/libcrypto/Interop.HMAC.cs
@@ -20,6 +20,12 @@ internal static partial class Interop
             return Success;
         }
 
+        internal static int HMAC_Init_ex(ref HMAC_CTX ctx, byte[] key, int key_len, IntPtr md, IntPtr zero)
+        {
+            HMAC_Init_exNative(ref ctx, key, key_len, md, zero);
+            return Success;
+        }
+
         internal static unsafe int HMAC_Update(ref HMAC_CTX ctx, byte* data, int len)
         {
             HMAC_UpdateNative(ref ctx, data, len);
@@ -34,6 +40,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.LibCrypto, EntryPoint = "HMAC_Init", ExactSpelling = true)]
         private extern static unsafe int HMAC_InitNative(out HMAC_CTX ctx, byte* key, int key_len, IntPtr md);
+
+        [DllImport(Libraries.LibCrypto, EntryPoint = "HMAC_Init_ex", ExactSpelling = true)]
+        private extern static void HMAC_Init_exNative(ref HMAC_CTX ctx, byte[] key, int key_len, IntPtr md, IntPtr zero);
 
         [DllImport(Libraries.LibCrypto, EntryPoint = "HMAC_Update", ExactSpelling = true)]
         private extern static unsafe int HMAC_UpdateNative(ref HMAC_CTX ctx, byte* data, int len);

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.HMAC.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.HMAC.cs
@@ -12,6 +12,9 @@ internal static partial class Interop
         internal extern static unsafe int HMAC_Init(out HMAC_CTX ctx, byte* key, int key_len, IntPtr md);
 
         [DllImport(Libraries.LibCrypto)]
+        internal extern static int HMAC_Init_ex(ref HMAC_CTX ctx, byte[] key, int key_len, IntPtr md, IntPtr zero);
+
+        [DllImport(Libraries.LibCrypto)]
         internal extern static unsafe int HMAC_Update(ref HMAC_CTX ctx, byte* data, int len);
 
         [DllImport(Libraries.LibCrypto)]

--- a/src/System.Security.Cryptography.DeriveBytes/tests/Rfc2898Tests.cs
+++ b/src/System.Security.Cryptography.DeriveBytes/tests/Rfc2898Tests.cs
@@ -207,7 +207,6 @@ namespace System.Security.Cryptography.DeriveBytesTests
         }
         
         [Fact]
-        [ActiveIssue(1956, PlatformID.AnyUnix)]
         public static void GetBytes_KnownValues_1()
         {
             TestKnownValue(
@@ -224,7 +223,6 @@ namespace System.Security.Cryptography.DeriveBytesTests
         }
 
         [Fact]
-        [ActiveIssue(1956, PlatformID.AnyUnix)]
         public static void GetBytes_KnownValues_2()
         {
             TestKnownValue(
@@ -241,7 +239,6 @@ namespace System.Security.Cryptography.DeriveBytesTests
         }
 
         [Fact]
-        [ActiveIssue(1956, PlatformID.AnyUnix)]
         public static void GetBytes_KnownValues_3()
         {
             TestKnownValue(
@@ -258,7 +255,6 @@ namespace System.Security.Cryptography.DeriveBytesTests
         }
 
         [Fact]
-        [ActiveIssue(1956, PlatformID.AnyUnix)]
         public static void GetBytes_KnownValues_4()
         {
             TestKnownValue(

--- a/src/System.Security.Cryptography.Hashing.Algorithms/tests/ReusabilityTests.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/tests/ReusabilityTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Security.Cryptography.Hashing.Algorithms.Tests
+{
+    public class ReusabilityTests
+    {
+        [Theory]
+        [MemberData("ReusabilityHashAlgorithms")]
+        public void TestReusability(HashAlgorithm hashAlgorithm)
+        {
+            using (hashAlgorithm)
+            {
+                byte[] input = { 8, 6, 7, 5, 3, 0, 9, };
+                byte[] hash1 = hashAlgorithm.ComputeHash(input);
+                byte[] hash2 = hashAlgorithm.ComputeHash(input);
+
+                Assert.Equal(hash1, hash2);
+            }
+        }
+
+        public static IEnumerable<object[]> ReusabilityHashAlgorithms()
+        {
+            return new[]
+            {
+                new object[] { MD5.Create(), },
+                new object[] { SHA1.Create(), },
+                new object[] { SHA256.Create(), },
+                new object[] { SHA384.Create(), },
+                new object[] { SHA512.Create(), },
+                new object[] { new HMACSHA1(), },
+                new object[] { new HMACSHA256(), },
+                new object[] { new HMACSHA384(), },
+                new object[] { new HMACSHA512(), },
+            };
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Hashing.Algorithms/tests/System.Security.Cryptography.Hashing.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/tests/System.Security.Cryptography.Hashing.Algorithms.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="HmacSha512Tests.cs" />
     <Compile Include="HmacTests.cs" />
     <Compile Include="MD5Tests.cs" />
+    <Compile Include="ReusabilityTests.cs" />
     <Compile Include="Rfc2202HmacTests.cs" />
     <Compile Include="Rfc4231HmacTests.cs" />
     <Compile Include="Sha1Tests.cs" />


### PR DESCRIPTION
The keyed hash algorithms need to use HMAC_Init_ex, which supports an in-place reset.  The unkeyed algorithms have to be reinitialized completely using EVP_DigestInit_ex, passing NULL leads to a SIGSEGV, so persist the algorithm pointer.

Added reusability tests, and enabled the DeriveBytes tests that were disabled due to this issue.

Fixes #1956.