### PR TITLE
Hide IPC test program from code coverage

### DIFF
--- a/src/Scenarios/tests/InterProcessCommunication/InterProcessCommunication.TestConsoleApp/InterProcessCommunication.TestConsoleApp.csproj
+++ b/src/Scenarios/tests/InterProcessCommunication/InterProcessCommunication.TestConsoleApp/InterProcessCommunication.TestConsoleApp.csproj
@@ -13,6 +13,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="TestConsoleApp.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/Scenarios/tests/InterProcessCommunication/InterProcessCommunication.TestConsoleApp/TestConsoleApp.cs
+++ b/src/Scenarios/tests/InterProcessCommunication/InterProcessCommunication.TestConsoleApp/TestConsoleApp.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Reflection;
 
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+
 namespace InterProcessCommunication.Tests
 {
     /// <summary>


### PR DESCRIPTION
The InterProcessCommunication console test app is showing up in our code
coverage report.  It's part of the test harness and can be excluded.