### PR TITLE
Cleanup CancellationToken and Task usage in System.Data.Common

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.Common/src/System/Data/Common/AdapterUtil.cs
@@ -16,21 +16,6 @@ namespace System.Data.Common
         // location so that the catcher of the exception will have the appropriate call stack.
         // This class is used so that there will be compile time checking of error messages.
 
-        static internal Task<T> CreatedTaskWithException<T>(Exception ex)
-        {
-            TaskCompletionSource<T> completion = new TaskCompletionSource<T>();
-            completion.SetException(ex);
-            return completion.Task;
-        }
-
-        static internal Task<T> CreatedTaskWithCancellation<T>()
-        {
-            TaskCompletionSource<T> completion = new TaskCompletionSource<T>();
-            completion.SetCanceled();
-            return completion.Task;
-        }
-
-
         // NOTE: Initializing a Task in SQL CLR requires the "UNSAFE" permission set (http://msdn.microsoft.com/en-us/library/ms172338.aspx)
         // Therefore we are lazily initializing these Tasks to avoid forcing customers to use the "UNSAFE" set when they are actually using no Async features
         static private Task<bool> s_trueTask = null;

--- a/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -157,7 +157,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = new CancellationTokenRegistration();
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(CancelIgnoreFailure);
+                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -166,8 +166,11 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    registration.Dispose();
                     return Task.FromException<int>(e);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
         }
@@ -203,7 +206,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = new CancellationTokenRegistration();
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(CancelIgnoreFailure);
+                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -212,8 +215,11 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    registration.Dispose();
                     return Task.FromException<DbDataReader>(e);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
         }
@@ -234,7 +240,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = new CancellationTokenRegistration();
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(CancelIgnoreFailure);
+                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -243,8 +249,11 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    registration.Dispose();
                     return Task.FromException<object>(e);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
         }

--- a/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -150,7 +150,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<int>();
+                return Task.FromCanceled<int>(cancellationToken);
             }
             else
             {
@@ -167,7 +167,7 @@ namespace System.Data.Common
                 catch (Exception e)
                 {
                     registration.Dispose();
-                    return ADP.CreatedTaskWithException<int>(e);
+                    return Task.FromException<int>(e);
                 }
             }
         }
@@ -196,7 +196,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<DbDataReader>();
+                return Task.FromCanceled<DbDataReader>(cancellationToken);
             }
             else
             {
@@ -213,7 +213,7 @@ namespace System.Data.Common
                 catch (Exception e)
                 {
                     registration.Dispose();
-                    return ADP.CreatedTaskWithException<DbDataReader>(e);
+                    return Task.FromException<DbDataReader>(e);
                 }
             }
         }
@@ -227,7 +227,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<object>();
+                return Task.FromCanceled<object>(cancellationToken);
             }
             else
             {
@@ -244,7 +244,7 @@ namespace System.Data.Common
                 catch (Exception e)
                 {
                     registration.Dispose();
-                    return ADP.CreatedTaskWithException<object>(e);
+                    return Task.FromException<object>(e);
                 }
             }
         }

--- a/src/System.Data.Common/src/System/Data/Common/DbConnection.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbConnection.cs
@@ -115,26 +115,22 @@ namespace System.Data.Common
 
         public virtual Task OpenAsync(CancellationToken cancellationToken)
         {
-            TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
-
             if (cancellationToken.IsCancellationRequested)
             {
-                taskCompletionSource.SetCanceled();
+                return Task.FromCanceled(cancellationToken);
             }
             else
             {
                 try
                 {
                     Open();
-                    taskCompletionSource.SetResult(null);
+                    return Task.CompletedTask;
                 }
                 catch (Exception e)
                 {
-                    taskCompletionSource.SetException(e);
+                    return Task.FromException(e);
                 }
             }
-
-            return taskCompletionSource.Task;
         }
 
         public void Dispose()

--- a/src/System.Data.Common/src/System/Data/Common/DbDataReader.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbDataReader.cs
@@ -188,7 +188,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<T>();
+                return Task.FromCanceled<T>(cancellationToken);
             }
             else
             {
@@ -198,7 +198,7 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    return ADP.CreatedTaskWithException<T>(e);
+                    return Task.FromException<T>(e);
                 }
             }
         }
@@ -216,7 +216,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<bool>();
+                return Task.FromCanceled<bool>(cancellationToken);
             }
             else
             {
@@ -226,7 +226,7 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    return ADP.CreatedTaskWithException<bool>(e);
+                    return Task.FromException<bool>(e);
                 }
             }
         }
@@ -244,7 +244,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<bool>();
+                return Task.FromCanceled<bool>(cancellationToken);
             }
             else
             {
@@ -254,7 +254,7 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    return ADP.CreatedTaskWithException<bool>(e);
+                    return Task.FromException<bool>(e);
                 }
             }
         }
@@ -268,7 +268,7 @@ namespace System.Data.Common
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<bool>();
+                return Task.FromCanceled<bool>(cancellationToken);
             }
             else
             {
@@ -278,7 +278,7 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    return ADP.CreatedTaskWithException<bool>(e);
+                    return Task.FromException<bool>(e);
                 }
             }
         }


### PR DESCRIPTION
Three things addressed:

1. CancellationTokenRegistrations were only being unregistered in the case of failure, not in the case of success, so registrations were being leaked into CancellationToken instances.  Fixed to always clean up.

2. CancellationToken.Register calls were resulting in a new delegate allocation on each call.  Fixed to pass the relevant state through as object state and to let the compiler cache the delegate for the lambda.

3. The code had some legacy helpers to create already-completed tasks.  These are no longer necessary.  Fixed by removing them and replacing call sites with usage of Task.FromException/Canceled.

#2444