### PR TITLE
Cleanup ByteArrayContent

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -10,9 +9,9 @@ namespace System.Net.Http
 {
     public class ByteArrayContent : HttpContent
     {
-        private byte[] _content;
-        private int _offset;
-        private int _count;
+        private readonly byte[] _content;
+        private readonly int _offset;
+        private readonly int _count;
 
         public ByteArrayContent(byte[] content)
         {
@@ -60,9 +59,7 @@ namespace System.Net.Http
 
         protected override Task<Stream> CreateContentReadStreamAsync()
         {
-            TaskCompletionSource<Stream> tcs = new TaskCompletionSource<Stream>();
-            tcs.TrySetResult(new MemoryStream(_content, _offset, _count, false));
-            return tcs.Task;
+            return Task.FromResult<Stream>(new MemoryStream(_content, _offset, _count, writable: false));
         }
     }
 }


### PR DESCRIPTION
- Use `Task.FromResult` instead of `TaskCompletionSource` (avoids the allocation)
- Make readonly fields `readonly`
- Remove unused `using`