### PR TITLE
Restoring the return type of the Expression<TDelegate>.Update

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
@@ -430,7 +430,7 @@ namespace System.Linq.Expressions
             return node;
         }
 
-        protected internal override Expression VisitLambda(LambdaExpression node)
+        protected internal override Expression VisitLambda<T>(Expression<T> node)
         {
             Out(
                 String.Format(CultureInfo.CurrentCulture,

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -326,7 +326,7 @@ namespace System.Linq.Expressions
             return node;
         }
 
-        protected internal override Expression VisitLambda(LambdaExpression node)
+        protected internal override Expression VisitLambda<T>(Expression<T> node)
         {
             if (node.Parameters.Count == 1)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -365,18 +365,6 @@ namespace System.Linq.Expressions
         /// otherwise, returns the original expression.</returns>
         protected internal virtual Expression VisitLambda<T>(Expression<T> node)
         {
-            return VisitLambda((LambdaExpression)node);
-        }
-
-        /// <summary>
-        /// Visits the children of the <see cref="LambdaExpression" />.
-        /// </summary>
-        /// <typeparam name="T">The type of the delegate.</typeparam>
-        /// <param name="node">The expression to visit.</param>
-        /// <returns>The modified expression, if it or any subexpression was modified;
-        /// otherwise, returns the original expression.</returns>
-        protected internal virtual Expression VisitLambda(LambdaExpression node)
-        {
             return node.Update(Visit(node.Body), VisitAndConvert(node.Parameters, "VisitLambda"));
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2694,7 +2694,7 @@ namespace System.Linq.Expressions.Interpreter
                 return node;
             }
 
-            protected internal override Expression VisitLambda(LambdaExpression node)
+            protected internal override Expression VisitLambda<T>(Expression<T> node)
             {
                 PushParameters(node.Parameters);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -2262,7 +2262,7 @@ namespace System.Linq.Expressions.Interpreter
                 _frame = frame;
             }
 
-            protected internal override Expression VisitLambda(LambdaExpression node)
+            protected internal override Expression VisitLambda<T>(Expression<T> node)
             {
                 _shadowedVars.Push(new Set<ParameterExpression>(node.Parameters));
                 Expression b = Visit(node.Body);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -120,23 +120,6 @@ namespace System.Linq.Expressions
 #endif 
         }
 
-        /// <summary>
-        /// Dispatches to the specific visit method for this node type.
-        /// </summary>
-        protected internal override Expression Accept(ExpressionVisitor visitor)
-        {
-            return visitor.VisitLambda(this);
-        }
-
-        public virtual LambdaExpression Update(Expression body, IEnumerable<ParameterExpression> parameters)
-        {
-            if (body == Body && parameters == Parameters)
-            {
-                return this;
-            }
-            return Expression.Lambda(Type, body, Name, TailCall, parameters);
-        }
-
 #if FEATURE_CORECLR
         internal abstract LambdaExpression Accept(Compiler.StackSpiller spiller);
 #endif 
@@ -178,7 +161,7 @@ namespace System.Linq.Expressions
         /// <param name="body">The <see cref="LambdaExpression.Body">Body</see> property of the result.</param>
         /// <param name="parameters">The <see cref="LambdaExpression.Parameters">Parameters</see> property of the result.</param>
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
-        public override LambdaExpression Update(Expression body, IEnumerable<ParameterExpression> parameters)
+        public Expression<TDelegate> Update(Expression body, IEnumerable<ParameterExpression> parameters)
         {
             if (body == Body && parameters == Parameters)
             {

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -3870,6 +3870,27 @@ namespace Tests
             Assert.Equal("null", f(null));
         }
 
+        static class System_Linq_Expressions_Expression_TDelegate__1
+        {
+            public static T Default<T>() { return default(T); }
+            public static void UseSystem_Linq_Expressions_Expression_TDelegate__1(bool call) // call this passing false
+            {
+                if (call)
+                {
+                    Default<System.Linq.Expressions.Expression<System.Object>>().Compile();
+                    Default<System.Linq.Expressions.Expression<System.Object>>().Update(
+                Default<System.Linq.Expressions.Expression>(),
+                Default<System.Collections.Generic.IEnumerable<System.Linq.Expressions.ParameterExpression>>());
+                }
+            }
+        }
+
+        [Fact]
+        public static void ExprT_Update()
+        {
+            System_Linq_Expressions_Expression_TDelegate__1.UseSystem_Linq_Expressions_Expression_TDelegate__1(false);
+        }
+
         public class TestComparers
         {
             public static bool CaseInsensitiveStringCompare(string s1, string s2)


### PR DESCRIPTION
The method is a public API and is used to return Expression< TDelegate >