### PR TITLE
Fix Process output flushing to not bail early

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/TestConsoleApp.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/TestConsoleApp.cs
@@ -45,6 +45,14 @@ namespace System.Diagnostics.ProcessTests
                         Sleep(100);
                     }
                 }
+                else if (args[0].Equals("manyOutputLines"))
+                {
+                    for (int i = 0; i < 144; i++)
+                    {
+                        Console.WriteLine("This is line #" + i + ".");
+                    }
+                    // no sleep here
+                }
                 else if (args[0].Equals("ipc"))
                 {
                     using (var inbound = new AnonymousPipeClientStream(PipeDirection.In, args[1]))


### PR DESCRIPTION
An accidental early return introduced in https://github.com/dotnet/corefx/commit/c377139032cdf6eac5b13a99e6d94dbe06fbadcc is causing output message flushing to end prematurely.

This fixes that and cleans up the related code.  It also introduces a test to output many lines and verify that all lines are received.  And another of our tests was actually passing because of this bug, so I fixed that, too.

Fixes https://github.com/dotnet/coreclr/issues/1176