### PR TITLE
Add checks for infinity to Complex.Pow verification

### DIFF
--- a/src/System.Runtime.Numerics/tests/Complex/ComplexTestSupport.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/ComplexTestSupport.cs
@@ -159,10 +159,21 @@ namespace ComplexTestSupport
 
         public static bool IsDiffTolerable(double d1, double d2)
         {
-            double diffRatio = (d1 - d2) / d1;
-            diffRatio *= Math.Pow(10, 6);
-            diffRatio = Math.Abs(diffRatio);
-            return (diffRatio < 1);
+            if (double.IsInfinity(d1))
+            {
+                return d1 == (d2 * 10);
+            }
+            else if (double.IsInfinity(d2))
+            {
+                return d2 == (d1 * 10);
+            }
+            else
+            {
+                double diffRatio = (d1 - d2) / d1;
+                diffRatio *= Math.Pow(10, 6);
+                diffRatio = Math.Abs(diffRatio);
+                return (diffRatio < 1);
+            }
         }
 
         public static void VerifyRealImaginaryProperties(Complex complex, double real, double imaginary, string message)


### PR DESCRIPTION
Several times now the standardNumericalFunctions_PowTest.RunTests_RandomValidValues test has failed in CI.  The issue is that random values are generated that result in so large or small values that the Complex.Pow(x,y) computation results in infinity.  The test then tries to verify the result by comparing it to the result of Complex.Exp(y*Complex.Log(x)).  It needs to do an approximate comparison, but that approximation doesn't take infinity into account.  This commit attempts to address that by checking to see if one of the values is infinity, and if it is, rather than subtracting one value from the other (which will result in infinity), it tries to nudge the other value a bit to see if it becomes a matching infinity.

Fixes #1432