### PR TITLE
More informative failure from Queryable_Tests.MatchSequencePattern()

### DIFF
--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -1789,7 +1789,8 @@ namespace Tests
                     Console.WriteLine(m);
                 }
             }
-
+            Assert.Equal(Enumerable.Empty<string>(), list.Select(mi => mi.Name));
+            Assert.Equal(Enumerable.Empty<string>(), list2.Select(mi => mi.Name));
             Assert.True(list.Count == 0 && list2.Count == 0);
         }
 


### PR DESCRIPTION
When experimenting with #2322 for a while I hit a snag with
Queryable_Tests.MatchSequencePattern. While this does Console.Write()
the error cases, that's not helpful if you don't hit the problem
locally, but do on the CI build.

This change makes the failure message more directly informative. It
leaves the old assertion in place, so no flaw in this change should
hide a bug that the test would previously have caught.