### PR TITLE
Remove some erroneous / unnecessary asserts in PipeStream on Unix

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -125,13 +125,7 @@ namespace System.IO.Pipes
         [SecuritySafeCritical]
         private Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            Debug.Assert(_handle != null, "_handle is null");
-            Debug.Assert(!_handle.IsClosed, "_handle is closed");
-            Debug.Assert(CanRead, "can't read");
-            Debug.Assert(buffer != null, "buffer is null");
-            Debug.Assert(offset >= 0, "offset is negative");
-            Debug.Assert(count >= 0, "count is negative");
-
+            // Delegate to the base Stream's ReadAsync, which will just invoke Read asynchronously.
             return base.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
@@ -164,13 +158,7 @@ namespace System.IO.Pipes
         [SecuritySafeCritical]
         private Task WriteAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            Debug.Assert(_handle != null, "_handle is null");
-            Debug.Assert(!_handle.IsClosed, "_handle is closed");
-            Debug.Assert(CanWrite, "can't write");
-            Debug.Assert(buffer != null, "buffer is null");
-            Debug.Assert(offset >= 0, "offset is negative");
-            Debug.Assert(count >= 0, "count is negative");
-
+            // Delegate to the base Stream's WriteAsync, which will just invoke Write asynchronously.
             return base.WriteAsync(buffer, offset, count, cancellationToken);
         }
 


### PR DESCRIPTION
The ReadAsyncCore / WriteAsyncCore methods were erroneously asserting for CanRead/CanWrite, when the implementation should instead have been failing with an exception.  It subsequently does, but in debug builds the asserts cause it to assert first.

There were also a bunch of asserts that were unnecessary because the values were just verified by the caller and are about to be verified again by the asynchronously invoked method.

I've simply removed all of these asserts.