### PR TITLE
Enable globstar in run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable globstar for the purposes of directory evaluation
+shopt -s globstar
+
 wait_on_pids()
 {
   # Wait on the last processes

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -347,6 +347,7 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
+        [ActiveIssue(2459)]
         public void DriveLetter_Unix()
         {
             // On Unix, there's no special casing for drive letters, which are valid file names

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{E6DAD59F-7CB7-4E70-B4C5-FCCBC3376EDE}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>System.Xml.RW.XmlWriterApiTests</AssemblyName>
+    <AssemblyName>System.Xml.RW.XmlWriterApi.Tests</AssemblyName>
     <RootNamespace>XmlWriterAPI.Test</RootNamespace>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DA6A9B7F-F311-49A4-8BBE-42EF3152C37B}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>System.Xml.RW.XmlReaderReadContentAs.Tests</AssemblyName>
+    <AssemblyName>System.Xml.RW.XmlReader.ReadContentAs.Tests</AssemblyName>
     <RootNamespace>XMLTests.ReaderWriter.ReadContentTests</RootNamespace>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
Globstar is not enabled by default, and a recent commit attempting to increase the number of directories being run for the Linux build actually skipped a bunch of stuff.  Enable globstar in the script (this is local) to fix.