### PR TITLE
Replace all non-test uses of new T[0] with Array.Empty<T>

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/EmptyReadOnlyCollection.cs
+++ b/src/Common/src/System/Dynamic/Utils/EmptyReadOnlyCollection.cs
@@ -10,6 +10,6 @@ namespace System.Dynamic.Utils
 {
     internal static class EmptyReadOnlyCollection<T>
     {
-        public static ReadOnlyCollection<T> Instance = new TrueReadOnlyCollection<T>(new T[0]);
+        public static ReadOnlyCollection<T> Instance = new TrueReadOnlyCollection<T>(Array.Empty<T>());
     }
 }

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -309,8 +309,8 @@ namespace System.Collections.Generic
         {
             T[] arr = new T[_size];
             if (_size == 0)
-                return arr;
-
+                return arr; // consider replacing with Array.Empty<T>() to be consistent with non-generic Queue
+            
             if (_head < _tail)
             {
                 Array.Copy(_array, _head, arr, 0, _size);

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObject.cs
@@ -22,7 +22,7 @@ namespace System.Dynamic
         /// Represents an empty array of type <see cref="DynamicMetaObject"/>. This field is read only.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2105:ArrayFieldsShouldNotBeReadOnly")]
-        public static readonly DynamicMetaObject[] EmptyMetaObjects = new DynamicMetaObject[0];
+        public static readonly DynamicMetaObject[] EmptyMetaObjects = Array.Empty<DynamicMetaObject>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicMetaObject"/> class.

--- a/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/RuleCache.cs
+++ b/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/RuleCache.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.CompilerServices
     [EditorBrowsable(EditorBrowsableState.Never), DebuggerStepThrough]
     public class RuleCache<T> where T : class
     {
-        private T[] _rules = new T[0];
+        private T[] _rules = Array.Empty<T>();
         private readonly Object _cacheLock = new Object();
 
         private const int MaxRules = 128;

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3159,7 +3159,7 @@ namespace System.Linq
 
         internal TElement[] ToArray()
         {
-            if (count == 0) return new TElement[0];
+            if (count == 0) return new TElement[0]; // consider replacing with Array.Empty<TElement>()
             if (items.Length == count) return items;
 
             var arr = new TElement[count];

--- a/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesCngCryptoDecryptor.cs
+++ b/src/System.Security.Cryptography.Encryption.Aes/src/Internal/Cryptography/AesCngCryptoDecryptor.cs
@@ -126,7 +126,7 @@ namespace Internal.Cryptography
             }
             else
             {
-                outputData = new byte[0];
+                outputData = Array.Empty<byte>();
             }
             return outputData;
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.GetChainStatusInformation.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.GetChainStatusInformation.cs
@@ -25,7 +25,7 @@ namespace Internal.Cryptography.Pal
         private static X509ChainStatus[] GetChainStatusInformation(CertTrustErrorStatus dwStatus)
         {
             if (dwStatus == CertTrustErrorStatus.CERT_TRUST_NO_ERROR)
-                return new X509ChainStatus[0];
+                return Array.Empty<X509ChainStatus>();
 
             int count = 0;
             for (uint bits = (uint)dwStatus; bits != 0; bits = bits >> 1)

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.X509Certificates
                 // We give the user a reference to the array since we'll never access it.
                 X509ChainStatus[] chainStatus = _lazyChainStatus;
                 if (chainStatus == null)
-                    chainStatus = _lazyChainStatus = (_pal == null ? new X509ChainStatus[0] : _pal.ChainStatus);
+                    chainStatus = _lazyChainStatus = (_pal == null ? Array.Empty<X509ChainStatus>() : _pal.ChainStatus);
                 return chainStatus;
             }
         }

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XAttribute.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XAttribute.cs
@@ -18,8 +18,6 @@ namespace System.Xml.Linq
     [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification = "Reviewed.")]
     public class XAttribute : XObject
     {
-        private static IEnumerable<XAttribute> s_emptySequence;
-
         /// <summary>
         /// Gets an empty collection of attributes.
         /// </summary>
@@ -27,8 +25,7 @@ namespace System.Xml.Linq
         {
             get
             {
-                if (s_emptySequence == null) s_emptySequence = new XAttribute[0];
-                return s_emptySequence;
+				return Array.Empty<XAttribute>();
             }
         }
 

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
@@ -30,8 +30,6 @@ namespace System.Xml.Linq
     [XmlSchemaProvider(null, IsAny = true)]
     public class XElement : XContainer, IXmlSerializable
     {
-        private static IEnumerable<XElement> s_emptySequence;
-
         /// <summary>
         /// Gets an empty collection of elements.
         /// </summary>
@@ -39,8 +37,7 @@ namespace System.Xml.Linq
         {
             get
             {
-                if (s_emptySequence == null) s_emptySequence = new XElement[0];
-                return s_emptySequence;
+				return Array.Empty<XElement>();
             }
         }
 

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -583,7 +583,7 @@ namespace System.Xml.Serialization
             mapping.TypeDesc = typeDesc;
             mapping.TypeName = Soap.UrType;
             mapping.Namespace = XmlSchema.Namespace;
-            mapping.Members = new MemberMapping[0];
+            mapping.Members = Array.Empty<MemberMapping>();
             mapping.IncludeInSchema = false;
             return mapping;
         }

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
@@ -530,13 +530,13 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public static XmlSerializer[] FromMappings(XmlMapping[] mappings, Type type)
         {
-            if (mappings == null || mappings.Length == 0) return new XmlSerializer[0];
+            if (mappings == null || mappings.Length == 0) return Array.Empty<XmlSerializer>();
             XmlSerializerImplementation contract = null;
             TempAssembly tempAssembly = null;
             {
                 if (XmlMapping.IsShallow(mappings))
                 {
-                    return new XmlSerializer[0];
+                    return Array.Empty<XmlSerializer>();
                 }
                 else
                 {
@@ -627,7 +627,7 @@ namespace System.Xml.Serialization
         public static XmlSerializer[] FromTypes(Type[] types)
         {
             if (types == null)
-                return new XmlSerializer[0];
+                return Array.Empty<XmlSerializer>();
             XmlReflectionImporter importer = new XmlReflectionImporter();
             XmlTypeMapping[] mappings = new XmlTypeMapping[types.Length];
             for (int i = 0; i < types.Length; i++)

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
@@ -83,7 +83,7 @@ namespace System.Xml.Serialization
         public XmlQualifiedName[] ToArray()
         {
             if (NamespaceList == null)
-                return new XmlQualifiedName[0];
+                return Array.Empty<XmlQualifiedName>();
             return (XmlQualifiedName[])NamespaceList.ToArray(typeof(XmlQualifiedName));
         }
 


### PR DESCRIPTION
I ran a little shell command to find and replace most of the occurrences of `new T[0]` in the repo:

    cd corefx
    grep -rl "new [^ (]*\[0\]" . | grep -vi test | xargs start notepad++

There were about 18 matches, with an additional match I spotted in `Queue<T>.ToArray`.

Additional notes:

 - Removed caching of `EmptySequence` in `XElement` and `XAttribute`; this is already done by `Array.Empty`.
 - The build should fail at first because I forgot to add `using` statements to the classes I changed. Will fix once the compiler tells where it can't recognize `Array`.