### PR TITLE
Relax regex in build.sh to also recognize Mono 4.0.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ __monoversion=$(mono --version | grep "version 4.[1-9]")
 
 if [ $? -ne 0 ]; then
     # if built from tarball, mono only identifies itself as 4.0.1
-    __monoversion=$(mono --version | egrep "version 4.0.1(.[0-9]+)?")
+    __monoversion=$(mono --version | egrep "version 4.0.[1-9]+(.[0-9]+)?")
     if [ $? -ne 0 ]; then
         echo "Mono 4.0.1.44 or later is required to build corefx. Please see https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md for more details."
         exit 1


### PR DESCRIPTION
Before, the script complained cause it only looked for 4.0.1.x. This change makes it possible to compile with Mono 4.0.2 as well.

/cc @josteink 