### PR TITLE
Fix invalid test: TimeZoneInfo.Local can be UTC

### DIFF
--- a/src/System.Runtime/tests/System/TimeZoneInfo.cs
+++ b/src/System.Runtime/tests/System/TimeZoneInfo.cs
@@ -41,17 +41,14 @@ public static class TimeZoneInfoTests
     {
         TimeZoneInfo local = TimeZoneInfo.Local;
         TimeZoneInfo utc = TimeZoneInfo.Utc;
-        Assert.NotEqual(local.DaylightName, utc.DaylightName);
-        Assert.NotEqual(local.DisplayName, utc.DisplayName);
-        Assert.NotEqual(local.StandardName, utc.StandardName);
 
-        Assert.NotEqual(local.DaylightName, null);
-        Assert.NotEqual(local.DisplayName, null);
-        Assert.NotEqual(local.StandardName, null);
+        Assert.NotNull(local.DaylightName);
+        Assert.NotNull(local.DisplayName);
+        Assert.NotNull(local.StandardName);
 
-        Assert.NotEqual(utc.DaylightName, null);
-        Assert.NotEqual(utc.DisplayName, null);
-        Assert.NotEqual(utc.StandardName, null);
+        Assert.NotNull(utc.DaylightName);
+        Assert.NotNull(utc.DisplayName);
+        Assert.NotNull(utc.StandardName);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2539

It's perfectly valid to have the local time zone set to UTC, especially in server/cloud/CI environments.

(Also cleaned up  `Assert.NotEqual(x, null)` -> `Assert.NotNull(x)` in the test.)

cc: @eerhardt @Priya91