### PR TITLE
Generate and use config.h

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -24,6 +24,7 @@ else ()
     message(FATAL_ERROR "Unknown build type. Set CMAKE_BUILD_TYPE to DEBUG or RELEASE.")
 endif ()
 
+include(configure.cmake)
+
 add_subdirectory(System.IO.Native)
 add_subdirectory(System.Security.Cryptography.Native)
-

--- a/src/Native/System.IO.Native/nativeio.cpp
+++ b/src/Native/System.IO.Native/nativeio.cpp
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#include "../config.h"
 #include "nativeio.h"
 #include <sys/stat.h>
 

--- a/src/Native/config.h.in
+++ b/src/Native/config.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+#cmakedefine01 HAVE_STAT64
+#cmakedefine01 HAVE_STAT_BIRTHTIME

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -1,0 +1,7 @@
+include(CheckFunctionExists)
+include(CheckStructHasMember)
+
+check_function_exists(stat64 HAVE_STAT64)
+check_struct_has_member("struct stat" st_birthtime "sys/types.h;sys/stat.h" HAVE_STAT_BIRTHTIME)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)


### PR DESCRIPTION
cc @stephentoub 

Previously, I had neglected to actually generate and use an appropriate config.h, which had the effect that HAVE_STAT64 and HAVE_STAT_BIRTHTIME were always treated as false.