### PR TITLE
Check the state before fetching the thread id

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Iterator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Iterator.cs
@@ -41,7 +41,7 @@ namespace System.IO
 
         public IEnumerator<TSource> GetEnumerator()
         {
-            if (_threadId == Environment.CurrentManagedThreadId && state == 0)
+            if (state == 0 && _threadId == Environment.CurrentManagedThreadId)
             {
                 state = 1;
                 return this;


### PR DESCRIPTION
Matches the change to LINQ's Iterator (#2142).