### PR TITLE
Disable C# 6 features until CI/build system updated

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -198,6 +198,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!-- Temporary until build/CI system is upgraded to C# 6: disable C# 6 features -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#'">
+    <LangVersion>5</LangVersion>
+  </PropertyGroup>
+
   <!-- Set up some common paths -->
   <PropertyGroup>
     <CommonPath>$(SourceDir)Common\src</CommonPath>


### PR DESCRIPTION
With Visual Studio 2015 released today (woo hoo!), I expect we're going to see the number of contributors using VS2015 and C# 6 increase, which is a good thing.  Unfortunately, our current build / CI system is currently limited to using the C# 5 compiler.  Speaking from experience, this makes for a frustrating time when one develops a change and everything passes locally, only to submit a PR and find that it fails in CI because a C# 6 feature was being used.

Until we can get our build and CI systems updated to use C# 6 (hopefully very soon), this change simply sets the LangVersion for our C# projects to C# 5 so that, even when using VS2015, attempting to build locally with C# 6 features will fail to compile.  This won't prevent all possible dependencies on C# 6, but it will avert most.