### PR TITLE
Fix Mac OS X build break due to deprecation warnings as errors

### DIFF
--- a/src/Native/System.IO.Native/nativeio.cpp
+++ b/src/Native/System.IO.Native/nativeio.cpp
@@ -7,7 +7,7 @@
 #include "nativeio.h"
 #include <sys/stat.h>
 
-#if HAVE_STAT64 && !(defined(__APPLE__) && defined(_AMD64_))
+#if HAVE_STAT64
 #    define stat_ stat64
 #    define fstat_ fstat64
 #else

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -3,6 +3,9 @@ project(System.Security.Cryptography.Native)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# Issue 2546 - Many deprecation warnings in System.Security.Cryptography.Native on Mac OS X
+add_compile_options(-Wno-deprecated-declarations)
+
 add_definitions(-DPIC=1)
 
 find_library(CRYPTO NAMES crypto)

--- a/src/Native/config.h.in
+++ b/src/Native/config.h.in
@@ -2,3 +2,12 @@
 
 #cmakedefine01 HAVE_STAT64
 #cmakedefine01 HAVE_STAT_BIRTHTIME
+
+// Mac OS X has stat64, but it is deprecated since plain stat now
+// provides the same 64-bit aware struct when targeting OS X > 10.5
+// and not passing _DARWIN_NO_64_BIT_INODE.
+#ifdef __APPLE__
+#    undef HAVE_STAT64
+#    define HAVE_STAT64 0
+#endif
+


### PR DESCRIPTION
Fixed the issue for System.IO.Native and disabled the warning and filed #2546 for System.Security.Cryptography.Native

cc @sokket @bartonjs 