### PR TITLE
Adds OSPlatform.FreeBSD.

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/OSPlatform.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/OSPlatform.cs
@@ -17,6 +17,14 @@ namespace System.Runtime.InteropServices
         private static readonly OSPlatform s_osx = new OSPlatform(OSXName);
         private static readonly OSPlatform s_windows = new OSPlatform(WindowsName);
 
+        public static OSPlatform FreeBSD
+        {
+            get
+            {
+                return s_freebsd;
+            }
+        }
+
         public static OSPlatform Linux
         {
             get

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/RuntimeInformation.FreeBSD.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/RuntimeInformation.FreeBSD.cs
@@ -1,15 +1,13 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace System.Runtime.InteropServices
 {
     public static class RuntimeInformation
     {
-        private static OSPlatform s_freeBSD = OSPlatform.Create("FREEBSD");
-
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
-            return s_freeBSD == osPlatform;
+            return OSPlatform.FreeBSD == osPlatform;
         }
     }
 }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
@@ -8,6 +8,21 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 {
     public class CheckPlatformTests
     {
+        [Fact, PlatformSpecific(PlatformID.FreeBSD)]
+        public void CheckFreeBSD()
+        {
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
+
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("linux")));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("UNIX")));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("DARWIN")));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("ubuntu")));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+        }
+
         [Fact, PlatformSpecific(PlatformID.Linux)]
         public void CheckLinux()
         {


### PR DESCRIPTION
In #2068, it was decided to hold off adding public property for FreeBSD
because at the time there wasn't much progress made for the platform
support. Since then, there has been some progress made for FreeBSD.
Also with #2141 merged, I have added a missing test for S.RT.I.RI.