### PR TITLE
BugFix: Refresh the process component to ensure Modules is updated.

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTests.cs
@@ -200,7 +200,13 @@ namespace System.Diagnostics.ProcessTests
             }
 
             // Ensure the process has loaded the modules.
-            Assert.True(SpinWait.SpinUntil(() => _process.Modules.Count > 0, WaitInMS));
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                if (_process.Modules.Count > 0)
+                    return true;
+                _process.Refresh();
+                return false;
+            }, WaitInMS));
 
             // Get MainModule property from a Process object
             ProcessModule mainModule = _process.MainModule;


### PR DESCRIPTION
To populate the process Modules, after the first OS call, if the modules hasn't been loaded yet, then the modules is filled with an empty collection. Hence subsequent calls to Modules doesn't update with latest loaded modules, since the Modules is not null (an empty collection). Adding process.refresh to spinwait, to ensure that the Modules is updated with the OS call.

Fixes #2395 

cc @stephentoub 