### PR TITLE
Cleanup minor issues in S.S.C.Encryption left from initial port

### DIFF
--- a/src/System.Security.Cryptography.Encryption/System.Security.Cryptography.Encryption.sln
+++ b/src/System.Security.Cryptography.Encryption/System.Security.Cryptography.Encryption.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22911.2
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.Encryption", "src\System.Security.Cryptography.Encryption.csproj", "{D04A73AE-E418-4ACD-A132-7688435BE8B5}"
 EndProject
@@ -13,10 +13,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D04A73AE-E418-4ACD-A132-7688435BE8B5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{54C20799-0F9C-4921-81E0-B3BEB73B451A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54C20799-0F9C-4921-81E0-B3BEB73B451A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54C20799-0F9C-4921-81E0-B3BEB73B451A}.Release|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/System.Security.Cryptography.Encryption/src/System.Security.Cryptography.Encryption.csproj
+++ b/src/System.Security.Cryptography.Encryption/src/System.Security.Cryptography.Encryption.csproj
@@ -2,19 +2,15 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Windows_Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D04A73AE-E418-4ACD-A132-7688435BE8B5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Encryption</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="System\Security\Cryptography\AsymmetricAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\CipherMode.cs" />

--- a/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/CryptoStream.cs
@@ -1,31 +1,29 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Diagnostics.Contracts;
-using System.Threading;
-using System.Threading.Tasks;
+
 
 namespace System.Security.Cryptography
 {
-    [System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     public class CryptoStream : Stream, IDisposable
     {
         // Member veriables
         private readonly Stream _stream;
-        private readonly ICryptoTransform _Transform;
-        private byte[] _InputBuffer;  // read from _stream before _Transform
-        private int _InputBufferIndex = 0;
-        private int _InputBlockSize;
-        private byte[] _OutputBuffer; // buffered output of _Transform
-        private int _OutputBufferIndex = 0;
-        private int _OutputBlockSize;
+        private readonly ICryptoTransform _transform;
         private readonly CryptoStreamMode _transformMode;
-        private bool _canRead = false;
-        private bool _canWrite = false;
-        private bool _finalBlockTransformed = false;
+        private byte[] _inputBuffer;  // read from _stream before _Transform
+        private int _inputBufferIndex;
+        private int _inputBlockSize;
+        private byte[] _outputBuffer; // buffered output of _Transform
+        private int _outputBufferIndex;
+        private int _outputBlockSize;
+        private bool _canRead;
+        private bool _canWrite;
+        private bool _finalBlockTransformed;
 
         // Constructors
 
@@ -33,7 +31,7 @@ namespace System.Security.Cryptography
         {
             _stream = stream;
             _transformMode = mode;
-            _Transform = transform;
+            _transform = transform;
             switch (_transformMode)
             {
                 case CryptoStreamMode.Read:
@@ -103,14 +101,14 @@ namespace System.Security.Cryptography
                 throw new NotSupportedException(SR.Cryptography_CryptoStream_FlushFinalBlockTwice);
             // We have to process the last block here.  First, we have the final block in _InputBuffer, so transform it
 
-            byte[] finalBytes = _Transform.TransformFinalBlock(_InputBuffer, 0, _InputBufferIndex);
+            byte[] finalBytes = _transform.TransformFinalBlock(_inputBuffer, 0, _inputBufferIndex);
 
             _finalBlockTransformed = true;
             // Now, write out anything sitting in the _OutputBuffer...
-            if (_canWrite && _OutputBufferIndex > 0)
+            if (_canWrite && _outputBufferIndex > 0)
             {
-                _stream.Write(_OutputBuffer, 0, _OutputBufferIndex);
-                _OutputBufferIndex = 0;
+                _stream.Write(_outputBuffer, 0, _outputBufferIndex);
+                _outputBufferIndex = 0;
             }
             // Write out finalBytes
             if (_canWrite)
@@ -130,21 +128,16 @@ namespace System.Security.Cryptography
                 _stream.Flush();
             }
             // zeroize plain text material before returning
-            if (_InputBuffer != null)
-                Array.Clear(_InputBuffer, 0, _InputBuffer.Length);
-            if (_OutputBuffer != null)
-                Array.Clear(_OutputBuffer, 0, _OutputBuffer.Length);
+            if (_inputBuffer != null)
+                Array.Clear(_inputBuffer, 0, _inputBuffer.Length);
+            if (_outputBuffer != null)
+                Array.Clear(_outputBuffer, 0, _outputBuffer.Length);
             return;
         }
 
         public override void Flush()
         {
             return;
-        }
-
-        public override Task FlushAsync(CancellationToken cancellationToken)
-        {
-            return base.FlushAsync(cancellationToken);
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -176,21 +169,21 @@ namespace System.Security.Cryptography
             // no bytes ready or we've delivered enough.
             int bytesToDeliver = count;
             int currentOutputIndex = offset;
-            if (_OutputBufferIndex != 0)
+            if (_outputBufferIndex != 0)
             {
                 // we have some already-transformed bytes in the output buffer
-                if (_OutputBufferIndex <= count)
+                if (_outputBufferIndex <= count)
                 {
-                    Buffer.BlockCopy(_OutputBuffer, 0, buffer, offset, _OutputBufferIndex);
-                    bytesToDeliver -= _OutputBufferIndex;
-                    currentOutputIndex += _OutputBufferIndex;
-                    _OutputBufferIndex = 0;
+                    Buffer.BlockCopy(_outputBuffer, 0, buffer, offset, _outputBufferIndex);
+                    bytesToDeliver -= _outputBufferIndex;
+                    currentOutputIndex += _outputBufferIndex;
+                    _outputBufferIndex = 0;
                 }
                 else
                 {
-                    Buffer.BlockCopy(_OutputBuffer, 0, buffer, offset, count);
-                    Buffer.BlockCopy(_OutputBuffer, count, _OutputBuffer, 0, _OutputBufferIndex - count);
-                    _OutputBufferIndex -= count;
+                    Buffer.BlockCopy(_outputBuffer, 0, buffer, offset, count);
+                    Buffer.BlockCopy(_outputBuffer, count, _outputBuffer, 0, _outputBufferIndex - count);
+                    _outputBufferIndex -= count;
                     return (count);
                 }
             }
@@ -208,34 +201,34 @@ namespace System.Security.Cryptography
             int numOutputBytes;
 
             // OK, see first if it's a multi-block transform and we can speed up things
-            if (bytesToDeliver > _OutputBlockSize)
+            if (bytesToDeliver > _outputBlockSize)
             {
-                if (_Transform.CanTransformMultipleBlocks)
+                if (_transform.CanTransformMultipleBlocks)
                 {
-                    int BlocksToProcess = bytesToDeliver / _OutputBlockSize;
-                    int numWholeBlocksInBytes = BlocksToProcess * _InputBlockSize;
+                    int BlocksToProcess = bytesToDeliver / _outputBlockSize;
+                    int numWholeBlocksInBytes = BlocksToProcess * _inputBlockSize;
                     byte[] tempInputBuffer = new byte[numWholeBlocksInBytes];
                     // get first the block already read
-                    Buffer.BlockCopy(_InputBuffer, 0, tempInputBuffer, 0, _InputBufferIndex);
-                    amountRead = _InputBufferIndex;
-                    amountRead += _stream.Read(tempInputBuffer, _InputBufferIndex, numWholeBlocksInBytes - _InputBufferIndex);
-                    _InputBufferIndex = 0;
-                    if (amountRead <= _InputBlockSize)
+                    Buffer.BlockCopy(_inputBuffer, 0, tempInputBuffer, 0, _inputBufferIndex);
+                    amountRead = _inputBufferIndex;
+                    amountRead += _stream.Read(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex);
+                    _inputBufferIndex = 0;
+                    if (amountRead <= _inputBlockSize)
                     {
-                        _InputBuffer = tempInputBuffer;
-                        _InputBufferIndex = amountRead;
+                        _inputBuffer = tempInputBuffer;
+                        _inputBufferIndex = amountRead;
                         goto slow;
                     }
                     // Make amountRead an integral multiple of _InputBlockSize
-                    int numWholeReadBlocksInBytes = (amountRead / _InputBlockSize) * _InputBlockSize;
+                    int numWholeReadBlocksInBytes = (amountRead / _inputBlockSize) * _inputBlockSize;
                     int numIgnoredBytes = amountRead - numWholeReadBlocksInBytes;
                     if (numIgnoredBytes != 0)
                     {
-                        _InputBufferIndex = numIgnoredBytes;
-                        Buffer.BlockCopy(tempInputBuffer, numWholeReadBlocksInBytes, _InputBuffer, 0, numIgnoredBytes);
+                        _inputBufferIndex = numIgnoredBytes;
+                        Buffer.BlockCopy(tempInputBuffer, numWholeReadBlocksInBytes, _inputBuffer, 0, numIgnoredBytes);
                     }
-                    byte[] tempOutputBuffer = new byte[(numWholeReadBlocksInBytes / _InputBlockSize) * _OutputBlockSize];
-                    numOutputBytes = _Transform.TransformBlock(tempInputBuffer, 0, numWholeReadBlocksInBytes, tempOutputBuffer, 0);
+                    byte[] tempOutputBuffer = new byte[(numWholeReadBlocksInBytes / _inputBlockSize) * _outputBlockSize];
+                    numOutputBytes = _transform.TransformBlock(tempInputBuffer, 0, numWholeReadBlocksInBytes, tempOutputBuffer, 0);
                     Buffer.BlockCopy(tempOutputBuffer, 0, buffer, currentOutputIndex, numOutputBytes);
                     // Now, tempInputBuffer and tempOutputBuffer are no more needed, so zeroize them to protect plain text
                     Array.Clear(tempInputBuffer, 0, tempInputBuffer.Length);
@@ -249,26 +242,26 @@ namespace System.Security.Cryptography
             // try to fill _InputBuffer so we have something to transform
             while (bytesToDeliver > 0)
             {
-                while (_InputBufferIndex < _InputBlockSize)
+                while (_inputBufferIndex < _inputBlockSize)
                 {
-                    amountRead = _stream.Read(_InputBuffer, _InputBufferIndex, _InputBlockSize - _InputBufferIndex);
+                    amountRead = _stream.Read(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex);
                     // first, check to see if we're at the end of the input stream
                     if (amountRead == 0) goto ProcessFinalBlock;
-                    _InputBufferIndex += amountRead;
+                    _inputBufferIndex += amountRead;
                 }
-                numOutputBytes = _Transform.TransformBlock(_InputBuffer, 0, _InputBlockSize, _OutputBuffer, 0);
-                _InputBufferIndex = 0;
+                numOutputBytes = _transform.TransformBlock(_inputBuffer, 0, _inputBlockSize, _outputBuffer, 0);
+                _inputBufferIndex = 0;
                 if (bytesToDeliver >= numOutputBytes)
                 {
-                    Buffer.BlockCopy(_OutputBuffer, 0, buffer, currentOutputIndex, numOutputBytes);
+                    Buffer.BlockCopy(_outputBuffer, 0, buffer, currentOutputIndex, numOutputBytes);
                     currentOutputIndex += numOutputBytes;
                     bytesToDeliver -= numOutputBytes;
                 }
                 else
                 {
-                    Buffer.BlockCopy(_OutputBuffer, 0, buffer, currentOutputIndex, bytesToDeliver);
-                    _OutputBufferIndex = numOutputBytes - bytesToDeliver;
-                    Buffer.BlockCopy(_OutputBuffer, bytesToDeliver, _OutputBuffer, 0, _OutputBufferIndex);
+                    Buffer.BlockCopy(_outputBuffer, 0, buffer, currentOutputIndex, bytesToDeliver);
+                    _outputBufferIndex = numOutputBytes - bytesToDeliver;
+                    Buffer.BlockCopy(_outputBuffer, bytesToDeliver, _outputBuffer, 0, _outputBufferIndex);
                     return count;
                 }
             }
@@ -276,33 +269,28 @@ namespace System.Security.Cryptography
 
         ProcessFinalBlock:
             // if so, then call TransformFinalBlock to get whatever is left
-            byte[] finalBytes = _Transform.TransformFinalBlock(_InputBuffer, 0, _InputBufferIndex);
+            byte[] finalBytes = _transform.TransformFinalBlock(_inputBuffer, 0, _inputBufferIndex);
             // now, since _OutputBufferIndex must be 0 if we're in the while loop at this point,
             // reset it to be what we just got back
-            _OutputBuffer = finalBytes;
-            _OutputBufferIndex = finalBytes.Length;
+            _outputBuffer = finalBytes;
+            _outputBufferIndex = finalBytes.Length;
             // set the fact that we've transformed the final block
             _finalBlockTransformed = true;
             // now, return either everything we just got or just what's asked for, whichever is smaller
-            if (bytesToDeliver < _OutputBufferIndex)
+            if (bytesToDeliver < _outputBufferIndex)
             {
-                Buffer.BlockCopy(_OutputBuffer, 0, buffer, currentOutputIndex, bytesToDeliver);
-                _OutputBufferIndex -= bytesToDeliver;
-                Buffer.BlockCopy(_OutputBuffer, bytesToDeliver, _OutputBuffer, 0, _OutputBufferIndex);
+                Buffer.BlockCopy(_outputBuffer, 0, buffer, currentOutputIndex, bytesToDeliver);
+                _outputBufferIndex -= bytesToDeliver;
+                Buffer.BlockCopy(_outputBuffer, bytesToDeliver, _outputBuffer, 0, _outputBufferIndex);
                 return (count);
             }
             else
             {
-                Buffer.BlockCopy(_OutputBuffer, 0, buffer, currentOutputIndex, _OutputBufferIndex);
-                bytesToDeliver -= _OutputBufferIndex;
-                _OutputBufferIndex = 0;
+                Buffer.BlockCopy(_outputBuffer, 0, buffer, currentOutputIndex, _outputBufferIndex);
+                bytesToDeliver -= _outputBufferIndex;
+                _outputBufferIndex = 0;
                 return (count - bytesToDeliver);
             }
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return base.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -323,55 +311,55 @@ namespace System.Security.Cryptography
             int currentInputIndex = offset;
             // if we have some bytes in the _InputBuffer, we have to deal with those first,
             // so let's try to make an entire block out of it
-            if (_InputBufferIndex > 0)
+            if (_inputBufferIndex > 0)
             {
-                if (count >= _InputBlockSize - _InputBufferIndex)
+                if (count >= _inputBlockSize - _inputBufferIndex)
                 {
                     // we have enough to transform at least a block, so fill the input block
-                    Buffer.BlockCopy(buffer, offset, _InputBuffer, _InputBufferIndex, _InputBlockSize - _InputBufferIndex);
-                    currentInputIndex += (_InputBlockSize - _InputBufferIndex);
-                    bytesToWrite -= (_InputBlockSize - _InputBufferIndex);
-                    _InputBufferIndex = _InputBlockSize;
+                    Buffer.BlockCopy(buffer, offset, _inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex);
+                    currentInputIndex += (_inputBlockSize - _inputBufferIndex);
+                    bytesToWrite -= (_inputBlockSize - _inputBufferIndex);
+                    _inputBufferIndex = _inputBlockSize;
                     // Transform the block and write it out
                 }
                 else
                 {
                     // not enough to transform a block, so just copy the bytes into the _InputBuffer
                     // and return
-                    Buffer.BlockCopy(buffer, offset, _InputBuffer, _InputBufferIndex, count);
-                    _InputBufferIndex += count;
+                    Buffer.BlockCopy(buffer, offset, _inputBuffer, _inputBufferIndex, count);
+                    _inputBufferIndex += count;
                     return;
                 }
             }
             // If the OutputBuffer has anything in it, write it out
-            if (_OutputBufferIndex > 0)
+            if (_outputBufferIndex > 0)
             {
-                _stream.Write(_OutputBuffer, 0, _OutputBufferIndex);
-                _OutputBufferIndex = 0;
+                _stream.Write(_outputBuffer, 0, _outputBufferIndex);
+                _outputBufferIndex = 0;
             }
             // At this point, either the _InputBuffer is full, empty, or we've already returned.
             // If full, let's process it -- we now know the _OutputBuffer is empty
             int numOutputBytes;
-            if (_InputBufferIndex == _InputBlockSize)
+            if (_inputBufferIndex == _inputBlockSize)
             {
-                numOutputBytes = _Transform.TransformBlock(_InputBuffer, 0, _InputBlockSize, _OutputBuffer, 0);
+                numOutputBytes = _transform.TransformBlock(_inputBuffer, 0, _inputBlockSize, _outputBuffer, 0);
                 // write out the bytes we just got 
-                _stream.Write(_OutputBuffer, 0, numOutputBytes);
+                _stream.Write(_outputBuffer, 0, numOutputBytes);
                 // reset the _InputBuffer
-                _InputBufferIndex = 0;
+                _inputBufferIndex = 0;
             }
             while (bytesToWrite > 0)
             {
-                if (bytesToWrite >= _InputBlockSize)
+                if (bytesToWrite >= _inputBlockSize)
                 {
                     // We have at least an entire block's worth to transform
                     // If the transform will handle multiple blocks at once, do that
-                    if (_Transform.CanTransformMultipleBlocks)
+                    if (_transform.CanTransformMultipleBlocks)
                     {
-                        int numWholeBlocks = bytesToWrite / _InputBlockSize;
-                        int numWholeBlocksInBytes = numWholeBlocks * _InputBlockSize;
-                        byte[] _tempOutputBuffer = new byte[numWholeBlocks * _OutputBlockSize];
-                        numOutputBytes = _Transform.TransformBlock(buffer, currentInputIndex, numWholeBlocksInBytes, _tempOutputBuffer, 0);
+                        int numWholeBlocks = bytesToWrite / _inputBlockSize;
+                        int numWholeBlocksInBytes = numWholeBlocks * _inputBlockSize;
+                        byte[] _tempOutputBuffer = new byte[numWholeBlocks * _outputBlockSize];
+                        numOutputBytes = _transform.TransformBlock(buffer, currentInputIndex, numWholeBlocksInBytes, _tempOutputBuffer, 0);
                         _stream.Write(_tempOutputBuffer, 0, numOutputBytes);
                         currentInputIndex += numWholeBlocksInBytes;
                         bytesToWrite -= numWholeBlocksInBytes;
@@ -379,27 +367,22 @@ namespace System.Security.Cryptography
                     else
                     {
                         // do it the slow way
-                        numOutputBytes = _Transform.TransformBlock(buffer, currentInputIndex, _InputBlockSize, _OutputBuffer, 0);
-                        _stream.Write(_OutputBuffer, 0, numOutputBytes);
-                        currentInputIndex += _InputBlockSize;
-                        bytesToWrite -= _InputBlockSize;
+                        numOutputBytes = _transform.TransformBlock(buffer, currentInputIndex, _inputBlockSize, _outputBuffer, 0);
+                        _stream.Write(_outputBuffer, 0, numOutputBytes);
+                        currentInputIndex += _inputBlockSize;
+                        bytesToWrite -= _inputBlockSize;
                     }
                 }
                 else
                 {
                     // In this case, we don't have an entire block's worth left, so store it up in the 
                     // input buffer, which by now must be empty.
-                    Buffer.BlockCopy(buffer, currentInputIndex, _InputBuffer, 0, bytesToWrite);
-                    _InputBufferIndex += bytesToWrite;
+                    Buffer.BlockCopy(buffer, currentInputIndex, _inputBuffer, 0, bytesToWrite);
+                    _inputBufferIndex += bytesToWrite;
                     return;
                 }
             }
             return;
-        }
-
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return base.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
         protected override void Dispose(bool disposing)
@@ -423,13 +406,13 @@ namespace System.Security.Cryptography
                     // since it's null after this
                     _finalBlockTransformed = true;
                     // we need to clear all the internal buffers
-                    if (_InputBuffer != null)
-                        Array.Clear(_InputBuffer, 0, _InputBuffer.Length);
-                    if (_OutputBuffer != null)
-                        Array.Clear(_OutputBuffer, 0, _OutputBuffer.Length);
+                    if (_inputBuffer != null)
+                        Array.Clear(_inputBuffer, 0, _inputBuffer.Length);
+                    if (_outputBuffer != null)
+                        Array.Clear(_outputBuffer, 0, _outputBuffer.Length);
 
-                    _InputBuffer = null;
-                    _OutputBuffer = null;
+                    _inputBuffer = null;
+                    _outputBuffer = null;
                     _canRead = false;
                     _canWrite = false;
                 }
@@ -444,12 +427,12 @@ namespace System.Security.Cryptography
 
         private void InitializeBuffer()
         {
-            if (_Transform != null)
+            if (_transform != null)
             {
-                _InputBlockSize = _Transform.InputBlockSize;
-                _InputBuffer = new byte[_InputBlockSize];
-                _OutputBlockSize = _Transform.OutputBlockSize;
-                _OutputBuffer = new byte[_OutputBlockSize];
+                _inputBlockSize = _transform.InputBlockSize;
+                _inputBuffer = new byte[_inputBlockSize];
+                _outputBlockSize = _transform.OutputBlockSize;
+                _outputBuffer = new byte[_outputBlockSize];
             }
         }
     }


### PR DESCRIPTION
Variables named with wrong casing, unnecessary overrides that just delegate to base, unnecessary usings, and platform-specific configurations for a platform-agnostic assembly.

Fixes #1753