### PR TITLE
Add async XLinq document/element loading and saving

### DIFF
--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XCData.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XCData.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -46,6 +49,27 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteCData(text);
+        }
+
+        /// <summary>
+        /// Write this <see cref="XCData"/> to the given <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XCData"/> to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The CancellationToken to use to request cancellation of this operation.
+        /// </param>
+        /// <returns>
+        /// A Task that represents the eventual completion of the operation.
+        /// </returns>
+        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null)
+                throw new ArgumentNullException("writer");
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            return writer.WriteCDataAsync(text);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XComment.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XComment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -90,6 +92,21 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteComment(value);
+        }
+
+        /// <summary>
+        /// Write this <see cref="XComment"/> to the passed in <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XComment"/> to.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteCommentAsync(value).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XComment.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XComment.cs
@@ -101,12 +101,13 @@ namespace System.Xml.Linq
         /// The <see cref="XmlWriter"/> to write this <see cref="XComment"/> to.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
-            if (writer == null) throw new ArgumentNullException("writer");
-
-            cancellationToken.ThrowIfCancellationRequested();
-            await writer.WriteCommentAsync(value).ConfigureAwait(false);
+            if (writer == null)
+                throw new ArgumentNullException("writer");
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            return writer.WriteCommentAsync(value);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Debug = System.Diagnostics.Debug;
 using IEnumerable = System.Collections.IEnumerable;
@@ -852,64 +854,9 @@ namespace System.Xml.Linq
         internal void ReadContentFrom(XmlReader r)
         {
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
-            XContainer c = this;
-            NamespaceCache eCache = new NamespaceCache();
-            NamespaceCache aCache = new NamespaceCache();
-            do
-            {
-                switch (r.NodeType)
-                {
-                    case XmlNodeType.Element:
-                        XElement e = new XElement(eCache.Get(r.NamespaceURI).GetName(r.LocalName));
-                        if (r.MoveToFirstAttribute())
-                        {
-                            do
-                            {
-                                e.AppendAttributeSkipNotify(new XAttribute(aCache.Get(r.Prefix.Length == 0 ? string.Empty : r.NamespaceURI).GetName(r.LocalName), r.Value));
-                            } while (r.MoveToNextAttribute());
-                            r.MoveToElement();
-                        }
-                        c.AddNodeSkipNotify(e);
-                        if (!r.IsEmptyElement)
-                        {
-                            c = e;
-                        }
-                        break;
-                    case XmlNodeType.EndElement:
-                        if (c.content == null)
-                        {
-                            c.content = string.Empty;
-                        }
-                        if (c == this) return;
-                        c = c.parent;
-                        break;
-                    case XmlNodeType.Text:
-                    case XmlNodeType.SignificantWhitespace:
-                    case XmlNodeType.Whitespace:
-                        c.AddStringSkipNotify(r.Value);
-                        break;
-                    case XmlNodeType.CDATA:
-                        c.AddNodeSkipNotify(new XCData(r.Value));
-                        break;
-                    case XmlNodeType.Comment:
-                        c.AddNodeSkipNotify(new XComment(r.Value));
-                        break;
-                    case XmlNodeType.ProcessingInstruction:
-                        c.AddNodeSkipNotify(new XProcessingInstruction(r.Name, r.Value));
-                        break;
-                    case XmlNodeType.DocumentType:
-                        c.AddNodeSkipNotify(new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), r.Value));
-                        break;
-                    case XmlNodeType.EntityReference:
-                        if (!r.CanResolveEntity) throw new InvalidOperationException(SR.InvalidOperation_UnresolvedEntityReference);
-                        r.ResolveEntity();
-                        break;
-                    case XmlNodeType.EndEntity:
-                        break;
-                    default:
-                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
-                }
-            } while (r.Read());
+
+            ContentReader cr = new ContentReader(this);
+            while (cr.ReadContentFrom(this, r) && r.Read()) ;
         }
 
         internal void ReadContentFrom(XmlReader r, LoadOptions o)
@@ -920,98 +867,107 @@ namespace System.Xml.Linq
                 return;
             }
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
-            XContainer c = this;
-            XNode n = null;
-            NamespaceCache eCache = new NamespaceCache();
-            NamespaceCache aCache = new NamespaceCache();
-            string baseUri = (o & LoadOptions.SetBaseUri) != 0 ? r.BaseURI : null;
-            IXmlLineInfo li = (o & LoadOptions.SetLineInfo) != 0 ? r as IXmlLineInfo : null;
+
+            ContentReader cr = new ContentReader(this);
+            while (cr.ReadContentFrom(this, r, o) && r.Read()) ;
+        }
+
+        internal async Task ReadContentFromAsync(XmlReader r, CancellationToken cancellationToken)
+        {
+            if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
+
+            ContentReader cr = new ContentReader(this);
             do
             {
-                string uri = r.BaseURI;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            while (cr.ReadContentFrom(this, r) && await r.ReadAsync().ConfigureAwait(false));
+        }
+
+        internal async Task ReadContentFromAsync(XmlReader r, LoadOptions o, CancellationToken cancellationToken)
+        {
+            if ((o & (LoadOptions.SetBaseUri | LoadOptions.SetLineInfo)) == 0)
+            {
+                await ReadContentFromAsync(r, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
+
+            ContentReader cr = new ContentReader(this);
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            while (cr.ReadContentFrom(this, r, o) && await r.ReadAsync().ConfigureAwait(false));
+        }
+        
+        /// <summary>
+        /// Contains the inner loop shared between ReadContentFrom / ReadContentFromAsync.
+        /// </summary>
+        private sealed class ContentReader
+        {
+            private readonly NamespaceCache _eCache = new NamespaceCache();
+            private readonly NamespaceCache _aCache = new NamespaceCache();
+            private readonly IXmlLineInfo _lineInfo;
+            private XContainer _currentContainer;
+            private string _baseUri;
+
+            public ContentReader(XContainer rootContainer)
+            {
+                _currentContainer = rootContainer;
+            }
+
+            public ContentReader(XContainer rootContainer, XmlReader r, LoadOptions o)
+            {
+                _currentContainer = rootContainer;
+                _baseUri = (o & LoadOptions.SetBaseUri) != 0 ? r.BaseURI : null;
+                _lineInfo = (o & LoadOptions.SetLineInfo) != 0 ? r as IXmlLineInfo : null;
+            }
+
+            public bool ReadContentFrom(XContainer rootContainer, XmlReader r)
+            {
                 switch (r.NodeType)
                 {
                     case XmlNodeType.Element:
+                        XElement e = new XElement(_eCache.Get(r.NamespaceURI).GetName(r.LocalName));
+                        if (r.MoveToFirstAttribute())
                         {
-                            XElement e = new XElement(eCache.Get(r.NamespaceURI).GetName(r.LocalName));
-                            if (baseUri != null && baseUri != uri)
+                            do
                             {
-                                e.SetBaseUri(uri);
-                            }
-                            if (li != null && li.HasLineInfo())
-                            {
-                                e.SetLineInfo(li.LineNumber, li.LinePosition);
-                            }
-                            if (r.MoveToFirstAttribute())
-                            {
-                                do
-                                {
-                                    XAttribute a = new XAttribute(aCache.Get(r.Prefix.Length == 0 ? string.Empty : r.NamespaceURI).GetName(r.LocalName), r.Value);
-                                    if (li != null && li.HasLineInfo())
-                                    {
-                                        a.SetLineInfo(li.LineNumber, li.LinePosition);
-                                    }
-                                    e.AppendAttributeSkipNotify(a);
-                                } while (r.MoveToNextAttribute());
-                                r.MoveToElement();
-                            }
-                            c.AddNodeSkipNotify(e);
-                            if (!r.IsEmptyElement)
-                            {
-                                c = e;
-                                if (baseUri != null)
-                                {
-                                    baseUri = uri;
-                                }
-                            }
-                            break;
+                                e.AppendAttributeSkipNotify(new XAttribute(_aCache.Get(r.Prefix.Length == 0 ? string.Empty : r.NamespaceURI).GetName(r.LocalName), r.Value));
+                            } while (r.MoveToNextAttribute());
+                            r.MoveToElement();
                         }
+                        _currentContainer.AddNodeSkipNotify(e);
+                        if (!r.IsEmptyElement)
+                        {
+                            _currentContainer = e;
+                        }
+                        break;
                     case XmlNodeType.EndElement:
+                        if (_currentContainer.content == null)
                         {
-                            if (c.content == null)
-                            {
-                                c.content = string.Empty;
-                            }
-                            // Store the line info of the end element tag.
-                            // Note that since we've got EndElement the current container must be an XElement
-                            XElement e = c as XElement;
-                            Debug.Assert(e != null, "EndElement received but the current container is not an element.");
-                            if (e != null && li != null && li.HasLineInfo())
-                            {
-                                e.SetEndElementLineInfo(li.LineNumber, li.LinePosition);
-                            }
-                            if (c == this) return;
-                            if (baseUri != null && c.HasBaseUri)
-                            {
-                                baseUri = c.parent.BaseUri;
-                            }
-                            c = c.parent;
-                            break;
+                            _currentContainer.content = string.Empty;
                         }
+                        if (_currentContainer == rootContainer) return false;
+                        _currentContainer = _currentContainer.parent;
+                        break;
                     case XmlNodeType.Text:
                     case XmlNodeType.SignificantWhitespace:
                     case XmlNodeType.Whitespace:
-                        if ((baseUri != null && baseUri != uri) ||
-                            (li != null && li.HasLineInfo()))
-                        {
-                            n = new XText(r.Value);
-                        }
-                        else
-                        {
-                            c.AddStringSkipNotify(r.Value);
-                        }
+                        _currentContainer.AddStringSkipNotify(r.Value);
                         break;
                     case XmlNodeType.CDATA:
-                        n = new XCData(r.Value);
+                        _currentContainer.AddNodeSkipNotify(new XCData(r.Value));
                         break;
                     case XmlNodeType.Comment:
-                        n = new XComment(r.Value);
+                        _currentContainer.AddNodeSkipNotify(new XComment(r.Value));
                         break;
                     case XmlNodeType.ProcessingInstruction:
-                        n = new XProcessingInstruction(r.Name, r.Value);
+                        _currentContainer.AddNodeSkipNotify(new XProcessingInstruction(r.Name, r.Value));
                         break;
                     case XmlNodeType.DocumentType:
-                        n = new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), r.Value);
+                        _currentContainer.AddNodeSkipNotify(new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), r.Value));
                         break;
                     case XmlNodeType.EntityReference:
                         if (!r.CanResolveEntity) throw new InvalidOperationException(SR.InvalidOperation_UnresolvedEntityReference);
@@ -1022,20 +978,127 @@ namespace System.Xml.Linq
                     default:
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
                 }
-                if (n != null)
+
+                return true;
+            }
+
+            public bool ReadContentFrom(XContainer rootContainer, XmlReader r, LoadOptions o)
+            {
+                XNode newNode = null;
+                string baseUri = r.BaseURI;
+
+                switch (r.NodeType)
                 {
-                    if (baseUri != null && baseUri != uri)
-                    {
-                        n.SetBaseUri(uri);
-                    }
-                    if (li != null && li.HasLineInfo())
-                    {
-                        n.SetLineInfo(li.LineNumber, li.LinePosition);
-                    }
-                    c.AddNodeSkipNotify(n);
-                    n = null;
+                    case XmlNodeType.Element:
+                        {
+                            XElement e = new XElement(_eCache.Get(r.NamespaceURI).GetName(r.LocalName));
+                            if (_baseUri != null && _baseUri != baseUri)
+                            {
+                                e.SetBaseUri(baseUri);
+                            }
+                            if (_lineInfo != null && _lineInfo.HasLineInfo())
+                            {
+                                e.SetLineInfo(_lineInfo.LineNumber, _lineInfo.LinePosition);
+                            }
+                            if (r.MoveToFirstAttribute())
+                            {
+                                do
+                                {
+                                    XAttribute a = new XAttribute(_aCache.Get(r.Prefix.Length == 0 ? string.Empty : r.NamespaceURI).GetName(r.LocalName), r.Value);
+                                    if (_lineInfo != null && _lineInfo.HasLineInfo())
+                                    {
+                                        a.SetLineInfo(_lineInfo.LineNumber, _lineInfo.LinePosition);
+                                    }
+                                    e.AppendAttributeSkipNotify(a);
+                                } while (r.MoveToNextAttribute());
+                                r.MoveToElement();
+                            }
+                            _currentContainer.AddNodeSkipNotify(e);
+                            if (!r.IsEmptyElement)
+                            {
+                                _currentContainer = e;
+                                if (_baseUri != null)
+                                {
+                                    _baseUri = baseUri;
+                                }
+                            }
+                            break;
+                        }
+                    case XmlNodeType.EndElement:
+                        {
+                            if (_currentContainer.content == null)
+                            {
+                                _currentContainer.content = string.Empty;
+                            }
+                            // Store the line info of the end element tag.
+                            // Note that since we've got EndElement the current container must be an XElement
+                            XElement e = _currentContainer as XElement;
+                            Debug.Assert(e != null, "EndElement received but the current container is not an element.");
+                            if (e != null && _lineInfo != null && _lineInfo.HasLineInfo())
+                            {
+                                e.SetEndElementLineInfo(_lineInfo.LineNumber, _lineInfo.LinePosition);
+                            }
+                            if (_currentContainer == rootContainer) return false;
+                            if (_baseUri != null && _currentContainer.HasBaseUri)
+                            {
+                                _baseUri = _currentContainer.parent.BaseUri;
+                            }
+                            _currentContainer = _currentContainer.parent;
+                            break;
+                        }
+                    case XmlNodeType.Text:
+                    case XmlNodeType.SignificantWhitespace:
+                    case XmlNodeType.Whitespace:
+                        if ((_baseUri != null && _baseUri != baseUri) ||
+                            (_lineInfo != null && _lineInfo.HasLineInfo()))
+                        {
+                            newNode = new XText(r.Value);
+                        }
+                        else
+                        {
+                            _currentContainer.AddStringSkipNotify(r.Value);
+                        }
+                        break;
+                    case XmlNodeType.CDATA:
+                        newNode = new XCData(r.Value);
+                        break;
+                    case XmlNodeType.Comment:
+                        newNode = new XComment(r.Value);
+                        break;
+                    case XmlNodeType.ProcessingInstruction:
+                        newNode = new XProcessingInstruction(r.Name, r.Value);
+                        break;
+                    case XmlNodeType.DocumentType:
+                        newNode = new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), r.Value);
+                        break;
+                    case XmlNodeType.EntityReference:
+                        if (!r.CanResolveEntity) throw new InvalidOperationException(SR.InvalidOperation_UnresolvedEntityReference);
+                        r.ResolveEntity();
+                        break;
+                    case XmlNodeType.EndEntity:
+                        break;
+                    default:
+                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
                 }
-            } while (r.Read());
+
+                if (newNode != null)
+                {
+                    if (_baseUri != null && _baseUri != baseUri)
+                    {
+                        newNode.SetBaseUri(baseUri);
+                    }
+
+                    if (_lineInfo != null && _lineInfo.HasLineInfo())
+                    {
+                        newNode.SetLineInfo(_lineInfo.LineNumber, _lineInfo.LinePosition);
+                    }
+
+                    _currentContainer.AddNodeSkipNotify(newNode);
+                    newNode = null;
+                }
+
+                return true;
+            }
         }
 
         internal void RemoveNode(XNode n)
@@ -1107,6 +1170,41 @@ namespace System.Xml.Linq
                     {
                         n = n.next;
                         n.WriteTo(writer);
+                    } while (n != content);
+                }
+            }
+        }
+
+        internal async Task WriteContentToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (content != null)
+            {
+                string stringContent = content as string;
+
+                if (stringContent != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    Task tWrite;
+
+                    if (this is XDocument)
+                    {
+                        tWrite = writer.WriteWhitespaceAsync(stringContent);
+                    }
+                    else
+                    {
+                        tWrite = writer.WriteStringAsync(stringContent);
+                    }
+
+                    await tWrite.ConfigureAwait(false);
+                }
+                else
+                {
+                    XNode n = (XNode)content;
+                    do
+                    {
+                        n = n.next;
+                        await n.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
                     } while (n != content);
                 }
             }

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XDocument.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XDocument.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 using Encoding = System.Text.Encoding;
@@ -269,6 +271,42 @@ namespace System.Xml.Linq
 
         /// <summary>
         /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
+        /// the passed <see cref="Stream"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the underlying <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> containing the raw XML to read into the newly
+        /// created <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="XDocument"/> containing the contents of the passed in
+        /// <see cref="Stream"/>.
+        /// </returns>
+        public static async Task<XDocument> LoadAsync(Stream stream, LoadOptions options, CancellationToken cancellationToken)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+
+            rs.Async = true;
+
+            using (XmlReader r = XmlReader.Create(stream, rs))
+            {
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
         /// the passed <see cref="TextReader"/> parameter.  
         /// </summary>
         /// <param name="textReader">
@@ -315,6 +353,42 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
+        /// the passed <see cref="TextReader"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="textReader">
+        /// A <see cref="TextReader"/> containing the raw XML to read into the newly
+        /// created <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="XDocument"/> containing the contents of the passed in
+        /// <see cref="TextReader"/>.
+        /// </returns>
+        public static async Task<XDocument> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken cancellationToken)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+
+            rs.Async = true;
+
+            using (XmlReader r = XmlReader.Create(textReader, rs))
+            {
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Create a new <see cref="XDocument"/> containing the contents of the
         /// passed in <see cref="XmlReader"/>.
         /// </summary>
@@ -350,6 +424,55 @@ namespace System.Xml.Linq
         {
             if (reader == null) throw new ArgumentNullException("reader");
             if (reader.ReadState == ReadState.Initial) reader.Read();
+
+            XDocument d = InitLoad(reader, options);
+            d.ReadContentFrom(reader, options);
+
+            if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
+            if (d.Root == null) throw new InvalidOperationException(SR.InvalidOperation_MissingRoot);
+            return d;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XDocument"/> containing the contents of the
+        /// passed in <see cref="XmlReader"/>.
+        /// </summary>
+        /// <param name="reader">
+        /// An <see cref="XmlReader"/> containing the XML to be read into the new
+        /// <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="XDocument"/> containing the contents of the passed
+        /// in <see cref="XmlReader"/>.
+        /// </returns>
+        public static async Task<XDocument> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
+        {
+            if (reader == null) throw new ArgumentNullException("reader");
+            if (reader.ReadState == ReadState.Initial)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await reader.ReadAsync().ConfigureAwait(false);
+            }
+
+            XDocument d = InitLoad(reader, options);
+            await d.ReadContentFromAsync(reader, options, cancellationToken).ConfigureAwait(false);
+
+            if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
+            if (d.Root == null) throw new InvalidOperationException(SR.InvalidOperation_MissingRoot);
+            return d;
+        }
+
+        /// <summary>
+        /// Performs shared initialization between Load and LoadAsync.
+        /// </summary>
+        static XDocument InitLoad(XmlReader reader, LoadOptions options)
+        {
             XDocument d = new XDocument();
             if ((options & LoadOptions.SetBaseUri) != 0)
             {
@@ -371,9 +494,6 @@ namespace System.Xml.Linq
             {
                 d.Declaration = new XDeclaration(reader);
             }
-            d.ReadContentFrom(reader, options);
-            if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
-            if (d.Root == null) throw new InvalidOperationException(SR.InvalidOperation_MissingRoot);
             return d;
         }
 
@@ -480,6 +600,40 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Output this <see cref="XDocument"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to output the XML to.  
+        /// </param>
+        /// <param name="options">
+        /// If SaveOptions.DisableFormatting is enabled the output is not indented.
+        /// If SaveOptions.OmitDuplicateNamespaces is enabled duplicate namespace declarations will be removed.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public async Task SaveAsync(Stream stream, SaveOptions options, CancellationToken cancellationToken)
+        {
+            XmlWriterSettings ws = GetXmlWriterSettings(options);
+
+            ws.Async = true;
+
+            if (_declaration != null && !string.IsNullOrEmpty(_declaration.Encoding))
+            {
+                try
+                {
+                    ws.Encoding = Encoding.GetEncoding(_declaration.Encoding);
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+
+            using (XmlWriter w = XmlWriter.Create(stream, ws))
+            {
+                await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Output this <see cref="XDocument"/> to the passed in <see cref="TextWriter"/>.
         /// </summary>
         /// <remarks>
@@ -518,6 +672,29 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Output this <see cref="XDocument"/> to a <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="textWriter">
+        /// The <see cref="TextWriter"/> to output the XML to.  
+        /// </param>
+        /// <param name="options">
+        /// If SaveOptions.DisableFormatting is enabled the output is not indented.
+        /// If SaveOptions.OmitDuplicateNamespaces is enabled duplicate namespace declarations will be removed.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public async Task SaveAsync(TextWriter textWriter, SaveOptions options, CancellationToken cancellationToken)
+        {
+            XmlWriterSettings ws = GetXmlWriterSettings(options);
+
+            ws.Async = true;
+
+            using (XmlWriter w = XmlWriter.Create(textWriter, ws))
+            {
+                await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Output this <see cref="XDocument"/> to an <see cref="XmlWriter"/>.
         /// </summary>
         /// <param name="writer">
@@ -528,6 +705,19 @@ namespace System.Xml.Linq
             WriteTo(writer);
         }
 
+        /// <summary>
+        /// Output this <see cref="XDocument"/> to an <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to output the XML to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        public async Task SaveAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            await WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Output this <see cref="XDocument"/>'s underlying XML tree to the
@@ -555,6 +745,41 @@ namespace System.Xml.Linq
             }
             WriteContentTo(writer);
             writer.WriteEndDocument();
+        }
+
+        /// <summary>
+        /// Output this <see cref="XDocument"/>'s underlying XML tree to the
+        /// passed in <see cref="XmlWriter"/>.
+        /// <seealso cref="XDocument.Save(XmlWriter)"/>
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to output the content of this 
+        /// <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Task tStart;
+            if (_declaration != null && _declaration.Standalone == "yes")
+            {
+                tStart = writer.WriteStartDocumentAsync(true);
+            }
+            else if (_declaration != null && _declaration.Standalone == "no")
+            {
+                tStart = writer.WriteStartDocumentAsync(false);
+            }
+            else
+            {
+                tStart = writer.WriteStartDocumentAsync();
+            }
+            await tStart.ConfigureAwait(false);
+
+            await WriteContentToAsync(writer, cancellationToken).ConfigureAwait(false);
+            await writer.WriteEndDocumentAsync().ConfigureAwait(false);
         }
 
         internal override void AddAttribute(XAttribute a)

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XDocumentType.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XDocumentType.cs
@@ -153,12 +153,13 @@ namespace System.Xml.Linq
         /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
-        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
-            if (writer == null) throw new ArgumentNullException("writer");
-
-            cancellationToken.ThrowIfCancellationRequested();
-            await writer.WriteDocTypeAsync(_name, _publicId, _systemId, _internalSubset).ConfigureAwait(false);
+            if (writer == null)
+                throw new ArgumentNullException("writer");
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            return writer.WriteDocTypeAsync(_name, _publicId, _systemId, _internalSubset);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XDocumentType.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XDocumentType.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -140,6 +142,23 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteDocType(_name, _publicId, _systemId, _internalSubset);
+        }
+
+        /// <summary>
+        /// Write this <see cref="XDocumentType"/> to the passed in <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XDocumentType"/> to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteDocTypeAsync(_name, _publicId, _systemId, _internalSubset).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
 using System.Xml.Schema;
+using System.Threading;
+using System.Threading.Tasks;
 
 using CultureInfo = System.Globalization.CultureInfo;
 using IEnumerable = System.Collections.IEnumerable;
@@ -136,9 +138,27 @@ namespace System.Xml.Linq
         {
         }
 
+        private XElement(AsyncConstructionSentry s) 
+        {
+            // Dummy ctor used to avoid public default ctor.  This is used
+            // by async methods meant to perform the same operations as
+            // the XElement constructors that do synchronous processing;
+            // the async methods instead construct an XElement using this
+            // constructor (which doesn't do any processing) and then themselves
+            // do the async processing.  This is because ctors can't be 'async'.
+        }
+        private struct AsyncConstructionSentry { }
+
         internal XElement(XmlReader r, LoadOptions o)
         {
             ReadElementFrom(r, o);
+        }
+
+        internal static async Task<XElement> CreateAsync(XmlReader r, CancellationToken cancellationToken)
+        {
+            XElement xe = new XElement(default(AsyncConstructionSentry));
+            await xe.ReadElementFromAsync(r, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+            return xe;
         }
 
         /// <summary>
@@ -588,6 +608,42 @@ namespace System.Xml.Linq
                 return Load(r, options);
             }
         }
+
+        /// <summary>
+        /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
+        /// the passed <see cref="Stream"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> containing the raw XML to read into the newly
+        /// created <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.</param>
+        /// <returns>
+        /// A new <see cref="XElement"/> containing the contents of the passed in
+        /// <see cref="Stream"/>.
+        /// </returns>
+        public static async Task<XElement> LoadAsync(Stream stream, LoadOptions options, CancellationToken cancellationToken)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+
+            rs.Async = true;
+
+            using (XmlReader r = XmlReader.Create(stream, rs))
+            {
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         /// <summary>
         /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
         /// the passed <see cref="TextReader"/> parameter.  
@@ -636,6 +692,41 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
+        /// the passed <see cref="TextReader"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="textReader">
+        /// A <see cref="TextReader"/> containing the raw XML to read into the newly
+        /// created <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.</param>
+        /// <returns>
+        /// A new <see cref="XElement"/> containing the contents of the passed in
+        /// <see cref="TextReader"/>.
+        /// </returns>
+        public static async Task<XElement> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken cancellationToken)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+
+            rs.Async = true;
+
+            using (XmlReader r = XmlReader.Create(textReader, rs))
+            {
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Create a new <see cref="XElement"/> containing the contents of the
         /// passed in <see cref="XmlReader"/>.
         /// </summary>
@@ -673,6 +764,40 @@ namespace System.Xml.Linq
             if (reader.MoveToContent() != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
             XElement e = new XElement(reader, options);
             reader.MoveToContent();
+            if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
+            return e;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XElement"/> containing the contents of the
+        /// passed in <see cref="XmlReader"/>.
+        /// </summary>
+        /// <param name="reader">
+        /// An <see cref="XmlReader"/> containing the XML to be read into the new
+        /// <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.</param>
+        /// <returns>
+        /// A new <see cref="XElement"/> containing the contents of the passed
+        /// in <see cref="XmlReader"/>.
+        /// </returns>
+        public static async Task<XElement> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
+        {
+            if (reader == null) throw new ArgumentNullException("reader");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (await reader.MoveToContentAsync().ConfigureAwait(false) != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
+
+            XElement e = new XElement(new AsyncConstructionSentry());
+            await e.ReadElementFromAsync(reader, options, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await reader.MoveToContentAsync().ConfigureAwait(false);
+
             if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
             return e;
         }
@@ -889,6 +1014,29 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Output this <see cref="XElement"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to output the XML to.  
+        /// </param>
+        /// <param name="options">
+        /// If SaveOptions.DisableFormatting is enabled the output is not indented.
+        /// If SaveOptions.OmitDuplicateNamespaces is enabled duplicate namespace declarations will be removed.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public async Task SaveAsync(Stream stream, SaveOptions options, CancellationToken cancellationToken)
+        {
+            XmlWriterSettings ws = GetXmlWriterSettings(options);
+
+            ws.Async = true;
+
+            using (XmlWriter w = XmlWriter.Create(stream, ws))
+            {
+                await SaveAsync(w, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Output this <see cref="XElement"/> to the passed in <see cref="TextWriter"/>.
         /// </summary>
         /// <remarks>
@@ -927,6 +1075,29 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Output this <see cref="XElement"/> to a <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="textWriter">
+        /// The <see cref="TextWriter"/> to output the XML to.  
+        /// </param>
+        /// <param name="options">
+        /// If SaveOptions.DisableFormatting is enabled the output is not indented.
+        /// If SaveOptions.OmitDuplicateNamespaces is enabled duplicate namespace declarations will be removed.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public async Task SaveAsync(TextWriter textWriter, SaveOptions options, CancellationToken cancellationToken)
+        {
+            XmlWriterSettings ws = GetXmlWriterSettings(options);
+
+            ws.Async = true;
+
+            using (XmlWriter w = XmlWriter.Create(textWriter, ws))
+            {
+                await SaveAsync(w, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Output this <see cref="XElement"/> to an <see cref="XmlWriter"/>.
         /// </summary>
         /// <param name="writer">
@@ -938,6 +1109,26 @@ namespace System.Xml.Linq
             writer.WriteStartDocument();
             WriteTo(writer);
             writer.WriteEndDocument();
+        }
+
+        /// <summary>
+        /// Output this <see cref="XElement"/> to an <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to output the XML to.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public async Task SaveAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteStartDocumentAsync().ConfigureAwait(false);
+
+            await WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteEndDocumentAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1048,6 +1239,19 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             new ElementWriter(writer).WriteElement(this);
+        }
+
+        /// <summary>
+        /// Write this <see cref="XElement"/> to the passed in <see cref="XmlTextWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlTextWriter"/> to write this <see cref="XElement"/> to.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+            await new ElementWriter(writer).WriteElementAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1740,6 +1944,38 @@ namespace System.Xml.Linq
 
         private void ReadElementFrom(XmlReader r, LoadOptions o)
         {
+            ReadElementFromImpl(r, o);
+
+            if (!r.IsEmptyElement)
+            {
+                r.Read();
+                ReadContentFrom(r, o);
+            }
+
+            r.Read();
+        }
+
+        private async Task ReadElementFromAsync(XmlReader r, LoadOptions o, CancellationToken cancellationTokentoken)
+        {
+            ReadElementFromImpl(r, o);
+
+            if (!r.IsEmptyElement)
+            {
+                cancellationTokentoken.ThrowIfCancellationRequested();
+                await r.ReadAsync().ConfigureAwait(false);
+
+                await ReadContentFromAsync(r, o, cancellationTokentoken).ConfigureAwait(false);
+            }
+
+            cancellationTokentoken.ThrowIfCancellationRequested();
+            await r.ReadAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Shared implementation between ReadElementFrom / ReadElementFromAsync.
+        /// </summary>
+        private void ReadElementFromImpl(XmlReader r, LoadOptions o)
+        {
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
             name = XNamespace.Get(r.NamespaceURI).GetName(r.LocalName);
             if ((o & LoadOptions.SetBaseUri) != 0)
@@ -1772,12 +2008,6 @@ namespace System.Xml.Linq
                 } while (r.MoveToNextAttribute());
                 r.MoveToElement();
             }
-            if (!r.IsEmptyElement)
-            {
-                r.Read();
-                ReadContentFrom(r, o);
-            }
-            r.Read();
         }
 
         internal void RemoveAttribute(XAttribute a)

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-
+using System.Threading;
+using System.Threading.Tasks;
 using IEnumerable = System.Collections.IEnumerable;
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 
@@ -245,6 +246,51 @@ namespace System.Xml.Linq
             }
         }
 
+        public async Task WriteElementAsync(XElement e, CancellationToken cancellationToken)
+        {
+            PushAncestors(e);
+            XElement root = e;
+            XNode n = e;
+            while (true)
+            {
+                e = n as XElement;
+                if (e != null)
+                {
+                    await WriteStartElementAsync(e, cancellationToken).ConfigureAwait(false);
+                    if (e.content == null)
+                    {
+                        await WriteEndElementAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        string s = e.content as string;
+                        if (s != null)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            await _writer.WriteStringAsync(s).ConfigureAwait(false);
+                            await WriteFullEndElementAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            n = ((XNode)e.content).next;
+                            continue;
+                        }
+                    }
+                }
+                else
+                {
+                    await n.WriteToAsync(_writer, cancellationToken).ConfigureAwait(false);
+                }
+                while (n != root && n == n.parent.content)
+                {
+                    n = n.parent;
+                    await WriteFullEndElementAsync(cancellationToken).ConfigureAwait(false);
+                }
+                if (n == root) break;
+                n = n.next;
+            }
+        }
+
         private string GetPrefixOfNamespace(XNamespace ns, bool allowDefaultNamespace)
         {
             string namespaceName = ns.NamespaceName;
@@ -300,9 +346,23 @@ namespace System.Xml.Linq
             _resolver.PopScope();
         }
 
+        private async Task WriteEndElementAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _writer.WriteEndElementAsync().ConfigureAwait(false);
+            _resolver.PopScope();
+        }
+
         private void WriteFullEndElement()
         {
             _writer.WriteFullEndElement();
+            _resolver.PopScope();
+        }
+
+        private async Task WriteFullEndElementAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _writer.WriteFullEndElementAsync().ConfigureAwait(false);
             _resolver.PopScope();
         }
 
@@ -321,6 +381,25 @@ namespace System.Xml.Linq
                     string localName = a.Name.LocalName;
                     string namespaceName = ns.NamespaceName;
                     _writer.WriteAttributeString(GetPrefixOfNamespace(ns, false), localName, namespaceName.Length == 0 && localName == "xmlns" ? XNamespace.xmlnsPrefixNamespace : namespaceName, a.Value);
+                } while (a != e.lastAttr);
+            }
+        }
+
+        async Task WriteStartElementAsync(XElement e, CancellationToken cancellationToken)
+        {
+            PushElement(e);
+            XNamespace ns = e.Name.Namespace;
+            await _writer.WriteStartElementAsync(GetPrefixOfNamespace(ns, true), e.Name.LocalName, ns.NamespaceName).ConfigureAwait(false);
+            XAttribute a = e.lastAttr;
+            if (a != null)
+            {
+                do
+                {
+                    a = a.next;
+                    ns = a.Name.Namespace;
+                    string localName = a.Name.LocalName;
+                    string namespaceName = ns.NamespaceName;
+                    await _writer.WriteAttributeStringAsync(GetPrefixOfNamespace(ns, false), localName, namespaceName.Length == 0 && localName == "xmlns" ? XNamespace.xmlnsPrefixNamespace : namespaceName, a.Value).ConfigureAwait(false);
                 } while (a != e.lastAttr);
             }
         }

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
@@ -474,9 +474,17 @@ namespace System.Xml.Linq
         /// <exception cref="InvalidOperationException">
         /// Thrown if the <see cref="XmlReader"/> is not positioned on a recognized node type.
         /// </exception>
-        public static async Task<XNode> ReadFromAsync(XmlReader reader, CancellationToken cancellationToken)
+        public static Task<XNode> ReadFromAsync(XmlReader reader, CancellationToken cancellationToken)
         {
-            if (reader == null) throw new ArgumentNullException("reader");
+            if (reader == null)
+                throw new ArgumentNullException("reader");
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<XNode>(cancellationToken);
+            return ReadFromAsyncInternal(reader, cancellationToken);
+        }
+
+        private static async Task<XNode> ReadFromAsyncInternal(XmlReader reader, CancellationToken cancellationToken)
+        {
             if (reader.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
 
             XNode ret;

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
@@ -7,6 +7,8 @@ using System.IO;
 using CultureInfo = System.Globalization.CultureInfo;
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 using StringBuilder = System.Text.StringBuilder;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Xml.Linq
 {
@@ -461,6 +463,64 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Creates an <see cref="XNode"/> from an <see cref="XmlReader"/>.
+        /// The runtime type of the node is determined by the node type
+        /// (<see cref="XObject.NodeType"/>) of the first node encountered
+        /// in the reader.
+        /// </summary>
+        /// <param name="reader">An <see cref="XmlReader"/> positioned at the node to read into this <see cref="XNode"/>.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>An <see cref="XNode"/> that contains the nodes read from the reader.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the <see cref="XmlReader"/> is not positioned on a recognized node type.
+        /// </exception>
+        public static async Task<XNode> ReadFromAsync(XmlReader reader, CancellationToken cancellationToken)
+        {
+            if (reader == null) throw new ArgumentNullException("reader");
+            if (reader.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
+
+            XNode ret;
+
+            switch (reader.NodeType)
+            {
+                case XmlNodeType.Text:
+                case XmlNodeType.SignificantWhitespace:
+                case XmlNodeType.Whitespace:
+                    ret = new XText(reader.Value);
+                    break;
+                case XmlNodeType.CDATA:
+                    ret = new XCData(reader.Value);
+                    break;
+                case XmlNodeType.Comment:
+                    ret = new XComment(reader.Value);
+                    break;
+                case XmlNodeType.DocumentType:
+                    var name = reader.Name;
+                    var publicId = reader.GetAttribute("PUBLIC");
+                    var systemId = reader.GetAttribute("SYSTEM");
+                    var internalSubset = reader.Value;
+
+                    ret = new XDocumentType(name, publicId, systemId, internalSubset);
+                    break;
+                case XmlNodeType.Element:
+                    return await XElement.CreateAsync(reader, cancellationToken).ConfigureAwait(false);
+                case XmlNodeType.ProcessingInstruction:
+                    var target = reader.Name;
+                    var data = reader.Value;
+
+                    ret = new XProcessingInstruction(target, data);
+                    break;
+                default:
+                    throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, reader.NodeType));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await reader.ReadAsync().ConfigureAwait(false);
+
+            return ret;
+        }
+
+        /// <summary>
         /// Removes this XNode from the underlying XML tree.
         /// </summary>
         /// <exception cref="InvalidOperationException">
@@ -557,6 +617,13 @@ namespace System.Xml.Linq
         /// </summary>
         /// <param name="writer">The <see cref="XmlWriter"/> to write the current node into.</param>
         public abstract void WriteTo(XmlWriter writer);
+
+        /// <summary>
+        /// Write the current node to an <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="XmlWriter"/> to write the current node into.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public abstract Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken);
 
         internal virtual void AppendText(StringBuilder sb)
         {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
@@ -127,12 +127,13 @@ namespace System.Xml.Linq
         /// The <see cref="XmlWriter"/> to write this <see cref="XProcessingInstruction"/> to.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
-            if (writer == null) throw new ArgumentNullException("writer");
-
-            cancellationToken.ThrowIfCancellationRequested();
-            await writer.WriteProcessingInstructionAsync(target, data).ConfigureAwait(false);
+            if (writer == null)
+                throw new ArgumentNullException("writer");
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            return writer.WriteProcessingInstructionAsync(target, data);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -116,6 +118,21 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteProcessingInstruction(target, data);
+        }
+
+        /// <summary>
+        /// Writes this <see cref="XProcessingInstruction"/> to the passed in <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XProcessingInstruction"/> to.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteProcessingInstructionAsync(target, data).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XText.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XText.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using StringBuilder = System.Text.StringBuilder;
 
 namespace System.Xml.Linq
@@ -87,6 +89,33 @@ namespace System.Xml.Linq
             {
                 writer.WriteString(text);
             }
+        }
+
+        /// <summary>
+        /// Write this <see cref="XText"/> to the given <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XText"/> to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Task t;
+            if (parent is XDocument)
+            {
+                t = writer.WriteWhitespaceAsync(text);
+            }
+            else
+            {
+                t = writer.WriteStringAsync(text);
+            }
+            await t.ConfigureAwait(false);
         }
 
         internal override void AppendText(StringBuilder sb)

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XText.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XText.cs
@@ -100,22 +100,16 @@ namespace System.Xml.Linq
         /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
-        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
-            if (writer == null) throw new ArgumentNullException("writer");
+            if (writer == null)
+                throw new ArgumentNullException("writer");
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
 
-            cancellationToken.ThrowIfCancellationRequested();
-
-            Task t;
-            if (parent is XDocument)
-            {
-                t = writer.WriteWhitespaceAsync(text);
-            }
-            else
-            {
-                t = writer.WriteStringAsync(text);
-            }
-            await t.ConfigureAwait(false);
+            return parent is XDocument ?
+                writer.WriteWhitespaceAsync(text) :
+                writer.WriteStringAsync(text);
         }
 
         internal override void AppendText(StringBuilder sb)

--- a/src/System.Xml.XDocument/tests/XDocument.Common/BridgeHelpers.cs
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/BridgeHelpers.cs
@@ -136,7 +136,7 @@ namespace CoreXml.Test.XLinq
             }
         }
 
-        public string GetTestFileName()
+        public static string GetTestFileName()
         {
             return Path.Combine(@"TestData\XmlReader\API\", pGenericXml);
         }

--- a/src/System.Xml.XDocument/tests/misc/LoadSaveAsyncTests.cs
+++ b/src/System.Xml.XDocument/tests/misc/LoadSaveAsyncTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using XmlCoreTest.Common;
+using Xunit;
+
+namespace CoreXml.Test.XLinq
+{
+    public class LoadSaveAsyncTests : BridgeHelpers
+    {
+        [Fact]
+        public static void ArgumentValidation()
+        {
+            // Verify that ArgumentNullExceptions are thrown when passing null to LoadAsync and SaveAsync
+            Assert.Throws<ArgumentNullException>(() => { XDocument.LoadAsync((XmlReader)null, LoadOptions.None, CancellationToken.None); });
+            Assert.Throws<ArgumentNullException>(() => { new XDocument().SaveAsync((XmlWriter)null, CancellationToken.None); });
+            Assert.Throws<ArgumentNullException>(() => { XElement.LoadAsync((XmlReader)null, LoadOptions.None, CancellationToken.None); });
+            Assert.Throws<ArgumentNullException>(() => { new XElement().SaveAsync((XmlWriter)null, CancellationToken.None); });
+        }
+
+        [Fact]
+        public static async Task AlreadyCanceled()
+        {
+            // Verify that providing an already canceled cancellation token will result in a canceled task
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => XDocument.LoadAsync(Stream.Null, LoadOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => XDocument.LoadAsync(StreamReader.Null, LoadOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => XDocument.LoadAsync(XmlReader.Create(Stream.Null), LoadOptions.None, new CancellationToken(true)));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => new XDocument().SaveAsync(Stream.Null, SaveOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => new XDocument().SaveAsync(StreamWriter.Null, SaveOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => new XDocument().SaveAsync(XmlWriter.Create(Stream.Null), new CancellationToken(true)));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => XElement.LoadAsync(Stream.Null, LoadOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => XElement.LoadAsync(StreamReader.Null, LoadOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => XElement.LoadAsync(XmlReader.Create(Stream.Null), LoadOptions.None, new CancellationToken(true)));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => new XElement().SaveAsync(Stream.Null, SaveOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => new XElement().SaveAsync(StreamWriter.Null, SaveOptions.None, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => new XElement().SaveAsync(XmlWriter.Create(Stream.Null), new CancellationToken(true)));
+        }
+
+        [Theory]
+        [MemberData("RoundtripOptions_MemberData")]
+        public static async Task RoundtripSyncAsyncMatches_XmlReader(bool document, LoadOptions loadOptions, SaveOptions saveOptions)
+        {
+            // Create reader and writer settings
+            var readerSettings = new XmlReaderSettings();
+            var writerSettings = new XmlWriterSettings();
+            if ((saveOptions & SaveOptions.OmitDuplicateNamespaces) != 0)
+            {
+                writerSettings.NamespaceHandling = NamespaceHandling.OmitDuplicates;
+            }
+            if ((saveOptions & SaveOptions.DisableFormatting) != 0)
+            {
+                writerSettings.Indent = false;
+                writerSettings.NewLineHandling = NewLineHandling.None;
+            }
+
+            // Roundtrip XML using synchronous and XmlReader/Writer
+            MemoryStream syncOutput = new MemoryStream();
+            using (XmlReader syncReader = XmlReader.Create(FilePathUtil.getStream(GetTestFileName()), readerSettings))
+            using (XmlWriter syncWriter = XmlWriter.Create(syncOutput, writerSettings))
+            {
+                if (document)
+                {
+                    XDocument syncDoc = XDocument.Load(syncReader, loadOptions);
+                    syncDoc.Save(syncWriter);
+                }
+                else
+                {
+                    XElement syncElement = XElement.Load(syncReader, loadOptions);
+                    syncElement.Save(syncWriter);
+                }
+            }
+
+            // Roundtrip XML using asynchronous and XmlReader/Writer
+            readerSettings.Async = true;
+            writerSettings.Async = true;
+            MemoryStream asyncOutput = new MemoryStream();
+            using (XmlReader asyncReader = XmlReader.Create(FilePathUtil.getStream(GetTestFileName()), readerSettings))
+            using (XmlWriter asyncWriter = XmlWriter.Create(asyncOutput, writerSettings))
+            {
+                if (document)
+                {
+                    XDocument asyncDoc = await XDocument.LoadAsync(asyncReader, loadOptions, CancellationToken.None);
+                    await asyncDoc.SaveAsync(asyncWriter, CancellationToken.None);
+                }
+                else
+                {
+                    XElement asyncElement = await XElement.LoadAsync(asyncReader, loadOptions, CancellationToken.None);
+                    await asyncElement.SaveAsync(asyncWriter, CancellationToken.None);
+                }
+            }
+
+            // Compare to make sure the synchronous and asynchronous results are the same
+            Assert.Equal(syncOutput.ToArray(), asyncOutput.ToArray());
+        }
+
+        [Theory]
+        [MemberData("RoundtripOptions_MemberData")]
+        public static async Task RoundtripSyncAsyncMatches_StreamReader(bool document, LoadOptions loadOptions, SaveOptions saveOptions)
+        {
+            // Roundtrip XML using synchronous and StreamReader/Writer
+            MemoryStream syncOutput = new MemoryStream();
+            using (StreamReader syncReader = new StreamReader(FilePathUtil.getStream(GetTestFileName())))
+            using (StreamWriter syncWriter = new StreamWriter(syncOutput))
+            {
+                if (document)
+                {
+                    XDocument syncDoc = XDocument.Load(syncReader, loadOptions);
+                    syncDoc.Save(syncWriter, saveOptions);
+                }
+                else
+                {
+                    XElement syncElement = XElement.Load(syncReader, loadOptions);
+                    syncElement.Save(syncWriter, saveOptions);
+                }
+            }
+
+            // Roundtrip XML using asynchronous and StreamReader/Writer
+            MemoryStream asyncOutput = new MemoryStream();
+            using (StreamReader asyncReader = new StreamReader(FilePathUtil.getStream(GetTestFileName())))
+            using (StreamWriter asyncWriter = new StreamWriter(asyncOutput))
+            {
+                if (document)
+                {
+                    XDocument asyncDoc = await XDocument.LoadAsync(asyncReader, loadOptions, CancellationToken.None);
+                    await asyncDoc.SaveAsync(asyncWriter, saveOptions, CancellationToken.None);
+                }
+                else
+                {
+                    XElement asyncElement = await XElement.LoadAsync(asyncReader, loadOptions, CancellationToken.None);
+                    await asyncElement.SaveAsync(asyncWriter, saveOptions, CancellationToken.None);
+                }
+            }
+
+            // Compare to make sure the synchronous and asynchronous results are the same
+            Assert.Equal(syncOutput.ToArray(), asyncOutput.ToArray());
+        }
+
+        [Theory]
+        [MemberData("RoundtripOptions_MemberData")]
+        public static async Task RoundtripSyncAsyncMatches_Stream(bool document, LoadOptions loadOptions, SaveOptions saveOptions)
+        {
+            // Roundtrip XML using synchronous and Stream
+            MemoryStream syncOutput = new MemoryStream();
+            using (Stream syncStream = FilePathUtil.getStream(GetTestFileName()))
+            {
+                if (document)
+                {
+                    XDocument syncDoc = XDocument.Load(syncStream, loadOptions);
+                    syncDoc.Save(syncOutput, saveOptions);
+                }
+                else
+                {
+                    XElement syncElement = XElement.Load(syncStream, loadOptions);
+                    syncElement.Save(syncOutput, saveOptions);
+                }
+            }
+
+            // Roundtrip XML using asynchronous and Stream
+            MemoryStream asyncOutput = new MemoryStream();
+            using (Stream asyncStream = FilePathUtil.getStream(GetTestFileName()))
+            {
+                if (document)
+                {
+                    XDocument asyncDoc = await XDocument.LoadAsync(asyncStream, loadOptions, CancellationToken.None);
+                    await asyncDoc.SaveAsync(asyncOutput, saveOptions, CancellationToken.None);
+                }
+                else
+                {
+                    XElement asyncElement = await XElement.LoadAsync(asyncStream, loadOptions, CancellationToken.None);
+                    await asyncElement.SaveAsync(asyncOutput, saveOptions, CancellationToken.None);
+                }
+            }
+
+            // Compare to make sure the synchronous and asynchronous results are the same
+            Assert.Equal(syncOutput.ToArray(), asyncOutput.ToArray());
+        }
+
+        // Inputs to the Roundtrip* tests:
+        // - Boolean for whether to test XDocument (true) or XElement (false)
+        // - LoadOptions value
+        // - SaveOptions value
+        public static IEnumerable<object[]> RoundtripOptions_MemberData
+        {
+            get
+            {
+                foreach (bool doc in new[] { true, false })
+                    foreach (LoadOptions loadOptions in Enum.GetValues(typeof(LoadOptions)))
+                        foreach (SaveOptions saveOptions in Enum.GetValues(typeof(SaveOptions)))
+                            yield return new object[] { doc, loadOptions, saveOptions };
+            }
+        }
+
+    }
+}

--- a/src/System.Xml.XDocument/tests/misc/System.Xml.XDocument.Misc.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/misc/System.Xml.XDocument.Misc.Tests.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Annotation.cs" />
+    <Compile Include="LoadSaveAsyncTests.cs" />
     <Compile Include="FunctionalTests.cs" />
     <Compile Include="PrefixNamespaceFixes.cs" />
     <Compile Include="RegressionTests.cs" />


### PR DESCRIPTION
This PR replaces #110.  I rebased on future, fixed up Cory's changes (a bunch of formatting changes and renames had been merged in the meantime), and then added a few commits of my own, fixing a bug, adding some tests, etc.  The tests roundtrip XML by loading and saving via both the sync and async APIs, and then compare the output, using a variety of settings.

cc: @scalablecory, @krwq, @weshaggard, @terrajobst 