### PR TITLE
Fixing bug #2545 where Directory.Move would not throw when it should

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MoveFileEx.cs
@@ -8,12 +8,14 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        private const uint MOVEFILE_COPY_ALLOWED = 2;
+
         [DllImport(Libraries.CoreFile_L2, EntryPoint = "MoveFileExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool MoveFileEx(string src, string dst, uint flags);
 
-        internal static bool MoveFile(string src, string dst)
+        internal static bool MoveFile(string src, string dst, bool copyCrossVolume = true)
         {
-            return MoveFileEx(src, dst, 2 /* MOVEFILE_COPY_ALLOWED */);
+            return MoveFileEx(src, dst, (copyCrossVolume ? MOVEFILE_COPY_ALLOWED : 0));
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -400,7 +400,7 @@ namespace System.IO
 
         public override void MoveDirectory(string sourceFullPath, string destFullPath)
         {
-            if (!Interop.mincore.MoveFile(sourceFullPath, destFullPath))
+            if (!Interop.mincore.MoveFile(sourceFullPath, destFullPath, copyCrossVolume: false))
             {
                 int errorCode = Marshal.GetLastWin32Error();
 


### PR DESCRIPTION
Fixing a bug in the Win32 FileSystem implementation where we would 
allow moving a directory across volumes only on Windows. This
contradicts the MSDN documentation for that function and also created
a functional difference on Linux where that call would throw, as expected.
This fix makes Windows throw like the other implementations and as the
contract states should happen.