### PR TITLE
Remove Tools dependency from System.Numerics.Vectors.WindowsRuntime

### DIFF
--- a/src/System.Numerics.Vectors.WindowsRuntime/src/project.json
+++ b/src/System.Numerics.Vectors.WindowsRuntime/src/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "System.Diagnostics.Tools": "4.1.0-beta-*",
     "System.Numerics.Vectors": "4.1.0-beta-*",
     "System.Runtime.WindowsRuntime": "4.0.0-beta-*",
   },

--- a/src/System.Numerics.Vectors.WindowsRuntime/src/project.lock.json
+++ b/src/System.Numerics.Vectors.WindowsRuntime/src/project.lock.json
@@ -465,7 +465,6 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "System.Diagnostics.Tools >= 4.1.0-beta-*",
       "System.Numerics.Vectors >= 4.1.0-beta-*",
       "System.Runtime.WindowsRuntime >= 4.0.0-beta-*"
     ],


### PR DESCRIPTION
System.Diagnostics.Tools isn't actually needed in this library at all, and the version used here is actually wrong anyways (package version is 4.0.0, not 4.1.0).