### PR TITLE
BugFix: Signature Decoder not providing ValueType or Class flag

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
@@ -356,11 +356,11 @@ namespace System.Reflection.Metadata.Decoding
             {
                 case HandleKind.TypeDefinition:
                     TypeDefinitionHandle typeDefHandle = (TypeDefinitionHandle)typeRefOrDefHandle;
-                    return provider.GetTypeFromDefinition(typeDefHandle);
+                    return provider.GetTypeFromDefinition(typeDefHandle, null);
 
                 case HandleKind.TypeReference:
                     TypeReferenceHandle typeRefHandle = (TypeReferenceHandle)typeRefOrDefHandle;
-                    return provider.GetTypeFromReference(typeRefHandle);
+                    return provider.GetTypeFromReference(typeRefHandle, null);
 
                 default:
                     throw new BadImageFormatException();

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 using System.Collections.Immutable;
 
 namespace System.Reflection.Metadata.Decoding
@@ -8,14 +7,13 @@ namespace System.Reflection.Metadata.Decoding
     public interface ISignatureTypeProvider<TType> : ITypeProvider<TType>
     {
         MetadataReader Reader { get; }
-
         TType GetFunctionPointerType(MethodSignature<TType> signature);
         TType GetGenericMethodParameter(int index);
         TType GetGenericTypeParameter(int index);
         TType GetModifiedType(TType unmodifiedType, ImmutableArray<CustomModifier<TType>> customModifiers);
         TType GetPinnedType(TType elementType);
         TType GetPrimitiveType(PrimitiveTypeCode typeCode);
-        TType GetTypeFromDefinition(TypeDefinitionHandle handle);
-        TType GetTypeFromReference(TypeReferenceHandle handle);
+        TType GetTypeFromDefinition(TypeDefinitionHandle handle, bool? isValueType);
+        TType GetTypeFromReference(TypeReferenceHandle handle, bool? isValueType);
     }
 }

--- a/src/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
@@ -85,8 +85,8 @@ namespace System.Reflection.Metadata.Tests
             }
 
             public string GetPrimitiveType(PrimitiveTypeCode typeCode) { return typeCode.ToString(); }
-            public string GetTypeFromDefinition(TypeDefinitionHandle handle) { return handle.RowId.ToString("X"); }
-            public string GetTypeFromReference(TypeReferenceHandle handle) { return handle.RowId.ToString("X"); }
+            public string GetTypeFromDefinition(TypeDefinitionHandle handle, bool? isValueType) { return handle.RowId.ToString("X"); }
+            public string GetTypeFromReference(TypeReferenceHandle handle, bool? isValueType) { return handle.RowId.ToString("X"); }
             public string GetByReferenceType(string elemenstring) { return elemenstring + "&"; }
             public string GetSZArrayType(string elemenstring) { return elemenstring + "[]"; }
             public string GetPointerType(string elemenstring) { return elemenstring + "*"; }


### PR DESCRIPTION
This change would fix #2314.

I just added to flags into the provider interface so that the api consumers can retrieve the information in case they need it. In order to do these they need to set the flag  ```bool NeedProjectedFlags``` to ```true``` . In this case they could know if it is a valuetype or class through the ```SignatureTypeCode TypeCode``` property added in ```ISignatureTypeProvider<TType>``` as well.

Adding @AlexGhiondea  