### PR TITLE
Add CreateOpenSslCryptographicException helper method and use it.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.NativeCrypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.NativeCrypto.cs
@@ -80,22 +80,22 @@ internal static partial class Interop
 
         internal static byte[] GetAsn1StringBytes(IntPtr asn1)
         {
-            return GetDynamicBuffer(GetAsn1StringBytes, asn1);
+            return GetDynamicBuffer((ptr, buf, i) => GetAsn1StringBytes(ptr, buf, i), asn1);
         }
 
         internal static byte[] GetX509Thumbprint(SafeX509Handle x509)
         {
-            return GetDynamicBuffer(GetX509Thumbprint, x509);
+            return GetDynamicBuffer((handle, buf, i) => GetX509Thumbprint(handle, buf, i), x509);
         }
 
         internal static byte[] GetX509NameRawBytes(IntPtr x509Name)
         {
-            return GetDynamicBuffer(GetX509NameRawBytes, x509Name);
+            return GetDynamicBuffer((ptr, buf, i) => GetX509NameRawBytes(ptr, buf, i), x509Name);
         }
 
         internal static byte[] GetX509PublicKeyParameterBytes(SafeX509Handle x509)
         {
-            return GetDynamicBuffer(GetX509PublicKeyParameterBytes, x509);
+            return GetDynamicBuffer((handle, buf, i) => GetX509PublicKeyParameterBytes(handle, buf, i), x509);
         }
 
         internal static void SetX509ChainVerifyTime(SafeX509StoreCtxHandle ctx, DateTime verifyTime)

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
@@ -78,7 +78,7 @@ internal static partial class Interop
 
             if (bytesNeeded < 0)
             {
-                throw new CryptographicException(GetOpenSslErrorString());
+                throw CreateOpenSslCryptographicException();
             }
 
             Debug.Assert(bytesNeeded != 0, "OBJ_obj2txt reported a zero-length response");
@@ -95,7 +95,7 @@ internal static partial class Interop
 
                 if (bytesNeeded < 0)
                 {
-                    throw new CryptographicException(GetOpenSslErrorString());
+                    throw CreateOpenSslCryptographicException();
                 }
 
                 Debug.Assert(

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ERR.cs
@@ -32,19 +32,39 @@ internal static partial class Interop
             const uint ReasonMask = 0x0FFF;
             const uint ERR_R_MALLOC_FAILURE = 64 | 1;
 
+            // The Windows cryptography library reports error codes through
+            // Marshal.GetLastWin32Error, which has a single value when the
+            // function exits, last writer wins.
+            //
+            // OpenSSL maintains an error queue. Calls to ERR_get_error read
+            // values out of the queue in the order that ERR_set_error wrote
+            // them. Nothing enforces that a single call into an OpenSSL
+            // function will guarantee at-most one error being set.
+            //
+            // In order to maintain parity in how error flows look between the
+            // Windows code and the OpenSSL-calling code, drain the queue
+            // whenever an Exception is desired, and report the exception
+            // related to the last value in the queue.
             uint error = ERR_get_error();
-            uint last = error;
+            uint lastRead = error;
 
-            while (last != 0)
+            // 0 (there's no named constant) is only returned when the calls
+            // to ERR_get_error exceed the calls to ERR_set_error.
+            while (lastRead != 0)
             {
-                last = ERR_get_error();
+                error = lastRead;
+                lastRead = ERR_get_error();
             }
 
+            // If we're in an error flow which results in an Exception, but
+            // no calls to ERR_set_error were made, throw the unadorned
+            // CryptographicException.
             if (error == 0)
             {
                 return new CryptographicException();
             }
 
+            // Inline version of the ERR_GET_REASON macro.
             uint reason = error & ReasonMask;
 
             if (reason == ERR_R_MALLOC_FAILURE)
@@ -52,6 +72,8 @@ internal static partial class Interop
                 return new OutOfMemoryException();
             }
 
+            // If there was an error code, and it wasn't something handled specially,
+            // use the OpenSSL error string as the message to a CryptographicException.
             return new CryptographicException(ERR_error_string_n(error));
         }
 

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ERR.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 
 internal static partial class Interop
@@ -17,13 +19,56 @@ internal static partial class Interop
         [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
         private static extern void ERR_error_string_n(uint e, StringBuilder buf, int len);
 
-        internal static string GetOpenSslErrorString()
+        private static string ERR_error_string_n(uint error)
         {
-            uint error = ERR_get_error();
             StringBuilder buf = new StringBuilder(1024);
-            
+
             ERR_error_string_n(error, buf, buf.Capacity);
             return buf.ToString();
+        }
+
+        internal static Exception CreateOpenSslCryptographicException()
+        {
+            const uint ReasonMask = 0x0FFF;
+            const uint ERR_R_MALLOC_FAILURE = 64 | 1;
+
+            uint error = ERR_get_error();
+            uint last = error;
+
+            while (last != 0)
+            {
+                last = ERR_get_error();
+            }
+
+            if (error == 0)
+            {
+                return new CryptographicException();
+            }
+
+            uint reason = error & ReasonMask;
+
+            if (reason == ERR_R_MALLOC_FAILURE)
+            {
+                return new OutOfMemoryException();
+            }
+
+            return new CryptographicException(ERR_error_string_n(error));
+        }
+
+        internal static void CheckValidOpenSslHandle(SafeHandle handle)
+        {
+            if (handle == null || handle.IsInvalid)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+        }
+
+        internal static void CheckValidOpenSslHandle(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
         }
     }
 }

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
@@ -40,7 +40,7 @@ internal static partial class Interop
 
             if (size < 1)
             {
-                throw new CryptographicException();
+                throw CreateOpenSslCryptographicException();
             }
 
             byte[] data = new byte[size];

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
@@ -27,10 +27,7 @@ internal static partial class Interop
 
                 THandle handle = d2i(IntPtr.Zero, ppData, data.Length);
 
-                if (handle.IsInvalid)
-                {
-                    throw new CryptographicException(GetOpenSslErrorString());
-                }
+                CheckValidOpenSslHandle(handle);
 
                 return handle;
             }

--- a/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesOpenSslCryptoTransform.cs
+++ b/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesOpenSslCryptoTransform.cs
@@ -305,12 +305,7 @@ namespace Internal.Cryptography
                 return;
             }
 
-            throw CreateOpenSslException();
-        }
-
-        private static Exception CreateOpenSslException()
-        {
-            return new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+            throw Interop.libcrypto.CreateOpenSslCryptographicException();
         }
     }
 }

--- a/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -177,7 +177,7 @@ namespace Internal.Cryptography
             if (result != Success)
             {
                 Debug.Assert(result == 0);
-                throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
             }
         }
     }

--- a/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -69,10 +69,8 @@ namespace Internal.Cryptography
                 }
 
                 _ctx = Interop.libcrypto.EVP_MD_CTX_create();
-                if (_ctx.IsInvalid)
-                {
-                    throw new CryptographicException();
-                }
+
+                Interop.libcrypto.CheckValidOpenSslHandle(_ctx);
 
                 Check(Interop.libcrypto.EVP_DigestInit_ex(_ctx, algorithmEvp, IntPtr.Zero));
             }

--- a/src/System.Security.Cryptography.RSA/src/Internal/Cryptography/RsaOpenSsl.cs
+++ b/src/System.Security.Cryptography.RSA/src/Internal/Cryptography/RsaOpenSsl.cs
@@ -160,7 +160,7 @@ namespace Internal.Cryptography
             SafeRsaHandle key = Interop.libcrypto.RSA_new();
             bool imported = false;
 
-            CheckInvalidNewKey(key);
+            Interop.libcrypto.CheckValidOpenSslHandle(key);
 
             try
             {
@@ -266,19 +266,11 @@ namespace Internal.Cryptography
             }
         }
 
-        private static void CheckInvalidNewKey(SafeRsaHandle key)
-        {
-            if (key == null || key.IsInvalid)
-            {
-                throw CreateOpenSslException();
-            }
-        }
-
         private static void CheckReturn(int returnValue)
         {
             if (returnValue == -1)
             {
-                throw CreateOpenSslException();
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
             }
         }
 
@@ -289,7 +281,7 @@ namespace Internal.Cryptography
                 return;
             }
 
-            throw CreateOpenSslException();
+            throw Interop.libcrypto.CreateOpenSslCryptographicException();
         }
 
         private SafeRsaHandle GenerateKey()
@@ -297,7 +289,7 @@ namespace Internal.Cryptography
             SafeRsaHandle key = Interop.libcrypto.RSA_new();
             bool generated = false;
 
-            CheckInvalidNewKey(key);
+            Interop.libcrypto.CheckValidOpenSslHandle(key);
 
             try
             {
@@ -325,11 +317,6 @@ namespace Internal.Cryptography
             }
 
             return key;
-        }
-
-        private static Exception CreateOpenSslException()
-        {
-            return new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
         }
 
         internal byte[] HashData(byte[] buffer, int offset, int count, HashAlgorithmName hashAlgorithmName)
@@ -365,7 +352,7 @@ namespace Internal.Cryptography
 
             if (!success)
             {
-                throw CreateOpenSslException();
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
             }
 
             Debug.Assert(

--- a/src/System.Security.Cryptography.RandomNumberGenerator/src/System/Security/Cryptography/RNGCryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.RandomNumberGenerator/src/System/Security/Cryptography/RNGCryptoServiceProvider.Unix.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography
                 {
                     if (Interop.libcrypto.RAND_pseudo_bytes(buf, data.Length) == -1)
                     {
-                        throw new CryptographicException();
+                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
                     }
                 }
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -29,7 +29,7 @@ namespace Internal.Cryptography.Pal
 
             if (!init)
             {
-                throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
             }
 
             _cert = handle;
@@ -45,6 +45,8 @@ namespace Internal.Cryptography.Pal
             {
                 using (SafeBioHandle bio = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
                 {
+                    Interop.libcrypto.CheckValidOpenSslHandle(bio);
+
                     Interop.libcrypto.BIO_write(bio, data, data.Length);
                     cert = Interop.libcrypto.PEM_read_bio_X509_AUX(bio, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
                 }
@@ -54,10 +56,7 @@ namespace Internal.Cryptography.Pal
                 cert = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_X509, data);
             }
 
-            if (cert.IsInvalid)
-            {
-                throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
-            }
+            Interop.libcrypto.CheckValidOpenSslHandle(cert);
 
             // X509_check_purpose has the effect of populating the sha1_hash value,
             // and other "initialize" type things.
@@ -65,7 +64,7 @@ namespace Internal.Cryptography.Pal
 
             if (!init)
             {
-                throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
             }
 
             _cert = cert;
@@ -275,28 +274,18 @@ namespace Internal.Cryptography.Pal
                 {
                     IntPtr ext = Interop.libcrypto.X509_get_ext(_cert, i);
 
-                    if (ext == IntPtr.Zero)
-                    {
-                        // This would happen on a bounds violation, but no error code is set.
-                        throw new CryptographicException();
-                    }
+                    Interop.libcrypto.CheckValidOpenSslHandle(ext);
 
                     IntPtr oidPtr = Interop.libcrypto.X509_EXTENSION_get_object(ext);
 
-                    if (oidPtr == IntPtr.Zero)
-                    {
-                        throw new CryptographicException();
-                    }
+                    Interop.libcrypto.CheckValidOpenSslHandle(oidPtr);
 
                     string oidValue = Interop.libcrypto.OBJ_obj2txt_helper(oidPtr);
                     Oid oid = new Oid(oidValue);
 
                     IntPtr dataPtr = Interop.libcrypto.X509_EXTENSION_get_data(ext);
 
-                    if (dataPtr == IntPtr.Zero)
-                    {
-                        throw new CryptographicException();
-                    }
+                    Interop.libcrypto.CheckValidOpenSslHandle(dataPtr);
 
                     byte[] extData = Interop.NativeCrypto.GetAsn1StringBytes(dataPtr);
                     bool critical = Interop.libcrypto.X509_EXTENSION_get_critical(ext);
@@ -330,7 +319,7 @@ namespace Internal.Cryptography.Pal
 
                 if (read < 0)
                 {
-                    throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
                 }
 
                 return builder.ToString();
@@ -352,10 +341,7 @@ namespace Internal.Cryptography.Pal
 
         private static X500DistinguishedName LoadX500Name(IntPtr namePtr)
         {
-            if (namePtr == IntPtr.Zero)
-            {
-                throw new CryptographicException();
-            }
+            Interop.libcrypto.CheckValidOpenSslHandle(namePtr);
 
             int negativeSize = Interop.NativeCrypto.GetX509NameRawBytes(namePtr, null, 0);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -104,22 +104,7 @@ namespace Internal.Cryptography.Pal
         {
             get
             {
-                int negativeSize = Interop.NativeCrypto.GetX509Thumbprint(_cert, null, 0);
-
-                if (negativeSize >= 0)
-                {
-                    throw new CryptographicException();
-                }
-
-                byte[] buf = new byte[-negativeSize];
-                int ret = Interop.NativeCrypto.GetX509Thumbprint(_cert, buf, buf.Length);
-
-                if (ret != 1)
-                {
-                    throw new CryptographicException();
-                }
-
-                return buf;
+                return Interop.NativeCrypto.GetX509Thumbprint(_cert);
             }
         }
 
@@ -136,22 +121,7 @@ namespace Internal.Cryptography.Pal
         {
             get
             {
-                int negativeLen = Interop.NativeCrypto.GetX509PublicKeyParameterBytes(_cert, null, 0);
-
-                if (negativeLen >= 0)
-                {
-                    throw new CryptographicException();
-                }
-
-                byte[] buf = new byte[-negativeLen];
-                int ret = Interop.NativeCrypto.GetX509PublicKeyParameterBytes(_cert, buf, buf.Length);
-
-                if (ret != 1)
-                {
-                    throw new CryptographicException();
-                }
-
-                return buf;
+                return Interop.NativeCrypto.GetX509PublicKeyParameterBytes(_cert);
             }
         }
 
@@ -343,21 +313,7 @@ namespace Internal.Cryptography.Pal
         {
             Interop.libcrypto.CheckValidOpenSslHandle(namePtr);
 
-            int negativeSize = Interop.NativeCrypto.GetX509NameRawBytes(namePtr, null, 0);
-
-            if (negativeSize > 0)
-            {
-                throw new CryptographicException();
-            }
-
-            byte[] buf = new byte[-negativeSize];
-            int ret = Interop.NativeCrypto.GetX509NameRawBytes(namePtr, buf, buf.Length);
-
-            if (ret != 1)
-            {
-                throw new CryptographicException();
-            }
-
+            byte[] buf = Interop.NativeCrypto.GetX509NameRawBytes(namePtr);
             return new X500DistinguishedName(buf);
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -53,10 +53,8 @@ namespace Internal.Cryptography.Pal
             using (SafeX509StoreHandle store = Interop.libcrypto.X509_STORE_new())
             using (SafeX509StoreCtxHandle storeCtx = Interop.libcrypto.X509_STORE_CTX_new())
             {
-                if (store.IsInvalid || storeCtx.IsInvalid)
-                {
-                    throw new CryptographicException();
-                }
+                Interop.libcrypto.CheckValidOpenSslHandle(store);
+                Interop.libcrypto.CheckValidOpenSslHandle(storeCtx);
 
                 foreach (X509Certificate2 cert in candidates)
                 {
@@ -64,7 +62,7 @@ namespace Internal.Cryptography.Pal
 
                     if (!Interop.libcrypto.X509_STORE_add_cert(store, pal.SafeHandle))
                     {
-                        throw new CryptographicException();
+                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
                     }
                 }
 
@@ -75,7 +73,7 @@ namespace Internal.Cryptography.Pal
 
                 if (!Interop.libcrypto.X509_STORE_CTX_init(storeCtx, store, leafHandle, IntPtr.Zero))
                 {
-                    throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
                 }
 
                 Interop.NativeCrypto.SetX509ChainVerifyTime(storeCtx, verificationTime);
@@ -84,7 +82,7 @@ namespace Internal.Cryptography.Pal
 
                 if (verify < 0)
                 {
-                    throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
                 }
 
                 using (SafeX509StackHandle chainStack = Interop.libcrypto.X509_STORE_CTX_get1_chain(storeCtx))

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -121,7 +121,7 @@ namespace Internal.Cryptography.Pal
 
                         if (elementCertPtr == IntPtr.Zero)
                         {
-                            throw new CryptographicException();
+                            throw Interop.libcrypto.CreateOpenSslCryptographicException();
                         }
 
                         // Duplicate the certificate handle

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -198,7 +198,7 @@ namespace Internal.Cryptography.Pal
 
                     if (oidPtr == IntPtr.Zero)
                     {
-                        throw new CryptographicException();
+                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
                     }
 
                     string oidValue = Interop.libcrypto.OBJ_obj2txt_helper(oidPtr);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -26,18 +26,12 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeX509NameHandle x509Name = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_X509_NAME, encodedDistinguishedName))
             {
-                if (x509Name.IsInvalid)
-                {
-                    throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
-                }
+                Interop.libcrypto.CheckValidOpenSslHandle(x509Name);
 
                 using (SafeBioHandle bioHandle = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
                 {
-                    if (bioHandle.IsInvalid)
-                    {
-                        throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
-                    }
-
+                    Interop.libcrypto.CheckValidOpenSslHandle(bioHandle);
+                    
                     OpenSslX09NameFormatFlags nativeFlags = ConvertFormatFlags(flag);
 
                     int written = Interop.libcrypto.X509_NAME_print_ex(
@@ -54,7 +48,7 @@ namespace Internal.Cryptography.Pal
 
                     if (read < 0)
                     {
-                        throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
+                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
                     }
 
                     return builder.ToString();
@@ -91,10 +85,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeAsn1BitStringHandle bitString = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_ASN1_BIT_STRING, encoded))
             {
-                if (bitString.IsInvalid)
-                {
-                    throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
-                }
+                Interop.libcrypto.CheckValidOpenSslHandle(bitString);
 
                 byte[] decoded = Interop.NativeCrypto.GetAsn1StringBytes(bitString.DangerousGetHandle());
 
@@ -168,6 +159,8 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeBasicConstraintsHandle constraints = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_BASIC_CONSTRAINTS, encoded))
             {
+                Interop.libcrypto.CheckValidOpenSslHandle(constraints);
+
                 Interop.libcrypto.BASIC_CONSTRAINTS* data = (Interop.libcrypto.BASIC_CONSTRAINTS*)constraints.DangerousGetHandle();
                 certificateAuthority = data->CA != 0;
 
@@ -195,6 +188,8 @@ namespace Internal.Cryptography.Pal
 
             using (SafeEkuExtensionHandle eku = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_EXTENDED_KEY_USAGE, encoded))
             {
+                Interop.libcrypto.CheckValidOpenSslHandle(eku);
+
                 int count = Interop.NativeCrypto.GetX509EkuFieldCount(eku);
 
                 for (int i = 0; i < count; i++)
@@ -224,6 +219,8 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeAsn1OctetStringHandle octetString = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_ASN1_OCTET_STRING, encoded))
             {
+                Interop.libcrypto.CheckValidOpenSslHandle(octetString);
+
                 subjectKeyIdentifier = Interop.NativeCrypto.GetAsn1StringBytes(octetString.DangerousGetHandle());
             }
         }
@@ -281,10 +278,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeRsaHandle rsaHandle = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_RSAPublicKey, encodedData))
             {
-                if (rsaHandle.IsInvalid)
-                {
-                    throw new CryptographicException(Interop.libcrypto.GetOpenSslErrorString());
-                }
+                Interop.libcrypto.CheckValidOpenSslHandle(rsaHandle);
 
                 RSAParameters rsaParameters = Interop.libcrypto.ExportRsaParameters(rsaHandle, false);
                 RSA rsa = new RSACryptoServiceProvider();


### PR DESCRIPTION
CreateOpenSslCryptographicException will drain out the error stack, using the first reported error for the exception.  If the error was an ERR_R_MALLOC_FAILURE code, use an OutOfMemoryException, otherwise a CryptographicException.

A pass was made over the code, and any throw statements which were preceded by a call into libcrypto use the new helper method.  Calls into NativeCrypto throw an unadorned CryptographicException.

This change also introduces CheckValidOpenSslHandle to make the handle checks easier on the eyes, and a few locations were noticed which did not check handle validity with the same thoroughness as the rest of the code.

Fixes #2211.