### PR TITLE
Separate platform-specifics out of shared FileSystem code

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -315,28 +315,6 @@ namespace System.IO
             return InternalGetFileDirectoryNames(path, path, searchPattern, true, true, searchOption);
         }
 
-
-        // Private class that holds search data that is passed around 
-        // in the heap based stack recursion
-        internal sealed class SearchData
-        {
-            public SearchData(String fullPath, String userPath, SearchOption searchOption)
-            {
-                Contract.Requires(fullPath != null && fullPath.Length > 0);
-                Contract.Requires(userPath != null && userPath.Length > 0);
-                Contract.Requires(searchOption == SearchOption.AllDirectories || searchOption == SearchOption.TopDirectoryOnly);
-
-                this.fullPath = fullPath;
-                this.userPath = userPath;
-                this.searchOption = searchOption;
-            }
-
-            public readonly string fullPath;     // Fully qualified search path excluding the search criteria in the end (ex, c:\temp\bar\foo)
-            public readonly string userPath;     // User specified path (ex, bar\foo)
-            public readonly SearchOption searchOption;
-        }
-
-
         // Returns fully qualified user path of dirs/files that matches the search parameters. 
         // For recursive search this method will search through all the sub dirs  and execute 
         // the given search criteria against every dir.

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -1,18 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Globalization;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Security;
-using System.Text;
-
-using Microsoft.Win32;
 
 namespace System.IO
 {
@@ -25,25 +17,8 @@ namespace System.IO
                 throw new ArgumentNullException("path");
             Contract.EndContractBlock();
 
-            Init(path);
-        }
-
-        [System.Security.SecurityCritical]
-        private void Init(String path)
-        {
-            // Special case "<DriveLetter>:" to point to "<CurrentDirectory>" instead
-            if ((path.Length == 2) && (path[1] == ':'))
-            {
-                OriginalPath = ".";
-            }
-            else
-            {
-                OriginalPath = path;
-            }
-
-            String fullPath = PathHelpers.GetFullPathInternal(path);
-
-            FullPath = fullPath;
+            OriginalPath = PathHelpers.ShouldReviseDirectoryPathToCurrent(path) ? "." : path;
+            FullPath = PathHelpers.GetFullPathInternal(path);
             DisplayPath = GetDisplayName(OriginalPath, FullPath);
         }
 
@@ -51,9 +26,9 @@ namespace System.IO
         internal DirectoryInfo(String fullPath, IFileSystemObject fileSystemObject) : base(fileSystemObject)
         {
             Debug.Assert(PathHelpers.GetRootLength(fullPath) > 0, "fullPath must be fully qualified!");
+            
             // Fast path when we know a DirectoryInfo exists.
             OriginalPath = Path.GetFileName(fullPath);
-
             FullPath = fullPath;
             DisplayPath = GetDisplayName(OriginalPath, FullPath);
         }
@@ -74,17 +49,20 @@ namespace System.IO
             [System.Security.SecuritySafeCritical]
             get
             {
-                String parentName;
-                // FullPath might be either "c:\bar" or "c:\bar\".  Handle 
-                // those cases, as well as avoiding mangling "c:\".
-                String s = FullPath;
-                if (s.Length > 3 && s[s.Length - 1] == Path.DirectorySeparatorChar)
-                    s = FullPath.Substring(0, FullPath.Length - 1);
-                parentName = Path.GetDirectoryName(s);
-                if (parentName == null)
-                    return null;
-                DirectoryInfo dir = new DirectoryInfo(parentName, null);
-                return dir;
+                string s = FullPath;
+
+                // FullPath might end in either "parent\child" or "parent\child", and in either case we want 
+                // the parent of child, not the child. Trim off an ending directory separator if there is one,
+                // but don't mangle the root.
+                if (!PathHelpers.IsRoot(s))
+                {
+                    s = PathHelpers.TrimEndingDirectorySeparator(s);
+                }
+
+                string parentName = Path.GetDirectoryName(s);
+                return parentName != null ? 
+                    new DirectoryInfo(parentName, null) :
+                    null;
             }
         }
 
@@ -457,40 +435,18 @@ namespace System.IO
             Debug.Assert(originalPath != null);
             Debug.Assert(fullPath != null);
 
-            String displayName = "";
-
-            // Special case "<DriveLetter>:" to point to "<CurrentDirectory>" instead
-            if ((originalPath.Length == 2) && (originalPath[1] == ':'))
-            {
-                displayName = ".";
-            }
-            else
-            {
-                displayName = GetDirName(fullPath);
-            }
-            return displayName;
+            return PathHelpers.ShouldReviseDirectoryPathToCurrent(originalPath) ?
+                "." :
+                GetDirName(fullPath);
         }
 
         private static String GetDirName(String fullPath)
         {
             Debug.Assert(fullPath != null);
 
-            String dirName = null;
-            if (fullPath.Length > 3)
-            {
-                String s = fullPath;
-                if (fullPath[fullPath.Length - 1] == Path.DirectorySeparatorChar)
-                {
-                    s = fullPath.Substring(0, fullPath.Length - 1);
-                }
-                dirName = Path.GetFileName(s);
-            }
-            else
-            {
-                dirName = fullPath;  // For rooted paths, like "c:\"
-            }
-            return dirName;
+            return PathHelpers.IsRoot(fullPath) ?
+                fullPath :
+                Path.GetFileName(PathHelpers.TrimEndingDirectorySeparator(fullPath));
         }
     }
 }
-

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
@@ -11,6 +11,13 @@ namespace System.IO
             return path.Length > 0 && IsDirectorySeparator(path[0]) ? 1 : 0;
         }
 
+        internal static bool ShouldReviseDirectoryPathToCurrent(string path)
+        {
+            // Unlike on Windows, there are no special cases on Unix where we'd want to ignore
+            // user-provided path and instead automatically use the current directory.
+            return false;
+        }
+
         internal static void CheckSearchPattern(string searchPattern)
         {
             // ".." should not be used to move up directories. On Windows, this is more strict, and ".."

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -40,6 +40,13 @@ namespace System.IO
             return i;
         }
 
+        internal static bool ShouldReviseDirectoryPathToCurrent(string path)
+        {
+            // In situations where this method is invoked, "<DriveLetter>:" should be special-cased 
+            // to instead go to the current directory.
+            return path.Length == 2 && path[1] == ':';
+        }
+
         // ".." can only be used if it is specified as a part of a valid File/Directory name. We disallow
         //  the user being able to use it to move up directories. Here are some examples eg 
         //    Valid: a..b  abc..d

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -37,9 +37,21 @@ namespace System.IO
                 throw new ArgumentException(SR.Arg_Path2IsRooted, "path2");
         }
 
+        internal static bool IsRoot(string path)
+        {
+            return path.Length == GetRootLength(path);
+        }
+
         internal static bool EndsInDirectorySeparator(String path)
         {
             return path.Length > 0 && IsDirectorySeparator(path[path.Length - 1]);
+        }
+
+        internal static string TrimEndingDirectorySeparator(string path)
+        {
+            return EndsInDirectorySeparator(path) ?
+                path.Substring(0, path.Length - 1) :
+                path;
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -88,8 +88,8 @@ namespace System.IO
         private const int STATE_FINISH = 4;
 
         private SearchResultHandler<TSource> _resultHandler;
-        private List<Directory.SearchData> _searchStack;
-        private Directory.SearchData _searchData;
+        private List<SearchData> _searchStack;
+        private SearchData _searchData;
         private String _searchCriteria;
         [System.Security.SecurityCritical]
         private SafeFindHandle _hnd = null;
@@ -119,7 +119,7 @@ namespace System.IO
 
             _oldMode = Interop.mincore.SetErrorMode(Interop.mincore.SEM_FAILCRITICALERRORS);
 
-            _searchStack = new List<Directory.SearchData>();
+            _searchStack = new List<SearchData>();
 
             String normalizedSearchPattern = NormalizeSearchPattern(searchPattern);
 
@@ -148,7 +148,7 @@ namespace System.IO
                 }
                 this._userPath = userPathTemp;
 
-                _searchData = new Directory.SearchData(_normalizedSearchPath, this._userPath, searchOption);
+                _searchData = new SearchData(_normalizedSearchPath, this._userPath, searchOption);
 
                 CommonInit();
             }
@@ -218,13 +218,13 @@ namespace System.IO
             this._userPath = userPath;
             this._searchOption = searchOption;
 
-            _searchStack = new List<Directory.SearchData>();
+            _searchStack = new List<SearchData>();
 
             if (searchCriteria != null)
             {
                 PathHelpers.CheckInvalidPathChars(fullPath, true);
 
-                _searchData = new Directory.SearchData(normalizedSearchPath, userPath, searchOption);
+                _searchData = new SearchData(normalizedSearchPath, userPath, searchOption);
                 CommonInit();
             }
             else
@@ -381,7 +381,7 @@ namespace System.IO
         }
 
         [System.Security.SecurityCritical]
-        private SearchResult CreateSearchResult(Directory.SearchData localSearchData, Interop.mincore.WIN32_FIND_DATA findData)
+        private SearchResult CreateSearchResult(SearchData localSearchData, Interop.mincore.WIN32_FIND_DATA findData)
         {
             string findData_fileName = findData.cFileName;
             Contract.Requires(findData_fileName.Length != 0 && !Path.IsPathRooted(findData_fileName),
@@ -400,7 +400,7 @@ namespace System.IO
         }
 
         [System.Security.SecurityCritical]  // auto-generated
-        private void AddSearchableDirsToStack(Directory.SearchData localSearchData)
+        private void AddSearchableDirsToStack(SearchData localSearchData)
         {
             Contract.Requires(localSearchData != null);
 
@@ -440,7 +440,7 @@ namespace System.IO
                         SearchOption option = localSearchData.searchOption;
 
                         // Setup search data for the sub directory and push it into the stack
-                        Directory.SearchData searchDataSubDir = new Directory.SearchData(tempFullPath, tempUserPath, option);
+                        SearchData searchDataSubDir = new SearchData(tempFullPath, tempUserPath, option);
 
                         _searchStack.Insert(incr++, searchDataSubDir);
                     }
@@ -616,6 +616,26 @@ namespace System.IO
                 return fi;
             }
         }
+    }
+
+    // Holds search data that is passed around 
+    // in the heap based stack recursion
+    internal sealed class SearchData
+    {
+        public SearchData(String fullPath, String userPath, SearchOption searchOption)
+        {
+            Contract.Requires(fullPath != null && fullPath.Length > 0);
+            Contract.Requires(userPath != null && userPath.Length > 0);
+            Contract.Requires(searchOption == SearchOption.AllDirectories || searchOption == SearchOption.TopDirectoryOnly);
+
+            this.fullPath = fullPath;
+            this.userPath = userPath;
+            this.searchOption = searchOption;
+        }
+
+        public readonly string fullPath;     // Fully qualified search path excluding the search criteria in the end (ex, c:\temp\bar\foo)
+        public readonly string userPath;     // User specified path (ex, bar\foo)
+        public readonly SearchOption searchOption;
     }
 
     internal sealed class SearchResult

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
@@ -54,6 +54,28 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void DriveLetter_Windows()
+        {
+            // On Windows, DirectoryInfo will replace "<DriveLetter>:" with "."
+            var driveLetter = new DirectoryInfo(Directory.GetCurrentDirectory()[0] + ":");
+            var current = new DirectoryInfo(".");
+            Assert.Equal(current.Name, driveLetter.Name);
+            Assert.Equal(current.FullName, driveLetter.FullName);
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void DriveLetter_Unix()
+        {
+            // On Unix, there's no special casing for drive letters, which are valid file names
+            var driveLetter = new DirectoryInfo("C:");
+            var current = new DirectoryInfo(".");
+            Assert.Equal("C:", driveLetter.Name);
+            Assert.Equal(Path.Combine(current.FullName, "C:"), driveLetter.FullName);
+        }
+
+        [Fact]
         [ActiveIssue(1222)]
         public void TrailingWhitespace()
         {


### PR DESCRIPTION
In a few places, we still have platform-specific code in shared System.IO.FileSystem code.  In particular, DirectoryInfo is doing various manipulations related to Windows path roots that can result in doing the wrong thing on Unix, e.g. creating a DirectoryInfo for "C:" on Unix should be for the directory named "C:", but instead today it'll follow the Windows-specific logic of rerouting to target the current directory.  This commit fixes that.  It also moves some code used only in the Windows implementation into Windows-specific files (e.g. Directory.SearchData).