### PR TITLE
Remove List<T> allocation from directory enumeration

### DIFF
--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -7,6 +7,15 @@ namespace System.Collections.Generic
     internal static class EnumerableHelpers
     {
         /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
+        internal static T[] ToArray<T>(IEnumerable<T> source)
+        {
+            int count;
+            T[] results = ToArray(source, out count);
+            Array.Resize(ref results, count);
+            return results;
+        }
+
+        /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
         /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>
         /// <returns>
         /// The resulting array.  The length of the array may be greater than <paramref name="length"/>,

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -46,6 +46,9 @@
     <Compile Include="System\IO\ReadLinesIterator.cs" />
     <Compile Include="System\IO\SearchOption.cs" />
     <Compile Include="System\IO\SearchTarget.cs" />
+    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+      <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -351,8 +351,7 @@ namespace System.IO
 
             IEnumerable<String> enumerable = FileSystem.Current.EnumeratePaths(path, searchPattern, searchOption,
                 (includeFiles ? SearchTarget.Files : 0) | (includeDirs ? SearchTarget.Directories : 0));
-            List<String> fileList = new List<String>(enumerable);
-            return fileList.ToArray();
+            return EnumerableHelpers.ToArray(enumerable);
         }
 
         public static IEnumerable<String> EnumerateDirectories(String path)

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -179,9 +179,8 @@ namespace System.IO
             Contract.Requires(searchPattern != null);
             Contract.Requires(searchOption == SearchOption.AllDirectories || searchOption == SearchOption.TopDirectoryOnly);
 
-            IEnumerable<FileInfo> enble = (IEnumerable<FileInfo>)FileSystem.Current.EnumerateFileSystemInfos(FullPath, searchPattern, searchOption, SearchTarget.Files);
-            List<FileInfo> fileList = new List<FileInfo>(enble);
-            return fileList.ToArray();
+            IEnumerable<FileInfo> enumerable = (IEnumerable<FileInfo>)FileSystem.Current.EnumerateFileSystemInfos(FullPath, searchPattern, searchOption, SearchTarget.Files);
+            return EnumerableHelpers.ToArray(enumerable);
         }
 
         // Returns an array of Files in the DirectoryInfo specified by path
@@ -228,8 +227,7 @@ namespace System.IO
             Contract.Requires(searchOption == SearchOption.AllDirectories || searchOption == SearchOption.TopDirectoryOnly);
 
             IEnumerable<FileSystemInfo> enumerable = FileSystem.Current.EnumerateFileSystemInfos(FullPath, searchPattern, searchOption, SearchTarget.Both);
-            List<FileSystemInfo> fileList = new List<FileSystemInfo>(enumerable);
-            return fileList.ToArray();
+            return EnumerableHelpers.ToArray(enumerable);
         }
 
         // Returns an array of strongly typed FileSystemInfo entries which will contain a listing
@@ -274,8 +272,7 @@ namespace System.IO
             Contract.Requires(searchOption == SearchOption.AllDirectories || searchOption == SearchOption.TopDirectoryOnly);
 
             IEnumerable<DirectoryInfo> enumerable = (IEnumerable<DirectoryInfo>)FileSystem.Current.EnumerateFileSystemInfos(FullPath, searchPattern, searchOption, SearchTarget.Directories);
-            List<DirectoryInfo> fileList = new List<DirectoryInfo>(enumerable);
-            return fileList.ToArray();
+            return EnumerableHelpers.ToArray(enumerable);
         }
 
         public IEnumerable<DirectoryInfo> EnumerateDirectories()


### PR DESCRIPTION
While working on some path-related functionality in System.IO.FileSystem, I noticed that our methods for iterating a directory are taking the enumerable of results, storing that into a list, and then converting that list into an array.  This commit changes four such methods to skip the middle-man.