### PR TITLE
Enable warnings-as-errors for the build

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -186,6 +186,12 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
+  <!-- Set up handling of build warnings -->
+  <PropertyGroup>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <!-- Set up some common paths -->
   <PropertyGroup>
     <CommonPath>$(SourceDir)Common\src</CommonPath>

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -23,7 +23,6 @@
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <CodeAnalysisRuleSet>System.Collections.Immutable.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -32,7 +31,6 @@
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/System.IO.MemoryMappedFiles.Tests.csproj
@@ -16,14 +16,12 @@
     <Optimize>false</Optimize>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/System.IO.MemoryMappedViewAccessor.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/System.IO.MemoryMappedViewAccessor.Tests.csproj
@@ -18,14 +18,12 @@
     <Optimize>false</Optimize>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream/System.IO.MemoryMappedViewStream.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream/System.IO.MemoryMappedViewStream.Tests.csproj
@@ -17,14 +17,12 @@
     <Optimize>false</Optimize>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -185,7 +185,7 @@ namespace System.IO.Pipes
             {
                 throw new InvalidOperationException(SR.InvalidOperation_PipeAlreadyDisconnected);
             }
-            if (CheckOperationsRequiresSetHandle && InternalHandle == null)
+            if (InternalHandle == null && CheckOperationsRequiresSetHandle)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_PipeHandleNotSet);
             }

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -23,7 +23,6 @@
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -32,7 +31,6 @@
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -21,7 +21,6 @@
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -29,7 +28,6 @@
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">

--- a/src/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -532,7 +532,7 @@ namespace System.Threading.Tasks.Tests
 
         private sealed class CountingScheduler : TaskScheduler
         {
-            public volatile int QueueTaskCalls = 0;
+            public int QueueTaskCalls = 0;
 
             protected override void QueueTask(Task task)
             {


### PR DESCRIPTION
I also explicitly enabled WarningLevel 4 for all projects, and fixed a few warnings that fire with the VS2013 compiler but not with the VS2015 compiler.

Fixes #1160.