### PR TITLE
Fix Process failing tests on OSX.

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.libproc.cs
+++ b/src/Common/src/Interop/OSX/Interop.libproc.cs
@@ -546,12 +546,10 @@ internal static partial class Interop
 
             // Get the PIDs rusage info
             int result = proc_pid_rusage(pid, RUSAGE_SELF, &info);
-            if (result <= 0)
+            if (result < 0)
             {
                 throw new Win32Exception(SR.RUsageFailure);
             }
-
-            Debug.Assert(result == Marshal.SizeOf<rusage_info_v3>());
 
             return info;
         }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -401,7 +401,6 @@ namespace System.Diagnostics.ProcessTests
         }
 
         [Fact]
-        [ActiveIssue(2184, PlatformID.OSX)]
         public void Process_ProcessorTime()
         {
             Assert.True(_process.UserProcessorTime.TotalSeconds >= 0);


### PR DESCRIPTION
proc_pid_rusage returns 0 on success, and -1 on failure. Removing throwing exception for result=0.
Removing debug assert on result, since it only stores 0/1 return code and not rusage_info_v3 struct size.

cc @stephentoub @sokket 

closes issue #2184 