### PR TITLE
Remove unnecessary throw in ProcessManager.GetModulesInfos on Linux

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -67,11 +67,6 @@ namespace System.Diagnostics
             }
 
             // Return the set of modules found
-            if (modules.Count == 0)
-            {
-                // Match Windows behavior when failing to enumerate modules
-                throw new Win32Exception(SR.EnumProcessModuleFailed);
-            }
             return modules.ToArray();
         }
 


### PR DESCRIPTION
When I implemented ProcessManager.GetModulesInfo for Linux, I'd thought that if Windows couldn't enumerate the modules, it would always throw an exception.  As evidenced by #2395, turns out that's not the case, so I'm removing the corresponding exception on Linux.