### PR TITLE
Fix bugs in OSX on process type implementations.

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.getsid.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.getsid.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+using pid_t = System.Int32;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [DllImport(Libraries.Libc)]
+        internal static extern pid_t getsid(pid_t pid);
+    }
+}

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -261,6 +261,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.ForkAndExecProcess.cs">
       <Link>Common\Interop\Unix\Interop.ForkAndExecProcess.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getsid.cs">
+      <Link>Common\Interop\Unix\Interop.getsid.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.ResourceLimits.cs">
       <Link>Common\Interop\Unix\Interop.ResourceLimits.cs</Link>
     </Compile>


### PR DESCRIPTION
In this commit, 

1. Added test coverage for properties on Process type, subsequent PRs will be opened to provide test coverage on Process methods, and other types and scenarios in this contract, as work is done incrementally.
2. Added implementation to get Session ID of a process on OSX.
3. Fixed bug in retrieving the priority of a task on OSX, we were reading the wrong struct value for this.

cc @stephentoub @joshfree @sokket 