### PR TITLE
Modified calls to GetTestFilePath within loops to not use the same filename

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.cs
@@ -61,12 +61,13 @@ namespace System.IO.FileSystem.Tests
         public void FileShareCreate()
         {
             // just check that the inputs are accepted, actual sharing varies by platform so we seperate the behavior testing
+            int i = 0;
             foreach (FileShare share in shares)
             {
-                using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, share))
+                using (FileStream fs = CreateFileStream(GetTestFilePath(i++), FileMode.Create, FileAccess.ReadWrite, share))
                 { }
 
-                using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write, share))
+                using (FileStream fs = CreateFileStream(GetTestFilePath(i++), FileMode.Create, FileAccess.Write, share))
                 { }
             }
         }
@@ -75,15 +76,16 @@ namespace System.IO.FileSystem.Tests
         public void FileShareOpenOrCreate()
         {
             // just check that the inputs are accepted, actual sharing varies by platform so we seperate the behavior testing
+            int i = 0;
             foreach (FileShare share in shares)
             {
-                using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.OpenOrCreate, FileAccess.ReadWrite, share))
+                using (FileStream fs = CreateFileStream(GetTestFilePath(i++), FileMode.OpenOrCreate, FileAccess.ReadWrite, share))
                 { }
 
-                using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.OpenOrCreate, FileAccess.Write, share))
+                using (FileStream fs = CreateFileStream(GetTestFilePath(i++), FileMode.OpenOrCreate, FileAccess.Write, share))
                 { }
 
-                using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.OpenOrCreate, FileAccess.Read, share))
+                using (FileStream fs = CreateFileStream(GetTestFilePath(i++), FileMode.OpenOrCreate, FileAccess.Read, share))
                 { }
             }
         }

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -26,12 +26,12 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        [ActiveIssue(1434)]
         public void ValidFileOptions()
         {
+            int i = 0;
             foreach(FileOptions option in Enum.GetValues(typeof(FileOptions)))
             {
-                using (CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, option))
+                using (CreateFileStream(GetTestFilePath(i++), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, option))
                 { }
             }
 

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -30,15 +30,22 @@ namespace System.IO.FileSystem.Tests
         }
 
         // Generates a test file path to use that is unique name per test case / call
-        public string GetTestFilePath([CallerMemberName]string fileName = null, [CallerLineNumber] int lineNumber = 0)
+        public string GetTestFilePath([CallerMemberName]string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
-            return Path.Combine(TestDirectory, String.Format("{0}_{1}", fileName ?? "testFile", lineNumber));
+            return Path.Combine(TestDirectory, String.Format("{0}_{1}", memberName ?? "testFile", lineNumber));
+        }
+
+        // Generates a test file path to use that is unique name per test case / call with an additional
+        // variable to specify a trailing identifier
+        public string GetTestFilePath(int index, [CallerMemberName]string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            return Path.Combine(TestDirectory, String.Format("{0}_{1}_{2}", memberName ?? "testFile", lineNumber, index));
         }
 
         // Generates a test file name to use that is unique name per test case / call
-        public string GetTestFileName([CallerMemberName]string fileName = null, [CallerLineNumber] int lineNumber = 0)
+        public string GetTestFileName([CallerMemberName]string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
-            return String.Format("{0}_{1}", fileName ?? "testFile", lineNumber);
+            return String.Format("{0}_{1}", memberName ?? "testFile", lineNumber);
         }
 
         public void Dispose()


### PR DESCRIPTION
- Added an overload to GetTestFilePath that takes an integer index parameter to add to the generated filename so that calls to the function within loops will be able to differentiate themselves
- Resolves #1434