### PR TITLE
System.Globalization.Tests.csproj: fix casing of file name

### DIFF
--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -120,7 +120,7 @@
     <Compile Include="NumberStyles\NumberStylesInteger.cs" />
     <Compile Include="NumberStyles\NumberStylesNone.cs" />
     <Compile Include="NumberStyles\NumberStylesNumber.cs" />
-    <Compile Include="RegionInfo\RegionInfo.cs" />
+    <Compile Include="RegionInfo\regioninfo.cs" />
     <Compile Include="RegionInfo\RegionInfoConstruction.cs" />
     <Compile Include="RegionInfo\regioninfo\RegionInfoCtor1.cs" />
     <Compile Include="RegionInfo\regioninfo\RegionInfoCtor2.cs" />


### PR DESCRIPTION
It didn't compile on Linux cause the file on disk has a different casing.