### PR TITLE
Ensure all Common includes use a <Link/>

### DIFF
--- a/src/Common/tests/SystemXml/ModuleCore/ModuleCore.csproj
+++ b/src/Common/tests/SystemXml/ModuleCore/ModuleCore.csproj
@@ -26,7 +26,9 @@
     <Compile Include="ctestmodule.cs" />
     <Compile Include="cvariation.cs" />
     <Compile Include="interop.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Common/tests/SystemXml/XmlCoreTest/XmlCoreTest.csproj
+++ b/src/Common/tests/SystemXml/XmlCoreTest/XmlCoreTest.csproj
@@ -24,7 +24,9 @@
     <Compile Include="UnicodeCharHelper.cs" />
     <Compile Include="WriterFactory.cs" />
     <Compile Include="TestData.g.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -26,7 +26,9 @@
     <Compile Include="Timeout.cs" />
     <Compile Include="ThreadSafety.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Console.csproj">

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -34,7 +34,9 @@
   <ItemGroup>
     <Compile Include="FileVersionInfoTest.cs" />
     <Compile Include="Interop\Interop.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- References used -->
   <ItemGroup>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -21,7 +21,9 @@
     <Compile Include="ProcessTests.cs" />
     <Compile Include="ProcessStandardConsoleTests.cs" />
     <Compile Include="ProcessStreamReadTests.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="ProcessTestBase.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -22,12 +22,24 @@
     <Compile Include="ZipFileTests.cs" />
     <Compile Include="ZipFileInvalidFileTests.cs" />
     <Compile Include="ZipFileReadOpenUpdateTests.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\CRC.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\FileData.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\LocalMemoryStream.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\StreamHelpers.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\ZipTestHelper.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\CRC.cs">
+      <Link>Common\Compression\Utilities\CRC.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\FileData.cs">
+      <Link>Common\Compression\Utilities\FileData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\LocalMemoryStream.cs">
+      <Link>Common\Compression\Utilities\LocalMemoryStream.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\StreamHelpers.cs">
+      <Link>Common\Compression\Utilities\StreamHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\ZipTestHelper.cs">
+      <Link>Common\Compression\Utilities\ZipTestHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -62,12 +62,16 @@
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="System\IO\Compression\DeflateStream.Windows.cs" />
     <Compile Include="System\IO\Compression\ZLibNative.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\IO\Compression\DeflateStream.Unix.cs" />
     <Compile Include="System\IO\Compression\ZLibNative.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -32,12 +32,24 @@
     <Compile Include="ZipArchive\zip_UpdateTests.cs" />
     <Compile Include="Utilities\StripHeaderAndFooter.cs" />
     <Compile Include="Utilities\WrappedStream.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\CRC.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\FileData.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\LocalMemoryStream.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\StreamHelpers.cs" />
-    <Compile Include="$(CommonTestPath)\Compression\Utilities\ZipTestHelper.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\CRC.cs">
+      <Link>Common\Compression\Utilities\CRC.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\FileData.cs">
+      <Link>Common\Compression\Utilities\FileData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\LocalMemoryStream.cs">
+      <Link>Common\Compression\Utilities\LocalMemoryStream.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\StreamHelpers.cs">
+      <Link>Common\Compression\Utilities\StreamHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Compression\Utilities\ZipTestHelper.cs">
+      <Link>Common\Compression\Utilities\ZipTestHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <!-- Temporary until we have new work in build tools to

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -33,7 +33,9 @@
     <Compile Include="FileSystemEventArgs.unit.cs" />
     <Compile Include="FileSystemWatcher.unit.cs" />
     <Compile Include="RenamedEventArgs.unit.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -206,7 +206,9 @@
     <Compile Include="FileInfo\CopyTo_str.cs" />
     <Compile Include="FileInfo\CopyTo_str_b.cs" />
     <!-- Helpers -->
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -22,7 +22,9 @@
     <Compile Include="AnonymousPipesThrowsTests.cs" />
     <Compile Include="NamedPipesSimpleTest.cs" />
     <Compile Include="NamedPipesThrowsTests.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Automatically added by VS -->
   <ItemGroup>

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -87,7 +87,9 @@
   </ItemGroup>
   <!-- Common or Common-branched source files -->
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Console.cs" />
+    <Compile Include="$(CommonTestPath)\System\Console.cs">
+      <Link>Common\System\Console.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Parallel.csproj">

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -130,7 +130,7 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\Http\HttpClientHandler.Unix.cs" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
-      <Link>NotImplemented.cs</Link>
+      <Link>Common\System\NotImplemented.cs</Link>
     </Compile>    
   </ItemGroup>
   

--- a/src/System.Net.Http/tests/System.Net.Http.Tests.csproj
+++ b/src/System.Net.Http/tests/System.Net.Http.Tests.csproj
@@ -22,245 +22,245 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />  
   
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\NotImplemented.cs">
-      <Link>ProductionCode\NotImplemented.cs</Link>
+    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+      <Link>ProductionCode\Common\System\NotImplemented.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\HttpKnownHeaderNames.cs">
-      <Link>ProductionCode\HttpKnownHeaderNames.cs</Link>
+      <Link>ProductionCode\Internal\HttpKnownHeaderNames.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\HttpStatusDescription.cs">
-      <Link>ProductionCode\HttpStatusDescription.cs</Link>
+      <Link>ProductionCode\Internal\HttpStatusDescription.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\HttpVersion.cs">
-      <Link>ProductionCode\HttpVersion.cs</Link>
+      <Link>ProductionCode\Internal\HttpVersion.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\ICloneable.cs">
-      <Link>ProductionCode\ICloneable.cs</Link>
+      <Link>ProductionCode\Internal\ICloneable.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\MailAddress.cs">
-      <Link>ProductionCode\MailAddress.cs</Link>
+      <Link>ProductionCode\Internal\MailAddress.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\DomainLiteralReader.cs">
-      <Link>ProductionCode\DomainLiteralReader.cs</Link>
+      <Link>ProductionCode\Internal\DomainLiteralReader.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\DotAtomReader.cs">
-      <Link>ProductionCode\DotAtomReader.cs</Link>
+      <Link>ProductionCode\Internal\DotAtomReader.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\MailAddressParser.cs">
-      <Link>ProductionCode\MailAddressParser.cs</Link>
+      <Link>ProductionCode\Internal\MailAddressParser.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\MailBnfHelper.cs">
-      <Link>ProductionCode\MailBnfHelper.cs</Link>
+      <Link>ProductionCode\Internal\MailBnfHelper.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\QuotedPairReader.cs">
-      <Link>ProductionCode\QuotedPairReader.cs</Link>
+      <Link>ProductionCode\Internal\QuotedPairReader.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\QuotedStringFormatReader.cs">
-      <Link>ProductionCode\QuotedStringFormatReader.cs</Link>
+      <Link>ProductionCode\Internal\QuotedStringFormatReader.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Mail\WhitespaceReader.cs">
-      <Link>ProductionCode\WhitespaceReader.cs</Link>
+      <Link>ProductionCode\Internal\WhitespaceReader.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\Logging.cs">
-      <Link>ProductionCode\Logging.cs</Link>
+      <Link>ProductionCode\Internal\Logging.cs</Link>
     </Compile>
     <Compile Include="..\src\Internal\UriHelper.cs">
-      <Link>ProductionCode\UriHelper.cs</Link>
+      <Link>ProductionCode\Internal\UriHelper.cs</Link>
     </Compile>
     <Compile Include="..\src\Shims\Uri.cs">
-      <Link>ProductionCode\Uri.cs</Link>
+      <Link>ProductionCode\Shims\Uri.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\ByteArrayContent.cs">
-      <Link>ProductionCode\ByteArrayContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\ByteArrayContent.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\ClientCertificateOption.cs">
-      <Link>ProductionCode\ClientCertificateOption.cs</Link>
+      <Link>ProductionCode\System\Net\Http\ClientCertificateOption.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\DelegatingHandler.cs">
-      <Link>ProductionCode\DelegatingHandler.cs</Link>
+      <Link>ProductionCode\System\Net\Http\DelegatingHandler.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\DelegatingStream.cs">
-      <Link>ProductionCode\DelegatingStream.cs</Link>
+      <Link>ProductionCode\System\Net\Http\DelegatingStream.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\FormUrlEncodedContent.cs">
-      <Link>ProductionCode\FormUrlEncodedContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\FormUrlEncodedContent.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\AuthenticationHeaderValue.cs">
-      <Link>ProductionCode\AuthenticationHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\AuthenticationHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\BaseHeaderParser.cs">
-      <Link>ProductionCode\BaseHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\BaseHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ByteArrayHeaderParser.cs">
-      <Link>ProductionCode\ByteArrayHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ByteArrayHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\CacheControlHeaderParser.cs">
-      <Link>ProductionCode\CacheControlHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\CacheControlHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\CacheControlHeaderValue.cs">
-      <Link>ProductionCode\CacheControlHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\CacheControlHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ContentDispositionHeaderValue.cs">
-      <Link>ProductionCode\ContentDispositionHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ContentDispositionHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ContentRangeHeaderValue.cs">
-      <Link>ProductionCode\ContentRangeHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ContentRangeHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\DateHeaderParser.cs">
-      <Link>ProductionCode\DateHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\DateHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\EntityTagHeaderValue.cs">
-      <Link>ProductionCode\EntityTagHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\EntityTagHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\GenericHeaderParser.cs">
-      <Link>ProductionCode\GenericHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\GenericHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HeaderUtilities.cs">
-      <Link>ProductionCode\HeaderUtilities.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HeaderUtilities.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpContentHeaders.cs">
-      <Link>ProductionCode\HttpContentHeaders.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpContentHeaders.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpGeneralHeaders.cs">
-      <Link>ProductionCode\HttpGeneralHeaders.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpGeneralHeaders.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpHeaderParser.cs">
-      <Link>ProductionCode\HttpHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpHeaders.cs">
-      <Link>ProductionCode\HttpHeaders.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpHeaders.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpHeaderValueCollection.cs">
-      <Link>ProductionCode\HttpHeaderValueCollection.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpHeaderValueCollection.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpRequestHeaders.cs">
-      <Link>ProductionCode\HttpRequestHeaders.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpRequestHeaders.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\HttpResponseHeaders.cs">
-      <Link>ProductionCode\HttpResponseHeaders.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\HttpResponseHeaders.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\Int32NumberHeaderParser.cs">
-      <Link>ProductionCode\Int32NumberHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\Int32NumberHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\Int64NumberHeaderParser.cs">
-      <Link>ProductionCode\Int64NumberHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\Int64NumberHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\MediaTypeHeaderParser.cs">
-      <Link>ProductionCode\MediaTypeHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\MediaTypeHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\MediaTypeHeaderValue.cs">
-      <Link>ProductionCode\MediaTypeHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\MediaTypeHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\MediaTypeWithQualityHeaderValue.cs">
-      <Link>ProductionCode\MediaTypeWithQualityHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\MediaTypeWithQualityHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\NameValueHeaderValue.cs">
-      <Link>ProductionCode\NameValueHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\NameValueHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\NameValueWithParametersHeaderValue.cs">
-      <Link>ProductionCode\NameValueWithParametersHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ObjectCollection.cs">
-      <Link>ProductionCode\ObjectCollection.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ObjectCollection.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ProductHeaderValue.cs">
-      <Link>ProductionCode\ProductHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ProductHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ProductInfoHeaderParser.cs">
-      <Link>ProductionCode\ProductInfoHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ProductInfoHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ProductInfoHeaderValue.cs">
-      <Link>ProductionCode\ProductInfoHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ProductInfoHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\RangeConditionHeaderValue.cs">
-      <Link>ProductionCode\RangeConditionHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\RangeConditionHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\RangeHeaderValue.cs">
-      <Link>ProductionCode\RangeHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\RangeHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\RangeItemHeaderValue.cs">
-      <Link>ProductionCode\RangeItemHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\RangeItemHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\RetryConditionHeaderValue.cs">
-      <Link>ProductionCode\RetryConditionHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\RetryConditionHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\StringWithQualityHeaderValue.cs">
-      <Link>ProductionCode\StringWithQualityHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\StringWithQualityHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\TimeSpanHeaderParser.cs">
-      <Link>ProductionCode\TimeSpanHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\TimeSpanHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\TransferCodingHeaderParser.cs">
-      <Link>ProductionCode\TransferCodingHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\TransferCodingHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\TransferCodingHeaderValue.cs">
-      <Link>ProductionCode\TransferCodingHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\TransferCodingHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\TransferCodingWithQualityHeaderValue.cs">
-      <Link>ProductionCode\TransferCodingWithQualityHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\TransferCodingWithQualityHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\UriHeaderParser.cs">
-      <Link>ProductionCode\UriHeaderParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\UriHeaderParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\ViaHeaderValue.cs">
-      <Link>ProductionCode\ViaHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\ViaHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\Headers\WarningHeaderValue.cs">
-      <Link>ProductionCode\WarningHeaderValue.cs</Link>
+      <Link>ProductionCode\System\Net\Http\Headers\WarningHeaderValue.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpClient.cs">
-      <Link>ProductionCode\HttpClient.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpClient.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpCompletionOption.cs">
-      <Link>ProductionCode\HttpCompletionOption.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpCompletionOption.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpContent.cs">
-      <Link>ProductionCode\HttpContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpContent.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpMessageHandler.cs">
-      <Link>ProductionCode\HttpMessageHandler.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpMessageHandler.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpMessageInvoker.cs">
-      <Link>ProductionCode\HttpMessageInvoker.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpMessageInvoker.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpMethod.cs">
-      <Link>ProductionCode\HttpMethod.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpMethod.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpParseResult.cs">
-      <Link>ProductionCode\HttpParseResult.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpParseResult.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpRequestException.cs">
-      <Link>ProductionCode\HttpRequestException.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpRequestException.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpRequestMessage.cs">
-      <Link>ProductionCode\HttpRequestMessage.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpRequestMessage.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpResponseMessage.cs">
-      <Link>ProductionCode\HttpResponseMessage.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpResponseMessage.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpRuleParser.cs">
-      <Link>ProductionCode\HttpRuleParser.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpRuleParser.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\HttpUtilities.cs">
-      <Link>ProductionCode\HttpUtilities.cs</Link>
+      <Link>ProductionCode\System\Net\Http\HttpUtilities.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\MessageProcessingHandler.cs">
-      <Link>ProductionCode\MessageProcessingHandler.cs</Link>
+      <Link>ProductionCode\System\Net\Http\MessageProcessingHandler.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\MultipartContent.cs">
-      <Link>ProductionCode\MultipartContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\MultipartContent.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\MultipartFormDataContent.cs">
-      <Link>ProductionCode\MultipartFormDataContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\MultipartFormDataContent.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\StreamContent.cs">
-      <Link>ProductionCode\StreamContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\StreamContent.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\StreamToStreamCopy.cs">
-      <Link>ProductionCode\StreamToStreamCopy.cs</Link>
+      <Link>ProductionCode\System\Net\Http\StreamToStreamCopy.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Net\Http\StringContent.cs">
-      <Link>ProductionCode\StringContent.cs</Link>
+      <Link>ProductionCode\System\Net\Http\StringContent.cs</Link>
     </Compile>
     <Compile Include="Fakes\HttpClientHandler.cs" />
     <Compile Include="Headers\AuthenticationHeaderValueTest.cs" />

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -14,10 +14,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\Collections\IEnumerableTest.cs" />
-    <Compile Include="$(CommonTestPath)\Collections\ICollectionTest.cs" />
-    <Compile Include="$(CommonTestPath)\Collections\IListTest.cs" />
-    <Compile Include="$(CommonTestPath)\Collections\Utils.cs" />
+    <Compile Include="$(CommonTestPath)\Collections\IEnumerableTest.cs">
+      <Link>Common\Collections\IEnumerableTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Collections\ICollectionTest.cs">
+      <Link>Common\Collections\ICollectionTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Collections\IListTest.cs">
+      <Link>Common\Collections\IListTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Collections\Utils.cs">
+      <Link>Common\Collections\Utils.cs</Link>
+    </Compile>
     <Compile Include="ComponentModel\INotifyPropertyChangingTests.cs" />
     <Compile Include="ComponentModel\PropertyChangingEventArgsTests.cs" />
     <Compile Include="KeyedCollection\TestMethods.cs" />

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -25,8 +25,12 @@
     <MergeDcjs>$(DefineConstants.Contains('MERGE_DCJS'))</MergeDcjs>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\__HResults.cs" />
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
+    <Compile Include="$(CommonPath)\System\__HResults.cs">
+      <Link>Common\System\__HResults.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+      <Link>Common\System\NotImplemented.cs</Link>
+    </Compile>
     <Compile Include="$(RuntimeSerializationSources)\Attributes.cs" />
     <Compile Include="$(RuntimeSerializationSources)\CodeGenerator.cs" />
     <Compile Include="$(RuntimeSerializationSources)\ClassDataContract.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -50,7 +50,9 @@
     <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
     <Compile Include="System\StringComparer.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -17,7 +17,9 @@
     <Compile Include="DataContractJsonSerializer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Console.cs" />
+    <Compile Include="$(CommonTestPath)\System\Console.cs">
+      <Link>Common\System\Console.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -19,7 +19,9 @@
     <Compile Include="MyResolver.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Console.cs" />
+    <Compile Include="$(CommonTestPath)\System\Console.cs">
+      <Link>Common\System\Console.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">

--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
@@ -17,9 +17,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SecureStringTests.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.geteuid.cs" />
-    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.geteuid.cs">
+      <Link>Common\Interop\Unix\libc\Interop.geteuid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
+      <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Security.SecureString.csproj">

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
@@ -53,7 +53,9 @@
     <Compile Include="XmlFactoryWriterTests.cs" />
     <Compile Include="XmlWriterTestCaseBase.cs" />
     <Compile Include="XmlWriterTestModule.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
@@ -82,7 +82,9 @@
     <Compile Include="TCXmlSpace.cs" />
     <Compile Include="TestFiles.cs" />
     <Compile Include="XmlException.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/System.Xml.XDocument/tests/XDocument.Common/XDocument.Common.csproj
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/XDocument.Common.csproj
@@ -24,7 +24,9 @@
     <Compile Include="InputSpace.cs" />
     <Compile Include="ManagedNodeWriter.cs" />
     <Compile Include="XLinqTestCase.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\SystemXml\XmlCoreTest\XmlCoreTest.csproj">

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/XDocument.Test.ModuleCore.csproj
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/XDocument.Test.ModuleCore.csproj
@@ -28,7 +28,9 @@
     <Compile Include="testspec.cs" />
     <Compile Include="testvariation.cs" />
     <Compile Include="util.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Xml.XDocument.csproj">

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -16,23 +16,57 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Xml\Schema\XmlUntypedConverter.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Schema\XsdDateTime.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Base64Encoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Bits.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Ref.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriter.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\SecureStringHasher.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriterBase64Encoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ValidateNames.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlCharType.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlStandalone.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlConvertEx.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ExceptionType.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XPathNavigatorEx.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlParsingHelper.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlAttributeCollectionEx.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs" />
+    <Compile Include="$(CommonPath)\System\Xml\Schema\XmlUntypedConverter.cs">
+      <Link>Common\System\Xml\Schema\XmlUntypedConverter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Schema\XsdDateTime.cs">
+      <Link>Common\System\Xml\Schema\XsdDateTime.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Base64Encoder.cs">
+      <Link>Common\System\Xml\Base64Encoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Bits.cs">
+      <Link>Common\System\Xml\Bits.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Ref.cs">
+      <Link>Common\System\Xml\Ref.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriter.cs">
+      <Link>Common\System\Xml\XmlRawWriter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\SecureStringHasher.cs">
+      <Link>Common\System\Xml\SecureStringHasher.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriterBase64Encoder.cs">
+      <Link>Common\System\Xml\XmlRawWriterBase64Encoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ValidateNames.cs">
+      <Link>Common\System\Xml\ValidateNames.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlCharType.cs">
+      <Link>Common\System\Xml\XmlCharType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlStandalone.cs">
+      <Link>Common\System\Xml\XmlStandalone.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlConvertEx.cs">
+      <Link>Common\System\Xml\XmlConvertEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ExceptionType.cs">
+      <Link>Common\System\Xml\ExceptionType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XPathNavigatorEx.cs">
+      <Link>Common\System\Xml\XPathNavigatorEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlParsingHelper.cs">
+      <Link>Common\System\Xml\XmlParsingHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlAttributeCollectionEx.cs">
+      <Link>Common\System\Xml\XmlAttributeCollectionEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs">
+      <Link>Common\System\Xml\XmlConst.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Xml\XmlAttributeEx.cs" />
@@ -46,7 +80,9 @@
     <Compile Include="System\Xml\XPathNodeList.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
+    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+      <Link>Common\System\NotImplemented.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Xml.XPath/src/System.Xml.XPath.csproj
+++ b/src/System.Xml.XPath/src/System.Xml.XPath.csproj
@@ -16,25 +16,63 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Xml\Base64Decoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Base64Encoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriterBase64Encoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\BinHexDecoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Bits.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ValidateNames.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlCharType.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlConvertEx.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ExceptionType.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlReaderExtensions.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlWriterExtensions.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\IncrementalReadDecoders.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ReadContentAsBinaryHelper.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriter.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlStandalone.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Schema\XmlUntypedConverter.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Schema\XsdDateTime.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XPathNavigatorEx.cs" />
+    <Compile Include="$(CommonPath)\System\Xml\Base64Decoder.cs">
+      <Link>Common\System\Xml\Base64Decoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Base64Encoder.cs">
+      <Link>Common\System\Xml\Base64Encoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriterBase64Encoder.cs">
+      <Link>Common\System\Xml\XmlRawWriterBase64Encoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\BinHexDecoder.cs">
+      <Link>Common\System\Xml\BinHexDecoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Bits.cs">
+      <Link>Common\System\Xml\Bits.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ValidateNames.cs">
+      <Link>Common\System\Xml\ValidateNames.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlCharType.cs">
+      <Link>Common\System\Xml\XmlCharType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlConvertEx.cs">
+      <Link>Common\System\Xml\XmlConvertEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ExceptionType.cs">
+      <Link>Common\System\Xml\ExceptionType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlReaderExtensions.cs">
+      <Link>Common\System\Xml\XmlReaderExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlWriterExtensions.cs">
+      <Link>Common\System\Xml\XmlWriterExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\IncrementalReadDecoders.cs">
+      <Link>Common\System\Xml\IncrementalReadDecoders.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ReadContentAsBinaryHelper.cs">
+      <Link>Common\System\Xml\ReadContentAsBinaryHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlRawWriter.cs">
+      <Link>Common\System\Xml\XmlRawWriter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlStandalone.cs">
+      <Link>Common\System\Xml\XmlStandalone.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs">
+      <Link>Common\System\Xml\XmlConst.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Schema\XmlUntypedConverter.cs">
+      <Link>Common\System\Xml\Schema\XmlUntypedConverter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Schema\XsdDateTime.cs">
+      <Link>Common\System\Xml\Schema\Ref.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XPathNavigatorEx.cs">
+      <Link>Common\System\Xml\XPathNavigatorEx.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Xml\Cache\XPathDocumentBuilder.cs" />
@@ -124,7 +162,9 @@
     <Compile Include="System\Xml\Xsl\XsltContext.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
+    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+      <Link>Common\System\NotImplemented.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
+++ b/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
@@ -20,20 +20,48 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Ref.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\SecureStringHasher.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlTextWriter.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\Base64Encoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlTextWriterBase64Encoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\BinHexEncoder.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlConvertEx.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ExceptionType.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlCharType.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\ValidateNames.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlParsingHelper.cs" />
-    <Compile Include="$(CommonPath)\System\Xml\XmlNameHelper.cs" />
+    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
+      <Link>Common\System\IO\StringBuilderCache.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Ref.cs">
+      <Link>Common\System\Xml\Ref.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\SecureStringHasher.cs">
+      <Link>Common\System\Xml\SecureStringHasher.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlTextWriter.cs">
+      <Link>Common\System\Xml\XmlTextWriter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\Base64Encoder.cs">
+      <Link>Common\System\Xml\Base64Encoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlTextWriterBase64Encoder.cs">
+      <Link>Common\System\Xml\XmlTextWriterBase64Encoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\BinHexEncoder.cs">
+      <Link>Common\System\Xml\BinHexEncoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlConvertEx.cs">
+      <Link>Common\System\Xml\XmlConvertEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ExceptionType.cs">
+      <Link>Common\System\Xml\ExceptionType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs">
+      <Link>Common\System\Xml\XmlConst.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlCharType.cs">
+      <Link>Common\System\Xml\XmlCharType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\ValidateNames.cs">
+      <Link>Common\System\Xml\ValidateNames.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlParsingHelper.cs">
+      <Link>Common\System\Xml\XmlParsingHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Xml\XmlNameHelper.cs">
+      <Link>Common\System\Xml\XmlNameHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Xml\Dom\DomNameTable.cs" />
@@ -73,7 +101,9 @@
     <Compile Include="System\Xml\XmlTextEncoder.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
+    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+      <Link>Common\System\NotImplemented.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
@@ -17,7 +17,9 @@
     <Compile Include="XmlSerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Console.cs" />
+    <Compile Include="$(CommonTestPath)\System\Console.cs">
+      <Link>Common\System\Console.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">


### PR DESCRIPTION
Modifies various .csproj files to ensure that all Includes for files under Common use a <Link/> so that Visual Studio shows the files under a Common folder rather than flattened in the root.

Fixes #144