### PR TITLE
Avoid internal enumerator allocations in HttpClient

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http.Headers
         private static readonly Action<string> s_checkIsValidToken = CheckIsValidToken;
 
         private bool _noCache;
-        private ICollection<string> _noCacheHeaders;
+        private ObjectCollection<string> _noCacheHeaders;
         private bool _noStore;
         private TimeSpan? _maxAge;
         private TimeSpan? _sharedMaxAge;
@@ -38,10 +38,10 @@ namespace System.Net.Http.Headers
         private bool _onlyIfCached;
         private bool _publicField;
         private bool _privateField;
-        private ICollection<string> _privateHeaders;
+        private ObjectCollection<string> _privateHeaders;
         private bool _mustRevalidate;
         private bool _proxyRevalidate;
-        private ICollection<NameValueHeaderValue> _extensions;
+        private ObjectCollection<NameValueHeaderValue> _extensions;
 
         public bool NoCache
         {
@@ -520,7 +520,7 @@ namespace System.Net.Http.Headers
         }
 
         private static bool TrySetOptionalTokenList(NameValueHeaderValue nameValue, ref bool boolField,
-            ref ICollection<string> destination)
+            ref ObjectCollection<string> destination)
         {
             Contract.Requires(nameValue != null);
 
@@ -619,7 +619,7 @@ namespace System.Net.Http.Headers
             sb.Append(value);
         }
 
-        private static void AppendValues(StringBuilder sb, IEnumerable<string> values)
+        private static void AppendValues(StringBuilder sb, ObjectCollection<string> values)
         {
             bool first = true;
             foreach (string value in values)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -21,8 +21,8 @@ namespace System.Net.Http.Headers
         private const string readDate = "read-date";
         private const string size = "size";
 
-        // Use ICollection<T> since we may have multiple parameters with the same name.
-        private ICollection<NameValueHeaderValue> _parameters;
+        // Use ObjectCollection<T> since we may have multiple parameters with the same name.
+        private ObjectCollection<NameValueHeaderValue> _parameters;
         private string _dispositionType;
 
         #endregion Fields
@@ -249,7 +249,7 @@ namespace System.Net.Http.Headers
             {
                 current++; // Skip delimiter.
                 int parameterLength = NameValueHeaderValue.GetNameValueListLength(input, current, ';',
-                    contentDispositionHeader.Parameters);
+                    (ObjectCollection<NameValueHeaderValue>)contentDispositionHeader.Parameters);
 
                 if (parameterLength == 0)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http.Headers
         // Validator
         internal static readonly Action<HttpHeaderValueCollection<string>, string> TokenValidator = ValidateToken;
 
-        internal static void SetQuality(ICollection<NameValueHeaderValue> parameters, double? value)
+        internal static void SetQuality(ObjectCollection<NameValueHeaderValue> parameters, double? value)
         {
             Contract.Requires(parameters != null);
 
@@ -62,7 +62,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        internal static double? GetQuality(ICollection<NameValueHeaderValue> parameters)
+        internal static double? GetQuality(ObjectCollection<NameValueHeaderValue> parameters)
         {
             Contract.Requires(parameters != null);
 
@@ -126,12 +126,12 @@ namespace System.Net.Http.Headers
             }
         }
 
-        internal static bool AreEqualCollections<T>(ICollection<T> x, ICollection<T> y)
+        internal static bool AreEqualCollections<T>(ObjectCollection<T> x, ObjectCollection<T> y) where T : class
         {
             return AreEqualCollections(x, y, null);
         }
 
-        internal static bool AreEqualCollections<T>(ICollection<T> x, ICollection<T> y, IEqualityComparer<T> comparer)
+        internal static bool AreEqualCollections<T>(ObjectCollection<T> x, ObjectCollection<T> y, IEqualityComparer<T> comparer) where T : class
         {
             if (x == null)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -10,7 +10,7 @@ namespace System.Net.Http.Headers
     {
         private const string charSet = "charset";
 
-        private ICollection<NameValueHeaderValue> _parameters;
+        private ObjectCollection<NameValueHeaderValue> _parameters;
         private string _mediaType;
 
         public string CharSet
@@ -177,7 +177,7 @@ namespace System.Net.Http.Headers
 
                 current++; // skip delimiter.
                 int parameterLength = NameValueHeaderValue.GetNameValueListLength(input, current, ';',
-                    mediaTypeHeader.Parameters);
+                    (ObjectCollection<NameValueHeaderValue>)mediaTypeHeader.Parameters);
 
                 if (parameterLength == 0)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeWithQualityHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeWithQualityHeaderValue.cs
@@ -9,8 +9,8 @@ namespace System.Net.Http.Headers
     {
         public double? Quality
         {
-            get { return HeaderUtilities.GetQuality(Parameters); }
-            set { HeaderUtilities.SetQuality(Parameters, value); }
+            get { return HeaderUtilities.GetQuality((ObjectCollection<NameValueHeaderValue>)Parameters); }
+            set { HeaderUtilities.SetQuality((ObjectCollection<NameValueHeaderValue>)Parameters, value); }
         }
 
         internal MediaTypeWithQualityHeaderValue()

--- a/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -143,7 +143,7 @@ namespace System.Net.Http.Headers
             return _name;
         }
 
-        internal static void ToString(ICollection<NameValueHeaderValue> values, char separator, bool leadingSeparator,
+        internal static void ToString(ObjectCollection<NameValueHeaderValue> values, char separator, bool leadingSeparator,
             StringBuilder destination)
         {
             Debug.Assert(destination != null);
@@ -164,7 +164,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        internal static string ToString(ICollection<NameValueHeaderValue> values, char separator, bool leadingSeparator)
+        internal static string ToString(ObjectCollection<NameValueHeaderValue> values, char separator, bool leadingSeparator)
         {
             if ((values == null) || (values.Count == 0))
             {
@@ -178,7 +178,7 @@ namespace System.Net.Http.Headers
             return sb.ToString();
         }
 
-        internal static int GetHashCode(ICollection<NameValueHeaderValue> values)
+        internal static int GetHashCode(ObjectCollection<NameValueHeaderValue> values)
         {
             if ((values == null) || (values.Count == 0))
             {
@@ -258,7 +258,7 @@ namespace System.Net.Http.Headers
         // Returns the length of a name/value list, separated by 'delimiter'. E.g. "a=b, c=d, e=f" adds 3
         // name/value pairs to 'nameValueCollection' if 'delimiter' equals ','.
         internal static int GetNameValueListLength(string input, int startIndex, char delimiter,
-            ICollection<NameValueHeaderValue> nameValueCollection)
+            ObjectCollection<NameValueHeaderValue> nameValueCollection)
         {
             Contract.Requires(nameValueCollection != null);
             Contract.Requires(startIndex >= 0);
@@ -296,7 +296,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        internal static NameValueHeaderValue Find(ICollection<NameValueHeaderValue> values, string name)
+        internal static NameValueHeaderValue Find(ObjectCollection<NameValueHeaderValue> values, string name)
         {
             Contract.Requires((name != null) && (name.Length > 0));
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/NameValueWithParametersHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/NameValueWithParametersHeaderValue.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Headers
     {
         private static readonly Func<NameValueHeaderValue> s_nameValueCreator = CreateNameValue;
 
-        private ICollection<NameValueHeaderValue> _parameters;
+        private ObjectCollection<NameValueHeaderValue> _parameters;
 
         public ICollection<NameValueHeaderValue> Parameters
         {
@@ -136,7 +136,7 @@ namespace System.Net.Http.Headers
             {
                 current++; // skip delimiter.
                 int parameterLength = NameValueHeaderValue.GetNameValueListLength(input, current, ';',
-                    nameValueWithParameters.Parameters);
+                    (ObjectCollection<NameValueHeaderValue>)nameValueWithParameters.Parameters);
 
                 if (parameterLength == 0)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace System.Net.Http.Headers
 {
     // We need to prevent 'null' values in the collection. Since List<T> allows them, we will create
     // a custom collection class. It is less efficient than List<T> but only used for small collections.
-    internal class ObjectCollection<T> : Collection<T> where T : class
+    internal sealed class ObjectCollection<T> : Collection<T> where T : class
     {
         private static readonly Action<T> s_defaultValidator = CheckNotNull;
 
-        private Action<T> _validator;
+        private readonly Action<T> _validator;
 
         public ObjectCollection()
             : this(s_defaultValidator)
@@ -19,8 +20,16 @@ namespace System.Net.Http.Headers
         }
 
         public ObjectCollection(Action<T> validator)
+            : base(new List<T>())
         {
             _validator = validator;
+        }
+
+        // This is only used internally to enumerate the collection
+        // without the enumerator allocation.
+        new public List<T>.Enumerator GetEnumerator()
+        {
+            return ((List<T>)Items).GetEnumerator();
         }
 
         protected override void InsertItem(int index, T item)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http.Headers
     public class RangeHeaderValue : ICloneable
     {
         private string _unit;
-        private ICollection<RangeItemHeaderValue> _ranges;
+        private ObjectCollection<RangeItemHeaderValue> _ranges;
 
         public string Unit
         {
@@ -66,21 +66,24 @@ namespace System.Net.Http.Headers
             StringBuilder sb = new StringBuilder(_unit);
             sb.Append('=');
 
-            bool first = true;
-            foreach (RangeItemHeaderValue range in Ranges)
+            if (_ranges != null)
             {
-                if (first)
+                bool first = true;
+                foreach (RangeItemHeaderValue range in _ranges)
                 {
-                    first = false;
-                }
-                else
-                {
-                    sb.Append(", ");
-                }
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        sb.Append(", ");
+                    }
 
-                sb.Append(range.From);
-                sb.Append('-');
-                sb.Append(range.To);
+                    sb.Append(range.From);
+                    sb.Append('-');
+                    sb.Append(range.To);
+                }
             }
 
             return sb.ToString();
@@ -96,16 +99,19 @@ namespace System.Net.Http.Headers
             }
 
             return string.Equals(_unit, other._unit, StringComparison.OrdinalIgnoreCase) &&
-                HeaderUtilities.AreEqualCollections(Ranges, other.Ranges);
+                HeaderUtilities.AreEqualCollections(_ranges, other._ranges);
         }
 
         public override int GetHashCode()
         {
             int result = StringComparer.OrdinalIgnoreCase.GetHashCode(_unit);
 
-            foreach (RangeItemHeaderValue range in Ranges)
+            if (_ranges != null)
             {
-                result = result ^ range.GetHashCode();
+                foreach (RangeItemHeaderValue range in _ranges)
+                {
+                    result = result ^ range.GetHashCode();
+                }
             }
 
             return result;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
@@ -8,8 +8,8 @@ namespace System.Net.Http.Headers
 {
     public class TransferCodingHeaderValue : ICloneable
     {
-        // Use ICollection<T> since we may have multiple parameters with the same name.
-        private ICollection<NameValueHeaderValue> _parameters;
+        // Use ObjectCollection<T> since we may have multiple parameters with the same name.
+        private ObjectCollection<NameValueHeaderValue> _parameters;
         private string _value;
 
         public string Value
@@ -109,7 +109,7 @@ namespace System.Net.Http.Headers
 
                 current++; // skip delimiter.
                 int parameterLength = NameValueHeaderValue.GetNameValueListLength(input, current, ';',
-                    transferCodingHeader.Parameters);
+                    (ObjectCollection<NameValueHeaderValue>)transferCodingHeader.Parameters);
 
                 if (parameterLength == 0)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingWithQualityHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingWithQualityHeaderValue.cs
@@ -9,8 +9,8 @@ namespace System.Net.Http.Headers
     {
         public double? Quality
         {
-            get { return HeaderUtilities.GetQuality(Parameters); }
-            set { HeaderUtilities.SetQuality(Parameters, value); }
+            get { return HeaderUtilities.GetQuality((ObjectCollection<NameValueHeaderValue>)Parameters); }
+            set { HeaderUtilities.SetQuality((ObjectCollection<NameValueHeaderValue>)Parameters, value); }
         }
 
         internal TransferCodingWithQualityHeaderValue()

--- a/src/System.Net.Http/tests/UnitTests/Headers/HeaderUtilitiesTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HeaderUtilitiesTest.cs
@@ -16,8 +16,8 @@ namespace System.Net.Http.Tests
         [Fact]
         public void AreEqualCollections_UseSetOfEqualCollections_ReturnsTrue()
         {
-            ICollection<NameValueHeaderValue> x = new List<NameValueHeaderValue>();
-            ICollection<NameValueHeaderValue> y = new List<NameValueHeaderValue>();
+            ObjectCollection<NameValueHeaderValue> x = new ObjectCollection<NameValueHeaderValue>();
+            ObjectCollection<NameValueHeaderValue> y = new ObjectCollection<NameValueHeaderValue>();
 
             Assert.True(HeaderUtilities.AreEqualCollections(x, y));
 
@@ -38,8 +38,8 @@ namespace System.Net.Http.Tests
         [Fact]
         public void AreEqualCollections_UseSetOfNotEqualCollections_ReturnsFalse()
         {
-            ICollection<NameValueHeaderValue> x = new List<NameValueHeaderValue>();
-            ICollection<NameValueHeaderValue> y = new List<NameValueHeaderValue>();
+            ObjectCollection<NameValueHeaderValue> x = new ObjectCollection<NameValueHeaderValue>();
+            ObjectCollection<NameValueHeaderValue> y = new ObjectCollection<NameValueHeaderValue>();
 
             Assert.True(HeaderUtilities.AreEqualCollections(x, y), "Expected '<empty>' == '<empty>'");
 


### PR DESCRIPTION
There are many places where `ObjectCollection<T>` instances are enumerated internally. Each time one of these collections is enumerated, an enumerator is allocated on the heap. This change avoids the enumerator allocation by using a struct enumerator (internal-only).