### PR TITLE
Fix run-test.sh to find all test projects

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -269,7 +269,7 @@ create_test_overlay
 TestsFailed=0
 numberOfProcesses=0
 maxProcesses=$(($(getconf _NPROCESSORS_ONLN)+1))
-for file in src/**/tests/*.Tests.csproj
+for file in src/**/tests/**/*.Tests.csproj
 do
   runtest $file &
   pids="$pids $!"


### PR DESCRIPTION
run-test.sh is currently looking for test projects of the form ```src/**/tests/*.csproj```, but some of our projects are nested a level down from that, e.g. ```src/**/tests/something/*.csproj```.