### PR TITLE
Use "-source" parameter in OSX build script, NuGet.Config was removed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ fi
 # Grab the MSBuild package if we don't have it already
 if [ ! -e "$__msbuildpath" ]; then
     echo "Restoring MSBuild..."
-    mono "$__nugetpath" install $__msbuildpackageid -Version $__msbuildpackageversion -ConfigFile "$__nugetconfig" -OutputDirectory "$__packageroot"
+    mono "$__nugetpath" install $__msbuildpackageid -Version $__msbuildpackageversion -source "https://www.myget.org/F/dotnet-buildtools/" -OutputDirectory "$__packageroot"
     if [ $? -ne 0 ]; then
         echo "Failed to restore MSBuild."
         exit 1


### PR DESCRIPTION
NuGet.Config was removed from source, this breaks the OSX build using build.sh.  Convert OSX build to restore buildtools using the "-source" parameter.