### PR TITLE
Fix currently inconsequential Path bug on Unix

### DIFF
--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -16,7 +16,7 @@ namespace System.IO
 
         private static readonly char[] InvalidPathChars = { '\0' };
         private static readonly char[] InvalidFileNameChars = { '\0', '/' };
-        private static readonly char[] InvalidPathCharsWithAdditionalChecks = InvalidFileNameChars; // no additional checks on Unix
+        private static readonly char[] InvalidPathCharsWithAdditionalChecks = InvalidPathChars; // no additional checks on Unix
 
         private static readonly int MaxPath = Interop.libc.MaxPath;
         private static readonly int MaxComponentLength = Interop.libc.MaxName;


### PR DESCRIPTION
InvalidPathCharsWithAdditionalChecks is used by CheckInvalidPathChars when checkAdditional is true.  The only caller of this method that sets it to true is in the Windows-specific code paths, which is why none of our tests on Unix fail due to InvalidPathCharsWithAdditionalChecks accidentally being set to InvalidFileNameChars instead of to the intended InvalidPathChars.  I'm fixing it now in case this is ever used in the future, at which time the '/' check would cause real problems :)