### PR TITLE
PLINQ - immediate cancellation of ToArray

### DIFF
--- a/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
@@ -190,6 +190,13 @@ namespace Test
             }
         }
 
+        // Return an enumerable which throws on first MoveNext.
+        // Useful for testing promptness of cancellation.
+        public static IEnumerable<object[]> ThrowOnFirstEnumeration()
+        {
+            yield return new object[] { Labeled.Label("ThrowOnFirstEnumeration", Enumerables<int>.ThrowOnEnumeration().AsParallel()), 8 };
+        }
+
         private static IEnumerable<Labeled<ParallelQuery<int>>> LabeledRanges(int start, int count)
         {
             yield return Labeled.Label("ParallelEnumerable.Range", ParallelEnumerable.Range(start, count));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
@@ -48,6 +48,7 @@ namespace Test
 
         [Theory]
         [MemberData("Ranges", (object)(new int[] { 1 }), MemberType = typeof(Sources))]
+        [MemberData("ThrowOnFirstEnumeration", MemberType = typeof(UnorderedSources))]
         public static void ToArray_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();


### PR DESCRIPTION
All the query operators have a check for whether they've already been canceled - except `ToArray` (well, and `SequenceEqual`, but that's a different problem).  `ToArray` calls a different method than the other query operators, and it appears to be missing the pre-emptive cancellation check - the methods are otherwise mostly identical.  This change adds the check.

Current behavior of `ToArray` in such a situation is to fire off the worker threads, which each perform one enumeration before checking for cancellation.  This change would prevent the worker threads from being started, so _may_ change use cases for some people.  Note that some operations (`SelectMany`, binaries) already perform the pre-emptive check anyways before enumerating a source, so the current behavior is very much dependent on what consumers call.

(besides the required discussion, will need to be rebased to account for other PRs I've submitted).