### PR TITLE
Implement RSA Sign/Verify on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
@@ -36,6 +36,14 @@ internal static partial class Interop
         [DllImport(Libraries.LibCrypto)]
         internal static extern int RSA_generate_key_ex(SafeRsaHandle rsa, int bits, SafeBignumHandle e, IntPtr zero);
 
+        [DllImport(Libraries.LibCrypto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool RSA_sign(int type, byte[] m, int m_len, byte[] sigret, out int siglen, SafeRsaHandle rsa);
+
+        [DllImport(Libraries.LibCrypto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool RSA_verify(int type, byte[] m, int m_len, byte[] sigbuf, int siglen, SafeRsaHandle rsa);
+
         internal static unsafe RSAParameters ExportRsaParameters(SafeRsaHandle key, bool includePrivateParameters)
         {
             Debug.Assert(

--- a/src/System.Security.Cryptography.RSA/src/Internal/Cryptography/HashAlgorithmName.cs
+++ b/src/System.Security.Cryptography.RSA/src/Internal/Cryptography/HashAlgorithmName.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Internal.Cryptography
+{
+    // Temporarily defining HashAlgorithmName here until it comes online officially with the contract refresh.
+    // (If the contract refresh is happening and this file is causing problems, just delete it)
+    internal struct HashAlgorithmName
+    {
+        public static HashAlgorithmName MD5 { get { return new HashAlgorithmName("MD5"); } }
+        public static HashAlgorithmName SHA1 { get { return new HashAlgorithmName("SHA1"); } }
+        public static HashAlgorithmName SHA256 { get { return new HashAlgorithmName("SHA256"); } }
+        public static HashAlgorithmName SHA384 { get { return new HashAlgorithmName("SHA384"); } }
+        public static HashAlgorithmName SHA512 { get { return new HashAlgorithmName("SHA512"); } }
+
+        private readonly string _name;
+
+        public HashAlgorithmName(string name)
+        {
+            _name = name;
+        }
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        public override string ToString()
+        {
+            return _name ?? string.Empty;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HashAlgorithmName && Equals((HashAlgorithmName)obj);
+        }
+
+        public bool Equals(HashAlgorithmName other)
+        {
+            return _name == other._name;
+        }
+
+        public override int GetHashCode()
+        {
+            return _name == null ? 0 : _name.GetHashCode();
+        }
+
+        public static bool operator ==(HashAlgorithmName left, HashAlgorithmName right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(HashAlgorithmName left, HashAlgorithmName right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.RSA/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.RSA/src/Resources/Strings.resx
@@ -216,4 +216,7 @@
   <data name="OpenCSP_Failed" xml:space="preserve">
     <value>OpenCSP failed with Error code </value>
   </data>
+  <data name="Cryptography_UnknownHashAlgorithm" xml:space="preserve">
+    <value>'{0}' is not a known hash algorithm.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.RSA/src/System.Security.Cryptography.RSA.csproj
+++ b/src/System.Security.Cryptography.RSA/src/System.Security.Cryptography.RSA.csproj
@@ -31,6 +31,7 @@
     <Reference Include="System.Threading" />
   </ItemGroup>-->
   <ItemGroup>
+    <Compile Include="Internal\Cryptography\HashAlgorithmName.cs" />
     <Compile Include="System\Security\Cryptography\CspProviderFlags.cs" />
     <Compile Include="System\Security\Cryptography\ICspAsymmetricAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\KeyNumber.cs" />
@@ -59,6 +60,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.EnsureOpenSslInitialized.cs">
       <Link>Common\Interop\Unix\libcoreclr\Interop.EnsureOpenSslInitialized.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ASN1.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.ASN1.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Bignum.cs</Link>
     </Compile>
@@ -70,6 +74,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Rsa.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs</Link>

--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-
+using System.Reflection;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -90,33 +90,69 @@ namespace System.Security.Cryptography
 
         public byte[] SignData(byte[] buffer, int offset, int count, object halg)
         {
-            // 1964: Implement RSA Sign/Verify on Unix.
-            throw new NotImplementedException();
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset < 0 || offset > buffer.Length)
+                throw new ArgumentOutOfRangeException("offset");
+            if (count < 0 || count > buffer.Length - offset)
+                throw new ArgumentOutOfRangeException("count");
+
+            HashAlgorithmName hashAlgorithmName = LookupHashAlgorithm(halg);
+
+            byte[] hash = _defer.HashData(buffer, offset, count, hashAlgorithmName);
+            return _defer.SignHash(hash, hashAlgorithmName);
         }
 
         public byte[] SignData(byte[] buffer, object halg)
         {
-            throw new NotImplementedException();
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+
+            return SignData(buffer, 0, buffer.Length, halg);
         }
 
         public byte[] SignData(Stream inputStream, object halg)
         {
-            throw new NotImplementedException();
+            if (inputStream == null)
+                throw new ArgumentNullException("inputStream");
+
+            HashAlgorithmName hashAlgorithmName = LookupHashAlgorithm(halg);
+
+            byte[] hash = _defer.HashData(inputStream, hashAlgorithmName);
+            return _defer.SignHash(hash, hashAlgorithmName);
         }
 
         public byte[] SignHash(byte[] rgbHash, string str)
         {
-            throw new NotImplementedException();
+            if (rgbHash == null)
+                throw new ArgumentNullException("rgbHash");
+
+            HashAlgorithmName hashAlgorithmName = LookupHashAlgorithm(str);
+
+            return _defer.SignHash(rgbHash, hashAlgorithmName);
         }
 
         public bool VerifyData(byte[] buffer, object halg, byte[] signature)
         {
-            throw new NotImplementedException();
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (signature == null)
+                throw new ArgumentNullException("signature");
+
+            HashAlgorithmName hashAlgorithmName = LookupHashAlgorithm(halg);
+            byte[] hash = _defer.HashData(buffer, 0, buffer.Length, hashAlgorithmName);
+            return _defer.VerifyHash(hash, signature, hashAlgorithmName);
         }
 
         public bool VerifyHash(byte[] rgbHash, string str, byte[] rgbSignature)
         {
-            throw new NotImplementedException();
+            if (rgbHash == null)
+                throw new ArgumentNullException("rgbHash");
+            if (rgbSignature == null)
+                throw new ArgumentNullException("rgbSignature");
+
+            HashAlgorithmName hashAlgorithmName = LookupHashAlgorithm(str);
+            return _defer.VerifyHash(rgbHash, rgbSignature, hashAlgorithmName);
         }
 
         public CspKeyContainerInfo CspKeyContainerInfo
@@ -167,6 +203,126 @@ namespace System.Security.Cryptography
             {
                 throw new PlatformNotSupportedException();
             } 
+        }
+
+        private static HashAlgorithmName LookupHashAlgorithm(object halg)
+        {
+            string algString = halg as string;
+
+            if (algString != null)
+            {
+                return LookupHashAlgorithm(algString);
+            }
+
+            HashAlgorithm hashAlgorithmInstance = halg as HashAlgorithm;
+
+            if (hashAlgorithmInstance != null)
+            {
+                return LookupHashAlgorithm(hashAlgorithmInstance);
+            }
+
+            Type hashAlgorithmType = halg as Type;
+
+            if (hashAlgorithmType != null)
+            {
+                return LookupHashAlgorithm(hashAlgorithmType);
+            }
+
+            throw new ArgumentException(SR.Argument_InvalidValue);
+        }
+
+        private static HashAlgorithmName LookupHashAlgorithm(Type hashAlgorithmType)
+        {
+            TypeInfo hashAlgTypeInfo = hashAlgorithmType.GetTypeInfo();
+
+            if (typeof(MD5).GetTypeInfo().IsAssignableFrom(hashAlgTypeInfo))
+            {
+                return HashAlgorithmName.MD5;
+            }
+
+            if (typeof(SHA1).GetTypeInfo().IsAssignableFrom(hashAlgTypeInfo))
+            {
+                return HashAlgorithmName.SHA1;
+            }
+
+            if (typeof(SHA256).GetTypeInfo().IsAssignableFrom(hashAlgTypeInfo))
+            {
+                return HashAlgorithmName.SHA256;
+            }
+
+            if (typeof(SHA384).GetTypeInfo().IsAssignableFrom(hashAlgTypeInfo))
+            {
+                return HashAlgorithmName.SHA384;
+            }
+
+            if (typeof(SHA512).GetTypeInfo().IsAssignableFrom(hashAlgTypeInfo))
+            {
+                return HashAlgorithmName.SHA512;
+            }
+
+            throw new ArgumentException(SR.Argument_InvalidValue);
+        }
+
+        private static HashAlgorithmName LookupHashAlgorithm(HashAlgorithm hashAlgorithm)
+        {
+            if (hashAlgorithm is MD5)
+            {
+                return HashAlgorithmName.MD5;
+            }
+
+            if (hashAlgorithm is SHA1)
+            {
+                return HashAlgorithmName.SHA1;
+            }
+
+            if (hashAlgorithm is SHA256)
+            {
+                return HashAlgorithmName.SHA256;
+            }
+
+            if (hashAlgorithm is SHA384)
+            {
+                return HashAlgorithmName.SHA384;
+            }
+
+            if (hashAlgorithm is SHA512)
+            {
+                return HashAlgorithmName.SHA512;
+            }
+
+            throw new ArgumentException(SR.Argument_InvalidValue);
+        }
+
+        private static HashAlgorithmName LookupHashAlgorithm(string algString)
+        {
+            const string Md5Oid = "1.2.840.113549.2.5";
+            const string Sha1Oid = "1.3.14.3.2.26";
+            const string Sha256Oid = "2.16.840.1.101.3.4.2.1";
+            const string Sha384Oid = "2.16.840.1.101.3.4.2.2";
+            const string Sha512Oid = "2.16.840.1.101.3.4.2.3";
+
+            if (algString.Length > 0 && !char.IsDigit(algString[0]))
+            {
+                // If algString is an understood OID FriendlyName it will become the numeric OID,
+                // otherwise it will remain as it was.
+                algString = new Oid(algString).Value ?? algString;
+            }
+
+            switch (algString)
+            {
+                case Md5Oid:
+                    return HashAlgorithmName.MD5;
+                case Sha1Oid:
+                    return HashAlgorithmName.SHA1;
+                case Sha256Oid:
+                    return HashAlgorithmName.SHA256;
+                case Sha384Oid:
+                    return HashAlgorithmName.SHA384;
+                case Sha512Oid:
+                    return HashAlgorithmName.SHA512;
+            }
+
+            throw new CryptographicException(SR.Cryptography_InvalidOID);
         }
     }
 }

--- a/src/System.Security.Cryptography.RSA/tests/SignVerify.cs
+++ b/src/System.Security.Cryptography.RSA/tests/SignVerify.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -9,7 +11,6 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class SignVerify
     {
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectedSignature_SHA1_2048()
         {
             byte[] expectedSignature = new byte[]
@@ -52,7 +53,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectedSignature_SHA256_1024()
         {
             byte[] expectedSignature = new byte[]
@@ -79,7 +79,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectedSignature_SHA256_2048()
         {
             byte[] expectedSignature = new byte[]
@@ -122,7 +121,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectSignature_SHA256_1024_Stream()
         {
             byte[] expectedSignature = new byte[]
@@ -158,7 +156,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifySignature_SHA1_2048()
         {
             byte[] signature = new byte[]
@@ -201,7 +198,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifySignature_SHA256_1024()
         {
             byte[] signature = new byte[]
@@ -228,7 +224,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifySignature_SHA256_2048()
         {
             byte[] signature = new byte[]
@@ -271,28 +266,24 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void SignAndVerify_SHA1_1024()
         {
             SignAndVerify(TestData.HelloBytes, "SHA1", TestData.RSA1024Params);
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void SignAndVerify_SHA1_2048()
         {
             SignAndVerify(TestData.HelloBytes, "SHA1", TestData.RSA2048Params);
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void SignAndVerify_SHA256_1024()
         {
             SignAndVerify(TestData.HelloBytes, "SHA256", TestData.RSA1024Params);
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void NegativeVerify_WrongAlgorithm()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -306,7 +297,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void NegativeVerify_WrongSignature()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -323,7 +313,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void NegativeVerify_TamperedData()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -336,7 +325,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void NegativeVerify_BadKeysize()
         {
             byte[] signature;
@@ -357,7 +345,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectedHashSignature_SHA1_2048()
         {
             byte[] expectedHashSignature = new byte[]
@@ -407,7 +394,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectedHashSignature_SHA256_1024()
         {
             byte[] expectedHashSignature = new byte[]
@@ -441,7 +427,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void ExpectedHashSignature_SHA256_2048()
         {
             byte[] expectedHashSignature = new byte[]
@@ -491,7 +476,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifyHashSignature_SHA1_2048()
         {
             byte[] hashSignature = new byte[]
@@ -541,7 +525,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifyHashSignature_SHA256_1024()
         {
             byte[] hashSignature = new byte[]
@@ -575,7 +558,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1964, PlatformID.AnyUnix)]
         public static void VerifyHashSignature_SHA256_2048()
         {
             byte[] hashSignature = new byte[]
@@ -622,6 +604,45 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
 
             VerifyHashSignature(hashSignature, dataHash, "SHA256", TestData.RSA2048Params);
+        }
+
+        [Theory]
+        [MemberData("AlgorithmIdentifiers")]
+        public static void AlgorithmLookups(string primaryId, object halg)
+        {
+            byte[] data = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
+                byte[] primary = rsa.SignData(data, primaryId);
+                byte[] lookup = rsa.SignData(data, halg);
+
+                Assert.Equal(primary, lookup);
+            }
+        }
+
+        public static IEnumerable<object[]> AlgorithmIdentifiers()
+        {
+            return new[]
+            {
+                new object[] { "MD5", MD5.Create() },
+                new object[] { "MD5", typeof(MD5) },
+                new object[] { "MD5", "1.2.840.113549.2.5" },
+                new object[] { "SHA1", SHA1.Create() },
+                new object[] { "SHA1", typeof(SHA1) },
+                new object[] { "SHA1", "1.3.14.3.2.26" },
+                new object[] { "SHA256", SHA256.Create() },
+                new object[] { "SHA256", typeof(SHA256) },
+                new object[] { "SHA256", "2.16.840.1.101.3.4.2.1" },
+                new object[] { "SHA384", SHA384.Create() },
+                new object[] { "SHA384", typeof(SHA384) },
+                new object[] { "SHA384", "2.16.840.1.101.3.4.2.2" },
+                new object[] { "SHA512", SHA512.Create() },
+                new object[] { "SHA512", typeof(SHA512) },
+                new object[] { "SHA512", "2.16.840.1.101.3.4.2.3" },
+            };
         }
 
         private static void ExpectSignature(


### PR DESCRIPTION
Fixes #1964.

Since the RSA contract refactoring hasn't come along yet, this still implements RSA publicly via RSACryptoServiceProvider.

It internally makes use of a temporary version of HashAlgorithmName, trying to set up for when the API changes come.