### PR TITLE
Make StreamToStreamCopy static

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -49,8 +49,7 @@ namespace System.Net.Http
 
             PrepareContent();
             // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
-            StreamToStreamCopy sc = new StreamToStreamCopy(_content, stream, _bufferSize, !_content.CanSeek);
-            return sc.StartAsync();
+            return StreamToStreamCopy.CopyAsync(_content, stream, _bufferSize, !_content.CanSeek);
         }
 
         protected internal override bool TryComputeLength(out long length)

--- a/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -8,69 +8,52 @@ using System.Threading.Tasks;
 namespace System.Net.Http
 {
     // This helper class is used to copy the content of a source stream to a destination stream.
-    // The type verifies if the source and/or destination stream are MemoryStreams (or derived types). If so, sync 
+    // The type verifies if the source and/or destination stream are MemoryStreams (or derived types). If so, sync
     // read/write is used on the MemoryStream to avoid context switches.
-    internal class StreamToStreamCopy
+    internal static class StreamToStreamCopy
     {
-        private byte[] _buffer;
-        private int _bufferSize;
-        private Stream _source;
-        private Stream _destination;
-        private bool _disposeSource;
-        private bool _sourceIsMemoryStream;
-        private bool _destinationIsMemoryStream;
-
-        public StreamToStreamCopy(Stream source, Stream destination, int bufferSize, bool disposeSource)
+        public static async Task CopyAsync(Stream source, Stream destination, int bufferSize, bool disposeSource)
         {
             Contract.Requires(source != null);
             Contract.Requires(destination != null);
             Contract.Requires(bufferSize > 0);
 
-            _buffer = new byte[bufferSize];
-            _source = source;
-            _destination = destination;
-            _bufferSize = bufferSize;
-            _disposeSource = disposeSource;
-            _sourceIsMemoryStream = source is MemoryStream;
-            _destinationIsMemoryStream = destination is MemoryStream;
-        }
+            byte[] buffer = new byte[bufferSize];
 
-        public async Task StartAsync()
-        {
             // If both streams are MemoryStreams, just copy the whole content at once to avoid context switches.
             // This will not block since it will just result in a memcopy.
-            if (_sourceIsMemoryStream && _destinationIsMemoryStream)
+            if (source is MemoryStream && destination is MemoryStream)
             {
                 for (; ;)
                 {
-                    int bytesRead = _source.Read(_buffer, 0, _bufferSize);
+                    int bytesRead = source.Read(buffer, 0, bufferSize);
                     if (bytesRead == 0)
                         break;
-                    _destination.Write(_buffer, 0, bytesRead);
+                    destination.Write(buffer, 0, bytesRead);
                 }
             }
             else
             {
                 for (; ;)
                 {
-                    int bytesRead = await _source.ReadAsync(_buffer, 0, _bufferSize).ConfigureAwait(false);
+                    int bytesRead = await source.ReadAsync(buffer, 0, bufferSize).ConfigureAwait(false);
                     if (bytesRead == 0)
                         break;
-                    await _destination.WriteAsync(_buffer, 0, bytesRead).ConfigureAwait(false);
+                    await destination.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
                 }
             }
 
             try
             {
-                if (_disposeSource)
+                if (disposeSource)
                 {
-                    _source.Dispose();
+                    source.Dispose();
                 }
             }
             catch (Exception e)
             {
                 // Dispose() should never throw, but since we're on an async codepath, make sure to catch the exception.
-                if (Logging.On) Logging.Exception(Logging.Http, this, "SetCompleted", e);
+                if (Logging.On) Logging.Exception(Logging.Http, null, "CopyAsync", e);
             }
         }
     }


### PR DESCRIPTION
Avoids the unnecessary instance allocation in `StreamContent.SerializeToStreamAsync()`.