### PR TITLE
Scrub additional [ComVisible] attributes from corefx

### DIFF
--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 
@@ -12,7 +11,6 @@ namespace System.IO
     // Provides methods for processing file system strings in a cross-platform manner.
     // Most of the methods don't do a complete parsing (such as examining a UNC hostname), 
     // but they will handle most string operations.  
-    [ComVisible(true)]
     public static partial class Path
     {
         // Platform specific alternate directory separator character.  

--- a/src/System.Runtime.Extensions/src/System/Random.cs
+++ b/src/System.Runtime.Extensions/src/System/Random.cs
@@ -19,7 +19,6 @@ using System.Diagnostics.Contracts;
 
 namespace System
 {
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class Random
     {
         //

--- a/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/CryptoStream.cs
@@ -3,12 +3,9 @@
 
 using System.Diagnostics.Contracts;
 using System.IO;
-using System.Runtime.InteropServices;
-
 
 namespace System.Security.Cryptography
 {
-    [ComVisible(true)]
     public class CryptoStream : Stream, IDisposable
     {
         // Member veriables

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -10,11 +10,7 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Security;
 
 namespace System.Threading
@@ -78,7 +74,6 @@ namespace System.Threading
     /// completed.
     /// </para>
     /// </remarks>
-    [ComVisible(false)]
     [DebuggerDisplay("Participant Count={ParticipantCount},Participants Remaining={ParticipantsRemaining}")]
     public class Barrier : IDisposable
     {

--- a/src/System.Threading/src/System/Threading/CountdownEvent.cs
+++ b/src/System.Threading/src/System/Threading/CountdownEvent.cs
@@ -7,10 +7,7 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace System.Threading
 {
@@ -24,7 +21,6 @@ namespace System.Threading
     /// completed, and Reset, which should only be used when no other threads are
     /// accessing the event.
     /// </remarks>
-    [ComVisible(false)]
     [DebuggerDisplay("Initial Count={InitialCount}, Current Count={CurrentCount}")]
     public class CountdownEvent : IDisposable
     {

--- a/src/System.Threading/src/System/Threading/Semaphore.cs
+++ b/src/System.Threading/src/System/Threading/Semaphore.cs
@@ -1,18 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
-using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
-using System.Security;
-using System.Security.Permissions;
-using System.Runtime.Versioning;
-using System.Runtime.ConstrainedExecution;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace System.Threading
 {
-    [ComVisibleAttribute(false)]
     public sealed partial class Semaphore : WaitHandle
     {
         private const int MAX_PATH = 260;

--- a/src/System.Xml.XmlSerializer/src/System/Collections/ArrayList.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Collections/ArrayList.cs
@@ -9,7 +9,6 @@
 **
 =============================================================================*/
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,7 +16,6 @@ using System.Diagnostics;
 namespace System.Collections
 {
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
     internal class ArrayList : List<object>
     {
         public ArrayList() { }

--- a/src/System.Xml.XmlSerializer/src/System/Collections/InternalHashtable.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Collections/InternalHashtable.cs
@@ -9,7 +9,6 @@
 **
 =============================================================================*/
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,7 +16,6 @@ using System.Diagnostics;
 namespace System.Collections
 {
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
     internal class InternalHashtable : Dictionary<object, object>
     {
         public InternalHashtable()


### PR DESCRIPTION
In #782 we scrubbed all of the [ComVisible] attributes from corefx, but more have snuck in since then.  Doing another pass.