### PR TITLE
Fix System.Security.Cryptography.RSA handle leaks

### DIFF
--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/CapiHelper.cs
@@ -184,6 +184,15 @@ namespace Internal.NativeCrypto
             return ret;
         }
 
+
+        /// <summary>
+        /// Acquire a handle to a crypto service provider and optionally a key container
+        /// </summary>
+        public static bool CryptAcquireContext(out SafeProvHandle psafeProvHandle, string pszContainer, string pszProvider, int dwProvType, uint dwFlags)
+        {
+            return Interop.CryptAcquireContext(out psafeProvHandle, pszContainer, pszProvider, dwProvType, dwFlags);
+        }
+
         /// <summary>
         /// This method opens the CSP using CRYPT_VERIFYCONTEXT
         /// KeyContainer cannot be null for the flag CRYPT_VERIFYCONTEXT
@@ -1344,6 +1353,30 @@ namespace Internal.NativeCrypto
                 }
             }
         }
+
+        /// <summary>
+        /// Destroy a crypto provider.
+        /// </summary>
+        public static bool CryptReleaseContext(IntPtr safeProvHandle, int dwFlags)
+        {
+            return Interop.CryptReleaseContext(safeProvHandle, dwFlags);
+        }
+
+        /// <summary>
+        /// Destroy a crypto key.
+        /// </summary>
+        public static bool CryptDestroyKey(IntPtr hKey)
+        {
+            return Interop.CryptDestroyKey(hKey);
+        }
+
+        /// <summary>
+        /// Destroy a crypto hash.
+        /// </summary>
+        public static bool CryptDestroyHash(IntPtr hHash)
+        {
+            return Interop.CryptDestroyHash(hHash);
+        }
     }//End of class CapiHelper : Wrappers
 
 
@@ -1388,7 +1421,7 @@ namespace Internal.NativeCrypto
             public static extern bool CryptGenKey(SafeProvHandle safeProvHandle, int Algid, int dwFlags, ref SafeKeyHandle safeKeyHandle);
 
             [DllImport(AdvapiDll, SetLastError = true)]
-            public static extern bool CryptReleaseContext(SafeProvHandle safeProvHandle, int dwFlags);
+            public static extern bool CryptReleaseContext(IntPtr safeProvHandle, int dwFlags);
 
             [DllImport(AdvapiDll, SetLastError = true)]
             public static extern bool CryptDecrypt(SafeKeyHandle safeKeyHandle, SafeHashHandle safeHashHandle, bool Final,
@@ -1428,6 +1461,14 @@ namespace Internal.NativeCrypto
             [DllImport(AdvapiDll, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CryptVerifySignatureW")]
             [return: MarshalAs(UnmanagedType.Bool)]
             public static extern bool CryptVerifySignature(SafeHashHandle hHash, byte[] pbSignature, int dwSigLen, SafeKeyHandle hPubKey, String sDescription, CryptSignAndVerifyHashFlags dwFlags);
+
+            [DllImport(AdvapiDll, CharSet = CharSet.Unicode, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool CryptDestroyKey(IntPtr hKey);
+
+            [DllImport(AdvapiDll, CharSet = CharSet.Unicode, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool CryptDestroyHash(IntPtr hHash);
         }
     } //End CapiHelper : Pinvokes
 

--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/SafeCryptoHandles.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/SafeCryptoHandles.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
+using Internal.NativeCrypto;
 
 namespace System.Security.Cryptography
 {
@@ -142,6 +144,22 @@ namespace System.Security.Cryptography
 
         protected override bool ReleaseHandle()
         {
+            // Make sure not to delete a key that we want to keep in the key container or an ephemeral key
+            if (!_fPersistKeyInCsp && 0 == (_flags & (uint)CapiHelper.CryptAcquireContextFlags.CRYPT_VERIFYCONTEXT))
+            {
+                // Delete the key container. 
+
+                uint flags = (_flags & (uint)CapiHelper.CryptAcquireContextFlags.CRYPT_MACHINE_KEYSET) | (uint)CapiHelper.CryptAcquireContextFlags.CRYPT_DELETEKEYSET;
+                SafeProvHandle hIgnoredProv;
+                bool ignoredSuccess = CapiHelper.CryptAcquireContext(out hIgnoredProv, _containerName, _providerName, _type, flags);
+
+                // Ignoring success result code as CryptAcquireContext is being called to delete a key container rather than acquire a context.
+                // If it fails, we can't do anything about it anyway as we're in a dispose method.
+            }
+
+            bool successfullyFreed = CapiHelper.CryptReleaseContext(handle, 0);
+            Debug.Assert(successfullyFreed);
+
             SetHandle(IntPtr.Zero);
             return true;
         }
@@ -216,7 +234,8 @@ namespace System.Security.Cryptography
         [SecurityCritical]
         protected override bool ReleaseHandle()
         {
-            //FreeKey(handle);
+            bool successfullyFreed = CapiHelper.CryptDestroyKey(handle);
+            Debug.Assert(successfullyFreed);
             return true;
         }
     }
@@ -247,7 +266,8 @@ namespace System.Security.Cryptography
         [SecurityCritical]
         protected override bool ReleaseHandle()
         {
-            //FreeHash(handle);
+            bool successfullyFreed = CapiHelper.CryptDestroyHash(handle);
+            Debug.Assert(successfullyFreed);
             return true;
         }
     }

--- a/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/SafeCryptoHandles.cs
+++ b/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/SafeCryptoHandles.cs
@@ -161,7 +161,7 @@ namespace System.Security.Cryptography
             Debug.Assert(successfullyFreed);
 
             SetHandle(IntPtr.Zero);
-            return true;
+            return successfullyFreed;
         }
     }
 
@@ -236,7 +236,7 @@ namespace System.Security.Cryptography
         {
             bool successfullyFreed = CapiHelper.CryptDestroyKey(handle);
             Debug.Assert(successfullyFreed);
-            return true;
+            return successfullyFreed;
         }
     }
 
@@ -268,7 +268,7 @@ namespace System.Security.Cryptography
         {
             bool successfullyFreed = CapiHelper.CryptDestroyHash(handle);
             Debug.Assert(successfullyFreed);
-            return true;
+            return successfullyFreed;
         }
     }
 }


### PR DESCRIPTION
Fixes #2229. Internal SafeHandles inside System.Security.Cryptography.RSA were ported
from closed source with their ReleaseHandle() implementations commented out
and never finished. This delta finishes them.