### PR TITLE
Switch default build log from diag to default

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -39,7 +39,7 @@ call :build %*
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%_buildlog%";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%_buildlog%";Append %* %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 


### PR DESCRIPTION
We were logging about 300 MB per incremental build and
the IO had a very noticeable impact on build time.

To get a diag log wen you actually need one:

   build.cmd /flp:v=diag