### PR TITLE
Fix WebHeaderCollection.GetEnumerator().

### DIFF
--- a/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
+++ b/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
@@ -593,7 +593,7 @@ namespace System.Net
             }
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
+        public override IEnumerator GetEnumerator()
         {
             return InnerCollection.Keys.GetEnumerator();
         }

--- a/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
+++ b/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
@@ -593,6 +593,11 @@ namespace System.Net
             }
         }
 
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
         public override IEnumerator GetEnumerator()
         {
             return InnerCollection.Keys.GetEnumerator();

--- a/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
+++ b/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
@@ -250,5 +250,21 @@ namespace System.Net.WebHeaderCollectionTests
                 "Accept: text/plain\r\nContent-Length: 123\r\n\r\n",
                 w.ToString());
         }
+
+        [Fact]
+        public void IterateCollection_Success()
+        {
+            WebHeaderCollection w = new WebHeaderCollection();
+            w["Accept"] = "text/plain";
+            w["Content-Length"] = "123";
+
+            string result = "";
+            foreach (var item in w)
+            {
+                result += item;
+            }
+
+            Assert.Equal("AcceptContent-Length", result);
+        }
     }
 }

--- a/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
+++ b/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
@@ -266,5 +266,22 @@ namespace System.Net.WebHeaderCollectionTests
 
             Assert.Equal("AcceptContent-Length", result);
         }
+
+        [Fact]
+        public void IterateIEnumerable_Success()
+        {
+            WebHeaderCollection w = new WebHeaderCollection();
+            w["Accept"] = "text/plain";
+            w["Content-Length"] = "123";
+
+            string result = "";
+            foreach (var item in (System.Collections.IEnumerable)w)
+            {
+                result += item;
+            }
+
+            Assert.Equal("AcceptContent-Length", result);
+        }
+
     }
 }


### PR DESCRIPTION
Change WebHeaderCollection.GetEnumerator() from an explicit implementation
to a public override to avoid delegating to the base collection. This change
also adds a test for this behavior.