### PR TITLE
Two minor path-related changes

### DIFF
--- a/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -24,17 +24,8 @@
   </ItemGroup>
   <!-- Windows -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
-      <Link>Common\System\IO\PathInternal.Windows.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseInsensitive.cs">
       <Link>Common\System\IO\PathInternal.CaseInsensitive.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <!-- Unix -->
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
-      <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- FreeBSD -->


### PR DESCRIPTION
Two minor-path related changes:

- System.IO.Compression.ZipFile was unnecessarily including PathInternals.Windows/Unix.cs

- A System.Runtime test for PathTooLongException was passing but for the wrong reason: on Windows it was testing a path longer than max path, whereas on Unix it happened to be passing because of limitations on directory length in a path.  I've tweaked it to avoid assumptions about max path length.

I found these by scrubbing through all of corefx looking for additional uses of max path.  The only other one now outside of System.IO.FileSystem / System.Runtime.Extensions and the associated interop files is in Semaphore, which limits a semaphore name to be MAX_PATH.  We'll need to address that separately when we determine how best to handle named synchronization primitives on Unix (the limit is unlikely to be the MAX_PATH equivalent on Unix.)