### PR TITLE
Fix OrderByDescending if comparer returns int.MinValue

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3105,7 +3105,10 @@ namespace System.Linq
                 if (next == null) return index1 - index2;
                 return next.CompareKeys(index1, index2);
             }
-            return descending ? -c : c;
+            // -c will result in a negative value for int.MinValue (-int.MinValue == int.MinValue).
+            // Flipping keys earlier is more likely to trigger something strange in a comparer,
+            // particularly as it comes to the sort being stable.
+            return (descending != (c > 0)) ? 1 : -1;
         }
     }
 

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -194,6 +194,26 @@ namespace System.Linq.Tests
             Assert.Equal(-10, minusTen.Max());
             Assert.Equal(1000, thousand.Max());
         }
+
+        private class ExtremeComparer : IComparer<int>
+        {
+            public int Compare(int x, int y)
+            {
+                if (x == y)
+                    return 0;
+                if (x < y)
+                    return int.MinValue;
+                return int.MaxValue;
+            }
+        }
+
+        [Fact]
+        public void OrderByExtremeComparer()
+        {
+            var outOfOrder = new[] { 7, 1, 0, 9, 3, 5, 4, 2, 8, 6 };
+            Assert.Equal(Enumerable.Range(0, 10), outOfOrder.OrderBy(i => i, new ExtremeComparer()));
+            Assert.Equal(Enumerable.Range(0, 10).Reverse(), outOfOrder.OrderByDescending(i => i, new ExtremeComparer()));
+        }
     }
 }
 


### PR DESCRIPTION
int.MinValue is a valid "x is less than y" result for a comparer but
OrderByDescending treats it incorrectly. Fix this.

Fix #2239