### PR TITLE
Enumerable.ToHashSet() Method

### DIFF
--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -1759,7 +1759,8 @@ namespace Tests
                      "AsEnumerable",
                      "ToList",
                      "Fold",
-                     "LeftJoin"
+                     "LeftJoin",
+                     "ToHashSet"
                  }
                 ).ToList();
 

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1071,6 +1071,17 @@ namespace System.Linq
             return d;
         }
 
+        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source)
+        {
+            return ToHashSet<TSource>(source, null);
+        }
+
+        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
+        {
+            if (source == null) throw Error.ArgumentNull("source");
+            return new HashSet<TSource>(source, comparer);
+        }
+
         public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
             return Lookup<TKey, TSource>.Create(source, keySelector, IdentityFunction<TSource>.Instance, null);

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="CachedEnumerator.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="EmptyEnumerable.cs" />
+    <Compile Include="ToHashSetTests.cs" />
     <Compile Include="Helpers\TestCollection.cs" />
     <Compile Include="Helpers\TestEnumerable.cs" />
     <Compile Include="Helpers\TestReadOnlyCollection.cs" />

--- a/src/System.Linq/tests/ToHashSetTests.cs
+++ b/src/System.Linq/tests/ToHashSetTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class ToHashSetTests
+    {
+        private class CustomComparer<T> : IEqualityComparer<T>
+        {
+            public bool Equals(T x, T y) { return EqualityComparer<T>.Default.Equals(x, y); }
+            public int GetHashCode(T obj) { return EqualityComparer<T>.Default.GetHashCode(obj); }
+            public override bool Equals(object obj)
+            {
+                return obj is CustomComparer<T>;
+            }
+            public override int GetHashCode()
+            {
+                return -465576218; // Equals all instances of same class, so randomly-produced constant.
+            }
+        }
+        [Fact]
+        public void NoExplicitComparer()
+        {
+            var hs = Enumerable.Range(0, 50).ToHashSet();
+            Assert.IsType<HashSet<int>>(hs);
+            Assert.Equal(50, hs.Count);
+            Assert.Equal(EqualityComparer<int>.Default, hs.Comparer);
+        }
+        [Fact]
+        public void ExplicitComparer()
+        {
+            var hs = Enumerable.Range(0, 50).ToHashSet(new CustomComparer<int>());
+            Assert.IsType<HashSet<int>>(hs);
+            Assert.Equal(50, hs.Count);
+            Assert.Equal(new CustomComparer<int>(), hs.Comparer);
+        }
+        [Fact]
+        public void TolerateNullElements()
+        {
+            // Unlike the keys of a dictionary, HashSet tolerates null items.
+            new string[] { "abc", null, "def" }.ToHashSet();
+        }
+        [Fact]
+        public void TolerateDuplicates()
+        {
+            // ToDictionary throws on duplicates, because that is the normal behaviour
+            // of Dictionary<TKey, TValue>.Add().
+            // By the same token, since the normal behaviour of HashSet<T>.Add()
+            // is to signal duplicates without an exception ToHashSet should
+            // tolerate duplicates.
+            var hs = Enumerable.Range(0, 50).Select(i => i / 5).ToHashSet();
+            // The OrderBy isn't strictly necessary, but that depends upon an
+            // implementation detail of HashSet, so explicitly force ordering.
+            Assert.Equal(Enumerable.Range(0, 10), hs.OrderBy(i => i));
+        }
+        [Fact]
+        public void ThrowOnNullSource()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IEnumerable<object>)null).ToHashSet());
+        }
+    }
+}

--- a/src/System.Linq/tests/ToHashSetTests.cs
+++ b/src/System.Linq/tests/ToHashSetTests.cs
@@ -40,7 +40,9 @@ namespace System.Linq.Tests
         public void TolerateNullElements()
         {
             // Unlike the keys of a dictionary, HashSet tolerates null items.
-            new string[] { "abc", null, "def" }.ToHashSet();
+            Assert.False(new HashSet<string>().Contains(null));
+            var hs = new string[] { "abc", null, "def" }.ToHashSet();
+            Assert.True(hs.Contains(null));
         }
         [Fact]
         public void TolerateDuplicates()


### PR DESCRIPTION
Fixes #2323

Overload for explicit selection of IEqualityComparer, overload
for defaulting to HashSet's default (which is EqualityComparer.Default).