### PR TITLE
Add FreeBSD property to OSPlatform

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/OSPlatform.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/OSPlatform.cs
@@ -41,6 +41,14 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        public static OSPlatform FreeBSD
+        {
+            get
+            {
+                return s_freebsd;
+            }
+        }
+
         private OSPlatform(string osPlatform)
         {
             if (osPlatform == null) throw new ArgumentNullException("osPlatform");

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/RuntimeInformation.FreeBSD.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/RuntimeInformation.FreeBSD.cs
@@ -5,11 +5,9 @@ namespace System.Runtime.InteropServices
 {
     public static class RuntimeInformation
     {
-        private static OSPlatform s_freeBSD = OSPlatform.Create("FREEBSD");
-
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
-            return s_freeBSD == osPlatform;
+            return OSPlatform.FreeBSD == osPlatform;
         }
     }
 }


### PR DESCRIPTION
The `s_freebsd` field was never used, this exposes it through a `FreeBSD` property on `OSPlatform`.