### PR TITLE
Set locked=true in Overlapped's project.lock.json files

### DIFF
--- a/src/System.Threading.Overlapped/src/project.lock.json
+++ b/src/System.Threading.Overlapped/src/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {

--- a/src/System.Threading.Overlapped/tests/project.lock.json
+++ b/src/System.Threading.Overlapped/tests/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {


### PR DESCRIPTION
Without this, they're getting modified any time someone builds locally.