### PR TITLE
Fix System.IO.FileSystem's PathHelpers for Unix

### DIFF
--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
     <Compile Include="System\IO\FileStream.Win32.cs" />
+    <Compile Include="System\IO\PathHelpers.Windows.cs" />
     <Compile Include="System\IO\Win32FileStream.cs" />
     <Compile Include="System\IO\Win32FileStreamCompletionSource.cs" />
     <Compile Include="System\IO\Win32FileSystem.cs" />
@@ -214,6 +215,7 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
     <Compile Include="System\IO\FileStream.Unix.cs" />
     <Compile Include="System\IO\FileSystem.Current.Unix.cs" />
+    <Compile Include="System\IO\PathHelpers.Unix.cs" />
     <Compile Include="System\IO\UnixFileStream.cs" />
     <Compile Include="System\IO\UnixFileSystem.cs" />
     <Compile Include="System\IO\UnixFileSystemObject.cs" />

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    internal static partial class PathHelpers
+    {
+        internal static int GetRootLength(string path)
+        {
+            CheckInvalidPathChars(path);
+            return path.Length > 0 && IsDirectorySeparator(path[0]) ? 1 : 0;
+        }
+
+        internal static void CheckSearchPattern(string searchPattern)
+        {
+            // ".." should not be used to move up directories. On Windows, this is more strict, and ".."
+            // can only be used in particular places in a name, whereas on Unix it can be used anywhere.
+            // So, throw if we find a ".." that's its own component in the path.
+            for (int index = 0; (index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) >= 0; index += 2)
+            {
+                if ((index == 0 || IsDirectorySeparator(searchPattern[index - 1])) && // previous character is directory separator
+                    (index + 2 == searchPattern.Length || IsDirectorySeparator(searchPattern[index + 2]))) // next character is directory separator
+                {
+                    throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
+                }
+            }
+        }
+
+        internal static bool IsDirectorySeparator(char c)
+        {
+            return c == Path.DirectorySeparatorChar;
+        }
+
+        internal static string GetFullPathInternal(string path)
+        {
+            // The Windows implementation trims off whitespace from the start and end of the path,
+            // and then based on whether that trimmed path is rooted decides to use the trimmed
+            // or original version.  On Unix, a filename can be composed of entirely whitespace
+            // characters, so we can't legimately do such trimming.  As such, we just delegate
+            // to the real GetFullPath.
+            return Path.GetFullPath(path);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    internal static partial class PathHelpers
+    {
+        // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
+        // String.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).    
+        internal static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
+        internal static readonly char[] TrimStartChars = { ' ' };
+
+        // Gets the length of the root DirectoryInfo or whatever DirectoryInfo markers
+        // are specified for the first part of the DirectoryInfo name.
+        // 
+        internal static int GetRootLength(String path)
+        {
+            CheckInvalidPathChars(path);
+
+            int i = 0;
+            int length = path.Length;
+
+            if (length >= 1 && (IsDirectorySeparator(path[0])))
+            {
+                // handles UNC names and directories off current drive's root.
+                i = 1;
+                if (length >= 2 && (IsDirectorySeparator(path[1])))
+                {
+                    i = 2;
+                    int n = 2;
+                    while (i < length && (!IsDirectorySeparator(path[i]) || --n > 0)) i++;
+                }
+            }
+            else if (length >= 2 && path[1] == Path.VolumeSeparatorChar)
+            {
+                // handles A:\foo.
+                i = 2;
+                if (length >= 3 && (IsDirectorySeparator(path[2]))) i++;
+            }
+            return i;
+        }
+
+        // ".." can only be used if it is specified as a part of a valid File/Directory name. We disallow
+        //  the user being able to use it to move up directories. Here are some examples eg 
+        //    Valid: a..b  abc..d
+        //    Invalid: ..ab   ab..  ..   abc..d\abc..
+        //
+        internal static void CheckSearchPattern(String searchPattern)
+        {
+            for (int index = 0; (index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) != -1; index += 2)
+            {
+                // Terminal ".." or "..\". File and directory names cannot end in "..".
+                if (index + 2 == searchPattern.Length || 
+                    IsDirectorySeparator(searchPattern[index + 2]))
+                {
+                    throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
+                }
+            }
+        }
+
+        internal static bool IsDirectorySeparator(char c)
+        {
+            return (c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar);
+        }
+
+        internal static string GetFullPathInternal(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            string pathTrimmed = path.TrimStart(TrimStartChars).TrimEnd(TrimEndChars);
+
+            return Path.GetFullPath(Path.IsPathRooted(pathTrimmed) ? pathTrimmed : path);
+        }
+
+        // this is a lightweight version of GetDirectoryName that doesn't renormalize
+        internal static string GetDirectoryNameInternal(string path)
+        {
+            string directory, file;
+            SplitDirectoryFile(path, out directory, out file);
+
+            // file is null when we reach the root
+            return (file == null) ? null : directory;
+        }
+
+        internal static void SplitDirectoryFile(string path, out string directory, out string file)
+        {
+            directory = null;
+            file = null;
+
+            // assumes a validated full path
+            if (path != null)
+            {
+                int length = path.Length;
+                int rootLength = GetRootLength(path);
+
+                // ignore a trailing slash
+                if (length > rootLength && EndsInDirectorySeparator(path))
+                    length--;
+
+                // find the pivot index between end of string and root
+                for (int pivot = length - 1; pivot >= rootLength; pivot--)
+                {
+                    if (IsDirectorySeparator(path[pivot]))
+                    {
+                        directory = path.Substring(0, pivot);
+                        file = path.Substring(pivot + 1, length - pivot - 1);
+                        return;
+                    }
+                }
+
+                // no pivot, return just the trimmed directory
+                directory = path.Substring(0, length);
+            }
+            
+        }
+
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -1,80 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
-using System.Diagnostics.Contracts;
-
 namespace System.IO
 {
-    // Many of the helper methods in System.IO.Path are internal to mscorlib.
-    // 
-    // These members are taken from src\NDP\clr\src\BCL\System\IO\Path.cs
-    // where an appropriate public member to port to does not exist, or has
-    // different behavior we cannot use for application compat.
-    internal static class PathHelpers
+    // Helper methods related to paths.  Some of these are copies of 
+    // internal members of System.IO.Path from System.Runtime.Extensions.dll.
+    internal static partial class PathHelpers
     {
-        // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
-        // String.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).    
-        internal static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
-        internal static readonly char[] TrimStartChars = { ' ' };
-
         // Array of the separator chars
         internal static readonly char[] DirectorySeparatorChars = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
         // String-representation of the directory-separator character, used when appending the character to another
         // string so as to avoid the boxing of the character when calling String.Concat(..., object).
         internal static readonly string DirectorySeparatorCharAsString = Path.DirectorySeparatorChar.ToString();
-
-        // Gets the length of the root DirectoryInfo or whatever DirectoryInfo markers
-        // are specified for the first part of the DirectoryInfo name.
-        // 
-        internal static int GetRootLength(String path)
-        {
-            CheckInvalidPathChars(path);
-
-            int i = 0;
-            int length = path.Length;
-
-            if (length >= 1 && (IsDirectorySeparator(path[0])))
-            {
-                // handles UNC names and directories off current drive's root.
-                i = 1;
-                if (length >= 2 && (IsDirectorySeparator(path[1])))
-                {
-                    i = 2;
-                    int n = 2;
-                    while (i < length && (!IsDirectorySeparator(path[i]) || --n > 0)) i++;
-                }
-            }
-            else if (length >= 2 && path[1] == Path.VolumeSeparatorChar)
-            {
-                // handles A:\foo.
-                i = 2;
-                if (length >= 3 && (IsDirectorySeparator(path[2]))) i++;
-            }
-            return i;
-        }
-
-        // ".." can only be used if it is specified as a part of a valid File/Directory name. We disallow
-        //  the user being able to use it to move up directories. Here are some examples eg 
-        //    Valid: a..b  abc..d
-        //    Invalid: ..ab   ab..  ..   abc..d\abc..
-        //
-        internal static void CheckSearchPattern(String searchPattern)
-        {
-            int index = 0;
-            while ((index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) != -1)
-            {
-                if (index + 2 == searchPattern.Length) // Terminal ".." . Files names cannot end in ".."
-                    throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
-
-                if (IsDirectorySeparator(searchPattern[index + 2]))
-                    throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
-
-                index += 2;
-            }
-        }
 
         internal static void CheckInvalidPathChars(String path, bool checkAdditional = false)
         {
@@ -99,72 +37,9 @@ namespace System.IO
                 throw new ArgumentException(SR.Arg_Path2IsRooted, "path2");
         }
 
-        internal static bool IsDirectorySeparator(char c)
-        {
-            return (c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar);
-        }
-
         internal static bool EndsInDirectorySeparator(String path)
         {
             return path.Length > 0 && IsDirectorySeparator(path[path.Length - 1]);
-        }
-
-        internal static string GetFullPathInternal(string path)
-        {
-            if (path == null)
-                throw new ArgumentNullException("path");
-
-            string pathTrimmed = path.TrimStart(TrimStartChars).TrimEnd(TrimEndChars);
-
-            return Path.GetFullPath(Path.IsPathRooted(pathTrimmed) ? pathTrimmed : path);
-        }
-
-        // this is a lightweight version of GetDirectoryName that doesn't renormalize
-        internal static string GetDirectoryNameInternal(string path)
-        {
-            string directory, file;
-            SplitDirectoryFile(path, out directory, out file);
-
-            // file is null when we reach the root
-            return (file == null) ? null : directory;
-        }
-
-        internal static void SplitDirectoryFile(string path, out string directory, out string file)
-        {
-            directory = null;
-            file = null;
-
-            // assumes a validated full path
-            if (path != null)
-            {
-                int length = path.Length;
-                int rootLength = GetRootLength(path);
-
-                // ignore a trailing slash
-                if (length > rootLength && EndsInDirectorySeparator(path))
-                    length--;
-
-                // find the pivot index between end of string and root
-                for (int pivot = length - 1; pivot >= rootLength; pivot--)
-                {
-                    if (IsDirectorySeparator(path[pivot]))
-                    {
-                        directory = path.Substring(0, pivot);
-                        file = path.Substring(pivot + 1, length - pivot - 1);
-                        return;
-                    }
-                }
-
-                // no pivot, return just the trimmed directory
-                directory = path.Substring(0, length);
-            }
-
-            return;
-        }
-
-        internal static StringComparison GetComparison(bool caseSensitive)
-        {
-            return caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -538,8 +538,7 @@ namespace System.IO
 
             private static string NormalizeSearchPattern(string searchPattern)
             {
-                searchPattern = searchPattern.TrimEnd(PathHelpers.TrimEndChars);
-                if (searchPattern.Equals(".") || searchPattern == "*.*")
+                if (searchPattern == "." || searchPattern == "*.*")
                 {
                     searchPattern = "*";
                 }

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -324,6 +324,7 @@ public class Directory_CreateDirectory
 #endif
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // whitespace in names is significant on Unix
     public static void CreateDirectory_NonSignificantTrailingWhiteSpace_TreatsAsNonSignificant()
     {
         using (TemporaryDirectory directory = new TemporaryDirectory())

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -92,7 +92,7 @@ public class Directory_Exists
         }
     }
 
-
+    [PlatformSpecific(PlatformID.Windows)] // trailing whitespace is significant in filenames
     [Fact]
     public static void Exists_ExistingDirectoryWithNonSignificantTrailingWhiteSpaceAsPath_ReturnsTrue()
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -184,10 +184,10 @@ public class Directory_GetFileSystemEntries_str : FileSystemTest
 
     [Fact]
     [PlatformSpecific(PlatformID.AnyUnix)]
-    [ActiveIssue(2205)]
     public void UnixFileNameWithSpaces()
     {
         String testDirPath = Path.Combine(TestDirectory, GetTestFileName());
+        Directory.CreateDirectory(testDirPath);
         using (File.Create(Path.Combine(testDirPath, " ")))
         using (File.Create(Path.Combine(testDirPath, "          ")))
         using (File.Create(Path.Combine(testDirPath, "\n")))
@@ -201,7 +201,6 @@ public class Directory_GetFileSystemEntries_str : FileSystemTest
 
     [Fact]
     [PlatformSpecific(PlatformID.AnyUnix)]
-    [ActiveIssue(2205)]
     public void UnixDirectoryNameWithSpaces()
     {
         String testDirPath = Path.Combine(TestDirectory, GetTestFileName());
@@ -214,6 +213,8 @@ public class Directory_GetFileSystemEntries_str : FileSystemTest
         Assert.Contains(Path.Combine(testDirPath, " "), results);
         Assert.Contains(Path.Combine(testDirPath, "          "), results);
         Assert.Contains(Path.Combine(testDirPath, "\n"), results);
+
+        testDir.Delete(true);
     }
     #endregion
 }

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -52,13 +52,6 @@ public class Directory_GetFileSystemEntries_str_str : Directory_GetFileSystemEnt
     }
 
     [Fact]
-    public void InvalidSearchPattern()
-    {
-        String strTempDir = Path.Combine("..ab ab.. .. abc..d", "abc..");
-        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, strTempDir));
-    }
-
-    [Fact]
     public void SearchPatternWithTrailingStar()
     {
         DirectoryInfo testDir = new DirectoryInfo(TestDirectory);
@@ -154,7 +147,7 @@ public class Directory_GetFileSystemEntries_str_str : Directory_GetFileSystemEnt
 
     [Fact]
     [PlatformSpecific(PlatformID.Windows)]
-    public void WildCharactersSearchPattern()
+    public void WindowsWildCharactersSearchPattern()
     {
         String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") +
                             new string(Path.DirectorySeparatorChar, 3);
@@ -163,7 +156,7 @@ public class Directory_GetFileSystemEntries_str_str : Directory_GetFileSystemEnt
 
     [Fact]
     [PlatformSpecific(PlatformID.Windows)]
-    public void SearchPatternWithSpaces()
+    public void WindowsSearchPatternWithSpaces()
     {
         Assert.Empty(GetEntries(TestDirectory, "           "));
         Assert.Empty(GetEntries(TestDirectory, "\n"));
@@ -174,8 +167,15 @@ public class Directory_GetFileSystemEntries_str_str : Directory_GetFileSystemEnt
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)]
+    public void WindowsSearchPatternWithDoubleDots()
+    {
+        string strTempDir = Path.Combine("..ab ab.. .. abc..d", "abc..");
+        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, strTempDir));
+    }
+
+    [Fact]
     [PlatformSpecific(PlatformID.AnyUnix)]
-    [ActiveIssue(2205)]
     public void UnixFilePathWithSpaces()
     {
         Assert.Throws<ArgumentException>(() => GetEntries("\0"));
@@ -188,6 +188,31 @@ public class Directory_GetFileSystemEntries_str_str : Directory_GetFileSystemEnt
             Assert.Contains(Path.Combine(TestDirectory, "          "), results);
             Assert.Contains(Path.Combine(TestDirectory, "\n"), results);
         }
+    }
+
+    [Fact]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public void UnixSearchPatternWithSpaces()
+    {
+        Assert.Empty(GetEntries(TestDirectory, "           "));
+        Assert.Empty(GetEntries(TestDirectory, "\n"));
+        Assert.Empty(GetEntries(TestDirectory, " "));
+        Assert.Empty(GetEntries(TestDirectory, ""));
+        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, "\0"));
+    }
+
+    [Fact]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public void UnixSearchPatternWithDoubleDots()
+    {
+        // search pattern is valid but directory doesn't exist
+        Assert.Throws<DirectoryNotFoundException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc..")));
+
+        // invalid search pattern trying to go up a directory with ..
+        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc", "..")));
+        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "..", "abc")));
+        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..", "..ab ab.. .. abc..d", "abc")));
+        Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..", "..ab ab.. .. abc..d", "abc") + Path.DirectorySeparatorChar));
     }
 
     #endregion

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
@@ -143,7 +143,6 @@ public class Directory_GetFiles_str : FileSystemTest
 
     [Fact]
     [PlatformSpecific(PlatformID.AnyUnix)]
-    [ActiveIssue(2205)]
     public void UnixFilePathWithSpaces()
     {
         Assert.Throws<ArgumentException>(() => GetFiles("\0"));

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
@@ -84,28 +84,30 @@ public class DirectoryInfo_GetFileSystemInfos_str
             }
             //-----------------------------------------------------------------
 
-            // [] ArgumentException for all whitespace
-            //-----------------------------------------------------------------
-            strLoc = "Loc_1190x";
+            if (Interop.IsWindows) // whitespace in names and periods at ends of search patterns is acceptable on Unix
+            {
+                // [] ArgumentException for all whitespace
+                //-----------------------------------------------------------------
+                strLoc = "Loc_1190x";
 
-            dir2 = new DirectoryInfo(".");
-            iCountTestcases++;
-            try
-            {
-                dir2.GetFileSystemInfos(Path.Combine("..ab ab.. .. abc..d", "abc.."));
-                iCountErrors++;
-                printerr("Error_2198y! Expected exception not thrown");
+                dir2 = new DirectoryInfo(".");
+                iCountTestcases++;
+                try
+                {
+                    dir2.GetFileSystemInfos(Path.Combine("..ab ab.. .. abc..d", "abc.."));
+                    iCountErrors++;
+                    printerr("Error_2198y! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                //-----------------------------------------------------------------
             }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
-            }
-            //-----------------------------------------------------------------
-
 
 
             // [] Should return zero length array for an empty directory

--- a/src/System.IO.FileSystem/tests/File/Create_str_i.cs
+++ b/src/System.IO.FileSystem/tests/File/Create_str_i.cs
@@ -192,35 +192,38 @@ public class File_Create_str_i
 
             strLoc = "loc_89tbh_1";
 
-            //see VSWhidbey bug 103341
-            filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
-            if (File.Exists(filName))
-                File.Delete(filName);
-            fs2 = File.Create(String.Format(" {0}", filName), 100);
-            iCountTestcases++;
-            if (!File.Exists(filName))
+            if (Interop.IsWindows) // tests are expecting whitespace at beginning of filename will be trimmed off, which it doesn't on Unix
             {
-                iCountErrors++;
-                printerr("Error_t87gy_1! File not created, file==" + filName);
-            }
-            fs2.Dispose();
-            File.Delete(filName);
-
-            strLoc = "loc_89tbh_3";
-
-            //see VSWhidbey bug 103341
-            filName = Path.Combine(" " + TestInfo.CurrentDirectory, " " + Path.GetRandomFileName());
-            if (File.Exists(filName))
+                //see VSWhidbey bug 103341
+                filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+                if (File.Exists(filName))
+                    File.Delete(filName);
+                fs2 = File.Create(String.Format(" {0}", filName), 100);
+                iCountTestcases++;
+                if (!File.Exists(filName))
+                {
+                    iCountErrors++;
+                    printerr("Error_t87gy_1! File not created, file==" + filName);
+                }
+                fs2.Dispose();
                 File.Delete(filName);
-            fs2 = File.Create(filName, 100);
-            iCountTestcases++;
-            if (!File.Exists(filName))
-            {
-                iCountErrors++;
-                printerr("Error_t87gy_3! File not created, file==" + filName);
+
+                strLoc = "loc_89tbh_3";
+
+                //see VSWhidbey bug 103341
+                filName = Path.Combine(" " + TestInfo.CurrentDirectory, " " + Path.GetRandomFileName());
+                if (File.Exists(filName))
+                    File.Delete(filName);
+                fs2 = File.Create(filName, 100);
+                iCountTestcases++;
+                if (!File.Exists(filName))
+                {
+                    iCountErrors++;
+                    printerr("Error_t87gy_3! File not created, file==" + filName);
+                }
+                fs2.Dispose();
+                File.Delete(filName);
             }
-            fs2.Dispose();
-            File.Delete(filName);
 
             if (File.Exists(filName))
                 File.Delete(filName);


### PR DESCRIPTION
The FileSystem's PathHelpers internal class contains some utility functions for processing paths.  Some of these functions are copies of non-exposed Path members, while others are unique.  A bunch of those members have Windows-specifics coded into them, which is causing problems when dealing with various special paths on Unix, for example paths that end with double dots, relative paths that begin with a space, etc.

This commit splits PathHelpers into a PathHelpers.cs, PathHelpers.Windows.cs, and PathHelpers.Unix.cs, and implements the Unix functions appropriately.

It also fixes up a variety of tests that are now failing because they were expecting the Windows behavior.

Fixes #2253, #2205