### PR TITLE
Fix small discrepancy in TaskExtensions.Unwrap

### DIFF
--- a/src/System.Threading.Tasks/src/System/Threading/Tasks/TaskExtensions.CoreCLR.cs
+++ b/src/System.Threading.Tasks/src/System/Threading/Tasks/TaskExtensions.CoreCLR.cs
@@ -215,14 +215,16 @@ namespace System.Threading.Tasks
             try
             {
                 task.GetAwaiter().GetResult();
+                Debug.Fail("Waiting on the canceled task should always result in an OCE, even if it's manufactured at the time of the wait.");
+                return new CancellationToken(true);
             }
             catch (OperationCanceledException oce)
             {
-                CancellationToken ct = oce.CancellationToken;
-                if (ct.IsCancellationRequested)
-                    return ct;
+                // This token may not have cancellation requested; that's ok.
+                // That can happen if, for example, the Task is canceled with
+                // TaskCompletionSource<T>.SetCanceled(), without a token.
+                return oce.CancellationToken;
             }
-            return new CancellationToken(true);
         }
 
         /// <summary>Dummy type to use as a void TResult.</summary>

--- a/src/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -470,6 +470,10 @@ namespace System.Threading.Tasks.Tests
                 yield return new object[] { Task.CompletedTask };
                 yield return new object[] { Task.FromCanceled(CreateCanceledToken()) };
                 yield return new object[] { Task.FromException(new FormatException()) };
+
+                var tcs = new TaskCompletionSource<int>();
+                tcs.SetCanceled(); // cancel task without a token
+                yield return new object[] { tcs.Task };
             }
         }
 
@@ -481,6 +485,10 @@ namespace System.Threading.Tasks.Tests
                 yield return new object[] { Task.FromResult("Tasks") };
                 yield return new object[] { Task.FromCanceled<string>(CreateCanceledToken()) };
                 yield return new object[] { Task.FromException<string>(new FormatException()) };
+
+                var tcs = new TaskCompletionSource<string>();
+                tcs.SetCanceled(); // cancel task without a token
+                yield return new object[] { tcs.Task };
             }
         }
 


### PR DESCRIPTION
This fixes a small behavioral difference between the mscorlib implementation of Unwrap and the corefx implementation of Wnwrap.  A Task can end in a canceled state but contain a CancellationToken that doesn't have cancellation requested, e.g. if TaskCompletionSource.SetCanceled() is used.  When Unwrap proxies such a task, the mscorlib implementation was appropriately reflecting that no-cancellation-requested state, whereas our corefx implementation was pretending it did have cancellation requested. This commit fixes the corefx implementation to match, and adds a few additional test cases to verify.