### PR TITLE
Don't use Array.Reverse in ImmutableArray<T>.Builder.Reverse

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -624,7 +624,21 @@ namespace System.Collections.Immutable
             /// </summary>
             public void Reverse()
             {
-                Array.Reverse(_elements, 0, _count);
+                // The non-generic Array.Reverse is not used because it does not perform
+                // well for non-primitive value types.
+                // If/when a generic Array.Reverse<T> becomes available, the below code
+                // can be deleted and replaced with a call to Array.Reverse<T>.
+                int i = 0;
+                int j = _count - 1;
+                T[] array = _elements;
+                while (i < j)
+                {
+                    T temp = array[i];
+                    array[i] = array[j];
+                    array[j] = temp;
+                    i++;
+                    j--;
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
The non-generic `Array.Reverse` does not perform well for non-primitive value types.

See the following for details:
https://github.com/dotnet/coreclr/pull/1231

Note: I considered adding a common `ArrayHelpers` class, as there are some other uses of `Array.Reverse` in corefx. However, the other uses didn't seem to warrant the use of the improved `Reverse`:
 - Crypto calls `Array.Reverse` on `byte[]` which is a primitive type that `Array.Reverse` has a fast-path for ([example](https://github.com/dotnet/corefx/blob/e7c238a0799519a837260f42eccedb5544402ed2/src/System.Security.Cryptography.RSA/src/System/Security/Cryptography/CapiHelper.cs#L1023), [example](https://github.com/dotnet/corefx/blob/683853af77ad76a39fdd951de07ee6811ea28a5b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs#L286), etc.).
 - [`Stack<T>.CopyTo`](https://github.com/dotnet/corefx/blob/6504501399c6f9ea4d48296058e7e9a57e41ca21/src/System.Collections/src/System/Collections/Generic/Stack.cs#L145) calls `Array.Reverse` only in a rare case
 - [`ReadOnlyCollectionBuilder<T>`](https://github.com/dotnet/corefx/blob/master/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs#L439) is internal and it doesn't look like `ReadOnlyCollectionBuilder.Reverse` is actually used at all.