### PR TITLE
Optimise First, Last, FirstOrDefault & LastOrDefault for OrderedEnumerable

### DIFF
--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
       <Link>System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
     <Compile Include="System\Linq\Enumerable.cs" />
     <Compile Include="System\Linq\Errors.cs" />
   </ItemGroup>

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq
@@ -832,18 +833,18 @@ namespace System.Linq
         public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            if (count <= 0) return new EmptyPartition<TSource>();
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.Take(count);
             return TakeIterator<TSource>(source, count);
         }
 
         private static IEnumerable<TSource> TakeIterator<TSource>(IEnumerable<TSource> source, int count)
         {
-            if (count > 0)
+            foreach (TSource element in source)
             {
-                foreach (TSource element in source)
-                {
-                    yield return element;
-                    if (--count == 0) break;
-                }
+                yield return element;
+                if (--count == 0) break;
             }
         }
 
@@ -884,18 +885,15 @@ namespace System.Linq
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null) throw Error.ArgumentNull("source");
-
+            if (count < 0) count = 0;
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.Skip(count);
             IList<TSource> sourceList = source as IList<TSource>;
             return sourceList != null ? SkipList(sourceList, count) : SkipIterator<TSource>(source, count);
         }
 
         private static IEnumerable<TSource> SkipList<TSource>(IList<TSource> source, int count)
         {
-            if (count < 0)
-            {
-                count = 0;
-            }
-
             while (count < source.Count)
             {
                 yield return source[count++];
@@ -1445,6 +1443,8 @@ namespace System.Linq
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.First();
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -1464,6 +1464,8 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
+            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
+            if (ordered != null) return ordered.First(predicate);
             foreach (TSource element in source)
             {
                 if (predicate(element)) return element;
@@ -1474,6 +1476,8 @@ namespace System.Linq
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.FirstOrDefault();
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -1493,6 +1497,8 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
+            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
+            if (ordered != null) return ordered.FirstOrDefault(predicate);
             foreach (TSource element in source)
             {
                 if (predicate(element)) return element;
@@ -1503,6 +1509,8 @@ namespace System.Linq
         public static TSource Last<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.Last();
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -1531,6 +1539,8 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
+            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
+            if (ordered != null) return ordered.Last(predicate);
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -1565,6 +1575,8 @@ namespace System.Linq
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.LastOrDefault();
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -1593,6 +1605,8 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
+            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
+            if (ordered != null) return ordered.LastOrDefault(predicate);
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -1712,23 +1726,29 @@ namespace System.Linq
         public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, int index)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.ElementAt(index);
             IList<TSource> list = source as IList<TSource>;
             if (list != null) return list[index];
-            if (index < 0) throw Error.ArgumentOutOfRange("index");
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            if (index >= 0)
             {
-                while (true)
+                using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) throw Error.ArgumentOutOfRange("index");
-                    if (index == 0) return e.Current;
-                    index--;
+                    while (e.MoveNext())
+                    {
+                        if (index == 0) return e.Current;
+                        index--;
+                    }
                 }
             }
+            throw Error.ArgumentOutOfRange("index");
         }
 
         public static TSource ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return partition.ElementAtOrDefault(index);
             if (index >= 0)
             {
                 IList<TSource> list = source as IList<TSource>;
@@ -1740,9 +1760,8 @@ namespace System.Linq
                 {
                     using (IEnumerator<TSource> e = source.GetEnumerator())
                     {
-                        while (true)
+                        while (e.MoveNext())
                         {
-                            if (!e.MoveNext()) break;
                             if (index == 0) return e.Current;
                             index--;
                         }
@@ -1756,10 +1775,11 @@ namespace System.Linq
         {
             long max = ((long)start) + count - 1;
             if (count < 0 || max > Int32.MaxValue) throw Error.ArgumentOutOfRange("count");
+            if (count == 0) return new EmptyPartition<int>();
             return new RangeIterator(start, count);
         }
 
-        private sealed class RangeIterator : Iterator<int>, IArrayProvider<int>, IListProvider<int>
+        private sealed class RangeIterator : Iterator<int>, IArrayProvider<int>, IListProvider<int>, IPartition<int>
         {
             private readonly int _start;
             private readonly int _end;
@@ -1777,10 +1797,10 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch(state)
+                switch (state)
                 {
                     case 1:
-                        if (_start == _end) break;
+                        Debug.Assert(_start != _end);
                         current = _start;
                         state = 2;
                         return true;
@@ -1820,15 +1840,60 @@ namespace System.Linq
 
                 return list;
             }
+
+            public IPartition<int> Skip(int count)
+            {
+                if (count >= _end - _start) return new EmptyPartition<int>();
+                return new RangeIterator(_start + count, _end - _start - count);
+            }
+
+            public IPartition<int> Take(int count)
+            {
+                int curCount = _end - _start;
+                if (count > curCount) count = curCount;
+                return new RangeIterator(_start, count);
+            }
+
+            public int ElementAt(int index)
+            {
+                if ((uint)index >= (uint)(_end - _start)) throw Error.ArgumentOutOfRange("index");
+                return _start + index;
+            }
+
+            public int ElementAtOrDefault(int index)
+            {
+                return (uint)index >= (uint)(_end - _start) ? 0 : _start + index;
+            }
+
+            public int First()
+            {
+                return _start;
+            }
+
+            public int FirstOrDefault()
+            {
+                return _start;
+            }
+
+            public int Last()
+            {
+                return _end - 1;
+            }
+
+            public int LastOrDefault()
+            {
+                return _end - 1;
+            }
         }
 
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)
         {
             if (count < 0) throw Error.ArgumentOutOfRange("count");
+            if (count == 0) new EmptyPartition<TResult>();
             return new RepeatIterator<TResult>(element, count);
         }
 
-        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>, IPartition<TResult>
         {
             private readonly int _count;
             private int _sent;
@@ -1878,6 +1943,49 @@ namespace System.Linq
                 for (int i = 0; i != _count; ++i) list.Add(current);
 
                 return list;
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                if (count >= _count) return new EmptyPartition<TResult>();
+                return new RepeatIterator<TResult>(current, _count - count);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                if (count > _count) count = _count;
+                return new RepeatIterator<TResult>(current, count);
+            }
+
+            public TResult ElementAt(int index)
+            {
+                if ((uint)index >= (uint)_count) throw Error.ArgumentOutOfRange("index");
+                return current;
+            }
+
+            public TResult ElementAtOrDefault(int index)
+            {
+                return (uint)index >= (uint)_count ? default(TResult) : current;
+            }
+
+            public TResult First()
+            {
+                return current;
+            }
+
+            public TResult FirstOrDefault()
+            {
+                return current;
+            }
+
+            public TResult Last()
+            {
+                return current;
+            }
+
+            public TResult LastOrDefault()
+            {
+                return current;
             }
         }
 
@@ -3711,13 +3819,208 @@ namespace System.Linq
         }
     }
 
-    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IArrayProvider<TElement>, IListProvider<TElement>
+    internal interface IPartition<TElement> : IEnumerable<TElement>, IArrayProvider<TElement>
+    {
+        IPartition<TElement> Skip(int count);
+
+        IPartition<TElement> Take(int count);
+
+        TElement ElementAt(int index);
+
+        TElement ElementAtOrDefault(int index);
+
+        TElement First();
+
+        TElement FirstOrDefault();
+
+        TElement Last();
+
+        TElement LastOrDefault();
+    }
+
+    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IListProvider<TElement>, IEnumerator<TElement>
+    {
+        public EmptyPartition()
+        {
+        }
+
+        public IEnumerator<TElement> GetEnumerator()
+        {
+            return this;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this;
+        }
+
+        public bool MoveNext()
+        {
+            return false;
+        }
+
+        [ExcludeFromCodeCoverage] // Shouldn't be called, and as undefined can return or throw anything anyway.
+        public TElement Current
+        {
+            get { return default(TElement); }
+        }
+
+        [ExcludeFromCodeCoverage] // Shouldn't be called, and as undefined can return or throw anything anyway.
+        object IEnumerator.Current
+        {
+            get { return default(TElement); }
+        }
+
+        void IEnumerator.Reset()
+        {
+            throw Error.NotSupported();
+        }
+
+        void IDisposable.Dispose()
+        {
+            // Do nothing.
+        }
+
+        public IPartition<TElement> Skip(int count)
+        {
+            return new EmptyPartition<TElement>();
+        }
+
+        public IPartition<TElement> Take(int count)
+        {
+            return new EmptyPartition<TElement>();
+        }
+
+        public TElement ElementAt(int index)
+        {
+            throw Error.ArgumentOutOfRange("index");
+        }
+
+        public TElement ElementAtOrDefault(int index)
+        {
+            return default(TElement);
+        }
+
+        public TElement First()
+        {
+            throw Error.NoElements();
+        }
+
+        public TElement FirstOrDefault()
+        {
+            return default(TElement);
+        }
+
+        public TElement Last()
+        {
+            throw Error.NoElements();
+        }
+
+        public TElement LastOrDefault()
+        {
+            return default(TElement);
+        }
+
+        public TElement[] ToArray()
+        {
+            return new TElement[0]; // consider replacing with Array.Empty<TElement>()
+        }
+
+        public List<TElement> ToList()
+        {
+            return new List<TElement>(0);
+        }
+    }
+
+    internal sealed class OrderedPartition<TElement> : IPartition<TElement>
+    {
+        private readonly OrderedEnumerable<TElement> _source;
+        private readonly int _minIndex;
+        private readonly int _maxIndex;
+
+        public OrderedPartition(OrderedEnumerable<TElement> source, int minIdx, int maxIdx)
+        {
+            _source = source;
+            _minIndex = minIdx;
+            _maxIndex = maxIdx;
+        }
+
+        public IEnumerator<TElement> GetEnumerator()
+        {
+            return _source.GetEnumerator(_minIndex, _maxIndex);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IPartition<TElement> Skip(int count)
+        {
+            int minIndex = _minIndex + count;
+            return minIndex >= _maxIndex
+                ? (IPartition<TElement>)new EmptyPartition<TElement>()
+                : new OrderedPartition<TElement>(_source, minIndex, _maxIndex);
+        }
+
+        public IPartition<TElement> Take(int count)
+        {
+            int maxIndex = _minIndex + count - 1;
+            if (maxIndex >= _maxIndex) maxIndex = _maxIndex;
+            return new OrderedPartition<TElement>(_source, _minIndex, maxIndex);
+        }
+
+        public TElement ElementAt(int index)
+        {
+            if ((uint)index > (uint)_maxIndex - _minIndex) throw Error.ArgumentOutOfRange("index");
+            return _source.ElementAt(index + _minIndex);
+        }
+
+        public TElement ElementAtOrDefault(int index)
+        {
+            return (uint)index <= (uint)_maxIndex - _minIndex ? _source.ElementAtOrDefault(index + _minIndex) : default(TElement);
+        }
+
+        public TElement First()
+        {
+            TElement result;
+            if (!_source.TryGetElementAt(_minIndex, out result)) throw Error.NoElements();
+            return result;
+        }
+
+        public TElement FirstOrDefault()
+        {
+            return _source.ElementAtOrDefault(_minIndex);
+        }
+
+        public TElement Last()
+        {
+            return _source.Last(_minIndex, _maxIndex);
+        }
+
+        public TElement LastOrDefault()
+        {
+            return _source.LastOrDefault(_minIndex, _maxIndex);
+        }
+
+        public TElement[] ToArray()
+        {
+            return _source.ToArray(_minIndex, _maxIndex);
+        }
+    }
+
+    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IArrayProvider<TElement>, IListProvider<TElement>, IPartition<TElement>
     {
         internal IEnumerable<TElement> source;
 
         private int[] SortedMap(Buffer<TElement> buffer)
         {
-            return GetEnumerableSorter(null).Sort(buffer.items, buffer.count);
+            return GetEnumerableSorter().Sort(buffer.items, buffer.count);
+        }
+
+        private int[] SortedMap(Buffer<TElement> buffer, int minIdx, int maxIdx)
+        {
+            return GetEnumerableSorter().Sort(buffer.items, buffer.count, minIdx, maxIdx);
         }
 
         public IEnumerator<TElement> GetEnumerator()
@@ -3758,9 +4061,60 @@ namespace System.Linq
             return list;
         }
 
+        internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
+        {
+            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            int count = buffer.count;
+            if (count > minIdx)
+            {
+                if (count <= maxIdx) maxIdx = count - 1;
+                if (minIdx == maxIdx) yield return GetEnumerableSorter().ElementAt(buffer.items, count, minIdx);
+                else
+                {
+                    int[] map = SortedMap(buffer, minIdx, maxIdx);
+                    while (minIdx <= maxIdx)
+                    {
+                        yield return buffer.items[map[minIdx]];
+                        ++minIdx;
+                    }
+                }
+            }
+        }
+
+        internal TElement[] ToArray(int minIdx, int maxIdx)
+        {
+            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            int count = buffer.count;
+            if (count <= minIdx) return new TElement[0];
+            if (count <= maxIdx) maxIdx = count - 1;
+            if (minIdx == maxIdx) return new TElement[] { GetEnumerableSorter().ElementAt(buffer.items, count, minIdx) };
+            int[] map = SortedMap(buffer, minIdx, maxIdx);
+            TElement[] array = new TElement[maxIdx - minIdx + 1];
+            int idx = 0;
+            while (minIdx <= maxIdx)
+            {
+                array[idx] = buffer.items[map[minIdx]];
+                ++idx;
+                ++minIdx;
+            }
+            return array;
+        }
+
+        private EnumerableSorter<TElement> GetEnumerableSorter()
+        {
+            return GetEnumerableSorter(null);
+        }
+
         internal abstract EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement> next);
 
-        IEnumerator IEnumerable.GetEnumerator()
+        internal CachingComparer<TElement> GetComparer()
+        {
+            return GetComparer(null);
+        }
+
+        internal abstract CachingComparer<TElement> GetComparer(CachingComparer<TElement> childComparer);
+
+    IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
@@ -3771,9 +4125,239 @@ namespace System.Linq
             result.parent = this;
             return result;
         }
+
+        public IPartition<TElement> Skip(int count)
+        {
+            return new OrderedPartition<TElement>(this, count, int.MaxValue);
+        }
+
+        public IPartition<TElement> Take(int count)
+        {
+            return new OrderedPartition<TElement>(this, 0, count - 1);
+        }
+
+        public bool TryGetElementAt(int index, out TElement result)
+        {
+            if (index == 0) return TryGetFirst(out result);
+            if (index > 0)
+            {
+                Buffer<TElement> buffer = new Buffer<TElement>(source);
+                int count = buffer.count;
+                if (index < count)
+                {
+                    result = GetEnumerableSorter().ElementAt(buffer.items, count, index);
+                    return true;
+                }
+            }
+            result = default(TElement);
+            return false;
+        }
+
+        public TElement ElementAt(int index)
+        {
+            TElement result;
+            if (!TryGetElementAt(index, out result)) throw Error.ArgumentOutOfRange("index");
+            return result;
+        }
+
+        public TElement ElementAtOrDefault(int index)
+        {
+            TElement result;
+            TryGetElementAt(index, out result);
+            return result;
+        }
+
+        private bool TryGetFirst(out TElement result)
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    result = default(TElement);
+                    return false;
+                }
+                TElement value = e.Current;
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (comparer.Compare(x, true) < 0) value = x;
+                }
+                result = value;
+                return true;
+            }
+        }
+
+        public TElement FirstOrDefault()
+        {
+            TElement result;
+            TryGetFirst(out result);
+            return result;
+        }
+
+        public TElement First()
+        {
+            TElement result;
+            if (!TryGetFirst(out result)) throw Error.NoElements();
+            return result;
+        }
+
+        public TElement First(Func<TElement, bool> predicate)
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                TElement value;
+                do
+                {
+                    if (!e.MoveNext()) throw Error.NoMatch();
+                    value = e.Current;
+                } while (!predicate(value));
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (predicate(x) && comparer.Compare(x, true) < 0) value = x;
+                }
+                return value;
+            }
+        }
+
+        public TElement FirstOrDefault(Func<TElement, bool> predicate)
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                TElement value;
+                do
+                {
+                    if (!e.MoveNext()) return default(TElement);
+                    value = e.Current;
+                } while (!predicate(value));
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (predicate(x) && comparer.Compare(x, true) < 0) value = x;
+                }
+                return value;
+            }
+        }
+
+        public TElement Last()
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                TElement value = e.Current;
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (comparer.Compare(x, false) >= 0) value = x;
+                }
+                return value;
+            }
+        }
+
+        public TElement LastOrDefault()
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) return default(TElement);
+                TElement value = e.Current;
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (comparer.Compare(x, false) >= 0) value = x;
+                }
+                return value;
+            }
+        }
+
+        public TElement Last(int minIdx, int maxIdx)
+        {
+            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            int count = buffer.count;
+            if (minIdx >= count) throw Error.NoElements();
+            if (maxIdx < count - 1) return GetEnumerableSorter().ElementAt(buffer.items, count, maxIdx);
+            // If we're here, we want the same results we would have got from
+            // Last(), but we've already buffered our source.
+            return Last(buffer);
+        }
+
+        public TElement LastOrDefault(int minIdx, int maxIdx)
+        {
+            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            int count = buffer.count;
+            if (minIdx >= count) return default(TElement);
+            if (maxIdx < count - 1) return GetEnumerableSorter().ElementAt(buffer.items, count, maxIdx);
+            return Last(buffer);
+        }
+
+        private TElement Last(Buffer<TElement> buffer)
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            TElement[] items = buffer.items;
+            int count = buffer.count;
+            TElement value = items[0];
+            comparer.SetElement(value);
+            for (int i = 1; i != count; ++i)
+            {
+                TElement x = items[i];
+                if (comparer.Compare(x, false) >= 0) value = x;
+            }
+            return value;
+        }
+
+        public TElement Last(Func<TElement, bool> predicate)
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                TElement value;
+                do
+                {
+                    if (!e.MoveNext()) throw Error.NoMatch();
+                    value = e.Current;
+                } while (!predicate(value));
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (predicate(x) && comparer.Compare(x, false) >= 0) value = x;
+                }
+                return value;
+            }
+        }
+
+        public TElement LastOrDefault(Func<TElement, bool> predicate)
+        {
+            CachingComparer<TElement> comparer = GetComparer();
+            using (IEnumerator<TElement> e = source.GetEnumerator())
+            {
+                TElement value;
+                do
+                {
+                    if (!e.MoveNext()) return default(TElement);
+                    value = e.Current;
+                } while (!predicate(value));
+                comparer.SetElement(value);
+                while (e.MoveNext())
+                {
+                    TElement x = e.Current;
+                    if (predicate(x) && comparer.Compare(x, false) > 0) value = x;
+                }
+                return value;
+            }
+        }
     }
 
-    internal class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
+    internal sealed class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
     {
         internal OrderedEnumerable<TElement> parent;
         internal Func<TElement, TKey> keySelector;
@@ -3797,6 +4381,75 @@ namespace System.Linq
             if (parent != null) sorter = parent.GetEnumerableSorter(sorter);
             return sorter;
         }
+
+        internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement> childComparer)
+        {
+            CachingComparer<TElement> cmp = childComparer == null
+                ? new CachingComparer<TElement, TKey>(keySelector, comparer, descending)
+                : new CachingComparerWithChild<TElement, TKey>(keySelector, comparer, descending, childComparer);
+            return parent != null ? parent.GetComparer(cmp) : cmp;
+        }
+    }
+
+    // A comparer that chains comparisons, and pushes through the last element found to be
+    // lower or higher (depending on use), so as to represent the sort of comparisons
+    // done by OrderBy().ThenBy() combinations.
+    internal abstract class CachingComparer<TElement>
+    {
+        internal abstract int Compare(TElement element, bool cacheLower);
+        internal abstract void SetElement(TElement element);
+    }
+
+    internal class CachingComparer<TElement, TKey> : CachingComparer<TElement>
+    {
+        protected readonly Func<TElement, TKey> KeySelector;
+        protected readonly IComparer<TKey> Comparer;
+        protected readonly bool Descending;
+        protected TKey LastKey;
+        public CachingComparer(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
+        {
+            KeySelector = keySelector;
+            Comparer = comparer;
+            Descending = descending;
+        }
+        internal override int Compare(TElement element, bool cacheLower)
+        {
+            TKey newKey = KeySelector(element);
+            int cmp = Descending ? Comparer.Compare(LastKey, newKey) : Comparer.Compare(newKey, LastKey);
+            if (cacheLower == cmp < 0) LastKey = newKey;
+            return cmp;
+        }
+        internal override void SetElement(TElement element)
+        {
+            LastKey = KeySelector(element);
+        }
+    }
+
+    internal sealed class CachingComparerWithChild<TElement, TKey> : CachingComparer<TElement, TKey>
+    {
+        private readonly CachingComparer<TElement> _child;
+        public CachingComparerWithChild(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, CachingComparer<TElement> child)
+            : base(keySelector, comparer, descending)
+        {
+            _child = child;
+        }
+        internal override int Compare(TElement element, bool cacheLower)
+        {
+            TKey newKey = KeySelector(element);
+            int cmp = Descending ? Comparer.Compare(LastKey, newKey) : Comparer.Compare(newKey, LastKey);
+            if (cmp == 0) return _child.Compare(element, cacheLower);
+            if (cacheLower == cmp < 0)
+            {
+                LastKey = newKey;
+                _child.SetElement(element);
+            }
+            return cmp;
+        }
+        internal override void SetElement(TElement element)
+        {
+            base.SetElement(element);
+            _child.SetElement(element);
+        }
     }
 
     internal abstract class EnumerableSorter<TElement>
@@ -3805,13 +4458,31 @@ namespace System.Linq
 
         internal abstract int CompareAnyKeys(int index1, int index2);
 
-        internal int[] Sort(TElement[] elements, int count)
+        private int[] ComputeMap(TElement[] elements, int count)
         {
             ComputeKeys(elements, count);
             int[] map = new int[count];
             for (int i = 0; i < count; i++) map[i] = i;
+            return map;
+        }
+
+        internal int[] Sort(TElement[] elements, int count)
+        {
+            int[] map = ComputeMap(elements, count);
             QuickSort(map, 0, count - 1);
             return map;
+        }
+
+        internal int[] Sort(TElement[] elements, int count, int minIdx, int maxIdx)
+        {
+            int[] map = ComputeMap(elements, count);
+            PartialQuickSort(map, 0, count - 1, minIdx, maxIdx);
+            return map;
+        }
+
+        internal TElement ElementAt(TElement[] elements, int count, int idx)
+        {
+            return elements[QuickSelect(ComputeMap(elements, count), count - 1, idx)];
         }
 
         private int CompareKeys(int index1, int index2)
@@ -3852,9 +4523,87 @@ namespace System.Linq
                 }
             } while (left < right);
         }
+
+        // Sorts the k elements between minIdx and maxIdx without sorting all elements
+        // Time complexity: O(n + k log k) best and average case. O(n²) worse case.  
+        private void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx)
+        {
+            do
+            {
+                int i = left;
+                int j = right;
+                int x = map[i + ((j - i) >> 1)];
+                do
+                {
+                    while (i < map.Length && CompareKeys(x, map[i]) > 0) i++;
+                    while (j >= 0 && CompareKeys(x, map[j]) < 0) j--;
+                    if (i > j) break;
+                    if (i < j)
+                    {
+                        int temp = map[i];
+                        map[i] = map[j];
+                        map[j] = temp;
+                    }
+                    i++;
+                    j--;
+                } while (i <= j);
+                if (minIdx >= i) left = i + 1;
+                else if (maxIdx <= j) right = j - 1;
+                if (j - left <= right - i)
+                {
+                    if (left < j) PartialQuickSort(map, left, j, minIdx, maxIdx);
+                    left = i;
+                }
+                else
+                {
+                    if (i < right) PartialQuickSort(map, i, right, minIdx, maxIdx);
+                    right = j;
+                }
+            } while (left < right);
+        }
+
+        // Finds the element that would be at idx if the collection was sorted.
+        // Time complexity: O(n) best and average case. O(n²) worse case.
+        private int QuickSelect(int[] map, int right, int idx)
+        {
+            int left = 0;
+            do
+            {
+                int i = left;
+                int j = right;
+                int x = map[i + ((j - i) >> 1)];
+                do
+                {
+                    while (i < map.Length && CompareKeys(x, map[i]) > 0) i++;
+                    while (j >= 0 && CompareKeys(x, map[j]) < 0) j--;
+                    if (i > j) break;
+                    if (i < j)
+                    {
+                        int temp = map[i];
+                        map[i] = map[j];
+                        map[j] = temp;
+                    }
+                    i++;
+                    j--;
+                } while (i <= j);
+                if (i <= idx) left = i + 1;
+                else right = j - 1;
+                if (j - left <= right - i)
+                {
+                    if (left < j) right = j;
+                    left = i;
+                }
+                else
+                {
+                    if (i < right) left = i;
+                    right = j;
+                }
+            } while (left < right);
+            return map[idx];
+        }
     }
 
-    internal class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
+    internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
     {
         internal Func<TElement, TKey> keySelector;
         internal IComparer<TKey> comparer;

--- a/src/System.Linq/tests/EmptyPartitionTests.cs
+++ b/src/System.Linq/tests/EmptyPartitionTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class EmptyPartitionTests
+    {
+        private static IEnumerable<T> GetEmptyPartition<T>()
+        {
+            return new T[0].Take(0);
+        }
+
+        [Fact]
+        public void EmptyPartitionIsEmpty()
+        {
+            Assert.Empty(GetEmptyPartition<int>());
+            Assert.Empty(GetEmptyPartition<string>());
+        }
+
+        [Fact]
+        public void NotSingleInstance()
+        {
+            Assert.NotSame(GetEmptyPartition<int>(), GetEmptyPartition<int>());
+        }
+
+        [Fact]
+        public void SkipNotSame()
+        {
+            var empty = GetEmptyPartition<int>();
+            Assert.NotSame(empty, empty.Skip(2));
+        }
+
+        [Fact]
+        public void TakeNotSame()
+        {
+            var empty = GetEmptyPartition<int>();
+            Assert.NotSame(empty, empty.Take(2));
+        }
+
+        [Fact]
+        public void ElementAtThrows()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => GetEmptyPartition<int>().ElementAt(0));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultIsDefault()
+        {
+            Assert.Equal(0, GetEmptyPartition<int>().ElementAtOrDefault(0));
+            Assert.Equal(null, GetEmptyPartition<string>().ElementAtOrDefault(0));
+        }
+
+        [Fact]
+        public void FirstThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetEmptyPartition<int>().First());
+        }
+
+        [Fact]
+        public void FirstOrDefaultIsDefault()
+        {
+            Assert.Equal(0, GetEmptyPartition<int>().FirstOrDefault());
+            Assert.Equal(null, GetEmptyPartition<string>().FirstOrDefault());
+        }
+
+        [Fact]
+        public void LastThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetEmptyPartition<int>().Last());
+        }
+
+        [Fact]
+        public void LastOrDefaultIsDefault()
+        {
+            Assert.Equal(0, GetEmptyPartition<int>().LastOrDefault());
+            Assert.Equal(null, GetEmptyPartition<string>().LastOrDefault());
+        }
+
+        [Fact]
+        public void ToArrayEmpty()
+        {
+            Assert.Empty(GetEmptyPartition<int>().ToArray());
+        }
+
+        [Fact]
+        public void ToListEmpty()
+        {
+            Assert.Empty(GetEmptyPartition<int>().ToList());
+        }
+
+        [Fact]
+        public void CantResetEnumerator()
+        {
+            IEnumerator<int> en = GetEmptyPartition<int>().GetEnumerator();
+            Assert.Throws<NotSupportedException>(() => en.Reset());
+        }
+    }
+}

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -256,5 +256,59 @@ namespace System.Linq.Tests
             Func<DateTime, int> keySelector = null;
             Assert.Throws<ArgumentNullException>("keySelector", () => Enumerable.Empty<DateTime>().OrderBy(keySelector));
         }
+
+        [Fact]
+        public void FirstOnOrdered()
+        {
+            Assert.Equal(0, Enumerable.Range(0, 10).Shuffle().OrderBy(i => i).First());
+            Assert.Equal(9, Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i).First());
+            Assert.Equal(10, Enumerable.Range(0, 100).Shuffle().OrderByDescending(i => i.ToString().Length).ThenBy(i => i).First());
+        }
+
+        [Fact]
+        public void FirstOnEmptyOrderedThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).First());
+        }
+
+        [Fact]
+        public void FirstOrDefaultOnOrdered()
+        {
+            Assert.Equal(0, Enumerable.Range(0, 10).Shuffle().OrderBy(i => i).FirstOrDefault());
+            Assert.Equal(9, Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i).FirstOrDefault());
+            Assert.Equal(10, Enumerable.Range(0, 100).Shuffle().OrderByDescending(i => i.ToString().Length).ThenBy(i => i).FirstOrDefault());
+            Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).FirstOrDefault());
+        }
+
+        [Fact]
+        public void LastOnOrdered()
+        {
+            Assert.Equal(9, Enumerable.Range(0, 10).Shuffle().OrderBy(i => i).Last());
+            Assert.Equal(0, Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i).Last());
+            Assert.Equal(10, Enumerable.Range(0, 100).Shuffle().OrderBy(i => i.ToString().Length).ThenByDescending(i => i).Last());
+        }
+
+        [Fact]
+        public void LastOnEmptyOrderedThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).Last());
+        }
+
+        [Fact]
+        public void LastOrDefaultOnOrdered()
+        {
+            Assert.Equal(9, Enumerable.Range(0, 10).Shuffle().OrderBy(i => i).LastOrDefault());
+            Assert.Equal(0, Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i).LastOrDefault());
+            Assert.Equal(10, Enumerable.Range(0, 100).Shuffle().OrderBy(i => i.ToString().Length).ThenByDescending(i => i).LastOrDefault());
+            Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).LastOrDefault());
+        }
+
+        [Fact]
+        public void EnumeratorDoesntContinue()
+        {
+            var enumerator = NumberRangeGuaranteedNotCollectionType(0, 3).Shuffle().OrderBy(i => i).GetEnumerator();
+            while (enumerator.MoveNext()) { }
+            Assert.False(enumerator.MoveNext());
+        }
     }
 }

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -1,0 +1,331 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class OrderedSubsetting : EnumerableTests
+    {
+        [Fact]
+        public void FirstMultipleTruePredicateResult()
+        {
+            Assert.Equal(10, Enumerable.Range(1, 99).OrderBy(i => i).First(x => x % 10 == 0));
+            Assert.Equal(100, Enumerable.Range(1, 999).Concat(Enumerable.Range(1001, 3)).OrderByDescending(i => i.ToString().Length).ThenBy(i => i).First(x => x % 10 == 0));
+        }
+
+        [Fact]
+        public void FirstOrDefaultMultipleTruePredicateResult()
+        {
+            Assert.Equal(10, Enumerable.Range(1, 99).OrderBy(i => i).FirstOrDefault(x => x % 10 == 0));
+            Assert.Equal(100, Enumerable.Range(1, 999).Concat(Enumerable.Range(1001, 3)).OrderByDescending(i => i.ToString().Length).ThenBy(i => i).FirstOrDefault(x => x % 10 == 0));
+        }
+
+        [Fact]
+        public void FirstNoTruePredicateResult()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Range(1, 99).OrderBy(i => i).First(x => x > 1000));
+        }
+
+        [Fact]
+        public void FirstEmptyOrderedEnumerable()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).First());
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).First(x => true));
+        }
+
+        [Fact]
+        public void FirstOrDefaultNoTruePredicateResult()
+        {
+            Assert.Equal(0, Enumerable.Range(1, 99).OrderBy(i => i).FirstOrDefault(x => x > 1000));
+        }
+
+        [Fact]
+        public void FirstOrDefaultEmptyOrderedEnumerable()
+        {
+            Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).FirstOrDefault());
+            Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).FirstOrDefault(x => true));
+        }
+
+        [Fact]
+        public void Last()
+        {
+            Assert.Equal(10, Enumerable.Range(1, 99).Reverse().OrderByDescending(i => i).Last(x => x % 10 == 0));
+            Assert.Equal(100, Enumerable.Range(1, 999).Concat(Enumerable.Range(1001, 3)).Reverse().OrderBy(i => i.ToString().Length).ThenByDescending(i => i).Last(x => x % 10 == 0));
+            Assert.Equal(10, Enumerable.Range(1, 10).OrderBy(i => 1).Last());
+        }
+
+        [Fact]
+        public void LastMultipleTruePredicateResult()
+        {
+            Assert.Equal(90, Enumerable.Range(1, 99).OrderBy(i => i).Last(x => x % 10 == 0));
+            Assert.Equal(90, Enumerable.Range(1, 999).Concat(Enumerable.Range(1001, 3)).OrderByDescending(i => i.ToString().Length).ThenBy(i => i).Last(x => x % 10 == 0));
+        }
+
+        [Fact]
+        public void LastOrDefaultMultipleTruePredicateResult()
+        {
+            Assert.Equal(90, Enumerable.Range(1, 99).OrderBy(i => i).LastOrDefault(x => x % 10 == 0));
+            Assert.Equal(90, Enumerable.Range(1, 999).Concat(Enumerable.Range(1001, 3)).OrderByDescending(i => i.ToString().Length).ThenBy(i => i).LastOrDefault(x => x % 10 == 0));
+        }
+
+        [Fact]
+        public void LastNoTruePredicateResult()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Range(1, 99).OrderBy(i => i).Last(x => x > 1000));
+        }
+
+        [Fact]
+        public void LastEmptyOrderedEnumerable()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).Last());
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).Last(x => true));
+        }
+
+        [Fact]
+        public void LastOrDefaultNoTruePredicateResult()
+        {
+            Assert.Equal(0, Enumerable.Range(1, 99).OrderBy(i => i).LastOrDefault(x => x > 1000));
+        }
+
+        [Fact]
+        public void LastOrDefaultEmptyOrderedEnumerable()
+        {
+            Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).LastOrDefault());
+            Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).LastOrDefault(x => true));
+        }
+
+        [Fact]
+        public void Take()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(Enumerable.Range(0, 20), ordered.Take(20));
+            Assert.Equal(Enumerable.Range(0, 30), ordered.Take(50).Take(30));
+            Assert.Empty(ordered.Take(0));
+            Assert.Empty(ordered.Take(-1));
+            Assert.Empty(ordered.Take(int.MinValue));
+            Assert.Equal(new int[] { 0 }, ordered.Take(1));
+            Assert.Equal(Enumerable.Range(0, 100), ordered.Take(101));
+            Assert.Equal(Enumerable.Range(0, 100), ordered.Take(int.MaxValue));
+            Assert.Equal(Enumerable.Range(0, 100), ordered.Take(100));
+            Assert.Equal(Enumerable.Range(0, 99), ordered.Take(99));
+            Assert.Equal(Enumerable.Range(0, 100), ordered);
+        }
+
+        [Fact]
+        public void TakeThenFirst()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(0, ordered.Take(20).First());
+            Assert.Equal(0, ordered.Take(20).FirstOrDefault());
+        }
+
+        [Fact]
+        public void TakeThenLast()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(19, ordered.Take(20).Last());
+            Assert.Equal(19, ordered.Take(20).LastOrDefault());
+        }
+
+        [Fact]
+        public void Skip()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(Enumerable.Range(20, 80), ordered.Skip(20));
+            Assert.Equal(Enumerable.Range(80, 20), ordered.Skip(50).Skip(30));
+            Assert.Equal(20, ordered.Skip(20).First());
+            Assert.Equal(20, ordered.Skip(20).FirstOrDefault());
+            Assert.Equal(Enumerable.Range(0, 100), ordered.Skip(0));
+            Assert.Equal(Enumerable.Range(0, 100), ordered.Skip(-1));
+            Assert.Equal(Enumerable.Range(0, 100), ordered.Skip(int.MinValue));
+            Assert.Equal(new int[] { 99 }, ordered.Skip(99));
+            Assert.Empty(ordered.Skip(101));
+            Assert.Empty(ordered.Skip(int.MaxValue));
+            Assert.Empty(ordered.Skip(100));
+            Assert.Equal(Enumerable.Range(1, 99), ordered.Skip(1));
+            Assert.Equal(Enumerable.Range(0, 100), ordered);
+        }
+
+        [Fact]
+        public void SkipThenFirst()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(20, ordered.Skip(20).First());
+            Assert.Equal(20, ordered.Skip(20).FirstOrDefault());
+        }
+
+        [Fact]
+        public void SkipExcessiveThenFirstThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Range(2, 10).Shuffle().OrderBy(i => i).Skip(20).First());
+        }
+
+        [Fact]
+        public void SkipExcessiveThenFirstOrDefault()
+        {
+            Assert.Equal(0, Enumerable.Range(2, 10).Shuffle().OrderBy(i => i).Skip(20).FirstOrDefault());
+        }
+
+        [Fact]
+        public void SkipExcessiveEmpty()
+        {
+            Assert.Empty(Enumerable.Range(0, 10).Shuffle().OrderBy(i => i).Skip(42));
+        }
+
+        [Fact]
+        public void SkipThenLast()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(99, ordered.Skip(20).Last());
+            Assert.Equal(99, ordered.Skip(20).LastOrDefault());
+        }
+
+        [Fact]
+        public void SkipExcessiveThenLastThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Range(2, 10).Shuffle().OrderBy(i => i).Skip(20).Last());
+        }
+
+        [Fact]
+        public void SkipExcessiveThenLastOrDefault()
+        {
+            Assert.Equal(0, Enumerable.Range(2, 10).Shuffle().OrderBy(i => i).Skip(20).LastOrDefault());
+        }
+
+        [Fact]
+        public void SkipAndTake()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(Enumerable.Range(20, 60), ordered.Skip(20).Take(60));
+            Assert.Equal(Enumerable.Range(30, 20), ordered.Skip(20).Skip(10).Take(50).Take(20));
+            Assert.Empty(ordered.Skip(10).Take(9).Take(0));
+            Assert.Empty(ordered.Skip(200).Take(10));
+            Assert.Empty(ordered.Skip(3).Take(0));
+        }
+
+        [Fact]
+        public void TakeThenTakeExcessive()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(ordered.Take(20), ordered.Take(20).Take(100));
+        }
+
+        [Fact]
+        public void TakeThenSkipAll()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Empty(ordered.Take(20).Skip(30));
+        }
+
+        [Fact]
+        public void SkipAndTakeThenFirst()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(20, ordered.Skip(20).Take(60).First());
+            Assert.Equal(20, ordered.Skip(20).Take(60).FirstOrDefault());
+        }
+
+        [Fact]
+        public void SkipAndTakeThenLast()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(79, ordered.Skip(20).Take(60).Last());
+            Assert.Equal(79, ordered.Skip(20).Take(60).LastOrDefault());
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            var source = Enumerable.Range(0, 100).Shuffle().ToArray();
+            var ordered = source.OrderBy(i => i);
+            Assert.Equal(42, ordered.ElementAt(42));
+            Assert.Equal(93, ordered.ElementAt(93));
+            Assert.Equal(99, ordered.ElementAt(99));
+            Assert.Equal(42, ordered.ElementAtOrDefault(42));
+            Assert.Equal(93, ordered.ElementAtOrDefault(93));
+            Assert.Equal(99, ordered.ElementAtOrDefault(99));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ordered.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ordered.ElementAt(100));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ordered.ElementAt(1000));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ordered.ElementAt(int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ordered.ElementAt(int.MaxValue));
+            Assert.Equal(0, ordered.ElementAtOrDefault(-1));
+            Assert.Equal(0, ordered.ElementAtOrDefault(100));
+            Assert.Equal(0, ordered.ElementAtOrDefault(1000));
+            Assert.Equal(0, ordered.ElementAtOrDefault(int.MinValue));
+            Assert.Equal(0, ordered.ElementAtOrDefault(int.MaxValue));
+            var skipped = ordered.Skip(10).Take(80);
+            Assert.Equal(52, skipped.ElementAt(42));
+            Assert.Equal(83, skipped.ElementAt(73));
+            Assert.Equal(89, skipped.ElementAt(79));
+            Assert.Equal(52, skipped.ElementAtOrDefault(42));
+            Assert.Equal(83, skipped.ElementAtOrDefault(73));
+            Assert.Equal(89, skipped.ElementAtOrDefault(79));
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(80));
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(1000));
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(int.MaxValue));
+            Assert.Equal(0, skipped.ElementAtOrDefault(-1));
+            Assert.Equal(0, skipped.ElementAtOrDefault(80));
+            Assert.Equal(0, skipped.ElementAtOrDefault(1000));
+            Assert.Equal(0, skipped.ElementAtOrDefault(int.MinValue));
+            Assert.Equal(0, skipped.ElementAtOrDefault(int.MaxValue));
+            skipped = ordered.Skip(1000).Take(20);
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => skipped.ElementAt(0));
+            Assert.Throws<InvalidOperationException>(() => skipped.First());
+            Assert.Throws<InvalidOperationException>(() => skipped.Last());
+            Assert.Equal(0, skipped.ElementAtOrDefault(-1));
+            Assert.Equal(0, skipped.ElementAtOrDefault(0));
+            Assert.Equal(0, skipped.FirstOrDefault());
+            Assert.Equal(0, skipped.LastOrDefault());
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            Assert.Equal(Enumerable.Range(10, 20), Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(10).Take(20).ToArray());
+        }
+
+        [Fact]
+        public void EmptyToArray()
+        {
+            Assert.Empty(Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).ToArray());
+        }
+
+        [Fact]
+        public void AttemptedMoreArray()
+        {
+            Assert.Equal(Enumerable.Range(0, 20), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Take(30).ToArray());
+        }
+
+        [Fact]
+        public void SingleElementToArray()
+        {
+            Assert.Equal(Enumerable.Repeat(10, 1), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Skip(10).Take(1).ToArray());
+        }
+
+        [Fact]
+        public void EnumeratorDoesntContinue()
+        {
+            var enumerator = NumberRangeGuaranteedNotCollectionType(0, 3).Shuffle().OrderBy(i => i).Skip(1).GetEnumerator();
+            while (enumerator.MoveNext()) { }
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+}

--- a/src/System.Linq/tests/RangeTests.cs
+++ b/src/System.Linq/tests/RangeTests.cs
@@ -141,5 +141,77 @@ namespace System.Linq.Tests
 
             Assert.Equal(expected, Enumerable.Range(start, count));
         }
+
+        [Fact]
+        public void Take()
+        {
+            Assert.Equal(Enumerable.Range(0, 10), Enumerable.Range(0, 20).Take(10));
+        }
+
+        [Fact]
+        public void TakeExcessive()
+        {
+            Assert.Equal(Enumerable.Range(0, 10), Enumerable.Range(0, 10).Take(int.MaxValue));
+        }
+
+        [Fact]
+        public void Skip()
+        {
+            Assert.Equal(Enumerable.Range(10, 10), Enumerable.Range(0, 20).Skip(10));
+        }
+
+        [Fact]
+        public void SkipExcessive()
+        {
+            Assert.Empty(Enumerable.Range(10, 10).Skip(20));
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            Assert.Equal(4, Enumerable.Range(0, 10).ElementAt(4));
+        }
+
+        [Fact]
+        public void ElementAtExcessiveThrows()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => Enumerable.Range(0, 10).ElementAt(100));
+        }
+
+        [Fact]
+        public void ElementAtOrDefault()
+        {
+            Assert.Equal(4, Enumerable.Range(0, 10).ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultExcessiveIsDefault()
+        {
+            Assert.Equal(0, Enumerable.Range(52, 10).ElementAtOrDefault(100));
+        }
+
+        [Fact]
+        public void First()
+        {
+            Assert.Equal(57, Enumerable.Range(57, 1000000000).First());
+        }
+
+        [Fact]
+        public void FirstOrDefault()
+        {
+            Assert.Equal(-100, Enumerable.Range(-100, int.MaxValue).FirstOrDefault());
+        }
+
+        [Fact]
+        public void Last()
+        {
+            Assert.Equal(1000000056, Enumerable.Range(57, 1000000000).Last());
+        }
+
+        [Fact]
+        public void LastOrDefault()
+        {
+            Assert.Equal(int.MaxValue - 101, Enumerable.Range(-100, int.MaxValue).LastOrDefault());
+        }
     }
 }

--- a/src/System.Linq/tests/RepeatTests.cs
+++ b/src/System.Linq/tests/RepeatTests.cs
@@ -146,5 +146,83 @@ namespace System.Linq.Tests
 
             Assert.Equal(expected, Enumerable.Repeat((int?)null, 4));
         }
+
+        [Fact]
+        public void Take()
+        {
+            Assert.Equal(Enumerable.Repeat(12, 8), Enumerable.Repeat(12, 12).Take(8));
+        }
+
+        [Fact]
+        public void TakeExcessive()
+        {
+            Assert.Equal(Enumerable.Repeat("", 4), Enumerable.Repeat("", 4).Take(22));
+        }
+
+        [Fact]
+        public void Skip()
+        {
+            Assert.Equal(Enumerable.Repeat(12, 8), Enumerable.Repeat(12, 12).Skip(4));
+        }
+
+        [Fact]
+        public void SkipExcessive()
+        {
+            Assert.Empty(Enumerable.Repeat(12, 8).Skip(22));
+        }
+
+        [Fact]
+        public void SkipNone()
+        {
+            Assert.Equal(Enumerable.Repeat(12, 8), Enumerable.Repeat(12, 8).Skip(0));
+        }
+
+        [Fact]
+        public void First()
+        {
+            Assert.Equal("Test", Enumerable.Repeat("Test", 42).First());
+        }
+
+        [Fact]
+        public void FirstOrDefault()
+        {
+            Assert.Equal("Test", Enumerable.Repeat("Test", 42).FirstOrDefault());
+        }
+
+        [Fact]
+        public void Last()
+        {
+            Assert.Equal("Test", Enumerable.Repeat("Test", 42).Last());
+        }
+
+        [Fact]
+        public void LastOrDefault()
+        {
+            Assert.Equal("Test", Enumerable.Repeat("Test", 42).LastOrDefault());
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            Assert.Equal("Test", Enumerable.Repeat("Test", 42).ElementAt(13));
+        }
+
+        [Fact]
+        public void ElementAtOrDefault()
+        {
+            Assert.Equal("Test", Enumerable.Repeat("Test", 42).ElementAtOrDefault(13));
+        }
+
+        [Fact]
+        public void ElementAtExcessive()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => Enumerable.Repeat(3, 3).ElementAt(100));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultExcessive()
+        {
+            Assert.Equal(0, Enumerable.Repeat(3, 3).ElementAtOrDefault(100));
+        }
     }
 }

--- a/src/System.Linq/tests/Shuffler.cs
+++ b/src/System.Linq/tests/Shuffler.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System.Linq.Tests
+{
+    public static class Shuffler
+    {
+        public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source, int seed)
+        {
+            return new ShuffledEnumerable<T>(source, seed);
+        }
+
+        public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
+        {
+            return new ShuffledEnumerable<T>(source);
+        }
+
+        private class ShuffledEnumerable<T> : IEnumerable<T>
+        {
+            private IEnumerable<T> _source;
+            private int? _seed;
+
+            public ShuffledEnumerable(IEnumerable<T> source)
+            {
+                _source = source;
+            }
+
+            public ShuffledEnumerable(IEnumerable<T> source, int seed)
+                : this(source)
+            {
+                _seed = seed;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                Random rnd = _seed.HasValue ? new Random(_seed.GetValueOrDefault()) : new Random();
+                T[] array = _source.ToArray();
+                int count = array.Length;
+                for (int i = array.Length - 1; i > 0; --i)
+                {
+                    int j = rnd.Next(0, i + 1);
+                    if (i != j)
+                    {
+                        T swapped = array[i];
+                        array[i] = array[j];
+                        array[j] = swapped;
+                    }
+                }
+                return ((IEnumerable<T>)array).GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="ElementAtOrDefaultTests.cs" />
     <Compile Include="ElementAtTests.cs" />
     <Compile Include="EmptyEnumerable.cs" />
+    <Compile Include="EmptyPartitionTests.cs" />
     <Compile Include="EnumerableDebugViewTests.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="ExceptTests.cs" />
@@ -45,6 +46,7 @@
     <Compile Include="OfTypeTests.cs" />
     <Compile Include="OrderByDescendingTests.cs" />
     <Compile Include="OrderByTests.cs" />
+    <Compile Include="OrderedSubsetting.cs" />
     <Compile Include="RangeTests.cs" />
     <Compile Include="RepeatTests.cs" />
     <Compile Include="ReverseTests.cs" />
@@ -52,6 +54,7 @@
     <Compile Include="SelectTests.cs" />
     <Compile Include="SequenceEqualTests.cs" />
     <Compile Include="ShortCircuitingTests.cs" />
+    <Compile Include="Shuffler.cs" />
     <Compile Include="SingleOrDefaultTests.cs" />
     <Compile Include="SingleTests.cs" />
     <Compile Include="SkipTests.cs" />


### PR DESCRIPTION
Fixes #2400

If you only want the first or last element of an ordered enumerable, you do
not need to O‎(n log n) (worse case, O(n²) but rare) operation of sorting
the entire set in O(n) space, but can instead to an O(n) retrieval of just
that element in O(1) space.
