### PR TITLE
Refactor and add tests for System.IO.Pipes library

### DIFF
--- a/src/System.IO.Pipes/tests/BaseCommonTests.cs
+++ b/src/System.IO.Pipes/tests/BaseCommonTests.cs
@@ -1,0 +1,309 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    public abstract class BaseCommonTests
+    {
+        public static void ConnectedPipeWriteBufferNullThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanWrite);
+
+            Assert.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, 0, 1));
+            Assert.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, 0, 1); } );
+        }
+
+        public static void ConnectedPipeWriteNegativeOffsetThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanWrite);
+
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Write(new byte[5], -1, 1));
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, -1, 1));
+
+            Assert.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, -1, 1); } );
+        }
+
+        public static void ConnectedPipeWriteNegativeCountThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanWrite);
+
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => pipe.Write(new byte[5], 0, -1));
+
+            // offset is checked before count
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Write(new byte[1], -1, -1));
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, -1, -1));
+
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => { pipe.WriteAsync(new byte[5], 0, -1); } );
+
+            // offset is checked before count
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.WriteAsync(new byte[1], -1, -1); } );
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, -1, -1); } );
+        }
+
+        public static void ConnectedPipeWriteArrayOutOfBoundsThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanWrite);
+
+            // offset out of bounds
+            Assert.Throws<ArgumentException>(null, () => pipe.Write(new byte[1], 1, 1));
+
+            // offset out of bounds for 0 count read
+            Assert.Throws<ArgumentException>(null, () => pipe.Write(new byte[1], 2, 0));
+
+            // offset out of bounds even for 0 length buffer
+            Assert.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], 1, 0));
+
+            // combination offset and count out of bounds
+            Assert.Throws<ArgumentException>(null, () => pipe.Write(new byte[2], 1, 2));
+
+            // edges
+            Assert.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], int.MaxValue, 0));
+            Assert.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], int.MaxValue, int.MaxValue));
+
+            Assert.Throws<ArgumentException>(() => pipe.Write(new byte[5], 3, 4));
+
+            // offset out of bounds
+            Assert.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[1], 1, 1); } );
+
+            // offset out of bounds for 0 count read
+            Assert.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[1], 2, 0); } );
+
+            // offset out of bounds even for 0 length buffer
+            Assert.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], 1, 0); } );
+
+            // combination offset and count out of bounds
+            Assert.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[2], 1, 2); } );
+
+            // edges
+            Assert.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], int.MaxValue, 0); } );
+            Assert.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], int.MaxValue, int.MaxValue); } );
+
+            Assert.Throws<ArgumentException>(() => { pipe.WriteAsync(new byte[5], 3, 4); } );
+        }
+
+        public static void ConnectedPipeReadOnlyThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.False(pipe.CanWrite);
+
+            Assert.Throws<NotSupportedException>(() => pipe.Write(new byte[5], 0, 5));
+
+            Assert.Throws<NotSupportedException>(() => pipe.WriteByte(123));
+
+            Assert.Throws<NotSupportedException>(() => pipe.Flush());
+
+            Assert.Throws<NotSupportedException>(() => pipe.OutBufferSize);
+
+            Assert.Throws<NotSupportedException>(() => pipe.WaitForPipeDrain());
+
+            Assert.Throws<NotSupportedException>(() => { pipe.WriteAsync(new byte[5], 0, 5); } );
+        }
+
+        public static void ConnectedPipeReadBufferNullThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanRead);
+
+            Assert.Throws<ArgumentNullException>(() => pipe.Read(null, 0, 1));
+
+            Assert.Throws<ArgumentNullException>(() => { pipe.ReadAsync(null, 0, 1); } );
+        }
+
+        public static void ConnectedPipeReadNegativeOffsetThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanRead);
+
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Read(new byte[6], -1, 1));
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, -1, 1));
+
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.ReadAsync(new byte[4], -1, 1); } );
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, -1, 1); } );
+        }
+
+        public static void ConnectedPipeReadNegativeCountThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanRead);
+
+            Assert.Throws<System.ArgumentOutOfRangeException>("count", () => pipe.Read(new byte[3], 0, -1));
+
+            // offset is checked before count
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Read(new byte[1], -1, -1));
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, -1, -1));
+
+            Assert.Throws<System.ArgumentOutOfRangeException>("count", () => { pipe.ReadAsync(new byte[7], 0, -1); } );
+
+            // offset is checked before count
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.ReadAsync(new byte[2], -1, -1); } );
+
+            // array is checked first
+            Assert.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, -1, -1); } );
+        }
+
+        public static void ConnectedPipeReadArrayOutOfBoundsThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanRead);
+
+            // offset out of bounds
+            Assert.Throws<ArgumentException>(null, () => pipe.Read(new byte[1], 1, 1));
+
+            // offset out of bounds for 0 count read
+            Assert.Throws<ArgumentException>(null, () => pipe.Read(new byte[1], 2, 0));
+
+            // offset out of bounds even for 0 length buffer
+            Assert.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], 1, 0));
+
+            // combination offset and count out of bounds
+            Assert.Throws<ArgumentException>(null, () => pipe.Read(new byte[2], 1, 2));
+
+            // edges
+            Assert.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], int.MaxValue, 0));
+            Assert.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], int.MaxValue, int.MaxValue));
+
+            Assert.Throws<ArgumentException>(() => pipe.Read(new byte[5], 3, 4));
+
+            // offset out of bounds
+            Assert.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[1], 1, 1); } );
+
+            // offset out of bounds for 0 count read
+            Assert.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[1], 2, 0); } );
+
+            // offset out of bounds even for 0 length buffer
+            Assert.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], 1, 0); } );
+
+            // combination offset and count out of bounds
+            Assert.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[2], 1, 2); } );
+
+            // edges
+            Assert.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], int.MaxValue, 0); } );
+            Assert.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], int.MaxValue, int.MaxValue); } );
+
+            Assert.Throws<ArgumentException>(() => { pipe.ReadAsync(new byte[5], 3, 4); } );
+        }
+
+        public static void ConnectedPipeWriteOnlyThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+            Assert.False(pipe.CanRead);
+
+            Assert.Throws<NotSupportedException>(() => pipe.Read(new byte[9], 0, 5));
+
+            Assert.Throws<NotSupportedException>(() => pipe.ReadByte());
+
+            Assert.Throws<NotSupportedException>(() => pipe.InBufferSize);
+
+            Assert.Throws<NotSupportedException>(() => { pipe.ReadAsync(new byte[10], 0, 5); } );
+        }
+
+        public static void ConnectedPipeUnsupportedOperationThrows(PipeStream pipe)
+        {
+            Assert.True(pipe.IsConnected);
+
+            Assert.Throws<NotSupportedException>(() => pipe.Length);
+
+            Assert.Throws<NotSupportedException>(() => pipe.SetLength(10L));
+
+            Assert.Throws<NotSupportedException>(() => pipe.Position);
+
+            Assert.Throws<NotSupportedException>(() => pipe.Position = 10L);
+
+            Assert.Throws<NotSupportedException>(() => pipe.Seek(10L, System.IO.SeekOrigin.Begin));
+        }
+
+        public static void ConnectedPipeCancelReadTokenThrows(PipeStream pipe)
+        {
+            byte[] buffer11 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            Assert.True(pipe.IsConnected);
+            Assert.True(pipe.CanRead);
+
+            var ctx = new CancellationTokenSource();
+            Task readToken = pipe.ReadAsync(buffer11, 0, buffer11.Length, ctx.Token);
+            ctx.Cancel();
+            Assert.ThrowsAsync<TimeoutException>(() => readToken);
+            Assert.ThrowsAsync<TimeoutException>(() => pipe.ReadAsync(buffer11, 0, buffer11.Length, ctx.Token));
+        }
+
+        public static void AfterDisconnectReadWritePipeThrows(PipeStream pipe)
+        {
+            Assert.False(pipe.IsConnected);
+
+            AfterDisconnectReadOnlyPipeThrows(pipe);
+            AfterDisconnectWriteOnlyPipeThrows(pipe);
+        }
+
+        public static void AfterDisconnectWriteOnlyPipeThrows(PipeStream pipe)
+        {
+            byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+            Assert.Throws<InvalidOperationException>(() => pipe.Write(buffer, 0, buffer.Length));
+            Assert.Throws<InvalidOperationException>(() => pipe.WriteByte(5));
+            Assert.Throws<InvalidOperationException>(() => { pipe.WriteAsync(buffer, 0, buffer.Length); } );
+            Assert.Throws<InvalidOperationException>(() => pipe.Flush());
+        }
+
+        public static void AfterDisconnectReadOnlyPipeThrows(PipeStream pipe)
+        {
+            byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+            Assert.Throws<InvalidOperationException>(() => pipe.Read(buffer, 0, buffer.Length));
+            Assert.Throws<InvalidOperationException>(() => pipe.ReadByte());
+            Assert.Throws<InvalidOperationException>(() => { pipe.ReadAsync(buffer, 0, buffer.Length); } );
+            Assert.Throws<InvalidOperationException>(() => pipe.IsMessageComplete);
+        }
+
+        public static void WhenDisposedPipeThrows(PipeStream pipe)
+        {
+            byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+            Assert.Throws<ObjectDisposedException>(() => pipe.Write(buffer, 0, buffer.Length));
+            Assert.Throws<ObjectDisposedException>(() => pipe.WriteByte(5));
+            Assert.Throws<ObjectDisposedException>(() => { pipe.WriteAsync(buffer, 0, buffer.Length); } );
+            Assert.Throws<ObjectDisposedException>(() => pipe.Flush());
+            Assert.Throws<ObjectDisposedException>(() => pipe.Read(buffer, 0, buffer.Length));
+            Assert.Throws<ObjectDisposedException>(() => pipe.ReadByte());
+            Assert.Throws<ObjectDisposedException>(() => { pipe.ReadAsync(buffer, 0, buffer.Length); } );
+            Assert.Throws<ObjectDisposedException>(() => pipe.IsMessageComplete);
+        }
+
+        public static void OtherSidePipeDisconnectWriteThrows(PipeStream pipe)
+        {
+            byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+            Assert.Throws<IOException>(() => pipe.Write(buffer, 0, buffer.Length));
+            Assert.Throws<IOException>(() => pipe.WriteByte(123));
+            Assert.Throws<IOException>(() => { pipe.WriteAsync(buffer, 0, buffer.Length); } );
+            Assert.Throws<IOException>(() => pipe.Flush());
+        }
+
+        public static void OtherSidePipeDisconnectVerifyRead(PipeStream pipe)
+        {
+            byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+            int length = pipe.Read(buffer, 0, buffer.Length);  // for some reason these are ok
+            Assert.Equal(0, length);
+            int byt = pipe.ReadByte();
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/NamedPipesThrowsTests.cs
+++ b/src/System.IO.Pipes/tests/NamedPipesThrowsTests.cs
@@ -8,20 +8,23 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    public class NamedPipesThrowsTests
+    public class NamedPipesThrowsTests : BaseCommonTests
     {
-        private static void NotReachable(object obj) { Assert.True(false, "This should not be reached."); }
-
         // Server Parameter Checking throws
         [Fact]
         public static void ServerNullPipeNameThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(null));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(null, PipeDirection.In));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(null, PipeDirection.In, 2));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(null, PipeDirection.In, 3, PipeTransmissionMode.Byte));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(null, PipeDirection.In, 3, PipeTransmissionMode.Byte, PipeOptions.None));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(null, PipeDirection.In, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.In));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.In, 2));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.In, 3, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.In, 3, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.In, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.Out));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.Out, 2));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.Out, 3, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.Out, 3, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeServerStream(null, PipeDirection.Out, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Fact]
@@ -33,6 +36,11 @@ namespace System.IO.Pipes.Tests
             Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.In, 3, PipeTransmissionMode.Byte));
             Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.In, 3, PipeTransmissionMode.Byte, PipeOptions.None));
             Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.In, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.Out));
+            Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.Out, 2));
+            Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.Out, 3, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.Out, 3, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentException>(() => new NamedPipeServerStream("", PipeDirection.Out, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Fact]
@@ -40,59 +48,240 @@ namespace System.IO.Pipes.Tests
         public static void ServerReservedPipeNameThrows()
         {
             const string reservedName = "anonymous";
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream(reservedName));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream(reservedName, PipeDirection.In));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream(reservedName, PipeDirection.In, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream(reservedName, PipeDirection.In, 1, PipeTransmissionMode.Byte));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream(reservedName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.None));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream(reservedName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.In));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.In, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.In, 1, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.Out));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.Out, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.Out, 1, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.InOut));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.InOut, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Fact]
         public static void ServerPipeDirectionThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", (PipeDirection)123));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", (PipeDirection)123, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", (PipeDirection)123, 1, PipeTransmissionMode.Byte));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", (PipeDirection)123, 1, PipeTransmissionMode.Byte, PipeOptions.None));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("tempx", (PipeDirection)123, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeServerStream("temp1", (PipeDirection)123));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeServerStream("temp1", (PipeDirection)123, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeServerStream("temp1", (PipeDirection)123, 1, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeServerStream("temp1", (PipeDirection)123, 1, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeServerStream("tempx", (PipeDirection)123, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Fact]
         public static void ServerServerInstancesThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp3", PipeDirection.Out, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp3", PipeDirection.Out, 0, PipeTransmissionMode.Byte));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp3", PipeDirection.Out, 0, PipeTransmissionMode.Byte, PipeOptions.None));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp3", PipeDirection.Out, 0, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.Out, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.Out, 0, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.Out, 0, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.Out, 0, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, 0, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, 0, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, 0, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Fact]
         public static void ServerTransmissionModeThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", PipeDirection.Out, 1, (PipeTransmissionMode)123));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", PipeDirection.Out, 1, (PipeTransmissionMode)123, PipeOptions.None));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("tempx", PipeDirection.Out, 1, (PipeTransmissionMode)123, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("transmissionMode", () => new NamedPipeServerStream("temp1", PipeDirection.Out, 1, (PipeTransmissionMode)123));
+            Assert.Throws<ArgumentOutOfRangeException>("transmissionMode", () => new NamedPipeServerStream("temp1", PipeDirection.Out, 1, (PipeTransmissionMode)123, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("transmissionMode", () => new NamedPipeServerStream("tempx", PipeDirection.Out, 1, (PipeTransmissionMode)123, PipeOptions.None, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("transmissionMode", () => new NamedPipeServerStream("temp1", PipeDirection.In, 1, (PipeTransmissionMode)123));
+            Assert.Throws<ArgumentOutOfRangeException>("transmissionMode", () => new NamedPipeServerStream("temp1", PipeDirection.In, 1, (PipeTransmissionMode)123, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("transmissionMode", () => new NamedPipeServerStream("tempx", PipeDirection.In, 1, (PipeTransmissionMode)123, PipeOptions.None, 0, 0));
         }
 
         [Fact]
         public static void ServerPipeOptionsThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp1", PipeDirection.Out, 1, PipeTransmissionMode.Byte, (PipeOptions)255));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("tempx", PipeDirection.Out, 1, PipeTransmissionMode.Byte, (PipeOptions)255, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => new NamedPipeServerStream("temp1", PipeDirection.Out, 1, PipeTransmissionMode.Byte, (PipeOptions)255));
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => new NamedPipeServerStream("tempx", PipeDirection.Out, 1, PipeTransmissionMode.Byte, (PipeOptions)255, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => new NamedPipeServerStream("temp1", PipeDirection.In, 1, PipeTransmissionMode.Byte, (PipeOptions)255));
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => new NamedPipeServerStream("tempx", PipeDirection.In, 1, PipeTransmissionMode.Byte, (PipeOptions)255, 0, 0));
         }
 
         [Fact]
         public static void ServerBufferSizeThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp2", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.None, -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeServerStream("temp2", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, -123));
+            Assert.Throws<ArgumentOutOfRangeException>("inBufferSize", () => new NamedPipeServerStream("temp2", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.None, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("outBufferSize", () => new NamedPipeServerStream("temp2", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, -123));
+            Assert.Throws<ArgumentOutOfRangeException>("inBufferSize", () => new NamedPipeServerStream("temp2", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.None, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("outBufferSize", () => new NamedPipeServerStream("temp2", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, -123));
+            Assert.Throws<ArgumentOutOfRangeException>("inBufferSize", () => new NamedPipeServerStream("temp2", PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.None, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("outBufferSize", () => new NamedPipeServerStream("temp2", PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, -123));
+
+
         }
 
         [Fact]
         public static void ServerNullPipeHandleThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeServerStream(PipeDirection.InOut, false, true, null));
+            Assert.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeServerStream(PipeDirection.InOut, false, true, null));
+            Assert.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeServerStream(PipeDirection.Out, false, true, null));
+            Assert.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeServerStream(PipeDirection.In, false, true, null));
+        }
+
+        [Fact]
+        public static void ServerWriteBufferNullThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteBufferNullThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerWriteNegativeOffsetThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteNegativeOffsetThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerWriteNegativeCountThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteNegativeCountThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerWriteArrayOutOfBoundsThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteArrayOutOfBoundsThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerWriteOnlyThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteOnlyThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerUnsupportedOperationThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeUnsupportedOperationThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerReadBufferNullThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadBufferNullThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerReadNegativeOffsetThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadNegativeOffsetThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerReadNegativeCountThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadNegativeCountThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerReadArrayOutOfBoundsThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadArrayOutOfBoundsThrows(server);
+            }
+        }
+
+        [Fact]
+        public static void ServerReadOnlyThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique3", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique3", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadOnlyThrows(server);
+            }
         }
 
         [Fact]
@@ -155,9 +344,7 @@ namespace System.IO.Pipes.Tests
 
                 Assert.Throws<ObjectDisposedException>(() => server.Disconnect());  // disconnect when disposed
                 Assert.Throws<ObjectDisposedException>(() => server.WaitForConnection());  // disconnect when disposed
-                Assert.Throws<ObjectDisposedException>(() => server.WriteByte(5));
-                Assert.Throws<ObjectDisposedException>(() => server.ReadByte());
-                Assert.Throws<ObjectDisposedException>(() => server.IsMessageComplete);
+                WhenDisposedPipeThrows(server);
             }
         }
 
@@ -169,14 +356,17 @@ namespace System.IO.Pipes.Tests
             {
                 Task clientConnect = client.ConnectAsync();
                 server.WaitForConnection();
+                await clientConnect;
+
                 Assert.Throws<InvalidOperationException>(() => server.IsMessageComplete);
                 Assert.Throws<InvalidOperationException>(() => server.WaitForConnection());
                 await Assert.ThrowsAsync<InvalidOperationException>(() => server.WaitForConnectionAsync());
 
                 server.Disconnect();
+
                 Assert.Throws<InvalidOperationException>(() => server.Disconnect());    // double disconnect
-                Assert.Throws<InvalidOperationException>(() => server.WriteByte(5));
-                Assert.Throws<InvalidOperationException>(() => server.IsMessageComplete);
+
+                AfterDisconnectWriteOnlyPipeThrows(server);
             }
 
             if (Interop.IsWindows) // on Unix, InOut doesn't result in the same Disconnect-based errors due to allowing for other connections
@@ -193,10 +383,10 @@ namespace System.IO.Pipes.Tests
                     await Assert.ThrowsAsync<InvalidOperationException>(() => server.WaitForConnectionAsync());
 
                     server.Disconnect();
+
                     Assert.Throws<InvalidOperationException>(() => server.Disconnect());    // double disconnect
-                    Assert.Throws<InvalidOperationException>(() => server.WriteByte(5));
-                    Assert.Throws<InvalidOperationException>(() => server.ReadByte());
-                    Assert.Throws<InvalidOperationException>(() => server.IsMessageComplete);
+
+                    AfterDisconnectReadWritePipeThrows(server);
                 }
             }
         }
@@ -224,7 +414,7 @@ namespace System.IO.Pipes.Tests
         public static void ServerInvalidPipeHandleThrows()
         {
             SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
-            Assert.Throws<ArgumentException>(() => new NamedPipeServerStream(PipeDirection.InOut, false, true, pipeHandle));
+            Assert.Throws<ArgumentException>("safePipeHandle", () => new NamedPipeServerStream(PipeDirection.InOut, false, true, pipeHandle));
         }
 
         [Fact]
@@ -256,8 +446,8 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientNullPipeNameParameterThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(null));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(".", null));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeClientStream(null));
+            Assert.Throws<ArgumentNullException>("pipeName", () => new NamedPipeClientStream(".", null));
         }
 
         [Fact]
@@ -270,10 +460,10 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientNullServerNameParameterThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(null, "client1"));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(null, "client1", PipeDirection.In));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(null, "client1", PipeDirection.In, PipeOptions.None));
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(null, "client1", PipeDirection.In, PipeOptions.None, Security.Principal.TokenImpersonationLevel.None));
+            Assert.Throws<ArgumentNullException>("serverName", () => new NamedPipeClientStream(null, "client1"));
+            Assert.Throws<ArgumentNullException>("serverName", () => new NamedPipeClientStream(null, "client1", PipeDirection.In));
+            Assert.Throws<ArgumentNullException>("serverName", () => new NamedPipeClientStream(null, "client1", PipeDirection.In, PipeOptions.None));
+            Assert.Throws<ArgumentNullException>("serverName", () => new NamedPipeClientStream(null, "client1", PipeDirection.In, PipeOptions.None, Security.Principal.TokenImpersonationLevel.None));
         }
 
         [Fact]
@@ -288,21 +478,21 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientPipeDiretionThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeClientStream(".", "client1", (PipeDirection)123));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeClientStream(".", "client1", (PipeDirection)123, PipeOptions.None));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeClientStream(".", "client1", (PipeDirection)123, PipeOptions.None, Security.Principal.TokenImpersonationLevel.None));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeClientStream(".", "client1", (PipeDirection)123));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeClientStream(".", "client1", (PipeDirection)123, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("direction", () => new NamedPipeClientStream(".", "client1", (PipeDirection)123, PipeOptions.None, Security.Principal.TokenImpersonationLevel.None));
         }
         [Fact]
         public static void ClientPipeOptionsThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeClientStream(".", "client1", PipeDirection.In, (PipeOptions)255));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeClientStream(".", "client1", PipeDirection.In, (PipeOptions)255, Security.Principal.TokenImpersonationLevel.None));
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => new NamedPipeClientStream(".", "client1", PipeDirection.In, (PipeOptions)255));
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => new NamedPipeClientStream(".", "client1", PipeDirection.In, (PipeOptions)255, Security.Principal.TokenImpersonationLevel.None));
         }
 
         [Fact]
         public static void ClientImpersonationLevelThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new NamedPipeClientStream(".", "client1", PipeDirection.In, PipeOptions.None, (System.Security.Principal.TokenImpersonationLevel)999));
+            Assert.Throws<ArgumentOutOfRangeException>("impersonationLevel", () => new NamedPipeClientStream(".", "client1", PipeDirection.In, PipeOptions.None, (System.Security.Principal.TokenImpersonationLevel)999));
         }
 
         [Fact]
@@ -310,22 +500,22 @@ namespace System.IO.Pipes.Tests
         {
             using (NamedPipeClientStream client = new NamedPipeClientStream("client1"))
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => client.Connect(-111));
-                Assert.Throws<ArgumentOutOfRangeException>(() => NotReachable(client.ConnectAsync(-111)));
+                Assert.Throws<ArgumentOutOfRangeException>("timeout", () => client.Connect(-111));
+                Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { client.ConnectAsync(-111); } );
             }
         }
 
         [Fact]
         public static void ClientNullHandleThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new NamedPipeClientStream(PipeDirection.InOut, false, true, null));
+            Assert.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeClientStream(PipeDirection.InOut, false, true, null));
         }
 
         [Fact]
         public static void ClientInvalidHandleThrows()
         {
             SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
-            Assert.Throws<ArgumentException>(() => new NamedPipeClientStream(PipeDirection.InOut, false, true, pipeHandle));
+            Assert.Throws<ArgumentException>("safePipeHandle", () => new NamedPipeClientStream(PipeDirection.InOut, false, true, pipeHandle));
         }
 
         [Fact]
@@ -393,6 +583,160 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        public static void ClientReadBufferNullThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadBufferNullThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientReadNegativeOffsetThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadNegativeOffsetThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientReadNegativeCountThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadNegativeCountThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientReadArrayOutOfBoundsThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadArrayOutOfBoundsThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientConnectedPipeReadOnlyThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.In))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeReadOnlyThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientWriteBufferNullThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteBufferNullThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientWriteNegativeOffsetThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteNegativeOffsetThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientWriteNegativeCountThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteNegativeCountThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientWriteArrayOutOfBoundsThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteArrayOutOfBoundsThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientWriteOnlyThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeWriteOnlyThrows(client);
+            }
+        }
+
+        [Fact]
+        public static void ClientUnsupportedOperationThrows()
+        {
+            using (NamedPipeServerStream server = new NamedPipeServerStream("unique4", PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", "unique4", PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                ConnectedPipeUnsupportedOperationThrows(client);
+            }
+        }
+
+        [Fact]
         public static async Task ClientAllReadyConnectedThrows()
         {
             using (NamedPipeServerStream server = new NamedPipeServerStream("testServer1", PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
@@ -448,9 +792,7 @@ namespace System.IO.Pipes.Tests
 
                 client.Dispose();
 
-                Assert.Throws<IOException>(() => server.Write(buffer, 0, buffer.Length));
-                Assert.Throws<IOException>(() => server.WriteByte(123));
-                Assert.Throws<IOException>(() => server.Flush());
+                OtherSidePipeDisconnectWriteThrows(server);
             }
 
             using (NamedPipeServerStream server = new NamedPipeServerStream("testServer2", PipeDirection.In))
@@ -467,8 +809,7 @@ namespace System.IO.Pipes.Tests
 
                 client.Dispose();
 
-                server.Read(buffer, 0, buffer.Length);
-                server.ReadByte();
+                OtherSidePipeDisconnectVerifyRead(server);
             }
 
             if (Interop.IsWindows) // Unix implementation of InOut doesn't fail on server.Write/Read when client disconnects due to allowing for additional connections
@@ -487,15 +828,10 @@ namespace System.IO.Pipes.Tests
 
                     client.Dispose();
 
-                    Assert.Throws<IOException>(() => server.Write(buffer, 0, buffer.Length));
-                    Assert.Throws<IOException>(() => server.WriteByte(123));
-                    Assert.Throws<IOException>(() => server.Flush());
-                    int length = server.Read(buffer, 0, buffer.Length);
-                    Assert.Equal(0, length);
-                    int byt = server.ReadByte();
+                    OtherSidePipeDisconnectWriteThrows(server);
+                    OtherSidePipeDisconnectVerifyRead(server);
                 }
             }
-
         }
 
         [Fact]
@@ -515,9 +851,7 @@ namespace System.IO.Pipes.Tests
 
                 server.Dispose();
 
-                Assert.Throws<IOException>(() => client.Write(buffer, 0, buffer.Length));
-                Assert.Throws<IOException>(() => client.WriteByte(123));
-                Assert.Throws<IOException>(() => client.Flush());
+                OtherSidePipeDisconnectWriteThrows(client);
             }
 
             if (Interop.IsWindows) // Unix implementation of InOut doesn't fail on server.Write/Read when client disconnects due to allowing for additional connections
@@ -536,15 +870,36 @@ namespace System.IO.Pipes.Tests
 
                     server.Dispose();
 
-                    Assert.Throws<IOException>(() => client.Write(buffer, 0, buffer.Length));
-                    Assert.Throws<IOException>(() => client.WriteByte(123));
-                    Assert.Throws<IOException>(() => client.Flush());
-                    int length = client.Read(buffer, 0, buffer.Length);
-                    Assert.Equal(0, length);
-                    int byt = client.ReadByte();
+                    OtherSidePipeDisconnectWriteThrows(client);
+                    OtherSidePipeDisconnectVerifyRead(client);
                 }
             }
+        }
 
+        // Unix port currently doesn't recognize conflicts in pipe direction
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void ClientConnectWrongConflictingDirection()
+        {
+            const string serverName1 = "testServer4";
+
+            using (NamedPipeServerStream server = new NamedPipeServerStream(serverName1, PipeDirection.Out))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", serverName1, PipeDirection.Out))
+            {
+                Assert.Throws<UnauthorizedAccessException>(() => client.Connect());
+
+                Assert.False(client.IsConnected);
+            }
+
+            const string serverName2 = "testServer5";
+
+            using (NamedPipeServerStream server = new NamedPipeServerStream(serverName2, PipeDirection.In))
+            using (NamedPipeClientStream client = new NamedPipeClientStream(".", serverName2, PipeDirection.In))
+            {
+                Assert.Throws<UnauthorizedAccessException>(() => client.Connect());
+
+                Assert.False(client.IsConnected);
+            }
         }
     }
 }

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="AnonymousPipesSimpleTest.cs" />
     <Compile Include="AnonymousPipesThrowsTests.cs" />
+    <Compile Include="BaseCommonTests.cs" />
     <Compile Include="NamedPipesSimpleTest.cs" />
     <Compile Include="NamedPipesThrowsTests.cs" />
     <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">


### PR DESCRIPTION
1) Refactor to base class, common test cases so they can be shared between the
    Anonymous/Named Client/Server combinations.

2) Modify the Anonymous/Named throws test classes to use new base class

3) Complete the various permutations of throws tests e.g. before write parameter checking was only done on Anonymous classes, now both Anonymous/Named and Client/Server

4) Add parameter name checking on various throws tests

5) Add tests for incompatible modes between client/server named pipes