### PR TITLE
Performance improvements to Skip and SkipWhile.

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading;
+using System.Runtime.ExceptionServices;
 
 namespace System.Linq
 {
@@ -676,21 +676,103 @@ namespace System.Linq
             }
         }
 
+        // Just in case somebody does something weird with the ordering of enumerator
+        // disposal, this wraps an enumerator that has been used, but not disposed,
+        // and disposes it when this is.
+        // If an exception had been found while skipping, this
+        // throws it on MoveNext.
+        private sealed class DeadEnumeratorWrapper<TSource> : IEnumerator<TSource>
+        {
+            private readonly IEnumerator<TSource> _corpse;
+            private ExceptionDispatchInfo _exception;
+
+            internal DeadEnumeratorWrapper(IEnumerator<TSource> corpse)
+                : this(corpse, null)
+            {
+            }
+
+            internal DeadEnumeratorWrapper(IEnumerator<TSource> corpse, ExceptionDispatchInfo exception)
+            {
+                _corpse = corpse;
+                _exception = exception;
+            }
+
+            public TSource Current
+            {
+                get { return default(TSource); }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            public bool MoveNext()
+            {
+                if (_exception != null)
+                {
+                    ExceptionDispatchInfo ex = _exception;
+                    _exception = null;
+                    ex.Throw();
+                }
+                return false;
+            }
+
+            public void Dispose()
+            {
+                _corpse.Dispose();
+            }
+
+            public void Reset()
+            {
+                throw new NotSupportedException();
+            }
+        }
+
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            return SkipIterator<TSource>(source, count);
+            return new SkipIterator<TSource>(source, count);
         }
 
-        private static IEnumerable<TSource> SkipIterator<TSource>(IEnumerable<TSource> source, int count)
+        private sealed class SkipIterator<TSource> : IEnumerable<TSource>
         {
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            private readonly IEnumerable<TSource> _source;
+            private readonly int _count;
+
+            public SkipIterator(IEnumerable<TSource> source, int count)
             {
-                while (count > 0 && e.MoveNext()) count--;
-                if (count <= 0)
+                _source = source;
+                _count = count > 0 ? count : 0;
+            }
+
+            public IEnumerator<TSource> GetEnumerator()
+            {
+                IEnumerator<TSource> sourceEnumerator = _source.GetEnumerator();
+                try
                 {
-                    while (e.MoveNext()) yield return e.Current;
+                    for (int count = _count; count != 0; --count)
+                    {
+                        // It should be harmless to have the recipient call MoveNext again.
+                        // but we guard against strange behaviour from shortcuts in the enumerator
+                        // It should also be harmless to dispose the enumerator here if we've
+                        // exhausted it, but we guard against strange behaviour in either the
+                        // enumerator or the caller.
+                        if (!sourceEnumerator.MoveNext()) return new DeadEnumeratorWrapper<TSource>(sourceEnumerator);
+                    }
+                    return sourceEnumerator;
                 }
+                catch (Exception ex)
+                {
+                    // Force the exception to happen on a MovedNext from the caller, rather than
+                    // here.
+                    return new DeadEnumeratorWrapper<TSource>(sourceEnumerator, ExceptionDispatchInfo.Capture(ex));
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
             }
         }
 
@@ -698,16 +780,87 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
-            return SkipWhileIterator<TSource>(source, predicate);
+            return new SkipWhileIterator<TSource>(source, predicate);
         }
 
-        private static IEnumerable<TSource> SkipWhileIterator<TSource>(IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        private sealed class SkipWhileIterator<TSource> : IEnumerable<TSource>, IEnumerator<TSource>
         {
-            bool yielding = false;
-            foreach (TSource element in source)
+            private readonly IEnumerable<TSource> _source;
+            private readonly Func<TSource, bool> _predicate;
+            private readonly int _threadId = Environment.CurrentManagedThreadId;
+            private IEnumerator<TSource> _enumerator;
+            private int _state;
+            private TSource _current;
+
+            internal SkipWhileIterator(IEnumerable<TSource> source, Func<TSource, bool> predicate)
             {
-                if (!yielding && !predicate(element)) yielding = true;
-                if (yielding) yield return element;
+                _source = source;
+                _predicate = predicate;
+            }
+
+            public IEnumerator<TSource> GetEnumerator()
+            {
+                // Don't short-circuit. These are almost always both true, so don't "save"
+                // time by branching after a very likely case.
+                var ret = _state == 0 & _threadId == Environment.CurrentManagedThreadId
+                    ? this : new SkipWhileIterator<TSource>(_source, _predicate);
+                ret._state = 1;
+                return ret;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public TSource Current
+            {
+                get { return _current; }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return _current; }
+            }
+
+            public bool MoveNext()
+            {
+                switch (_state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        while (_enumerator.MoveNext())
+                        {
+                            TSource item = _enumerator.Current;
+                            if (!_predicate(item))
+                            {
+                                _current = item;
+                                _state = 2;
+                                return true;
+                            }
+                        }
+                        break;
+                    case 2:
+                        if (_enumerator.MoveNext())
+                        {
+                            _current = _enumerator.Current;
+                            return true;
+                        }
+                        break;
+                }
+                _state = -1;
+                return false;
+            }
+
+            public void Dispose()
+            {
+                if (_enumerator != null) _enumerator.Dispose();
+                _enumerator = null;
+            }
+
+            void IEnumerator.Reset()
+            {
+                throw new NotSupportedException();
             }
         }
 
@@ -715,18 +868,88 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
-            return SkipWhileIterator<TSource>(source, predicate);
+            return new SkipWhileWithIndexIterator<TSource>(source, predicate);
         }
 
-        private static IEnumerable<TSource> SkipWhileIterator<TSource>(IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
+        private sealed class SkipWhileWithIndexIterator<TSource> : IEnumerable<TSource>, IEnumerator<TSource>
         {
-            int index = -1;
-            bool yielding = false;
-            foreach (TSource element in source)
+            private readonly IEnumerable<TSource> _source;
+            private readonly Func<TSource, int, bool> _predicate;
+            private readonly int _threadId = Environment.CurrentManagedThreadId;
+            private IEnumerator<TSource> _enumerator;
+            private int _state;
+            private TSource _current;
+
+            public SkipWhileWithIndexIterator(IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
             {
-                checked { index++; }
-                if (!yielding && !predicate(element, index)) yielding = true;
-                if (yielding) yield return element;
+                _source = source;
+                _predicate = predicate;
+            }
+
+            public IEnumerator<TSource> GetEnumerator()
+            {
+                // Don't short-circuit. These are almost always both true, so don't "save"
+                // time by branching after a very likely case.
+                var ret = _state == 0 & _threadId == Environment.CurrentManagedThreadId
+                    ? this : new SkipWhileWithIndexIterator<TSource>(_source, _predicate);
+                ret._state = 1;
+                return ret;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public TSource Current
+            {
+                get { return _current; }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return _current; }
+            }
+
+            public bool MoveNext()
+            {
+                switch (_state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        int index = -1;
+                        while (_enumerator.MoveNext())
+                        {
+                            TSource item = _enumerator.Current;
+                            if (!_predicate(item, checked(++index)))
+                            {
+                                _current = item;
+                                _state = 2;
+                                return true;
+                            }
+                        }
+                        break;
+                    case 2:
+                        if (_enumerator.MoveNext())
+                        {
+                            _current = _enumerator.Current;
+                            return true;
+                        }
+                        break;
+                }
+                _state = -1;
+                return false;
+            }
+
+            public void Dispose()
+            {
+                if (_enumerator != null) _enumerator.Dispose();
+                _enumerator = null;
+            }
+
+            void IEnumerator.Reset()
+            {
+                throw new NotSupportedException();
             }
         }
 


### PR DESCRIPTION
Fixes #2238
(And I think this is the last bit to separate out of the original PR)

https://github.com/hackcraft/Enumerable-Tester/raw/master/Skip%20performance.ods
shows a comparison of the old and new approaches. Improvements are made in
the vast majority of cases, and with Skip in particular can be significant.

Edge-cases of disposal and exception ordering are dealt with; duplicating the
behaviour found with the current implementation.

(This ignores the matter of ordered skips as per #2401).