### PR TITLE
Reduce HttpWebResponse header allocations

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1871,12 +1871,11 @@ namespace System.Net.Http
                     Interop.WinHttp.WINHTTP_QUERY_CONTENT_ENCODING);
                 if (!string.IsNullOrEmpty(contentEncoding))
                 {
-                    contentEncoding = contentEncoding.ToUpperInvariant();
-                    if (contentEncoding.Contains(EncodingNameDeflate))
+                    if (contentEncoding.IndexOf(EncodingNameDeflate, StringComparison.OrdinalIgnoreCase) > -1)
                     {
                         useDeflateDecompression = true;
                     }
-                    else if (contentEncoding.Contains(EncodingNameGzip))
+                    else if (contentEncoding.IndexOf(EncodingNameGzip, StringComparison.OrdinalIgnoreCase) > -1)
                     {
                         useGzipDecompression = true;
                     }

--- a/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -177,8 +177,7 @@ namespace System.Net
             if (enumerator.MoveNext())
             {
                 // Multi-valued header
-                var buffer = new StringBuilder();
-                buffer.Append(headerValue);
+                var buffer = new StringBuilder(headerValue);
 
                 do
                 {

--- a/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -167,22 +167,29 @@ namespace System.Net
 
         private string GetHeaderValueAsString(IEnumerable<string> values)
         {
-            var buffer = new StringBuilder();
-
             // There is always at least one value even if it is an empty string.
             var enumerator = values.GetEnumerator();
             bool success = enumerator.MoveNext();
             Debug.Assert(success, "There should be at least one value");
-            buffer.Append(enumerator.Current);
 
-            // Handle more values if present.
-            while (enumerator.MoveNext())
+            string headerValue = enumerator.Current;
+
+            if (enumerator.MoveNext())
             {
-                buffer.Append(", ");
-                buffer.Append(enumerator.Current);
+                // Multi-valued header
+                var buffer = new StringBuilder();
+                buffer.Append(headerValue);
+
+                do
+                {
+                    buffer.Append(", ");
+                    buffer.Append(enumerator.Current);
+                } while (enumerator.MoveNext());
+
+                return buffer.ToString();
             }
 
-            return buffer.ToString();
+            return headerValue;
         }
     }
 }


### PR DESCRIPTION
Removed unnecessary ToUpperInvariant allocation in WinHttpHandler.

HttpWebResponse created a StringBuilder for every header in the response to handle possible multi-values. Common case is a single value so lazy create the buffer when there is more than 1.