### PR TITLE
Reduce allocation threshold of BigIntegerCalculator

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -26,7 +26,7 @@ namespace System.Numerics
 
         // Mutable for unit testing...
         private static int SquareThreshold = 32;
-        private static int AllocationThreshold = 4096;
+        private static int AllocationThreshold = 256;
 
         [SecuritySafeCritical]
         private unsafe static void Square(uint* value, int valueLength,


### PR DESCRIPTION
The aftermath of #2291 leads to the final conclusion that this is the better value. A bigger threshold doesn't have a noticeable effect.