### PR TITLE
Fix outstanding issues in Unix RSA tests

### DIFF
--- a/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
@@ -83,16 +83,6 @@ internal static partial class Interop
                     rsaParameters.Q = ExtractBignum(rsaStructure->q, halfModulus);
                     rsaParameters.DQ = ExtractBignum(rsaStructure->dmq1, halfModulus);
                     rsaParameters.InverseQ = ExtractBignum(rsaStructure->iqmp, halfModulus);
-
-                    if (rsaParameters.D == null ||
-                        rsaParameters.P == null ||
-                        rsaParameters.DP == null ||
-                        rsaParameters.Q == null ||
-                        rsaParameters.DQ == null ||
-                        rsaParameters.InverseQ == null)
-                    {
-                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
-                    }
                 }
             }
             finally

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
@@ -83,6 +83,16 @@ internal static partial class Interop
                     rsaParameters.Q = ExtractBignum(rsaStructure->q, halfModulus);
                     rsaParameters.DQ = ExtractBignum(rsaStructure->dmq1, halfModulus);
                     rsaParameters.InverseQ = ExtractBignum(rsaStructure->iqmp, halfModulus);
+
+                    if (rsaParameters.D == null ||
+                        rsaParameters.P == null ||
+                        rsaParameters.DP == null ||
+                        rsaParameters.Q == null ||
+                        rsaParameters.DQ == null ||
+                        rsaParameters.InverseQ == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                    }
                 }
             }
             finally

--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -17,11 +17,13 @@ namespace System.Security.Cryptography
         public RSACryptoServiceProvider()
         {
             _defer = new RSAOpenSsl();
+            _legalKeySizesValue = _defer.LegalKeySizes;
         }
 
         public RSACryptoServiceProvider(int dwKeySize)
         {
             _defer = new RSAOpenSsl(dwKeySize);
+            _legalKeySizesValue = _defer.LegalKeySizes;
         }
 
         public RSACryptoServiceProvider(int dwKeySize, CspParameters parameters)

--- a/src/System.Security.Cryptography.RSA/tests/ImportExport.cs
+++ b/src/System.Security.Cryptography.RSA/tests/ImportExport.cs
@@ -155,7 +155,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(1984, PlatformID.AnyUnix)]
         public static void PublicOnlyPrivateExport()
         {
             RSAParameters imported = new RSAParameters

--- a/src/System.Security.Cryptography.RSA/tests/KeyGeneration.cs
+++ b/src/System.Security.Cryptography.RSA/tests/KeyGeneration.cs
@@ -8,14 +8,12 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class KeyGeneration
     {
         [Fact]
-        [ActiveIssue(1984, PlatformID.AnyUnix)]
         public static void GenerateMinKey()
         {
             GenerateKey(rsa => GetMin(rsa.LegalKeySizes));
         }
 
         [Fact]
-        [ActiveIssue(1984, PlatformID.AnyUnix)]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(rsa => GetSecondMin(rsa.LegalKeySizes));


### PR DESCRIPTION
Fixes #1984.

For `PublicOnlyPrivateExport`, RsaOpenSsl was doing a modified success case where RSACryptoServiceProvider (Windows) was throwing, changed RsaOpenSsl to also throw.

For the two key generation tests, the Unix RSACryptoServiceProvider wrapper didn't load the LegalKeySizes information from the RsaOpenSsl instance, resulting in a `null`-dereference during the test execution.

```
./corerun xunit.console.netcore.exe System.Security.Cryptography.RSA.Tests.dll -notrait category=nonlinuxtests

xUnit.net console test runner (64-bit .NET Core)
Copyright (C) 2014 Outercurve Foundation.

Discovering: System.Security.Cryptography.RSA.Tests
Discovered:  System.Security.Cryptography.RSA.Tests
Starting:    System.Security.Cryptography.RSA.Tests
Finished:    System.Security.Cryptography.RSA.Tests

=== TEST EXECUTION SUMMARY ===
   System.Security.Cryptography.RSA.Tests  Total: 52, Errors: 0, Failed: 0, Skipped: 0, Time: 9.267s
```