### PR TITLE
Add missing unit tests for System.Environment class

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -18,9 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
-    <Compile Include="System\Environment.NewLine.cs" />
-    <Compile Include="System\Environment.ProcessorCount.cs" />
-    <Compile Include="System\Environment.StackTrace.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\Path.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
@@ -48,7 +45,11 @@
     <Compile Include="System\Convert.ToUInt64.cs" />
     <Compile Include="System\Environment.ExpandEnvironmentVariables.cs" />
     <Compile Include="System\Environment.GetEnvironmentVariable.cs" />
+    <Compile Include="System\Environment.NewLine.cs" />
+    <Compile Include="System\Environment.ProcessorCount.cs" />
     <Compile Include="System\Environment.SetEnvironmentVariable.cs" />
+    <Compile Include="System\Environment.StackTrace.cs" />
+    <Compile Include="System\Environment.TickCount.cs" />
     <Compile Include="System\Math.cs" />
     <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
@@ -59,7 +60,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
-    <Compile Include="System\Environment.TickCount.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Runtime.Extensions.CoreCLR.csproj">

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -18,6 +18,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
+    <Compile Include="System\Environment.NewLine.cs" />
+    <Compile Include="System\Environment.ProcessorCount.cs" />
+    <Compile Include="System\Environment.StackTrace.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\Path.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
@@ -56,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <Compile Include="System\Environment.TickCount.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Runtime.Extensions.CoreCLR.csproj">

--- a/src/System.Runtime.Extensions/tests/System/Environment.NewLine.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.NewLine.cs
@@ -9,21 +9,18 @@ namespace System.Runtime.Extensions.Tests
 {
     public class EnvironmentNewLine
     {
+        [PlatformSpecific(PlatformID.Windows)]
         [Fact]
-        public void NewLineTest()
+        public void Windows_NewLineTest()
         {
-            //arrange
-            string expectedNewLine = Interop.IsWindows ? "\r\n" : "\n";
+            Assert.Equal("\r\n", Environment.NewLine);
+        }
 
-            //act
-            string actualNewLine = Environment.NewLine;
-
-            //assert
-            Assert.Equal(expectedNewLine, actualNewLine);
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public void Unix_NewLineTest()
+        {
+            Assert.Equal("\n", Environment.NewLine);
         }
     }
-
-
-
-
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.NewLine.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.NewLine.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class EnvironmentNewLine
+    {
+        [Fact]
+        public void NewLineTest()
+        {
+            //arrange
+            string expectedNewLine = Interop.IsWindows ? "\r\n" : "\n";
+
+            //act
+            string actualNewLine = Environment.NewLine;
+
+            //assert
+            Assert.Equal(expectedNewLine, actualNewLine);
+        }
+    }
+
+
+
+
+}

--- a/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class EnvironmentProcessorCount
+    {
+        [Fact]
+        public void ProcessorCountTest()
+        {
+            //arrange
+            int expected;
+
+            if(Interop.IsWindows)
+            {
+                SYSTEM_INFO sysInfo = new SYSTEM_INFO();
+                SYSTEM_INFO.GetSystemInfo(ref sysInfo);
+                expected = sysInfo.dwNumberOfProcessors;
+            }
+            else
+            {
+                int _SC_NPROCESSORS_ONLN = Interop.IsOSX ? 58 : 84;
+                expected = (int)sysconf(_SC_NPROCESSORS_ONLN);                
+            }
+
+            //act
+            int actual = Environment.ProcessorCount;
+
+            //assert
+            Assert.True(actual > 0);
+            Assert.Equal(expected, actual);
+        }
+
+        [DllImport("libc")]
+        private static extern long sysconf(int name);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SYSTEM_INFO
+        {
+            internal int dwOemId; // This is a union of a DWORD and a struct containing 2 WORDs.
+            internal int dwPageSize;
+            internal IntPtr lpMinimumApplicationAddress;
+            internal IntPtr lpMaximumApplicationAddress;
+            internal IntPtr dwActiveProcessorMask;
+            internal int dwNumberOfProcessors;
+            internal int dwProcessorType;
+            internal int dwAllocationGranularity;
+            internal short wProcessorLevel;
+            internal short wProcessorRevision;
+            [DllImport("api-ms-win-core-sysinfo-l1-1-0.dll", SetLastError = true)]
+            internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+        }
+
+
+    }
+
+    
+
+    
+}

--- a/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -60,6 +60,7 @@ namespace System.Runtime.Extensions.Tests
 
         class TestClass
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public TestClass()
             {
                 EnvironmentStackTrace.StaticFrame(null);

--- a/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class EnvironmentStackTrace
+    {
+        static string s_stackTrace;
+
+        [Fact]
+        public void StackTraceTest()
+        {
+            //arrange
+            List<string> knownFrames = new List<string>()
+            {
+                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.StaticFrame(Object obj)",
+                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.TestClass..ctor()",
+                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.GenericFrame[T1,T2](T1 t1, T2 t2)",
+                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.TestFrame()"
+            };
+
+            //act
+            Task.Run(() => TestFrame()).Wait();
+
+            //assert
+            int index = 0;
+            foreach(string frame in knownFrames)
+            {
+                index = s_stackTrace.IndexOf(frame, index);
+                Assert.True(index > -1);
+                index += frame.Length;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void TestFrame()
+        {
+            GenericFrame<DateTime, StringBuilder>(DateTime.Now, null);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void GenericFrame<T1, T2>(T1 t1, T2 t2)
+        {
+            var test = new TestClass();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void StaticFrame(object obj)
+        {
+            s_stackTrace = Environment.StackTrace;
+        }
+
+        class TestClass
+        {
+            public TestClass()
+            {
+                EnvironmentStackTrace.StaticFrame(null);
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+using System.Threading;
 using Xunit;
 
 namespace System.Runtime.Extensions.Tests
@@ -13,18 +13,8 @@ namespace System.Runtime.Extensions.Tests
         [Fact]
         public void TickCountTest()
         {
-            //arrange
-            const int milliSeconds = 1000;
             int start = Environment.TickCount;
-
-            //act
-            Task.Delay(milliSeconds).Wait();
-            int end = Environment.TickCount;
-
-            //assert
-            Console.WriteLine("Start - " + start);
-            Console.WriteLine("End - " + end);
-            Assert.True(end - start >= milliSeconds);
+            Assert.True(SpinWait.SpinUntil(() => Environment.TickCount > start, TimeSpan.FromSeconds(1)));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class EnvironmentTickCount
+    {
+        [Fact]
+        public void TickCountTest()
+        {
+            //arrange
+            const int milliSeconds = 1000;
+            int start = Environment.TickCount;
+
+            //act
+            Task.Delay(milliSeconds).Wait();
+            int end = Environment.TickCount;
+
+            //assert
+            Console.WriteLine("Start - " + start);
+            Console.WriteLine("End - " + end);
+            Assert.True(end - start >= milliSeconds);
+        }
+    }
+}


### PR DESCRIPTION
The following public APIs from System.Enironment did not have any unit test coverage
- Environment.NewLine.cs
- Environment.ProcessorCount.cs
- Environment.TickCount.cs
- Environment.StackTrace.cs