### PR TITLE
IO: Add GetActualCasing to File and Directory

### DIFF
--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -7,6 +7,7 @@
     "System.Globalization": "4.0.10-beta-*",
     "System.IO": "4.0.10-beta-*",
     "System.IO.FileSystem.Primitives": "4.0.0-beta-*",
+    "System.Linq": "4.0.0-beta-*",
     "System.Reflection": "4.0.10-beta-*",
     "System.Reflection.Primitives": "4.0.0-beta-*",
     "System.Resources.ResourceManager": "4.0.0-beta-*",

--- a/src/System.IO.FileSystem/src/project.lock.json
+++ b/src/System.IO.FileSystem/src/project.lock.json
@@ -82,6 +82,21 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
+      "System.Linq/4.0.0-beta-23024": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23024",
+          "System.Collections": "4.0.10-beta-23024",
+          "System.Resources.ResourceManager": "4.0.0-beta-23024",
+          "System.Diagnostics.Debug": "4.0.10-beta-23024",
+          "System.Runtime.Extensions": "4.0.10-beta-23024"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
       "System.Private.Uri/4.0.0-beta-23024": {
         "runtime": {
           "lib/DNXCore50/System.Private.Uri.dll": {}

--- a/src/System.IO.FileSystem/tests/Directory/GetActualCasing.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetActualCasing.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Xunit;
+
+public class Directory_GetActualPath
+{
+    [Theory]
+    [PlatformSpecific(PlatformID.Windows)]
+    [InlineData(TestInfo.CurrentDirectory)]
+    [InlineData(@"\\localhost\" + TestInfo.CurrentDirectory.Replace(':', '$'))]
+    public static void TrueCasingTest_Truthy(string path)
+    {
+        Assert.Equal(path, Directory.GetActualCasing(path.ToUpper()));
+    }
+
+    [Theory]
+    [PlatformSpecific(PlatformID.Windows)]
+    [InlineData(Environment.SystemDirectory)]
+    [InlineData(Environment.SystemDirectory.ToUpper())]
+    public static void TrueCasingTest_Falsy(string path)
+    {
+        Assert.NotEqual(path, Directory.GetActualCasing(path));
+    }
+
+    [Theory]
+    [PlatformSpecific(PlatformID.Windows)]
+    [InlineData(@"\\rand0m-server\devnul")]
+    [InlineData(Environment.SystemDirectory + @"\KERNEL32.DlL")]
+    [InlineData(Environment.SystemDirectory + @"\RANDOM-NON_EXISTING-Slug\")]
+    public static void TrueCasingTest_Throwy(string path)
+    {
+        Assert.Throws(typeof(DirectoryNotFoundException), Directory.GetActualCasing(path));
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/GetActualCasing.cs
+++ b/src/System.IO.FileSystem/tests/File/GetActualCasing.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Xunit;
+
+public class File_GetActualPath
+{
+    [Fact]
+    [PlatformSpecific(PlatformID.Windows)]
+    public static void TrueCasingTest_Truthy()
+    {
+        string unicodedFileName = Path.Combine(TestInfo.CurrentDirectory, "тратата.text.txt");
+        
+        File.Create(unicodedFileName).Dispose();
+
+        Assert.Equal(unicodedFileName, File.GetActualCasing(unicodedFileName.ToUpper()));
+
+        File.Delete(unicodedFileName);
+
+        string path = @"\\localhost\" + Environment.SystemDirectory.Replace(':', '$') + @"\kernel32.dll";
+
+        Assert.Equal(path, File.GetActualCasing(path.ToUpper()));
+    }
+
+    [Theory]
+    [PlatformSpecific(PlatformID.Windows)]
+    [InlineData(Environment.SystemDirectory + @"\KERNEL32.DlL")]
+    [InlineData(Environment.SystemDirectory.ToUpper() + @"\kernel32.dll")]
+    public static void TrueCasingTest_Falsy(string path)
+    {
+        Assert.NotEqual(path, File.GetActualCasing(path));
+    }
+
+    [Theory]
+    [PlatformSpecific(PlatformID.Windows)]
+    [InlineData(@"\\rand0m-server\devnul\blah.txt")]
+    [InlineData(Environment.SystemDirectory + @"\RANDOM-NON_EXISTING-Slug\KERNEL32_INVALID.DlL")]
+    public static void TrueCasingTest_Throwy(string path)
+    {
+        Assert.Throws(typeof(FileNotFoundException), File.GetActualCasing(path));
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="DirectoryInfo\Delete.cs" />
     <Compile Include="DirectoryInfo\Delete_bool.cs" />
     <Compile Include="DirectoryInfo\Exists.cs" />
+    <Compile Include="Directory\GetActualCasing.cs" />
     <Compile Include="FileStream\Flush.Sharing.cs" />
     <Compile Include="FileStream\Flush_toDisk.cs" />
     <Compile Include="FileStream\SafeFileHandle.cs" />
@@ -72,6 +73,7 @@
     <Compile Include="FileStream\ctor_str_fm_fa_fs.cs" />
     <Compile Include="FileStream\ctor_str_fm_fa.cs" />
     <Compile Include="FileStream\ctor_str_fm.cs" />
+    <Compile Include="File\GetActualCasing.cs" />
     <Compile Include="UnseekableFileStream.cs" />
     <Compile Include="FSAssert.cs" />
     <Compile Include="FileSystemTest.cs" />


### PR DESCRIPTION
Uses kernel32 interoped method `GetLongPathName` to determine the
actual casing of file and directory paths on disk as well as network.

Issue-URL: #1086.