### PR TITLE
Add P2P reference for new IO tests to System.Runtime.Extensions

### DIFF
--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -8,8 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
-    <!-- Setting temporarily until we can publish a new package drop of Runtime.Extensions -->
-    <TestWithLocalLibraries>true</TestWithLocalLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +27,18 @@
       <Project>{879c23dc-d828-4dfb-8e92-abbc11b71035}</Project>
       <Name>System.IO.FileSystem</Name>
       <Private>True</Private>
+    </ProjectReference>
+
+    <!-- 
+      Until an updated packages is published, temporarily copy the locally built System.Runtime.Extensions library
+      but still reference the contract from the package for compiling. 
+      Issue https://github.com/dotnet/corefx/issues/2519 is tracking the removal of this ProjectReference
+    -->
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.CoreCLR.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Until we can publish a new packages with the new System.Runtime.Extensions
implementation reference the locally built version. We need to change to a
P2P reference to avoid the race condition that is inherit in using
TestWithLocalLibraries. That can only be used if we know all the
dependencies are built first.

This fixes issue #2516, which I was also hitting.