### PR TITLE
Avoid empty allocations in ConcurrentBag.GetEnumerator()

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -543,7 +543,7 @@ namespace System.Collections.Concurrent
         {
             // Short path if the bag is empty
             if (_headList == null)
-                return new List<T>().GetEnumerator(); // empty list
+                return ((IEnumerable<T>)Array.Empty<T>()).GetEnumerator();
 
             bool lockTaken = false;
             try


### PR DESCRIPTION
Avoid allocating a ```List<T>``` and an enumerator when the bag is empty.

(Noticed this while looking at #2335.)