### PR TITLE
Adding new Unit Tests to the FileSystemWatcher code base

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
@@ -77,7 +77,7 @@ public partial class FileSystemWatcher_4000_Tests
     }
 
     [Fact, ActiveIssue(2279)]
-    public static void FileSystemWatcher_ChangeWatchedFolder()
+    public static void FileSystemWatcher_Changed_WatchedFolder()
     {
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
@@ -92,5 +92,30 @@ public partial class FileSystemWatcher_4000_Tests
 
             Utility.ExpectEvent(eventOccured, "changed");
         }
+    }
+
+    [Fact]
+    public static void FileSystemWatcher_Changed_NestedDirectories()
+    {
+        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Changed, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
+        {
+            Directory.SetLastAccessTime(ttd.Path, DateTime.Now);
+            Utility.ExpectEvent(are, "changed");
+        },
+        NotifyFilters.DirectoryName | NotifyFilters.LastAccess);
+    }
+
+    [Fact]
+    public static void FileSystemWatcher_Changed_FileInNestedDirectory()
+    {
+        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Changed, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
+        {
+            using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
+            {
+                Directory.SetLastAccessTime(nestedFile.Path, DateTime.Now);
+                Utility.ExpectEvent(are, "changed");
+            }
+        },
+        NotifyFilters.DirectoryName | NotifyFilters.LastAccess | NotifyFilters.FileName);
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -111,4 +111,16 @@ public partial class FileSystemWatcher_4000_Tests
             Utility.ExpectNoEvent(eventOccured, "created");
         }
     }
+
+    [Fact]
+    public static void FileSystemWatcher_Created_FileCreatedInNestedDirectory()
+    {
+        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Created, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
+        {
+            using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
+            {
+                Utility.ExpectEvent(are, "nested file created", 1000 * 30);
+            }
+        });
+    }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Threading;
 using Xunit;
@@ -78,5 +77,28 @@ public partial class FileSystemWatcher_4000_Tests
 
             Utility.ExpectNoEvent(eventOccured, "created");
         }
+    }
+
+    [Fact]
+    public static void FileSystemWatcher_Renamed_NestedDirectory()
+    {
+        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Renamed, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
+        {
+            ttd.Move(ttd.Path + "_2");
+            Utility.ExpectEvent(are, "renamed");
+        });
+    }
+
+    [Fact]
+    public static void FileSystemWatcher_Renamed_FileInNestedDirectory()
+    {
+        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Renamed, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
+        {
+            using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
+            {
+                nestedFile.Move(nestedFile.Path + "_2");
+                Utility.ExpectEvent(are, "renamed");
+            }
+        });
     }
 }


### PR DESCRIPTION
Adding new UTs to the FSW class and fixing a bug in the Linux FSW where we would debug assert when cleaning up or when receiving an IGNORE notification for a directory that did not exist on disk