### PR TITLE
Optimizations for ImmutableArray

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -597,11 +597,6 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> Add(T item)
         {
             var self = this;
-            if (self.Length == 0)
-            {
-                return ImmutableArray.Create(item);
-            }
-
             return self.Insert(self.Length, item);
         }
 
@@ -686,6 +681,10 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
             var self = this;
+            
+            if (self.IsEmpty)
+                return self;
+            
             int index = self.IndexOf(oldValue, equalityComparer);
             if (index < 0)
             {
@@ -721,6 +720,10 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
+            
+            if (self.IsEmpty)
+                return self;
+            
             int index = self.IndexOf(item, equalityComparer);
             return index < 0
                 ? self
@@ -792,6 +795,9 @@ namespace System.Collections.Immutable
             self.ThrowNullRefIfNotInitialized();
             Requires.NotNull(items, "items");
             Requires.NotNull(equalityComparer, "equalityComparer");
+            
+            if (self.IsEmpty)
+                return self;
 
             var indexesToRemove = new SortedSet<int>();
             foreach (var item in items)
@@ -834,11 +840,11 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, IEqualityComparer<T> equalityComparer)
         {
             var self = this;
+            self.ThrowNullRefIfNotInitialized();
             Requires.NotNull(items.array, "items");
-
+            
             if (items.IsEmpty)
             {
-                self.ThrowNullRefIfNotInitialized();
                 return self;
             }
             else if (items.Length == 1)
@@ -1096,7 +1102,7 @@ namespace System.Collections.Immutable
         public IEnumerable<TResult> OfType<TResult>()
         {
             var self = this;
-            if (self.array == null || self.array.Length == 0)
+            if (self.IsDefaultOrEmpty)
             {
                 return Enumerable.Empty<TResult>();
             }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -545,21 +545,34 @@ namespace System.Collections.Immutable
             Requires.NotNull(items, "items");
 
             if (self.Length == 0)
-            {
                 return ImmutableArray.CreateRange(items);
-            }
             
-            T[] other = items.ToArray();
-            if (other.Length == 0)
+            if (items is ICollection<T>)
             {
-                return self;
+                ICollection<T> other = (ICollection<T>)items;
+                
+                if (other.Count == 0)
+                    return self;
+                
+                T[] dest = new T[self.Length + other.Count];
+                Array.Copy(self.array, 0, dest, 0, index);
+                other.CopyTo(dest, index);
+                Array.Copy(self.array, index, dest, index + other.Count, self.Length - index);
+                return new ImmutableArray<T>(dest);
             }
-
-            T[] tmp = new T[self.Length + other.Length];
-            Array.Copy(self.array, 0, tmp, 0, index);
-            Array.Copy(other, 0, tmp, index, other.Length);
-            Array.Copy(self.array, index, tmp, index + other.Length, self.Length - index);
-            return new ImmutableArray<T>(tmp);
+            else
+            {
+                T[] other = items.ToArray();
+                
+                if (other.Length == 0)
+                    return self;
+    
+                T[] tmp = new T[self.Length + other.Length];
+                Array.Copy(self.array, 0, tmp, 0, index);
+                Array.Copy(other, 0, tmp, index, other.Length);
+                Array.Copy(self.array, index, tmp, index + other.Length, self.Length - index);
+                return new ImmutableArray<T>(tmp);
+            }
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -890,7 +890,7 @@ namespace System.Collections.Immutable
 
             List<int> removeIndexes = null;
             
-            int i;
+            int i = 0;
             for (; i < self.array.Length; i++)
             {
                 if (match(self.array[i]))

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -888,16 +888,25 @@ namespace System.Collections.Immutable
             if (self.IsEmpty)
                 return self;
 
-            List<int> removeIndexes = new List<int>();
-            for (int i = 0; i < self.array.Length; i++)
+            List<int> removeIndexes = null;
+            
+            int i;
+            for (; i < self.array.Length; i++)
             {
                 if (match(self.array[i]))
                 {
+                    removeIndexes = new List<int>();
                     removeIndexes.Add(i);
+                    break;
                 }
             }
+            for (; i < self.array.Length; i++)
+            {
+                if (match(self.array[i]))
+                    removeIndexes.Add(i);
+            }
 
-            return removeIndexes.Count != 0 ?
+            return removeIndexes != null ?
                 self.RemoveAtRange(removeIndexes) :
                 self;
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -555,7 +555,7 @@ namespace System.Collections.Immutable
                     return self;
                 
                 T[] dest = new T[self.Length + other.Count];
-                other.CopyTo(dest, index);
+                other.CopyTo(dest, index); // keep this before so any changes it makes to unintended parts of the array are overwritten by Array.Copy
                 Array.Copy(self.array, 0, dest, 0, index);
                 Array.Copy(self.array, index, dest, index + other.Count, self.Length - index);
                 return new ImmutableArray<T>(dest);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -587,7 +587,7 @@ namespace System.Collections.Immutable
             }
             else if (items.IsEmpty)
             {
-                return new ImmutableArray<T>(self.array);
+                return self;
             }
 
             return self.InsertRange(index, items.array);
@@ -728,7 +728,7 @@ namespace System.Collections.Immutable
             self.ThrowNullRefIfNotInitialized();
             int index = self.IndexOf(item, equalityComparer);
             return index < 0
-                ? new ImmutableArray<T>(self.array)
+                ? self
                 : self.RemoveAt(index);
         }
 
@@ -875,9 +875,7 @@ namespace System.Collections.Immutable
             Requires.NotNull(match, "match");
 
             if (self.IsEmpty)
-            {
-                return new ImmutableArray<T>(self.array);
-            }
+                return self;
 
             List<int> removeIndexes = null;
             for (int i = 0; i < self.array.Length; i++)
@@ -942,14 +940,14 @@ namespace System.Collections.Immutable
             Requires.Range(index >= 0, "index");
             Requires.Range(count >= 0 && index + count <= self.Length, "count");
 
-            if (comparer == null)
-            {
-                comparer = Comparer<T>.Default;
-            }
-
             // 0 and 1 element arrays don't need to be sorted.
             if (count > 1)
             {
+                if (comparer == null)
+                {
+                    comparer = Comparer<T>.Default;
+                }
+
                 // Avoid copying the entire array when the array is already sorted.
                 bool outOfOrder = false;
                 for (int i = index + 1; i < index + count; i++)
@@ -970,7 +968,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-            return new ImmutableArray<T>(self.array);
+            return self;
         }
 
         /// <summary>
@@ -1642,7 +1640,7 @@ namespace System.Collections.Immutable
             if (indexesToRemove.Count == 0)
             {
                 // Be sure to return a !IsDefault instance.
-                return new ImmutableArray<T>(self.array);
+                return self;
             }
 
             var newArray = new T[self.Length - indexesToRemove.Count];

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -682,9 +682,6 @@ namespace System.Collections.Immutable
         {
             var self = this;
             
-            if (self.IsEmpty)
-                return self;
-            
             int index = self.IndexOf(oldValue, equalityComparer);
             if (index < 0)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -555,8 +555,8 @@ namespace System.Collections.Immutable
                     return self;
                 
                 T[] dest = new T[self.Length + other.Count];
-                Array.Copy(self.array, 0, dest, 0, index);
                 other.CopyTo(dest, index);
+                Array.Copy(self.array, 0, dest, 0, index);
                 Array.Copy(self.array, index, dest, index + other.Count, self.Length - index);
                 return new ImmutableArray<T>(dest);
             }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -583,7 +583,7 @@ namespace System.Collections.Immutable
 
             if (self.IsEmpty)
             {
-                return new ImmutableArray<T>(items.array);
+                return items;
             }
             else if (items.IsEmpty)
             {
@@ -636,7 +636,7 @@ namespace System.Collections.Immutable
             if (self.IsEmpty)
             {
                 // Be sure what we return is marked as initialized.
-                return new ImmutableArray<T>(items.array);
+                return items;
             }
             else if (items.IsEmpty)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -442,7 +442,7 @@ namespace System.Collections.Immutable
             }
             else
             {
-                for (int i = startIndex; i >= startIndex - count + 1; i--)
+                for (int i = startIndex; i > startIndex - count; i--)
                 {
                     if (equalityComparer.Equals(item, self.array[i]))
                     {
@@ -548,22 +548,17 @@ namespace System.Collections.Immutable
             {
                 return ImmutableArray.CreateRange(items);
             }
-
-            int count = ImmutableExtensions.GetCount(ref items);
-            if (count == 0)
+            
+            T[] other = items.ToArray();
+            if (other.Length == 0)
             {
                 return self;
             }
 
-            T[] tmp = new T[self.Length + count];
+            T[] tmp = new T[self.Length + other.Length];
             Array.Copy(self.array, 0, tmp, 0, index);
-            int sequenceIndex = index;
-            foreach (var item in items)
-            {
-                tmp[sequenceIndex++] = item;
-            }
-
-            Array.Copy(self.array, index, tmp, index + count, self.Length - index);
+            Array.Copy(other, 0, tmp, index, other.Length);
+            Array.Copy(self.array, index, tmp, index + other.Length, self.Length - index);
             return new ImmutableArray<T>(tmp);
         }
 
@@ -877,21 +872,16 @@ namespace System.Collections.Immutable
             if (self.IsEmpty)
                 return self;
 
-            List<int> removeIndexes = null;
+            List<int> removeIndexes = new List<int>();
             for (int i = 0; i < self.array.Length; i++)
             {
                 if (match(self.array[i]))
                 {
-                    if (removeIndexes == null)
-                    {
-                        removeIndexes = new List<int>();
-                    }
-
                     removeIndexes.Add(i);
                 }
             }
 
-            return removeIndexes != null ?
+            return removeIndexes.Count != 0 ?
                 self.RemoveAtRange(removeIndexes) :
                 self;
         }


### PR DESCRIPTION
This is a total of four commits so far to ``ImmutableArray`1.cs``.

 - Highlight: Wrapper-returning methods that used to return a `new ImmutableArray<T>(self.array)` now return `self`. ImmutableArray is a struct, overrides Equals, and is immutable, which makes 2 different ImmutableArrays pointing to the same array very very hard to distinguish from each other.

 - `InsertRange` now enumerates only once over the collection when inserting it into the new array. This also makes methods such as `InsertRange(int, ImmutableArray)` faster because that just inserts the inner array into this method, and when `ToArray()` detects that the enumerable is an array is just does a copy operation and never calls `foreach` at all.

(The downside to this is that we shouldn't even have to call `ToArray()` if the enumerable is already an `ICollection<T>`, so there should be some kind of overload of `InsertRange` for that.)

 - `ImmutableArray.Remove` and `ImmutableArray.Replace` now return `this` immediately if `this` is empty.

 - `Add` checks for empty, then calls `Insert`, which also checks for empty. Removed the check in `Add`.

 - Removed the lazy initialization of `List<int>` in `RemoveAll`: the default `List` ctor is very cheap (sets underlying array to an empty array), so it is definitely not worth the null check every iteration of the loop.