### PR TITLE
Fix Process.WaitForExit premature timeout on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -367,7 +367,7 @@ namespace System.Diagnostics
             Debug.Assert(!Monitor.IsEntered(_gate));
 
             // Track the time the we start waiting.
-            long startTime = GetTimestamp();
+            long startTime = Stopwatch.GetTimestamp();
 
             // Polling loop
             while (true)
@@ -379,7 +379,7 @@ namespace System.Diagnostics
                 // We're in a polling loop... determine how much time remains
                 int remainingTimeout = millisecondsTimeout == Timeout.Infinite ?
                     Timeout.Infinite :
-                    (int)Math.Max(millisecondsTimeout - (GetTimestamp() - startTime), 0);
+                    (int)Math.Max(millisecondsTimeout - ((Stopwatch.GetTimestamp() - startTime) / (double)Stopwatch.Frequency * 1000), 0);
 
                 lock (_gate)
                 {
@@ -509,12 +509,6 @@ namespace System.Diagnostics
                     }
                 }
             });
-        }
-
-        /// <summary>Gets a current time stamp.</summary>
-        private static long GetTimestamp()
-        {
-            return Stopwatch.GetTimestamp();
         }
 
     }


### PR DESCRIPTION
The Process.WaitForExit implementation on Unix is mixing up units, resulting in WaitForExits with timeouts exiting much earlier than the specified timeout.  The code is using Stopwatch.GetTimestamp to get a current timestamp, subtracting the current timestamp from one gathered when the wait started, and then subtracting that difference from the specified timeout.  But the specified timeout is in milliseconds, and the timestamp is in ticks, such that the difference measured in ticks is quickly larger than the timeout value in milliseconds.  The fix just converts the difference from ticks to milliseconds before subtracing from the timeout value.