### PR TITLE
Fix new c++ compiler warning after moving to C++ 14

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestNativeService/NativeTestService.cpp
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestNativeService/NativeTestService.cpp
@@ -137,7 +137,7 @@ int _tmain(int argc, _TCHAR* argv [])
 		}
 		else
 		{
-			wprintf(L"error: Invalid action '%s'\n", action);
+			wprintf(L"error: Invalid action '%s'\n", action.c_str());
 			return -1;
 		}
 	}


### PR DESCRIPTION
nativetestservice.cpp(140): warning C4477: 'wprintf' : format string '%s' requires an argument of type 'wchar_t *', but variadic argument 1 has type 'std::wstring *'