### PR TITLE
Disable MMF IPC test

### DIFF
--- a/src/Scenarios/tests/InterProcessCommunication/MemoryMappedFilesTests.cs
+++ b/src/Scenarios/tests/InterProcessCommunication/MemoryMappedFilesTests.cs
@@ -9,6 +9,7 @@ namespace InterProcessCommunication.Tests
 {
     public class MemoryMappedFilesTests : IpcTestBase
     {
+        [ActiveIssue(2498, PlatformID.AnyUnix)]
         [Fact]
         public void DataShared()
         {


### PR DESCRIPTION
It's causing some CI runs to fail (#2498).  Disabling until I have time to investigate why.