### PR TITLE
Fix ObjectDisposedException in FileSystemWatcher tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
@@ -86,9 +86,10 @@ public partial class FileSystemWatcher_4000_Tests
     {
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
-        using (AutoResetEvent createOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created))
-        using (AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted))
         {
+            AutoResetEvent createOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
             watcher.IncludeSubdirectories = true;
@@ -125,9 +126,10 @@ public partial class FileSystemWatcher_4000_Tests
     {
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
-        using (AutoResetEvent createOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created))
-        using (AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted))
         {
+            AutoResetEvent createOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
             watcher.IncludeSubdirectories = true;

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
@@ -102,15 +102,16 @@ public static class Utility
     }
 
     public static void TestNestedDirectoriesHelper(
-    WatcherChangeTypes change,
-    Action<AutoResetEvent, TemporaryTestDirectory> action,
-    NotifyFilters changeFilers = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName)
+        WatcherChangeTypes change,
+        Action<AutoResetEvent, TemporaryTestDirectory> action,
+        NotifyFilters changeFilers = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName)
     {
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
-        using (AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created))
-        using (AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, change))
         {
+            AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, change);
+
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
             watcher.NotifyFilter = changeFilers;


### PR DESCRIPTION
In my code review of @sokket's new FileSystemWatcher tests (#2347), I'd encouraged him to clean up some of the AutoResetEvents that were being created, in the name of good hygiene.  But this introduces a sporadic failure in the tests due to a race condition.

The way that FileSystemWatcher is designed, stopping events on the instance doesn't actually prevent any in-progress operations from being processed, nor does stopping block until all in-process events have completed.  As such, if after stopping processing we dispose of an event that's going to be set by one of the callbacks, it's possible such a set could occur from an in-flight operation after we've already disposed of the event, leading to an ObjectDisposedException that crashes the tests.

I contemplated adding synchronization to FSW itself to avoid these kinds of race conditions, e.g. by ensuring that the call to set "Enabled = false;" won't return until all in-progress operations have completed, but that could cause deadlocks not currently possible.  As such, I simply stopped explicitly disposing of the events created in the tests, leaving the cleanup to finalization (as is already done for most other events in the tests).

Fixes #2448