### PR TITLE
Allow extended syntax for paths

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
 namespace System.IO
@@ -8,6 +9,10 @@ namespace System.IO
     /// <summary>Contains internal path helpers that are shared between many projects.</summary>
     internal static partial class PathInternal
     {
+        // Therre is only one invalid path character in Unix
+        private const char InvalidPathChar = '\0';
+        internal static readonly char[] InvalidPathChars = { InvalidPathChar };
+
         /// <summary>Returns a value indicating if the given path contains invalid characters.</summary>
         internal static bool HasIllegalCharacters(string path, bool checkAdditional = false)
         {
@@ -15,17 +20,26 @@ namespace System.IO
 
             foreach (char c in path)
             {
-                // Same as Path.InvalidPathChars, unrolled here for performance
-                if (c == '\0')
+                // Same as InvalidPathChars, unrolled here for performance
+                if (c == InvalidPathChar)
                     return true;
-
-                // checkAdditional is meant to check for additional characters 
-                // permitted in a search path but disallowed in a normal path.
-                // In Windows this is * and ?,but Unix permits such characters
-                // in the filename so checkAdditional is ignored.
             }
 
             return false;
+        }
+
+        internal static int GetRootLength(string path)
+        {
+            PathInternal.CheckInvalidPathChars(path);
+            return path.Length > 0 && IsDirectorySeparator(path[0]) ? 1 : 0;
+        }
+
+        internal static bool IsDirectorySeparator(char c)
+        {
+            // The alternatie directory separator char is the same as the directory separator,
+            // so we only need to check one.
+            Debug.Assert(Path.DirectorySeparatorChar == Path.AltDirectorySeparatorChar);
+            return c == Path.DirectorySeparatorChar;
         }
     }
 }

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -8,6 +8,29 @@ namespace System.IO
     /// <summary>Contains internal path helpers that are shared between many projects.</summary>
     internal static partial class PathInternal
     {
+        internal const string LongPathPrefix = @"\\?\";
+        internal const string UNCPathPrefix = @"\\";
+        internal const string UNCLongPathPrefixToInsert = @"?\UNC\";
+        internal const string UNCLongPathPrefix = @"\\?\UNC\";
+
+        internal static readonly char[] InvalidPathChars =
+        {
+            '\"', '<', '>', '|', '\0',
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+            (char)31
+        };
+
+        internal static readonly char[] InvalidPathCharsWithAdditionalChecks = // This is used by HasIllegalCharacters
+        {
+            '\"', '<', '>', '|', '\0',
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+            (char)31, '*', '?'
+        };
+
         /// <summary>
         /// Returns a value indicating if the given path contains invalid characters (", &lt;, &gt;, | 
         /// NUL, or any ASCII char whose integer representation is in the range of 1 through 31), 
@@ -19,19 +42,67 @@ namespace System.IO
 
             Contract.Requires(path != null);
 
-            foreach (char c in path)
-            {
-                // Note: Same as Path.InvalidPathChars, unrolled here for performance
-                if (c == '\"' || c == '<' || c == '>' || c == '|' || c < 32)
-                    return true;
+            // Question mark is a normal part of extended path syntax (\\?\)
+            int startIndex = path.StartsWith(LongPathPrefix, StringComparison.Ordinal) ? LongPathPrefix.Length : 0;
+            return path.IndexOfAny(checkAdditional ? InvalidPathCharsWithAdditionalChecks : InvalidPathChars, startIndex) >= 0;
+        }
 
-                // used when path cannot contain search strings.
-                if (checkAdditional &&
-                    (c == '?' || c == '*'))
-                    return true;
+        /// <summary>
+        /// Gets the length of the root of the path (drive, share, etc.).
+        /// </summary>
+        internal static int GetRootLength(string path)
+        {
+            CheckInvalidPathChars(path);
+
+            int i = 0;
+            int length = path.Length;
+            int volumeSeparatorLength = 2;  // Length to the colon "C:"
+            int uncRootLength = 2;          // Length to the start of the server name "\\"
+
+            bool extendedSyntax = path.StartsWith(LongPathPrefix, StringComparison.Ordinal);
+            bool extendedUncSyntax = extendedSyntax && path.StartsWith(UNCLongPathPrefix, StringComparison.Ordinal);
+            if (extendedSyntax)
+            {
+                // Shift the position we look for the root from to account for the extended prefix
+                if (extendedUncSyntax)
+                {
+                    // "C:" -> "\\?\C:"
+                    uncRootLength = UNCLongPathPrefix.Length;
+                }
+                else
+                {
+                    // "\\" -> "\\?\UNC\"
+                    volumeSeparatorLength += LongPathPrefix.Length;
+                }
             }
 
-            return false;
+            if ((!extendedSyntax || extendedUncSyntax) && length > 0 && IsDirectorySeparator(path[0]))
+            {
+                // UNC or simple rooted path (e.g. "\foo", NOT "\\?\C:\foo")
+
+                i = 1; //  Drive rooted (\foo) is one character
+                if (extendedUncSyntax || (length > 1 && (IsDirectorySeparator(path[1]))))
+                {
+                    // UNC (\\?\UNC\ or \\), scan past the next two directory separators at most
+                    // (e.g. to \\?\UNC\Server\Share or \\Server\Share\)
+                    i = uncRootLength;
+                    int n = 2; // Maximum separators to skip
+                    while (i < length && (!IsDirectorySeparator(path[i]) || --n > 0)) i++;
+                }
+            }
+            else if (length >= volumeSeparatorLength && path[volumeSeparatorLength - 1] == Path.VolumeSeparatorChar)
+            {
+                // Path is at least longer than where we expect a colon, and has a colon (\\?\A:, A:)
+                // If the colon is followed by a directory separator, move past it
+                i = volumeSeparatorLength;
+                if (length >= volumeSeparatorLength + 1 && (IsDirectorySeparator(path[volumeSeparatorLength]))) i++;
+            }
+            return i;
+        }
+
+        internal static bool IsDirectorySeparator(char c)
+        {
+            return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
         }
     }
 }

--- a/src/Common/src/System/IO/PathInternal.cs
+++ b/src/Common/src/System/IO/PathInternal.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Contracts;
+
+namespace System.IO
+{
+    /// <summary>Contains internal path helpers that are shared between many projects.</summary>
+    internal static partial class PathInternal
+    {
+        /// <summary>
+        /// Checks for invalid path characters in the given path.
+        /// </summary>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <exception cref="System.ArgumentException">Thrown if the path has invalid characters.</exception>
+        /// <param name="path">The path to check for invalid characters.</param>
+        /// <param name="checkAdditional">Set to true to check for characters that are only valid in specific contexts (such as search characters on Windows).</param>
+        internal static void CheckInvalidPathChars(string path, bool checkAdditional = false)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            if (PathInternal.HasIllegalCharacters(path, checkAdditional))
+                throw new ArgumentException(SR.Argument_InvalidPathChars, "path");
+        }
+    }
+}

--- a/src/System.IO.FileSystem.DriveInfo/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem.DriveInfo/src/Resources/Strings.resx
@@ -126,6 +126,9 @@
   <data name="Arg_InvalidDriveChars" xml:space="preserve">
     <value>Illegal characters in drive name '{0}'.</value>
   </data>
+  <data name="Argument_InvalidPathChars" xml:space="preserve">
+    <value>Illegal characters in path.</value>
+  </data>
   <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
     <value>Specified file length was too large for the file system.</value>
   </data>

--- a/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -32,6 +32,9 @@
     <Compile Include="$(CommonPath)\System\__HResults.cs">
       <Link>Common\System\__HResults.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
+      <Link>Common\System\IO\PathInternal.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="System\IO\__Error.cs" />

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -52,6 +52,9 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
+      <Link>Common\System\IO\PathInternal.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Windows -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -486,7 +486,7 @@ namespace System.IO
             Contract.EndContractBlock();
 
             String fullPath = PathHelpers.GetFullPathInternal(path);
-            String root = fullPath.Substring(0, PathHelpers.GetRootLength(fullPath));
+            String root = fullPath.Substring(0, PathInternal.GetRootLength(fullPath));
 
             return root;
         }
@@ -494,7 +494,7 @@ namespace System.IO
         internal static String InternalGetDirectoryRoot(String path)
         {
             if (path == null) return null;
-            return path.Substring(0, PathHelpers.GetRootLength(path));
+            return path.Substring(0, PathInternal.GetRootLength(path));
         }
 
         /*===============================CurrentDirectory===============================

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -25,7 +25,7 @@ namespace System.IO
         [System.Security.SecuritySafeCritical]
         internal DirectoryInfo(String fullPath, IFileSystemObject fileSystemObject) : base(fileSystemObject)
         {
-            Debug.Assert(PathHelpers.GetRootLength(fullPath) > 0, "fullPath must be fully qualified!");
+            Debug.Assert(PathInternal.GetRootLength(fullPath) > 0, "fullPath must be fully qualified!");
             
             // Fast path when we know a DirectoryInfo exists.
             OriginalPath = Path.GetFileName(fullPath);

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -195,7 +195,7 @@ namespace System.IO
                 // Otherwise, FillAttributeInfo removes it and we may return a false positive.
                 // GetFullPath should never return null
                 Debug.Assert(path != null, "File.Exists: GetFullPath returned null");
-                if (path.Length > 0 && PathHelpers.IsDirectorySeparator(path[path.Length - 1]))
+                if (path.Length > 0 && PathInternal.IsDirectorySeparator(path[path.Length - 1]))
                 {
                     return false;
                 }

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -24,14 +24,6 @@ namespace System.IO
             // Prevent access to your disk drives as raw block devices.
             if (fullPath.StartsWith("\\\\.\\", StringComparison.Ordinal))
                 throw new ArgumentException(SR.Arg_DevicesNotSupported, paramName);
-
-            // Check for additional invalid characters.  Most invalid characters were checked above
-            // in our call to Path.GetFullPath(path);
-            if (fullPath.IndexOfAny(s_additionalInvalidChars) != -1)
-                throw new ArgumentException(SR.Argument_InvalidPathChars, paramName);
-
-            if (fullPath.IndexOf(':', 2) != -1)
-                throw new NotSupportedException(SR.Argument_PathFormatNotSupported);
         }
 
         private static readonly char[] s_additionalInvalidChars = new[] { '?', '*' };

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
@@ -50,7 +50,7 @@ namespace System.IO
                     char ch = FullPath[i];
                     if (ch == '.')
                         return FullPath.Substring(i, length - i);
-                    if (PathHelpers.IsDirectorySeparator(ch) || ch == Path.VolumeSeparatorChar)
+                    if (PathInternal.IsDirectorySeparator(ch) || ch == Path.VolumeSeparatorChar)
                         break;
                 }
                 return String.Empty;

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
@@ -5,12 +5,6 @@ namespace System.IO
 {
     internal static partial class PathHelpers
     {
-        internal static int GetRootLength(string path)
-        {
-            CheckInvalidPathChars(path);
-            return path.Length > 0 && IsDirectorySeparator(path[0]) ? 1 : 0;
-        }
-
         internal static bool ShouldReviseDirectoryPathToCurrent(string path)
         {
             // Unlike on Windows, there are no special cases on Unix where we'd want to ignore
@@ -25,17 +19,12 @@ namespace System.IO
             // So, throw if we find a ".." that's its own component in the path.
             for (int index = 0; (index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) >= 0; index += 2)
             {
-                if ((index == 0 || IsDirectorySeparator(searchPattern[index - 1])) && // previous character is directory separator
-                    (index + 2 == searchPattern.Length || IsDirectorySeparator(searchPattern[index + 2]))) // next character is directory separator
+                if ((index == 0 || PathInternal.IsDirectorySeparator(searchPattern[index - 1])) && // previous character is directory separator
+                    (index + 2 == searchPattern.Length || PathInternal.IsDirectorySeparator(searchPattern[index + 2]))) // next character is directory separator
                 {
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
                 }
             }
-        }
-
-        internal static bool IsDirectorySeparator(char c)
-        {
-            return c == Path.DirectorySeparatorChar;
         }
 
         internal static string GetFullPathInternal(string path)

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -10,36 +10,6 @@ namespace System.IO
         internal static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
         internal static readonly char[] TrimStartChars = { ' ' };
 
-        // Gets the length of the root DirectoryInfo or whatever DirectoryInfo markers
-        // are specified for the first part of the DirectoryInfo name.
-        // 
-        internal static int GetRootLength(String path)
-        {
-            CheckInvalidPathChars(path);
-
-            int i = 0;
-            int length = path.Length;
-
-            if (length >= 1 && (IsDirectorySeparator(path[0])))
-            {
-                // handles UNC names and directories off current drive's root.
-                i = 1;
-                if (length >= 2 && (IsDirectorySeparator(path[1])))
-                {
-                    i = 2;
-                    int n = 2;
-                    while (i < length && (!IsDirectorySeparator(path[i]) || --n > 0)) i++;
-                }
-            }
-            else if (length >= 2 && path[1] == Path.VolumeSeparatorChar)
-            {
-                // handles A:\foo.
-                i = 2;
-                if (length >= 3 && (IsDirectorySeparator(path[2]))) i++;
-            }
-            return i;
-        }
-
         internal static bool ShouldReviseDirectoryPathToCurrent(string path)
         {
             // In situations where this method is invoked, "<DriveLetter>:" should be special-cased 
@@ -58,16 +28,11 @@ namespace System.IO
             {
                 // Terminal ".." or "..\". File and directory names cannot end in "..".
                 if (index + 2 == searchPattern.Length || 
-                    IsDirectorySeparator(searchPattern[index + 2]))
+                    PathInternal.IsDirectorySeparator(searchPattern[index + 2]))
                 {
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
                 }
             }
-        }
-
-        internal static bool IsDirectorySeparator(char c)
-        {
-            return (c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar);
         }
 
         internal static string GetFullPathInternal(string path)
@@ -99,7 +64,7 @@ namespace System.IO
             if (path != null)
             {
                 int length = path.Length;
-                int rootLength = GetRootLength(path);
+                int rootLength = PathInternal.GetRootLength(path);
 
                 // ignore a trailing slash
                 if (length > rootLength && EndsInDirectorySeparator(path))
@@ -108,7 +73,7 @@ namespace System.IO
                 // find the pivot index between end of string and root
                 for (int pivot = length - 1; pivot >= rootLength; pivot--)
                 {
-                    if (IsDirectorySeparator(path[pivot]))
+                    if (PathInternal.IsDirectorySeparator(path[pivot]))
                     {
                         directory = path.Substring(0, pivot);
                         file = path.Substring(pivot + 1, length - pivot - 1);

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -14,15 +14,6 @@ namespace System.IO
         // string so as to avoid the boxing of the character when calling String.Concat(..., object).
         internal static readonly string DirectorySeparatorCharAsString = Path.DirectorySeparatorChar.ToString();
 
-        internal static void CheckInvalidPathChars(String path, bool checkAdditional = false)
-        {
-            if (path == null)
-                throw new ArgumentNullException("path");
-
-            if (PathInternal.HasIllegalCharacters(path, checkAdditional))
-                throw new ArgumentException(SR.Argument_InvalidPathChars, "path");
-        }
-
         // System.IO.Path has both public Combine and internal InternalCombine
         // members.  InternalCombine performs these extra validations on the second 
         // argument.  This provides a convenient helper to maintain this extra
@@ -39,12 +30,12 @@ namespace System.IO
 
         internal static bool IsRoot(string path)
         {
-            return path.Length == GetRootLength(path);
+            return path.Length == PathInternal.GetRootLength(path);
         }
 
         internal static bool EndsInDirectorySeparator(String path)
         {
-            return path.Length > 0 && IsDirectorySeparator(path[path.Length - 1]);
+            return path.Length > 0 && PathInternal.IsDirectorySeparator(path[path.Length - 1]);
         }
 
         internal static string TrimEndingDirectorySeparator(string path)

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -107,7 +107,7 @@ namespace System.IO
             }
 
             // For paths that are only // or /// 
-            if (length == 2 && PathHelpers.IsDirectorySeparator(fullPath[1]))
+            if (length == 2 && PathInternal.IsDirectorySeparator(fullPath[1]))
             {
                 throw new IOException(SR.Format(SR.IO_CannotCreateDirectory, fullPath));
             }
@@ -121,7 +121,7 @@ namespace System.IO
             // Attempt to figure out which directories don't exist, and only create the ones we need.
             bool somepathexists = false;
             Stack<string> stackDir = new Stack<string>();
-            int lengthRoot = PathHelpers.GetRootLength(fullPath);
+            int lengthRoot = PathInternal.GetRootLength(fullPath);
             if (length > lengthRoot)
             {
                 int i = length - 1;
@@ -137,7 +137,7 @@ namespace System.IO
                         somepathexists = true;
                     }
 
-                    while (i > lengthRoot && !PathHelpers.IsDirectorySeparator(fullPath[i]))
+                    while (i > lengthRoot && !PathInternal.IsDirectorySeparator(fullPath[i]))
                     {
                         i--;
                     }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -53,10 +53,10 @@ namespace System.IO
             if (length >= 2 && PathHelpers.EndsInDirectorySeparator(fullPath))
                 length--;
 
-            int lengthRoot = PathHelpers.GetRootLength(fullPath);
+            int lengthRoot = PathInternal.GetRootLength(fullPath);
 
             // For UNC paths that are only // or /// 
-            if (length == 2 && PathHelpers.IsDirectorySeparator(fullPath[1]))
+            if (length == 2 && PathInternal.IsDirectorySeparator(fullPath[1]))
                 throw new IOException(SR.Format(SR.IO_CannotCreateDirectory, fullPath));
 
             // We can save a bunch of work if the directory we want to create already exists.  This also
@@ -90,7 +90,7 @@ namespace System.IO
                     else
                         somepathexists = true;
 
-                    while (i > lengthRoot && !PathHelpers.IsDirectorySeparator(fullPath[i])) i--;
+                    while (i > lengthRoot && !PathInternal.IsDirectorySeparator(fullPath[i])) i--;
                     i--;
                 }
             }
@@ -435,7 +435,7 @@ namespace System.IO
         [System.Security.SecurityCritical]
         private static SafeFileHandle OpenHandle(string fullPath, bool asDirectory)
         {
-            String root = fullPath.Substring(0, PathHelpers.GetRootLength(fullPath));
+            String root = fullPath.Substring(0, PathInternal.GetRootLength(fullPath));
             if (root == fullPath && root[1] == Path.VolumeSeparatorChar)
             {
                 // intentionally not fullpath, most upstack public APIs expose this as path.

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -222,7 +222,7 @@ namespace System.IO
 
             if (searchCriteria != null)
             {
-                PathHelpers.CheckInvalidPathChars(fullPath, true);
+                PathInternal.CheckInvalidPathChars(fullPath, true);
 
                 _searchData = new SearchData(normalizedSearchPath, userPath, searchOption);
                 CommonInit();
@@ -479,7 +479,7 @@ namespace System.IO
 
             String searchCriteria = null;
             char lastChar = fullPathMod[fullPathMod.Length - 1];
-            if (PathHelpers.IsDirectorySeparator(lastChar))
+            if (PathInternal.IsDirectorySeparator(lastChar))
             {
                 // Can happen if the path is C:\temp, in which case GetDirectoryName would return C:\
                 searchCriteria = fullSearchString.Substring(fullPathMod.Length);
@@ -502,7 +502,7 @@ namespace System.IO
 
             // If path ends in a trailing slash (\), append a * or we'll get a "Cannot find the file specified" exception
             char lastChar = tempStr[tempStr.Length - 1];
-            if (PathHelpers.IsDirectorySeparator(lastChar) || lastChar == Path.VolumeSeparatorChar)
+            if (PathInternal.IsDirectorySeparator(lastChar) || lastChar == Path.VolumeSeparatorChar)
             {
                 tempStr = tempStr + "*";
             }

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -15,7 +15,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         #endregion
-        
+
         #region UniversalTests
 
         [Fact]
@@ -128,7 +128,7 @@ namespace System.IO.FileSystem.Tests
         public void WindowsNonSignificantWhiteSpaceAsPath_ReturnsFalse()
         {
             // Checks that errors aren't thrown when calling Exists() on impossible paths
-            Assert.All((IOInputs.GetNonSignificantTrailingWhiteSpace()), (component) =>
+            Assert.All(IOInputs.GetWhiteSpace(), (component) =>
             {
                 Assert.False(Exists(component));
             });
@@ -145,7 +145,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Linux | PlatformID.FreeBSD)] 
+        [PlatformSpecific(PlatformID.Linux | PlatformID.FreeBSD)]
         public void DoesCaseSensitiveComparions()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -159,7 +159,7 @@ namespace System.IO.FileSystem.Tests
         public void TrimTrailingWhitespacePath()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            Assert.All((IOInputs.GetNonSignificantTrailingWhiteSpace()), (component) =>
+            Assert.All(IOInputs.GetWhiteSpace(), (component) =>
             {
                 Assert.True(Exists(testDir.FullName + component)); // string concat in case Path.Combine() trims whitespace before Exists gets to it
             });
@@ -169,9 +169,9 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)] // alternate data stream
         public void PathWithAlternateDataStreams_ReturnsFalse()
         {
-            Assert.All((IOInputs.GetPathsWithAlternativeDataStreams()), (component) =>
+            Assert.All(IOInputs.GetWhiteSpace(), (component) =>
             {
-                Assert.False(Exists(component)); 
+                Assert.False(Exists(component));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -124,7 +124,7 @@ namespace System.IO.FileSystem.Tests
         [ActiveIssue(2402)]
         public void WindowsWhiteSpaceAsPath_ThrowsArgumentException()
         {
-            var paths = IOInputs.GetNonSignificantTrailingWhiteSpace();
+            var paths = IOInputs.GetWhiteSpace();
             Assert.All(paths, (path) =>
             {
                 Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(path));
@@ -135,7 +135,7 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void UnixWhiteSpaceAsPath_Allowed()
         {
-            var paths = IOInputs.GetNonSignificantTrailingWhiteSpace();
+            var paths = IOInputs.GetWhiteSpace();
             Assert.All(paths, (path) =>
             {
                 new DirectoryInfo(TestDirectory).CreateSubdirectory(path);
@@ -149,7 +149,7 @@ namespace System.IO.FileSystem.Tests
         public void WindowsNonSignificantTrailingWhiteSpace()
         {
             // Windows will remove all nonsignificant whitespace in a path
-            var components = IOInputs.GetNonSignificantTrailingWhiteSpace();
+            var components = IOInputs.GetWhiteSpace();
 
             Assert.All(components, (component) =>
             {
@@ -178,7 +178,7 @@ namespace System.IO.FileSystem.Tests
         {
             // Unix treats trailing/prename whitespace as significant and a part of the name.
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            var components = IOInputs.GetNonSignificantTrailingWhiteSpace();
+            var components = IOInputs.GetWhiteSpace();
 
             Assert.All(components, (component) =>
             {

--- a/src/System.IO.FileSystem/tests/File/Create_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Create_str.cs
@@ -50,6 +50,21 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void ValidCreation_ExtendedSyntax()
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(@"\\?\" + GetTestFilePath());
+            Assert.StartsWith(@"\\?\", testDir.FullName);
+            string testFile = Path.Combine(testDir.FullName, GetTestFileName());
+            using (FileStream stream = Create(testFile))
+            {
+                Assert.True(File.Exists(testFile));
+                Assert.Equal(0, stream.Length);
+                Assert.Equal(0, stream.Position);
+            }
+        }
+
+        [Fact]
         public void CreateInParentDirectory()
         {
             string testFile = GetTestFileName();

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -43,13 +43,8 @@ internal static class IOInputs
         yield return "V1.0.0.0000";
     }
 
-    public static IEnumerable<string> GetNonSignificantTrailingWhiteSpace()
+    public static IEnumerable<string> GetControlWhiteSpace()
     {
-        yield return " ";
-        yield return "  ";
-        yield return "   ";
-        yield return "    ";
-        yield return "     ";
         yield return "\t";
         yield return "\t\t";
         yield return "\t\t\t";
@@ -60,6 +55,20 @@ internal static class IOInputs
         yield return "\t\n\t\n";
         yield return "\n\t\n";
         yield return "\n\t\n\t";
+    }
+
+    public static IEnumerable<string> GetSimpleWhiteSpace()
+    {
+        yield return " ";
+        yield return "  ";
+        yield return "   ";
+        yield return "    ";
+        yield return "     ";
+    }
+
+    public static IEnumerable<string> GetWhiteSpace()
+    {
+        return GetControlWhiteSpace().Concat(GetSimpleWhiteSpace());
     }
 
     public static IEnumerable<string> GetUncPathsWithoutShareName()
@@ -153,8 +162,6 @@ internal static class IOInputs
             yield return @"\\?\";
             yield return @"\\?\UNC\";
             yield return @"\\?\UNC\Server";
-            yield return @"\\?\UNC\Server\Share";
-            yield return @"\\?\UNC\Server\Share\FileName.txt";
 
             /* Bug 1011730.  CoreCLR checks : before invalid characters and throws NotSupportedException for these.
             yield return @"\\?\C:";

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -8,6 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <!-- Setting temporarily until we can publish a new package drop of Runtime.Extensions -->
+    <TestWithLocalLibraries>true</TestWithLocalLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NuGetTargetFrameworkMoniker>DNXCore,Version=v5.0</NuGetTargetFrameworkMoniker>
-	<!-- System.IO.Path conflicts between type in partial facade and in mscorlib -->
+    <!-- System.IO.Path conflicts between type in partial facade and in mscorlib -->
     <NoWarn>0436</NoWarn> 
   </PropertyGroup>
 
@@ -38,10 +38,13 @@
 
   <ItemGroup>
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelDictionary.cs">
-      <Link>System\Collections\Generic\LowLevelDictionary.cs</Link>
+      <Link>Common\System\Collections\Generic\LowLevelDictionary.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
-      <Link>System\IO\StringBuilderCache.cs</Link>
+      <Link>Common\System\IO\StringBuilderCache.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
+      <Link>Common\System\IO\PathInternal.cs</Link>
     </Compile>
   </ItemGroup>
 
@@ -51,7 +54,7 @@
     <Compile Include="System\IO\Path.Win32.cs" />
     <Compile Include="System\IO\PathHelper.Windows.cs" />
     <Compile Include="$(CommonPath)\System\IO\Win32Marshal.cs">
-      <Link>System\IO\Win32Marshal.cs</Link>
+      <Link>Common\System\IO\Win32Marshal.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -88,6 +91,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.QueryPerformanceFrequency.cs">
       <Link>Common\Interop\Windows\mincore\Interop.QueryPerformanceFrequency.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+      <Link>Common\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
   </ItemGroup>
 
@@ -135,6 +141,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.RAND.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.RAND.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
+      <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -16,24 +16,6 @@ namespace System.IO
 
         private const string DirectorySeparatorCharAsString = "\\";
 
-        private static readonly char[] InvalidPathChars = 
-        { 
-            '\"', '<', '>', '|', '\0', 
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, 
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, 
-            (char)31 
-        };
-
-        private static readonly char[] InvalidPathCharsWithAdditionalChecks = // This is used by HasIllegalCharacters
-        { 
-            '\"', '<', '>', '|', '\0', 
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, 
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, 
-            (char)31, '*', '?' 
-        };
-
         private static readonly char[] InvalidFileNameChars = 
         { 
             '\"', '<', '>', '|', '\0', 
@@ -44,7 +26,7 @@ namespace System.IO
         };
 
         // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
-        // string.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).    
+        // string.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).
         private static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
 
         // The max total path is 260, and the max individual component length is 255. 
@@ -53,49 +35,9 @@ namespace System.IO
         private static readonly int MaxComponentLength = 255;
         private const int MaxLongPath = 32000;
 
-        private const string LongPathPrefix = @"\\?\";
-        private const string UNCPathPrefix = @"\\";
-        private const string UNCLongPathPrefixToInsert = @"?\UNC\";
-        private const string UNCLongPathPrefix = @"\\?\UNC\";
-
-        private static bool IsDirectorySeparator(char c)
-        {
-            return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar;
-        }
-
         private static bool IsDirectoryOrVolumeSeparator(char c)
         {
-            return IsDirectorySeparator(c) || VolumeSeparatorChar == c;
-        }
-
-        // Gets the length of the root DirectoryInfo or whatever DirectoryInfo markers
-        // are specified for the first part of the DirectoryInfo name.
-        // 
-        private static int GetRootLength(string path)
-        {
-            CheckInvalidPathChars(path);
-
-            int i = 0;
-            int length = path.Length;
-
-            if (length >= 1 && IsDirectorySeparator(path[0]))
-            {
-                // handles UNC names and directories off current drive's root.
-                i = 1;
-                if (length >= 2 && (IsDirectorySeparator(path[1])))
-                {
-                    i = 2;
-                    int n = 2;
-                    while (i < length && (!IsDirectorySeparator(path[i]) || --n > 0)) i++;
-                }
-            }
-            else if (length >= 2 && path[1] == VolumeSeparatorChar)
-            {
-                // handles A:\foo.
-                i = 2;
-                if (length >= 3 && (IsDirectorySeparator(path[2]))) i++;
-            }
-            return i;
+            return PathInternal.IsDirectorySeparator(c) || VolumeSeparatorChar == c;
         }
 
         // Expands the given path to a fully qualified path. 
@@ -106,8 +48,10 @@ namespace System.IO
             string fullPath = GetFullPathInternal(path);
 
             // Emulate FileIOPermissions checks, retained for compatibility
-            CheckInvalidPathChars(fullPath, true);
-            if (fullPath.Length > 2 && fullPath.IndexOf(':', 2) != -1)
+            PathInternal.CheckInvalidPathChars(fullPath, true);
+
+            int startIndex = fullPath.StartsWith(PathInternal.LongPathPrefix, StringComparison.Ordinal) ? PathInternal.LongPathPrefix.Length + 2 : 2;
+            if (fullPath.Length > startIndex && fullPath.IndexOf(':', startIndex) != -1)
             {
                 throw new NotSupportedException(SR.Argument_PathFormatNotSupported);
             }
@@ -115,21 +59,109 @@ namespace System.IO
             return fullPath;
         }
 
+        /// <summary>
+        /// Checks for known bad extended paths (paths that start with \\?\)
+        /// </summary>
+        /// <param name="fullCheck">Check for invalid characters if true.</param>
+        /// <returns>'true' if the path passes validity checks.</returns>
+        private static bool ValidateExtendedPath(string path, bool fullCheck)
+        {
+            if (path.Length == PathInternal.LongPathPrefix.Length)
+            {
+                // Effectively empty and therefore invalid
+                return false;
+            }
+
+            if (path.StartsWith(PathInternal.UNCLongPathPrefix, StringComparison.Ordinal))
+            {
+                // UNC specific checks
+                if (path.Length == PathInternal.UNCLongPathPrefix.Length || path[PathInternal.UNCLongPathPrefix.Length] == DirectorySeparatorChar)
+                {
+                    // Effectively empty and therefore invalid (\\?\UNC\ or \\?\UNC\\)
+                    return false;
+                }
+
+                int serverShareSeparator = path.IndexOf(DirectorySeparatorChar, PathInternal.UNCLongPathPrefix.Length);
+                if (serverShareSeparator == -1 || serverShareSeparator == path.Length - 1)
+                {
+                    // Need at least a Server\Share
+                    return false;
+                }
+            }
+
+            // Segments can't be empty "\\" or contain *just* "." or ".."
+            char twoBack = '?';
+            char oneBack = DirectorySeparatorChar;
+            char currentCharacter;
+            bool periodSegment = false;
+            for (int i = PathInternal.LongPathPrefix.Length; i < path.Length; i++)
+            {
+                currentCharacter = path[i];
+                switch (currentCharacter)
+                {
+                    case '\\':
+                        if (oneBack == DirectorySeparatorChar || periodSegment)
+                            throw new ArgumentException(SR.Arg_PathIllegal);
+                        periodSegment = false;
+                        break;
+                    case '.':
+                        periodSegment = (oneBack == DirectorySeparatorChar || (twoBack == DirectorySeparatorChar && oneBack == '.'));
+                        break;
+                    default:
+                        periodSegment = false;
+                        break;
+                }
+
+                twoBack = oneBack;
+                oneBack = currentCharacter;
+            }
+
+            if (periodSegment)
+            {
+                return false;
+            }
+
+            if (fullCheck)
+            {
+                // Look for illegal path characters.
+                PathInternal.CheckInvalidPathChars(path);
+            }
+
+            return true;
+        }
+
         [System.Security.SecurityCritical]  // auto-generated
         private unsafe static string NormalizePath(string path, bool fullCheck, int maxPathLength, bool expandShortPaths)
         {
             Contract.Requires(path != null, "path can't be null");
+
+            // If the path is in extended syntax, we don't need to normalize, but we still do some basic validity checks
+            if (path.StartsWith(PathInternal.LongPathPrefix, StringComparison.Ordinal))
+            {
+                if (!ValidateExtendedPath(path, fullCheck))
+                {
+                    throw new ArgumentException(SR.Arg_PathIllegal);
+                }
+
+                // \\?\GLOBALROOT gives access to devices out of the scope of the current user, we
+                // don't want to allow this for security reasons.
+                // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx#nt_namespaces
+                if (path.StartsWith(@"\\?\globalroot", StringComparison.OrdinalIgnoreCase))
+                    throw new ArgumentException(SR.Arg_PathGlobalRoot);
+
+                return path;
+            }
 
             // If we're doing a full path check, trim whitespace and look for
             // illegal path characters.
             if (fullCheck)
             {
                 // Trim whitespace off the end of the string.
-                // Win32 normalization trims only U+0020. 
+                // Win32 normalization trims only U+0020.
                 path = path.TrimEnd(TrimEndChars);
 
                 // Look for illegal path characters.
-                CheckInvalidPathChars(path);
+                PathInternal.CheckInvalidPathChars(path);
             }
 
             int index = 0;
@@ -173,7 +205,7 @@ namespace System.IO
             // LEGACY: This code is here for backwards compatibility reasons. It 
             // ensures that \\foo.cs\bar.cs stays \\foo.cs\bar.cs instead of being
             // turned into \foo.cs\bar.cs.
-            if (path.Length > 0 && IsDirectorySeparator(path[0]))
+            if (path.Length > 0 && PathInternal.IsDirectorySeparator(path[0]))
             {
                 newBuffer.Append('\\');
                 index++;
@@ -193,7 +225,7 @@ namespace System.IO
                 // addition we consume all spaces after the last other char
                 // in a directory name up until the directory separator.
 
-                if (IsDirectorySeparator(currentChar))
+                if (PathInternal.IsDirectorySeparator(currentChar))
                 {
                     // If we have a path like "123.../foo", remove the trailing dots.
                     // However, if we found "c:\temp\..\bar" or "c:\temp\...\bar", don't.
@@ -258,7 +290,7 @@ namespace System.IO
                         if (numSpaces > 0 && firstSegment)
                         {
                             // Handle strings like " \\server\share".
-                            if (index + 1 < path.Length && IsDirectorySeparator(path[index + 1]))
+                            if (index + 1 < path.Length && PathInternal.IsDirectorySeparator(path[index + 1]))
                             {
                                 newBuffer.Append(DirectorySeparatorChar);
                             }
@@ -528,8 +560,7 @@ namespace System.IO
             {
                 /* Throw an ArgumentException for paths like \\, \\server, \\server\
                    This check can only be properly done after normalizing, so
-                   \\foo\.. will be properly rejected.  Also, reject \\?\GLOBALROOT\
-                   (an internal kernel path) because it provides aliases for drives. */
+                   \\foo\.. will be properly rejected. */
                 if (newBuffer.Length > 1 && newBuffer[0] == '\\' && newBuffer[1] == '\\')
                 {
                     int startIndex = 2;
@@ -547,14 +578,6 @@ namespace System.IO
                     }
                     if (startIndex == result)
                         throw new ArgumentException(SR.Arg_PathIllegalUNC);
-
-                    // Check for \\?\Globalroot, an internal mechanism to the kernel
-                    // that provides aliases for drives and other undocumented stuff.
-                    // The kernel team won't even describe the full set of what
-                    // is available here - we don't want managed apps mucking 
-                    // with this for security reasons.
-                    if (newBuffer.OrdinalStartsWith("\\\\?\\globalroot", true))
-                        throw new ArgumentException(SR.Arg_PathGlobalRoot);
                 }
             }
 
@@ -580,21 +603,21 @@ namespace System.IO
 
         internal static string AddLongPathPrefix(string path)
         {
-            if (path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+            if (path.StartsWith(PathInternal.LongPathPrefix, StringComparison.Ordinal))
                 return path;
 
-            if (path.StartsWith(UNCPathPrefix, StringComparison.Ordinal))
-                return path.Insert(2, UNCLongPathPrefixToInsert); // Given \\server\share in longpath becomes \\?\UNC\server\share  => UNCLongPathPrefix + path.SubString(2); => The actual command simply reduces the operation cost.
+            if (path.StartsWith(PathInternal.UNCPathPrefix, StringComparison.Ordinal))
+                return path.Insert(2, PathInternal.UNCLongPathPrefixToInsert); // Given \\server\share in longpath becomes \\?\UNC\server\share  => UNCLongPathPrefix + path.SubString(2); => The actual command simply reduces the operation cost.
 
-            return LongPathPrefix + path;
+            return PathInternal.LongPathPrefix + path;
         }
 
         internal static string RemoveLongPathPrefix(string path)
         {
-            if (!path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+            if (!path.StartsWith(PathInternal.LongPathPrefix, StringComparison.Ordinal))
                 return path;
 
-            if (path.StartsWith(UNCLongPathPrefix, StringComparison.OrdinalIgnoreCase))
+            if (path.StartsWith(PathInternal.UNCLongPathPrefix, StringComparison.OrdinalIgnoreCase))
                 return path.Remove(2, 6); // Given \\?\UNC\server\share we return \\server\share => @'\\' + path.SubString(UNCLongPathPrefix.Length) => The actual command simply reduces the operation cost.
 
             return path.Substring(4);
@@ -604,10 +627,10 @@ namespace System.IO
         {
             string path = pathSB.ToString();
             
-            if (!path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+            if (!path.StartsWith(PathInternal.LongPathPrefix, StringComparison.Ordinal))
                 return pathSB;
 
-            if (path.StartsWith(UNCLongPathPrefix, StringComparison.OrdinalIgnoreCase))
+            if (path.StartsWith(PathInternal.UNCLongPathPrefix, StringComparison.OrdinalIgnoreCase))
                 return pathSB.Remove(2, 6); // Given \\?\UNC\server\share we return \\server\share => @'\\' + path.SubString(UNCLongPathPrefix.Length) => The actual command simply reduces the operation cost.
 
             return pathSB.Remove(0, 4);
@@ -644,15 +667,14 @@ namespace System.IO
         {
             if (path != null)
             {
-                CheckInvalidPathChars(path);
+                PathInternal.CheckInvalidPathChars(path);
 
                 int length = path.Length;
-                if ((length >= 1 && IsDirectorySeparator(path[0])) || 
+                if ((length >= 1 && PathInternal.IsDirectorySeparator(path[0])) || 
                     (length >= 2 && path[1] == VolumeSeparatorChar))
                     return true;
             }
             return false;
         }
-
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -33,7 +33,7 @@ namespace System.IO
         {
             if (path != null)
             {
-                CheckInvalidPathChars(path);
+                PathInternal.CheckInvalidPathChars(path);
 
                 string s = path;
                 for (int i = path.Length - 1; i >= 0; i--)
@@ -69,7 +69,7 @@ namespace System.IO
         {
             if (path != null)
             {
-                CheckInvalidPathChars(path);
+                PathInternal.CheckInvalidPathChars(path);
 
                 string normalizedPath = NormalizePath(path, fullCheck: false);
 
@@ -112,13 +112,13 @@ namespace System.IO
 
                 path = normalizedPath;
 
-                int root = GetRootLength(path);
+                int root = PathInternal.GetRootLength(path);
                 int i = path.Length;
                 if (i > root)
                 {
                     i = path.Length;
                     if (i == root) return null;
-                    while (i > root && !IsDirectorySeparator(path[--i])) ;
+                    while (i > root && !PathInternal.IsDirectorySeparator(path[--i])) ;
                     return path.Substring(0, i);
                 }
             }
@@ -127,7 +127,7 @@ namespace System.IO
 
         public static char[] GetInvalidPathChars()
         {
-            return (char[])InvalidPathChars.Clone();
+            return (char[])PathInternal.InvalidPathChars.Clone();
         }
 
         public static char[] GetInvalidFileNameChars()
@@ -145,7 +145,7 @@ namespace System.IO
             if (path == null)
                 return null;
 
-            CheckInvalidPathChars(path);
+            PathInternal.CheckInvalidPathChars(path);
             int length = path.Length;
             for (int i = length - 1; i >= 0; i--)
             {
@@ -198,7 +198,7 @@ namespace System.IO
         {
             if (path != null)
             {
-                CheckInvalidPathChars(path);
+                PathInternal.CheckInvalidPathChars(path);
 
                 int length = path.Length;
                 for (int i = length - 1; i >= 0; i--)
@@ -237,7 +237,7 @@ namespace System.IO
         {
             if (path == null) return null;
             path = NormalizePath(path, fullCheck: false);
-            return path.Substring(0, GetRootLength(path));
+            return path.Substring(0, PathInternal.GetRootLength(path));
         }
 
         // Returns a cryptographically strong random 8.3 string that can be 
@@ -272,7 +272,7 @@ namespace System.IO
         {
             if (path != null)
             {
-                CheckInvalidPathChars(path);
+                PathInternal.CheckInvalidPathChars(path);
 
                 for (int i = path.Length - 1; i >= 0; i--)
                 {
@@ -293,8 +293,8 @@ namespace System.IO
                 throw new ArgumentNullException((path1 == null) ? "path1" : "path2");
             Contract.EndContractBlock();
 
-            CheckInvalidPathChars(path1);
-            CheckInvalidPathChars(path2);
+            PathInternal.CheckInvalidPathChars(path1);
+            PathInternal.CheckInvalidPathChars(path2);
 
             return CombineNoChecks(path1, path2);
         }
@@ -305,9 +305,9 @@ namespace System.IO
                 throw new ArgumentNullException((path1 == null) ? "path1" : (path2 == null) ? "path2" : "path3");
             Contract.EndContractBlock();
 
-            CheckInvalidPathChars(path1);
-            CheckInvalidPathChars(path2);
-            CheckInvalidPathChars(path3);
+            PathInternal.CheckInvalidPathChars(path1);
+            PathInternal.CheckInvalidPathChars(path2);
+            PathInternal.CheckInvalidPathChars(path3);
 
             return CombineNoChecks(path1, path2, path3);
         }
@@ -338,7 +338,7 @@ namespace System.IO
                     continue;
                 }
 
-                CheckInvalidPathChars(paths[i]);
+                PathInternal.CheckInvalidPathChars(paths[i]);
 
                 if (IsPathRooted(paths[i]))
                 {
@@ -501,20 +501,6 @@ namespace System.IO
             } while (i < len);
 
             return StringBuilderCache.GetStringAndRelease(sb);
-        }
-
-        private static bool HasIllegalCharacters(string path, bool checkAdditional)
-        {
-            Contract.Requires(path != null);
-            return path.IndexOfAny(checkAdditional ? InvalidPathCharsWithAdditionalChecks : InvalidPathChars) >= 0;
-        }
-
-        private static void CheckInvalidPathChars(string path, bool checkAdditional = false)
-        {
-            Debug.Assert(path != null);
-
-            if (HasIllegalCharacters(path, checkAdditional))
-                throw new ArgumentException(SR.Argument_InvalidPathChars, "path");
         }
     }
 }


### PR DESCRIPTION
Initial implementation of extended syntax support for paths on Windows (\\\\?\\). Basic scenarios work, I'll be adding additional tests (and any necessary fixes) in subsequent commits.

This is the first stage of #645- #2411.
