### PR TITLE
Avoid a closure/delegate allocation in WinHttpHandler

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1092,7 +1092,7 @@ namespace System.Net.Http
                 return;
             }
 
-            var cancellationTokenRegistration = state.CancellationToken.Register(() => { state.Tcs.TrySetCanceled(); });
+            var cancellationTokenRegistration = state.CancellationToken.Register(s => ((RequestState)s).Tcs.TrySetCanceled(), state);
 
             try
             {


### PR DESCRIPTION
One-line change to avoid a closure and delegate allocation on each call.