### PR TITLE
Fix System.IO.Native shim

### DIFF
--- a/src/Native/System.IO.Native/nativeio.cpp
+++ b/src/Native/System.IO.Native/nativeio.cpp
@@ -27,7 +27,7 @@ static void ConvertFileStats(const struct stat_& src, FileStats* dst)
     dst->StatusChangeTime = src.st_ctime;
 
 #if HAVE_STAT_BIRTHTIME
-    dst->CreationTime = src->st_birthtime;
+    dst->CreationTime = src.st_birthtime;
     dst->Flags |= FILESTATS_FLAGS_HAS_CREATION_TIME;
 #endif
 }


### PR DESCRIPTION
The type of src is a const reference, not a const pointer. So use direct
member access instead of pointer access. This changes allows to build
the shim on FreeBSD. Tested on both FreeBSD and Linux.