### PR TITLE
Add Linux ARM target for Native libraries.

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -11,6 +11,13 @@ add_compile_options(-Wall -Werror -fPIC)
 
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
     add_definitions(-DBIT64=1)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
+    add_definitions(-DBIT32=1)
+    # Because we don't use CMAKE_C_COMPILER/CMAKE_CXX_COMPILER to use clang
+    # we have to set the triple by adding a compiler argument
+    add_compile_options(-target armv7-linux-gnueabihf)
+    add_compile_options(-mthumb)
+    add_compile_options(-mfpu=vfpv3)
 endif ()
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)

--- a/src/Native/build.sh
+++ b/src/Native/build.sh
@@ -3,7 +3,7 @@
 usage()
 {
     echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [clangx.y]"
-    echo "BuildArch can be: x64"
+    echo "BuildArch can be: x64, arm"
     echo "BuildType can be: Debug, Release"
     echo "clean - optional argument to force a clean build."
     echo "verbose - optional argument to enable verbose build output."
@@ -84,7 +84,7 @@ echo "Commencing CoreFX Native build"
 
 # Argument types supported by this script:
 #
-# Build architecture - valid value is: x64.
+# Build architecture - valid values are: x64, arm.
 # Build Type         - valid values are: Debug, Release
 #
 # Set the default arguments for build
@@ -147,6 +147,10 @@ for i in "$@"
         x64)
             __BuildArch=x64
             __MSBuildBuildArch=x64
+            ;;
+        arm)
+            __BuildArch=arm
+            __MSBuildBuildArch=arm
             ;;
         debug)
             __BuildType=Debug


### PR DESCRIPTION
Simply adds the ARM target required for the native components. The compile options mirror those of coreclr, only thing I am unsure of is if the MSBuild target should be upper or lower case?