### PR TITLE
PLINQ - Correct type used in constructor.

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ZipQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ZipQueryOperator.cs
@@ -43,7 +43,7 @@ namespace System.Linq.Parallel
         //
 
         internal ZipQueryOperator(
-            ParallelQuery<TLeftInput> leftChildSource, IEnumerable<TRightInput> rightChildSource,
+            ParallelQuery<TLeftInput> leftChildSource, ParallelQuery<TRightInput> rightChildSource,
             Func<TLeftInput, TRightInput, TOutput> resultSelector)
             : this(
                 QueryOperator<TLeftInput>.AsQueryOperator(leftChildSource),


### PR DESCRIPTION
For some reason, PLINQ's version of `Zip` references `IEnumerable` for the second operator, instead of `ParallelQuery`.  Since it was immediately casting (pretty much), it's unlikely this had any negative effects, but it's something to correct.