### PR TITLE
Fix warnings in System.Linq.Expressions.Test again

### DIFF
--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -2815,11 +2815,6 @@ namespace Tests
         [Fact]
         public static void NullGuidConstant()
         {
-            Expression<Func<Guid, bool>> f = g => g != null;
-            var d = f.Compile();
-            Assert.True(d(Guid.NewGuid()));
-            Assert.True(d(default(Guid))); // default(Guid) is not really null
-
             Expression<Func<Guid?, bool>> f2 = g2 => g2 != null;
             var d2 = f2.Compile();
             Assert.True(d2(Guid.NewGuid()));


### PR DESCRIPTION
These were fixed once, but got re-broken, presumably through a
merge resolution. I'm re-fixing them. The warnings prevent tests from
running cleanly, because the build fails with warnings/errors.

This reintroduces the fix by
@stephentoub (commit f874fee8d01d43cbf1e3b8ca67270360c9ef8174)
that was removed (presumably accidentally) by
@VSadov (commit ca97a51dfdb7e741caf108e8c21b2debb5c903fd)