### PR TITLE
CoreFX 32 bit support

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.readdir.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.readdir.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
+        [DllImport(Libraries.Libc, SetLastError = true, EntryPoint = "readdir64")]
         internal static extern IntPtr readdir(SafeDirHandle dirp);
 
         internal static unsafe DType GetDirEntType(IntPtr dirEnt)

--- a/src/Common/src/Interop/Unix/libc/Interop.ftruncate.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.ftruncate.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
+        [DllImport(Libraries.Libc, SetLastError = true, EntryPoint = "ftruncate64")]
         internal static extern int ftruncate(int fd, off_t length);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.lseek.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.lseek.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
+        [DllImport(Libraries.Libc, SetLastError = true, EntryPoint = "lseek64")]
         internal static extern off_t lseek(int fd, off_t offset, SeekWhence whence);
 
         internal enum SeekWhence

--- a/src/Common/src/Interop/Unix/libc/Interop.mkstemps.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.mkstemps.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
+        [DllImport(Libraries.Libc, SetLastError = true, EntryPoint = "mkstemps64")]
         internal static extern int mkstemps(byte[] template, int suffixlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.mmap.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.mmap.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
+        [DllImport(Libraries.Libc, SetLastError = true, EntryPoint = "mmap64")]
         internal static extern IntPtr mmap(
             IntPtr addr, size_t len, 
             MemoryMappedProtections prot, MemoryMappedFlags flags,

--- a/src/Common/src/Interop/Unix/libc/Interop.open.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.open.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
+        [DllImport(Libraries.Libc, SetLastError = true, EntryPoint = "open64")]
         internal static extern int open(string filename, OpenFlags flags, mode_t mode);
     }
 }


### PR DESCRIPTION
Whilst working on the ARM version of CoreCLR I ran into a few issues because CoreFX assumes that the file functions will be the large file support versions in some cases, where they are not. I have added support to those that I have found and know that the LFS version exists. I wasn't sure on the best way to do this change, so I have currently added an EntryPoint parameter to the DllImport attribute, though I could also rename the functions but that touches a lot of code for no benefit in my eyes. I don't believe this should cause any breaks on other platforms but CI should show if it does.

Related to https://github.com/dotnet/coreclr/pull/1210