### PR TITLE
Add test coverage to System.Diagnostics.Process types.

### DIFF
--- a/src/Common/tests/System/Diagnostics/AssertWithCallerAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/AssertWithCallerAttributes.cs
@@ -201,17 +201,20 @@ internal static class Assert
         catch (Exception e) { throw WrapException(e, path, line); }
     }
 
-    public static void False(bool condition,
+    public static void False(bool condition, string userMessage = null,
         [CallerFilePath] string path = null, [CallerLineNumber] int line = 0)
     {
-        try { Xunit.Assert.False(condition); }
-        catch (Exception e) { throw WrapException(e, path, line); }
-    }
-
-    public static void False(bool condition, string userMessage,
-        [CallerFilePath] string path = null, [CallerLineNumber] int line = 0)
-    {
-        try { Xunit.Assert.False(condition, userMessage); }
+        try
+        {
+            if (userMessage == null)
+            {
+                Xunit.Assert.False(condition);
+            }
+            else
+            {
+                Xunit.Assert.False(condition, userMessage);
+            }
+        }
         catch (Exception e) { throw WrapException(e, path, line); }
     }
 
@@ -604,7 +607,7 @@ internal static class Assert
     // so to use it we derive a custom exception type
     internal sealed class WrapperXunitException : XunitException
     {
-        internal WrapperXunitException(string message, Exception innerException) : 
+        internal WrapperXunitException(string message, Exception innerException) :
             base(message, innerException)
         {
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -511,6 +511,7 @@ namespace System.Diagnostics
                     {
                         newThreadsArray[i] = new ProcessThread(_isRemoteMachine, _processId, (ThreadInfo)_processInfo._threadInfoList[i]);
                     }
+
                     ProcessThreadCollection newThreads = new ProcessThreadCollection(newThreadsArray);
                     _threads = newThreads;
                 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -118,7 +118,7 @@ namespace System.Diagnostics
                         pi._threadInfoList.Add(new ThreadInfo
                         {
                             _processId = pid,
-                            _threadId = tid,
+                            _threadId = (ulong)tid,
                             _basePriority = pi.BasePriority,
                             _currentPriority = (int)stat.nice,
                             _startAddress = (IntPtr)stat.startstack,

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -56,8 +56,8 @@ namespace System.Diagnostics
                 var ti = new ThreadInfo()
                 {
                     _processId = pid,
-                    _threadId = (int)t.Key, // The OS X thread ID is 64-bits, but we're forced to truncate due to the public API signature
-                    _basePriority = 0,
+                    _threadId = t.Key,
+                    _basePriority = procInfo.BasePriority,
                     _startAddress = IntPtr.Zero
                 };
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -677,7 +677,7 @@ namespace System.Diagnostics
                         threadInfo._processId = (int)value;
                         break;
                     case ValueId.ThreadId:
-                        threadInfo._threadId = (int)value;
+                        threadInfo._threadId = (ulong)value;
                         break;
                     case ValueId.BasePriority:
                         threadInfo._basePriority = (int)value;
@@ -992,7 +992,7 @@ namespace System.Diagnostics
                     ThreadInfo threadInfo = new ThreadInfo();
 
                     threadInfo._processId = (int)ti.UniqueProcess;
-                    threadInfo._threadId = (int)ti.UniqueThread;
+                    threadInfo._threadId = (ulong)ti.UniqueThread;
                     threadInfo._basePriority = ti.BasePriority;
                     threadInfo._currentPriority = ti.Priority;
                     threadInfo._startAddress = ti.StartAddress;

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.OSX.cs
@@ -16,22 +16,11 @@ namespace System.Diagnostics
         {
             get
             {
-                int nice = 0;
-                int result = Interop.libc.getpriority(Interop.libc.PriorityWhich.PRIO_DARWIN_THREAD, _threadInfo._threadId, out nice);
-                if (result != 0)
-                {
-                    throw new System.ComponentModel.Win32Exception();
-                }
-
-                return Interop.libc.GetThreadPriorityFromNiceValue(nice);
+                throw new PlatformNotSupportedException();
             }
             set
             {
-                int result = Interop.libc.setpriority(Interop.libc.PriorityWhich.PRIO_DARWIN_THREAD, _threadInfo._threadId, Interop.libc.GetNiceValueFromThreadPriority(value));
-                if (result != 0)
-                {
-                    throw new System.ComponentModel.Win32Exception();
-                }
+                throw new PlatformNotSupportedException();
             }
         }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Windows.cs
@@ -171,7 +171,7 @@ namespace System.Diagnostics
         private SafeThreadHandle OpenThreadHandle(int access)
         {
             EnsureState(State.IsLocal);
-            return ProcessManager.OpenThread(_threadInfo._threadId, access);
+            return ProcessManager.OpenThread((int)_threadInfo._threadId, access);
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.cs
@@ -53,7 +53,7 @@ namespace System.Diagnostics
         /// </devdoc>
         public int Id
         {
-            get { return _threadInfo._threadId; }
+            get { return (int)_threadInfo._threadId; }
         }
 
         /// <devdoc>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ThreadInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ThreadInfo.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
     /// <internalonly/>
     internal sealed class ThreadInfo
     {
-        internal int _threadId;
+        internal ulong _threadId;
         internal int _processId;
         internal int _basePriority;
         internal int _currentPriority;

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Interop.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 
 namespace System.Diagnostics.ProcessTests
 {
@@ -23,15 +25,35 @@ namespace System.Diagnostics.ProcessTests
             public uint PeakPagefileUsage;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct USER_INFO_1
+        {
+            public string usri1_name;
+            public string usri1_password;
+            public uint usri1_password_age;
+            public uint usri1_priv;
+            public string usri1_home_dir;
+            public string usri1_comment;
+            public uint usri1_flags;
+            public string usri1_script_path;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TOKEN_USER
+        {
+            public SID_AND_ATTRIBUTES User;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SID_AND_ATTRIBUTES
+        {
+            public IntPtr Sid;
+            public int Attributes;
+        }
+
         [DllImport("api-ms-win-core-memory-l1-1-1.dll")]
         public static extern bool GetProcessWorkingSetSizeEx(SafeProcessHandle hProcess, out IntPtr lpMinimumWorkingSetSize, out IntPtr lpMaximumWorkingSetSize, out uint flags);
-
-        [DllImport("api-ms-win-core-processthreads-l1-1-0", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
-        public static extern int GetPriorityClass(SafeProcessHandle handle);
-
-        [DllImport("kernel32.dll", CharSet = System.Runtime.InteropServices.CharSet.Ansi, SetLastError = true)]
-        public static extern SafeProcessHandle GetCurrentProcess();
-
+        
         [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]
         internal static extern int GetCurrentProcessId();
 
@@ -58,5 +80,66 @@ namespace System.Diagnostics.ProcessTests
 
         [DllImport("api-ms-win-core-console-l1-1-0.dll")]
         internal extern static int SetConsoleOutputCP(int codePage);
+
+        [DllImport("netapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal extern static uint NetUserAdd(string servername, uint level, ref USER_INFO_1 buf, out uint parm_err);
+
+        [DllImport("netapi32.dll")]
+        internal extern static uint NetUserDel(string servername, string username);
+
+        [DllImport("advapi32.dll")]
+        internal static extern bool OpenProcessToken(SafeProcessHandle ProcessHandle, uint DesiredAccess, out SafeProcessHandle TokenHandle);
+
+        [DllImport("advapi32.dll")]
+        internal static extern bool GetTokenInformation(SafeProcessHandle TokenHandle, uint TokenInformationClass, IntPtr TokenInformation, int TokenInformationLength, ref int ReturnLength);
+
+        internal static bool NetUserAdd(string username, string password)
+        {
+            USER_INFO_1 userInfo = new USER_INFO_1();
+            userInfo.usri1_name = username;
+            userInfo.usri1_password = password;
+            userInfo.usri1_priv = 1;
+
+            uint parm_err;
+            uint result = NetUserAdd(null, 1, ref userInfo, out parm_err);
+
+            if (result != 0)
+            {
+                throw new Win32Exception();
+            }
+
+            return true;
+        }
+
+        internal static bool ProcessTokenToSid(SafeProcessHandle token, out SecurityIdentifier sid)
+        {
+            bool ret = false;
+            sid = null;
+            IntPtr tu = IntPtr.Zero;
+            try
+            {
+                TOKEN_USER tokUser;
+                const int bufLength = 256;
+
+                tu = Marshal.AllocHGlobal(bufLength);
+                int cb = bufLength;
+                ret = GetTokenInformation(token, 1, tu, cb, ref cb);
+                if (ret)
+                {
+                    tokUser = Marshal.PtrToStructure<TOKEN_USER>(tu);
+                    sid = new SecurityIdentifier(tokUser.User.Sid);
+                }
+                return ret;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            finally
+            {
+                if (tu != IntPtr.Zero)
+                    Marshal.FreeHGlobal(tu);
+            }
+        }
     }
 }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessModuleTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessModuleTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Security;
+using System.IO;
+using Xunit;
+using System.Threading;
+
+namespace System.Diagnostics.ProcessTests
+{
+    public class ProcessModuleTests : ProcessTestBase
+    {
+        [Fact, PlatformSpecific(~PlatformID.OSX)]
+        public void TestModulePropertiesExceptOnOSX()
+        {
+            string fileName = CoreRunName;
+            if (global::Interop.IsWindows)
+                fileName = string.Format("{0}.exe", CoreRunName);
+
+            // Ensure the process has loaded the modules.
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                if (_process.Modules.Count > 0)
+                    return true;
+                _process.Refresh();
+                return false;
+            }, WaitInMS));
+
+            ProcessModuleCollection moduleCollection = _process.Modules;
+            Assert.True(moduleCollection.Count > 0);
+
+            ProcessModule coreRunModule = _process.MainModule;
+            Assert.True(coreRunModule.BaseAddress.ToInt64() > 0);
+            Assert.True(coreRunModule.EntryPointAddress.ToInt64() >= 0);
+            Assert.Equal(fileName, coreRunModule.ModuleName);
+            Assert.True(coreRunModule.ModuleMemorySize > 0);
+            Assert.EndsWith(fileName, coreRunModule.FileName);
+
+            Assert.Equal(string.Format("System.Diagnostics.ProcessModule ({0})", fileName), coreRunModule.ToString());
+        }
+
+        [Fact, PlatformSpecific(PlatformID.OSX)]
+        public void TestModulePropertiesOnOSX()
+        {
+            // Getting modules for a process given a pid is not supported on OSX.
+            ProcessModuleCollection moduleCollection = _process.Modules;
+            Assert.Equal(0, moduleCollection.Count);
+            Assert.Null(_process.MainModule);
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessStartInfoTests.cs
@@ -3,8 +3,12 @@
 
 using System.Collections.Generic;
 using System.Security;
+using System.Security.Principal;
+using Microsoft.Win32;
 using System.IO;
 using Xunit;
+using Microsoft.Win32.SafeHandles;
+using System.Linq;
 
 namespace System.Diagnostics.ProcessTests
 {
@@ -197,18 +201,21 @@ namespace System.Diagnostics.ProcessTests
 
             psi = new ProcessStartInfo("filename", "-arg1 -arg2");
             Assert.Equal("-arg1 -arg2", psi.Arguments);
+
+            psi.Arguments = "-arg3 -arg4";
+            Assert.Equal("-arg3 -arg4", psi.Arguments);
         }
 
-        [Fact]
-        public void TestCreateNoWindowProperty()
+        [Theory, InlineData(true), InlineData(false)]
+        public void TestCreateNoWindowProperty(bool value)
         {
             Process testProcess = CreateProcessInfinite();
             try
             {
-                testProcess.StartInfo.CreateNoWindow = true;
+                testProcess.StartInfo.CreateNoWindow = value;
                 testProcess.Start();
 
-                Assert.True(testProcess.StartInfo.CreateNoWindow);
+                Assert.Equal(value, testProcess.StartInfo.CreateNoWindow);
             }
             finally
             {
@@ -219,14 +226,52 @@ namespace System.Diagnostics.ProcessTests
             }
         }
 
-        [Fact, PlatformSpecific(PlatformID.Windows)]
+        [Fact, PlatformSpecific(PlatformID.Windows), OuterLoop] // Requires admin privileges
         public void TestUserCredentialsPropertiesOnWindows()
         {
-            // test the defaults here.
-            Assert.Equal(string.Empty, _process.StartInfo.Domain);
-            Assert.Equal(string.Empty, _process.StartInfo.UserName);
-            Assert.Equal(default(SecureString), _process.StartInfo.Password);
-            Assert.False(_process.StartInfo.LoadUserProfile);
+            string username = "test", password = "PassWord123!!";
+            
+            if (Interop.NetUserAdd(username, password))
+            {
+                Process p = CreateProcessInfinite();
+
+                p.StartInfo.LoadUserProfile = true;
+                p.StartInfo.UserName = username;
+                p.StartInfo.Password = GetSecureString(password);
+
+                SafeProcessHandle handle = null;
+                try
+                {
+                    p.Start();
+                    if (Interop.OpenProcessToken(p.SafeHandle, 0x8u, out handle))
+                    {
+                        SecurityIdentifier sid;
+                        if (Interop.ProcessTokenToSid(handle, out sid))
+                        {
+                            string actualUserName = sid.Translate(typeof(NTAccount)).ToString();
+                            int indexOfDomain = actualUserName.IndexOf('\\');
+                            if (indexOfDomain != -1)
+                                actualUserName = actualUserName.Substring(indexOfDomain + 1);
+
+                            bool isProfileLoaded = GetNamesOfUserProfiles().Any(profile => profile.Equals(username));
+
+                            Assert.Equal(username, actualUserName);
+                            Assert.True(isProfileLoaded);
+                        }
+                    }
+                }
+                finally
+                {
+                    if (handle != null)
+                        handle.Dispose();
+
+                    if (!p.HasExited)
+                        p.Kill();
+
+                    Interop.NetUserDel(null, username);
+                    Assert.True(p.WaitForExit(WaitInMS));
+                }
+            }
         }
 
         [Fact, PlatformSpecific(PlatformID.AnyUnix)]
@@ -238,9 +283,57 @@ namespace System.Diagnostics.ProcessTests
             Assert.Throws<PlatformNotSupportedException>(() => _process.StartInfo.LoadUserProfile);
         }
 
+        [Fact]
         public void TestWorkingDirectoryProperty()
         {
-            Assert.Equal(Directory.GetCurrentDirectory(), _process.StartInfo.WorkingDirectory);
+            // check defaults
+            Assert.Equal(string.Empty, _process.StartInfo.WorkingDirectory);
+
+            Process p = CreateProcessInfinite();
+            p.StartInfo.WorkingDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                p.Start();
+                Assert.Equal(Directory.GetCurrentDirectory(), p.StartInfo.WorkingDirectory);
+            }
+            finally
+            {
+                if (!p.HasExited)
+                    p.Kill();
+
+                Assert.True(p.WaitForExit(WaitInMS));
+            }
+        }
+
+        private unsafe SecureString GetSecureString(string password)
+        {
+            fixed (char* p = password)
+                return new SecureString(p, password.Length);
+        }
+
+        private static List<string> GetNamesOfUserProfiles()
+        {
+            List<string> userNames = new List<string>();
+
+            string[] names = Registry.Users.GetSubKeyNames();
+            for (int i = 1; i < names.Length; i++)
+            {
+                try
+                {
+                    SecurityIdentifier sid = new SecurityIdentifier(names[i]);
+                    string userName = sid.Translate(typeof(NTAccount)).ToString();
+                    int indexofDomain = userName.IndexOf('\\');
+                    if (indexofDomain != -1)
+                    {
+                        userName = userName.Substring(indexofDomain + 1);
+                        userNames.Add(userName);
+                    }
+                }
+                catch (Exception) { }
+            }
+
+            return userNames;
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
@@ -373,6 +371,9 @@ namespace System.Diagnostics.ProcessTests
             try
             {
                 p.Start();
+
+                // Ensure process has been started, should not throw.
+                Process accessProcessFromMachine = Process.GetProcessById(p.Id);
                 Assert.True(p.StartTime.ToUniversalTime() <= DateTime.UtcNow, string.Format("Process StartTime is larger than later time."));
             }
             finally

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessThreadTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Security;
+using System.IO;
+using Xunit;
+
+namespace System.Diagnostics.ProcessTests
+{
+    public class ProcessThreadTests : ProcessTestBase
+    {
+        [Fact]
+        public void TestCommonPriorityAndTimeProperties()
+        {
+            ProcessThreadCollection threadCollection = _process.Threads;
+            Assert.True(threadCollection.Count > 0);
+
+            ProcessThread thread = threadCollection[0];
+
+            if (ThreadState.Terminated != thread.ThreadState)
+            {
+                Assert.Equal(_process.BasePriority, thread.BasePriority);
+                Assert.True(thread.CurrentPriority >= 0, "Thread CurrentPriority");
+                Assert.True(thread.PrivilegedProcessorTime.TotalSeconds >= 0, "Thread PrivilegedProcessorTime");
+                Assert.True(thread.UserProcessorTime.TotalSeconds >= 0, "Thread UserProcessorTime");
+                Assert.True(thread.TotalProcessorTime.TotalSeconds >= 0, "Thread TotalProcessorTime");
+            }
+        }
+
+        [Fact]
+        public void TestStartTimeProperty()
+        {
+            ProcessThreadCollection threadCollection = _process.Threads;
+            Assert.True(threadCollection.Count > 0);
+
+            ProcessThread thread = threadCollection[0];
+
+            if (global::Interop.IsOSX)
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => thread.StartTime);
+                return;
+            }
+
+            if (ThreadState.Initialized != thread.ThreadState)
+            {
+                Assert.True(thread.StartTime.ToUniversalTime() <= DateTime.UtcNow, "Thread StartTime");
+            }
+        }
+
+        [Fact]
+        public void TestStartAddressProperty()
+        {
+            ProcessThread thread = _process.Threads[0];
+            Assert.Equal(global::Interop.IsOSX, thread.StartAddress == IntPtr.Zero);
+        }
+
+        [Fact]
+        public void TestPriorityLevelProperty()
+        {
+            ProcessThread thread = _process.Threads[0];
+
+            if (global::Interop.IsOSX)
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => thread.PriorityLevel);
+                Assert.Throws<PlatformNotSupportedException>(() => thread.PriorityLevel = ThreadPriorityLevel.AboveNormal);
+                return;
+            }
+
+            ThreadPriorityLevel originalPriority = thread.PriorityLevel;
+
+            if (global::Interop.IsLinux)
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => thread.PriorityLevel = ThreadPriorityLevel.AboveNormal);
+                return;
+            }
+
+            try
+            {
+                thread.PriorityLevel = ThreadPriorityLevel.AboveNormal;
+                Assert.Equal(ThreadPriorityLevel.AboveNormal, thread.PriorityLevel);
+            }
+            finally
+            {
+                thread.PriorityLevel = originalPriority;
+                Assert.Equal(originalPriority, thread.PriorityLevel);
+            }
+        }
+
+        [Fact]
+        public void TestThreadStateProperty()
+        {
+            ProcessThread thread = _process.Threads[0];
+            if (ThreadState.Wait != thread.ThreadState)
+            {
+                Assert.Throws<InvalidOperationException>(() => thread.WaitReason);
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -12,10 +12,15 @@
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\AssertWithCallerAttributes.cs">
+      <Link>Common\tests\System\Diagnostics\AssertWithCallerAttributes.cs</Link>
+    </Compile>
     <Compile Include="ProcessModuleTests.cs" />
     <Compile Include="ProcessStartInfoTests.cs" />
     <Compile Include="Interop.cs" />

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ProcessModuleTests.cs" />
     <Compile Include="ProcessStartInfoTests.cs" />
     <Compile Include="Interop.cs" />
     <Compile Include="ProcessTests.cs" />
@@ -25,6 +26,7 @@
       <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="ProcessTestBase.cs" />
+    <Compile Include="ProcessThreadTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.json
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.json
@@ -4,6 +4,7 @@
     "System.Collections": "4.0.10-beta-*",
     "System.Console": "4.0.0-beta-*",
     "System.IO": "4.0.10-beta-*",
+    "System.IO.FileSystem": "4.0.0-beta-*",
     "System.IO.Pipes": "4.0.0-beta-*",
     "System.Linq": "4.0.0-beta-*",
     "System.Runtime": "4.0.20-beta-*",

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.json
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.Win32.Primitives": "4.0.0-beta-*",
+    "Microsoft.Win32.Registry": "4.0.0-beta-*",
     "System.Collections": "4.0.10-beta-*",
     "System.Console": "4.0.0-beta-*",
     "System.IO": "4.0.10-beta-*",
@@ -13,6 +14,7 @@
     "System.Runtime.Handles": "4.0.0-beta-*",
     "System.Resources.ResourceManager": "4.0.0-beta-*",
     "System.Security.SecureString": "4.0.0-beta-*",
+    "System.Security.Principal.Windows": "4.0.0-beta-*",
     "System.Text.Encoding": "4.0.10-beta-*",
     "System.Text.Encoding.CodePages": "4.0.0-beta-*",
     "System.Threading": "4.0.10-beta-*",

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.lock.json
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.lock.json
@@ -80,6 +80,29 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
+      "System.IO.FileSystem/4.0.0-beta-23024": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23024",
+          "System.Runtime.InteropServices": "4.0.20-beta-23024",
+          "System.Resources.ResourceManager": "4.0.0-beta-23024",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23024",
+          "System.Runtime.Handles": "4.0.0-beta-23024",
+          "System.Threading.Overlapped": "4.0.0-beta-23024",
+          "System.Text.Encoding": "4.0.10-beta-23024",
+          "System.IO": "4.0.10-beta-23024",
+          "System.Collections": "4.0.10-beta-23024",
+          "System.Threading.Tasks": "4.0.10-beta-23024",
+          "System.Runtime.Extensions": "4.0.10-beta-23024",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23024",
+          "System.Threading": "4.0.10-beta-23024"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.dll": {}
+        }
+      },
       "System.IO.FileSystem.Primitives/4.0.0-beta-23024": {
         "dependencies": {
           "System.Runtime": "4.0.20-beta-23024"
@@ -584,6 +607,30 @@
         "ref/dotnet/zh-hant/System.IO.xml",
         "ref/net46/_._",
         "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+      ]
+    },
+    "System.IO.FileSystem/4.0.0-beta-23024": {
+      "serviceable": true,
+      "sha512": "CUlwZ5kM4QRQgsVj9/QQIr86hLr7U/E6evFXg6643qd63BppdfORu46tyQMxS/gsdrT4PiIRu7rrrguXiBR5ww==",
+      "files": [
+        "System.IO.FileSystem.4.0.0-beta-23024.nupkg",
+        "System.IO.FileSystem.4.0.0-beta-23024.nupkg.sha512",
+        "System.IO.FileSystem.nuspec",
+        "lib/DNXCore50/System.IO.FileSystem.dll",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
+        "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.xml",
+        "ref/dotnet/it/System.IO.FileSystem.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "ref/net46/System.IO.FileSystem.dll"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0-beta-23024": {
@@ -1239,6 +1286,7 @@
       "System.Collections >= 4.0.10-beta-*",
       "System.Console >= 4.0.0-beta-*",
       "System.IO >= 4.0.10-beta-*",
+      "System.IO.FileSystem >= 4.0.0-beta-*",
       "System.IO.Pipes >= 4.0.0-beta-*",
       "System.Linq >= 4.0.0-beta-*",
       "System.Runtime >= 4.0.20-beta-*",

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.lock.json
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/project.lock.json
@@ -15,6 +15,23 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
+      "Microsoft.Win32.Registry/4.0.0-beta-23024": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23024",
+          "System.Runtime.InteropServices": "4.0.20-beta-23024",
+          "System.Resources.ResourceManager": "4.0.0-beta-23024",
+          "System.Runtime.Handles": "4.0.0-beta-23024",
+          "System.Runtime.Extensions": "4.0.10-beta-23024",
+          "System.Collections": "4.0.10-beta-23024",
+          "System.Globalization": "4.0.10-beta-23024"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
       "System.Collections/4.0.10-beta-23024": {
         "dependencies": {
           "System.Runtime": "4.0.20-beta-23024"
@@ -240,6 +257,24 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
+      "System.Security.Claims/4.0.0-beta-23024": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23024",
+          "System.Security.Principal": "4.0.0-beta-23024",
+          "System.IO": "4.0.0-beta-23024",
+          "System.Resources.ResourceManager": "4.0.0-beta-23024",
+          "System.Collections": "4.0.0-beta-23024",
+          "System.Diagnostics.Debug": "4.0.0-beta-23024",
+          "System.Globalization": "4.0.0-beta-23024",
+          "System.Runtime.Extensions": "4.0.0-beta-23024"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Claims.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23024": {
         "dependencies": {
           "System.Runtime": "4.0.20-beta-23024",
@@ -264,6 +299,26 @@
         },
         "runtime": {
           "lib/dotnet/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-beta-23024": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23024",
+          "System.Resources.ResourceManager": "4.0.0-beta-23024",
+          "System.Collections": "4.0.0-beta-23024",
+          "System.Runtime.InteropServices": "4.0.0-beta-23024",
+          "System.Security.Claims": "4.0.0-beta-23024",
+          "System.Security.Principal": "4.0.0-beta-23024",
+          "System.Diagnostics.Debug": "4.0.0-beta-23024",
+          "System.Reflection": "4.0.0-beta-23024",
+          "System.Runtime.Extensions": "4.0.0-beta-23024",
+          "System.Threading": "4.0.10-beta-23024"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
       "System.Security.SecureString/4.0.0-beta-23024": {
@@ -436,7 +491,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00058": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00063": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -485,6 +540,29 @@
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/net46/Microsoft.Win32.Primitives.dll"
+      ]
+    },
+    "Microsoft.Win32.Registry/4.0.0-beta-23024": {
+      "serviceable": true,
+      "sha512": "CjFtCuQcX0BEo7gQaI7y+mHph+QTcQf1gQiVV6Pog4PNgjMUjoefF0xEEVEbxWKAVJ66Ugf2i6r+UG3pxoUTKA==",
+      "files": [
+        "Microsoft.Win32.Registry.4.0.0-beta-23024.nupkg",
+        "Microsoft.Win32.Registry.4.0.0-beta-23024.nupkg.sha512",
+        "Microsoft.Win32.Registry.nuspec",
+        "lib/DNXCore50/Microsoft.Win32.Registry.dll",
+        "lib/net46/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/it/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.Collections/4.0.10-beta-23024": {
@@ -903,6 +981,29 @@
         "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
+    "System.Security.Claims/4.0.0-beta-23024": {
+      "serviceable": true,
+      "sha512": "xaHzmKrBTZYBs3S5NYM3jjLIP8SfPwUsthEez3QtQCY+wdGZm9o6dLJHWIjAA/c+Z4BHnIGEaibm32F3HnRBGQ==",
+      "files": [
+        "System.Security.Claims.4.0.0-beta-23024.nupkg",
+        "System.Security.Claims.4.0.0-beta-23024.nupkg.sha512",
+        "System.Security.Claims.nuspec",
+        "lib/dotnet/System.Security.Claims.dll",
+        "lib/net46/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
+        "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
+        "ref/dotnet/fr/System.Security.Claims.xml",
+        "ref/dotnet/it/System.Security.Claims.xml",
+        "ref/dotnet/ja/System.Security.Claims.xml",
+        "ref/dotnet/ko/System.Security.Claims.xml",
+        "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/zh-hans/System.Security.Claims.xml",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "ref/net46/System.Security.Claims.dll"
+      ]
+    },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23024": {
       "serviceable": true,
       "sha512": "LGHXdvs2WCJjLSKuvn+0SDZhevPyaHNwHx3BiojKsCYPfP3RmTqVMWAAn/tGpn18zV6E1TWGhuJt8xWtbjJk0Q==",
@@ -952,6 +1053,29 @@
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
         "ref/win8/_._"
+      ]
+    },
+    "System.Security.Principal.Windows/4.0.0-beta-23024": {
+      "serviceable": true,
+      "sha512": "0f8xoStHj+BucI7BND7GB8i27o+9LM4xpg7xf5KRE9qyavrMl+GvzYdS+6fkBIdRt3wxM8PGlkS4kia5xhIT0w==",
+      "files": [
+        "System.Security.Principal.Windows.4.0.0-beta-23024.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23024.nupkg.sha512",
+        "System.Security.Principal.Windows.nuspec",
+        "lib/DNXCore50/System.Security.Principal.Windows.dll",
+        "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
+        "ref/net46/System.Security.Principal.Windows.dll"
       ]
     },
     "System.Security.SecureString/4.0.0-beta-23024": {
@@ -1254,11 +1378,12 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00058": {
-      "sha512": "RBvpUtoMBeqXYDI+QXt4TIFMBFV3he+KPsTfyAuAiHtqwsrkJoxsA3gF7doOOpKKJ4QKtt7d1YBD3mLusLyveQ==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00063": {
+      "serviceable": true,
+      "sha512": "zKiufaM6OjPM8VGxeWUli5cdpqbe4MhanZPM0rMMQgorJO5/UXHpehEx5kFraTPccAA2FNQ/xl+2d/LoMpsLaw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00058.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00058.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00063.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00063.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -1283,6 +1408,7 @@
   "projectFileDependencyGroups": {
     "": [
       "Microsoft.Win32.Primitives >= 4.0.0-beta-*",
+      "Microsoft.Win32.Registry >= 4.0.0-beta-*",
       "System.Collections >= 4.0.10-beta-*",
       "System.Console >= 4.0.0-beta-*",
       "System.IO >= 4.0.10-beta-*",
@@ -1295,6 +1421,7 @@
       "System.Runtime.Handles >= 4.0.0-beta-*",
       "System.Resources.ResourceManager >= 4.0.0-beta-*",
       "System.Security.SecureString >= 4.0.0-beta-*",
+      "System.Security.Principal.Windows >= 4.0.0-beta-*",
       "System.Text.Encoding >= 4.0.10-beta-*",
       "System.Text.Encoding.CodePages >= 4.0.0-beta-*",
       "System.Threading >= 4.0.10-beta-*",


### PR DESCRIPTION
In this commit, represented internal ThreadInfo.threadId from int to ulong, as OSX
threadIds are 64 bit. Changed implementation of PriorityLevel property on
a Thread on OSX to throw PNSE. Added tests to types ProcessModule and
ProcessThread.

cc @stephentoub @pallavit 