### PR TITLE
Remove extraneous ProjectTypeGuids causing load failures

### DIFF
--- a/src/System.IO.FileSystem.Watcher/System.IO.FileSystem.Watcher.sln
+++ b/src/System.IO.FileSystem.Watcher/System.IO.FileSystem.Watcher.sln
@@ -6,10 +6,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.Watche
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.Watcher.Tests", "tests\System.IO.FileSystem.Watcher.Tests.csproj", "{20411A66-C7A4-4941-8FA2-66308365FD22}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{4B06330D-B839-4D9B-AC32-D510B7AB9FB9}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{613515D7-B799-4EB8-B262-C54A2279C77B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Linux_Debug|Any CPU = Linux_Debug|Any CPU
@@ -43,10 +39,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{20411A66-C7A4-4941-8FA2-66308365FD22} = {4B06330D-B839-4D9B-AC32-D510B7AB9FB9}
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A} = {613515D7-B799-4EB8-B262-C54A2279C77B}
-		{613515D7-B799-4EB8-B262-C54A2279C77B} = {4B06330D-B839-4D9B-AC32-D510B7AB9FB9}
 	EndGlobalSection
 EndGlobal

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{20411A66-C7A4-4941-8FA2-66308365FD22}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Watcher.Tests</AssemblyName>
   </PropertyGroup>

--- a/src/System.Xml.XDocument/tests/Properties/System.Xml.XDocument.Properties.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/Properties/System.Xml.XDocument.Properties.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D24E2563-7A46-4368-94D4-B3A39E9EF1B5}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Properties.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>

--- a/src/System.Xml.XDocument/tests/SDMSample/System.Xml.XDocument.SDMSample.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/SDMSample/System.Xml.XDocument.SDMSample.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F6C73170-9333-4B52-B3FA-A536C5EA6A48}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.SDMSample.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>

--- a/src/System.Xml.XDocument/tests/Streaming/System.Xml.XDocument.Streaming.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/Streaming/System.Xml.XDocument.Streaming.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CB11B315-2567-4574-977D-89E3135243C4}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Streaming.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>

--- a/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{10EFE488-FAB4-43DA-847D-FF057BFF52AC}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.TreeManipulation.Tests</AssemblyName>
     <RootNamespace>XLinqTests</RootNamespace>

--- a/src/System.Xml.XDocument/tests/XDocument.Common/XDocument.Common.csproj
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/XDocument.Common.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{52666206-B6C9-49FA-A1D7-D0A0C68807B0}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>cXDocument.Common</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/XDocument.Test.ModuleCore.csproj
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/XDocument.Test.ModuleCore.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{979510CE-9042-4F8D-9C74-EE03B89194CC}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>XDocument.Test.ModuleCore</AssemblyName>
     <RootNamespace>Microsoft.Test.ModuleCore</RootNamespace>

--- a/src/System.Xml.XDocument/tests/misc/System.Xml.XDocument.Misc.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/misc/System.Xml.XDocument.Misc.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{35FA1FA9-A504-4B9E-93F0-E5D03C21BECA}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Misc.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/System.Xml.XDocument.xNodeBuilder.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/System.Xml.XDocument.xNodeBuilder.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.xNodeBuilder.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>

--- a/src/System.Xml.XDocument/tests/xNodeReader/System.Xml.XDocument.xNodeReader.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/xNodeReader/System.Xml.XDocument.xNodeReader.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6E1C5358-7F04-4791-8B5F-6A5A4E42ABF1}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.xNodeReader.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>


### PR DESCRIPTION
Several projects are no longer loading correctly in VS for me.  It's happening for projects and only for projects that contain a <ProjectTypeGuids/> node in the .csproj, related to portable libraries.  These entries are unnecessary, and I'm simply deleting them, after which the projects load in VS successfully. (I'm also removing some unnecessary good in one of our .slns that's causing unnecessary hierarchy in Solution Explorer.)