### PR TITLE
Add support for PFX files on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.NativeCrypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.NativeCrypto.cs
@@ -13,10 +13,19 @@ internal static partial class Interop
         private delegate int NegativeSizeReadMethod<in THandle>(THandle handle, byte[] buf, int cBuf);
 
         [DllImport(Libraries.CryptoInterop)]
+        internal static extern int BioTell(SafeBioHandle bio);
+
+        [DllImport(Libraries.CryptoInterop)]
+        internal static extern int BioSeek(SafeBioHandle bio, int pos);
+
+        [DllImport(Libraries.CryptoInterop)]
         private static extern int GetX509Thumbprint(SafeX509Handle x509, byte[] buf, int cBuf);
 
         [DllImport(Libraries.CryptoInterop)]
         private static extern int GetX509NameRawBytes(IntPtr x509Name, byte[] buf, int cBuf);
+
+        [DllImport(Libraries.CryptoInterop)]
+        internal static extern SafeX509Handle ReadX509AsDerFromBio(SafeBioHandle bio);
 
         [DllImport(Libraries.CryptoInterop)]
         internal static extern IntPtr GetX509NotBefore(SafeX509Handle x509);

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.BIO.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.BIO.cs
@@ -19,6 +19,9 @@ internal static partial class Interop
         internal static extern SafeBioHandle BIO_new(IntPtr type);
 
         [DllImport(Libraries.LibCrypto)]
+        internal static extern SafeBioHandle BIO_new_file(string filename, string mode);
+
+        [DllImport(Libraries.LibCrypto)]
         internal static extern IntPtr BIO_s_mem();
 
         [DllImport(Libraries.LibCrypto)]

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.Rsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.Rsa.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class libcrypto
+    {
+        [DllImport(Libraries.LibCrypto)]
+        internal static extern SafeRsaHandle EVP_PKEY_get1_RSA(SafeEvpPkeyHandle pkey);
+    }
+}

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libcrypto
+    {
+        [DllImport(Libraries.LibCrypto)]
+        internal static extern void EVP_PKEY_free(IntPtr pkey);
+    }
+}

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.Pkcs12.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.Pkcs12.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class libcrypto
+    {
+        [DllImport(Libraries.LibCrypto)]
+        internal static unsafe extern SafePkcs12Handle d2i_PKCS12(IntPtr zero, byte** ppin, int len);
+
+        [DllImport(Libraries.LibCrypto)]
+        internal static extern SafePkcs12Handle d2i_PKCS12_bio(SafeBioHandle bio, IntPtr zero);
+
+        [DllImport(Libraries.LibCrypto)]
+        internal static extern void PKCS12_free(IntPtr p12);
+        
+        [DllImport(Libraries.CryptoInterop, CharSet = CharSet.Ansi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool PKCS12_parse(SafePkcs12Handle p12, string pass, out SafeEvpPkeyHandle pkey, out SafeX509Handle cert, out SafeX509StackHandle ca);
+    }
+}

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.Rsa.cs
@@ -22,6 +22,10 @@ internal static partial class Interop
         internal static unsafe extern SafeRsaHandle d2i_RSAPublicKey(IntPtr zero, byte** ppin, int len);
 
         [DllImport(Libraries.LibCrypto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool RSA_up_ref(IntPtr rsa);
+
+        [DllImport(Libraries.LibCrypto)]
         internal static extern void RSA_free(IntPtr rsa);
 
         [DllImport(Libraries.LibCrypto)]

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 
         internal unsafe delegate int I2DFunc<in THandle>(THandle handle, byte** @out);
 
-        internal static unsafe THandle OpenSslD2I<THandle>(D2IFunc<THandle> d2i, byte[] data)
+        internal static unsafe THandle OpenSslD2I<THandle>(D2IFunc<THandle> d2i, byte[] data, bool checkHandle=true)
             where THandle : SafeHandle
         {
             // The OpenSSL d2i_* functions are set up for cascaded calls, so they increment *ppData while reading.
@@ -27,7 +27,10 @@ internal static partial class Interop
 
                 THandle handle = d2i(IntPtr.Zero, ppData, data.Length);
 
-                CheckValidOpenSslHandle(handle);
+                if (checkHandle)
+                {
+                    CheckValidOpenSslHandle(handle);
+                }
 
                 return handle;
             }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPkeyHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPkeyHandle.Unix.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafeEvpPkeyHandle : SafeHandle
+    {
+        private SafeEvpPkeyHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.libcrypto.EVP_PKEY_free(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+    }
+}

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafePkcs12Handle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafePkcs12Handle.Unix.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafePkcs12Handle : SafeHandle
+    {
+        private SafePkcs12Handle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.libcrypto.PKCS12_free(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+    }
+}

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Security;
 using System.Runtime.InteropServices;
 
@@ -25,6 +26,23 @@ namespace Microsoft.Win32.SafeHandles
         public override bool IsInvalid
         {
             get { return handle == IntPtr.Zero; }
+        }
+
+        internal static SafeRsaHandle DuplicateHandle(IntPtr handle)
+        {
+            Debug.Assert(handle != IntPtr.Zero);
+
+            // Reliability: Allocate the SafeHandle before calling RSA_up_ref so
+            // that we don't lose a tracked reference in low-memory situations.
+            SafeRsaHandle safeHandle = new SafeRsaHandle();
+
+            if (!Interop.libcrypto.RSA_up_ref(handle))
+            {
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+            }
+
+            safeHandle.SetHandle(handle);
+            return safeHandle;
         }
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -775,3 +775,76 @@ GetX509RootStorePath()
 
     return dir;
 }
+
+/*
+Function:
+ReadX509AsDerFromBio
+
+Used by System.Security.Cryptography.X509Certificates' OpenSslX509CertificateReader when attempting
+to turn the contents of a file into an ICertificatePal object.
+
+Return values:
+If bio containns a valid DER-encoded X509 object, a pointer to that X509 structure that was deserialized,
+otherwise NULL.
+*/
+X509*
+ReadX509AsDerFromBio(
+    BIO* bio)
+{
+    return d2i_X509_bio(bio, NULL);
+}
+
+/*
+Function:
+BioTell
+
+Used by System.Security.Cryptography.X509Certificates' OpenSslX509CertificateReader when attempting
+to turn the contents of a file into an ICertificatePal object to allow seeking back to the start point
+in the event of a deserialization failure.
+
+Return values:
+The current seek position of the BIO if it is a file-related BIO, -1 on NULL inputs, and has unspecified
+behavior on non-file, non-null BIO objects.
+
+See also:
+OpenSSL's BIO_tell
+*/
+int BioTell(
+    BIO* bio)
+{
+    if (!bio)
+    {
+        return -1;
+    }
+
+    return BIO_tell(bio);
+}
+
+/*
+Function:
+BioTell
+
+Used by System.Security.Cryptography.X509Certificates' OpenSslX509CertificateReader when attempting
+to turn the contents of a file into an ICertificatePal object to seek back to the start point
+in the event of a deserialization failure.
+
+Return values:
+-1 if bio is NULL
+-1 if bio is a file-related BIO and seek fails
+0 if bio is a file-related BIO and seek succeeds
+otherwise unspecified
+
+See also:
+OpenSSL's BIO_seek
+*/
+int BioSeek(
+    BIO* bio,
+    int ofs)
+{
+    if (!bio)
+    {
+        return -1;
+    }
+
+    return BIO_seek(bio, ofs);
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePal.cs
@@ -12,7 +12,6 @@ namespace Internal.Cryptography
     internal interface ICertificatePal : IDisposable
     {
         bool HasPrivateKey { get; }
-        AsymmetricAlgorithm PrivateKey { get; }
         IntPtr Handle { get; }
         string Issuer { get; }
         string Subject { get; }
@@ -31,12 +30,7 @@ namespace Internal.Cryptography
         X500DistinguishedName SubjectName { get; }
         X500DistinguishedName IssuerName { get; }
         IEnumerable<X509Extension> Extensions { get; }
-
-        /// <summary>
-        /// Set the private key object. The additional "publicKey" argument is used to validate that the private key corresponds to the existing publicKey.
-        /// </summary>
-        void SetPrivateKey(AsymmetricAlgorithm privateKey, AsymmetricAlgorithm publicKey);
-
+        RSA GetRSAPrivateKey();
         string GetNameInfo(X509NameType nameType, bool forIssuer);
         void AppendPrivateKeyInfo(StringBuilder sb);
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
 {
@@ -16,9 +18,64 @@ namespace Internal.Cryptography.Pal
             return new OpenSslX509CertificateReader(Interop.libcrypto.X509_dup(handle));
         }
 
-        public static ICertificatePal FromBlob(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+        public static unsafe ICertificatePal FromBlob(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
         {
-            return new OpenSslX509CertificateReader(rawData);
+            // If we can see a hyphen, assume it's PEM.  Otherwise try DER-X509, then fall back to DER-PKCS12.
+            SafeX509Handle cert;
+
+            // PEM
+            if (rawData[0] == '-')
+            {
+                using (SafeBioHandle bio = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
+                {
+                    Interop.libcrypto.CheckValidOpenSslHandle(bio);
+
+                    Interop.libcrypto.BIO_write(bio, rawData, rawData.Length);
+                    cert = Interop.libcrypto.PEM_read_bio_X509_AUX(bio, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                }
+
+                Interop.libcrypto.CheckValidOpenSslHandle(cert);
+            }
+
+            // DER-X509
+            cert = Interop.libcrypto.OpenSslD2I((ptr, b, i) => Interop.libcrypto.d2i_X509(ptr, b, i), rawData, checkHandle: false);
+
+            if (!cert.IsInvalid)
+            {
+                return new OpenSslX509CertificateReader(cert);
+            }
+
+            // DER-PKCS12
+            OpenSslPkcs12Reader pfx;
+
+            if (OpenSslPkcs12Reader.TryRead(rawData, out pfx))
+            {
+                using (pfx)
+                {
+                    pfx.Decrypt(password);
+
+                    ICertificatePal first = null;
+
+                    foreach (OpenSslX509CertificateReader certPal in pfx.ReadCertificates())
+                    {
+                        // When requesting an X509Certificate2 from a PFX only the first entry is
+                        // returned.  Other entries should be disposed.
+                        if (first == null)
+                        {
+                            first = certPal;
+                        }
+                        else
+                        {
+                            certPal.Dispose();
+                        }
+                    }
+
+                    return first;
+                }
+            }
+
+            // Unsupported
+            throw Interop.libcrypto.CreateOpenSslCryptographicException();
         }
 
         public static ICertificatePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -80,7 +80,13 @@ namespace Internal.Cryptography.Pal
 
         public static ICertificatePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
         {
-            throw new NotImplementedException();
+            // If we can't open the file, fail right away.
+            using (SafeBioHandle fileBio = Interop.libcrypto.BIO_new_file(fileName, "rb"))
+            {
+                Interop.libcrypto.CheckValidOpenSslHandle(fileBio);
+
+                return OpenSslX509CertificateReader.FromBio(fileBio, password);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Internal.Cryptography.Pal
+{
+    internal sealed class OpenSslPkcs12Reader : IDisposable
+    {
+        private readonly SafePkcs12Handle _pkcs12Handle;
+        private SafeEvpPkeyHandle _evpPkeyHandle;
+        private SafeX509Handle _x509Handle;
+        private SafeX509StackHandle _caStackHandle;
+
+        private OpenSslPkcs12Reader(SafePkcs12Handle pkcs12Handle)
+        {
+            _pkcs12Handle = pkcs12Handle;
+        }
+
+        public unsafe static bool TryRead(byte[] data, out OpenSslPkcs12Reader pkcs12Reader)
+        {
+            SafePkcs12Handle handle = Interop.libcrypto.OpenSslD2I(
+                (ptr, b, i) => Interop.libcrypto.d2i_PKCS12(ptr, b, i),
+                data,
+                checkHandle: false);
+
+            if (!handle.IsInvalid)
+            {
+                pkcs12Reader = new OpenSslPkcs12Reader(handle);
+                return true;
+            }
+
+            pkcs12Reader = null;
+            return false;
+        }
+
+        public static bool TryRead(SafeBioHandle fileBio, out OpenSslPkcs12Reader pkcs12Reader)
+        {
+            SafePkcs12Handle p12 = Interop.libcrypto.d2i_PKCS12_bio(fileBio, IntPtr.Zero);
+
+            if (!p12.IsInvalid)
+            {
+                pkcs12Reader = new OpenSslPkcs12Reader(p12);
+                return true;
+            }
+
+            pkcs12Reader = null;
+            return false;
+        }
+
+        public void Dispose()
+        {
+            if (_caStackHandle != null)
+            {
+                _caStackHandle.Dispose();
+                _caStackHandle = null;
+            }
+
+            if (_x509Handle != null)
+            {
+                _x509Handle.Dispose();
+                _x509Handle = null;
+            }
+
+            if (_evpPkeyHandle != null)
+            {
+                _evpPkeyHandle.Dispose();
+                _evpPkeyHandle = null;
+            }
+
+            if (_pkcs12Handle != null)
+            {
+                _pkcs12Handle.Dispose();
+            }
+        }
+
+        public void Decrypt(string password)
+        {
+            bool parsed = Interop.libcrypto.PKCS12_parse(
+                _pkcs12Handle,
+                password,
+                out _evpPkeyHandle,
+                out _x509Handle,
+                out _caStackHandle);
+
+            if (!parsed)
+            {
+                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+            }
+        }
+
+        public List<OpenSslX509CertificateReader> ReadCertificates()
+        {
+            var certs = new List<OpenSslX509CertificateReader>();
+
+            if (_caStackHandle != null && !_caStackHandle.IsInvalid)
+            {
+                int caCertCount = Interop.NativeCrypto.GetX509StackFieldCount(_caStackHandle);
+
+                for (int i = 0; i < caCertCount; i++)
+                {
+                    IntPtr certPtr = Interop.NativeCrypto.GetX509StackField(_caStackHandle, i);
+
+                    if (certPtr != IntPtr.Zero)
+                    {
+                        // The STACK_OF(X509) still needs to be cleaned up, so duplicate the handle out of it.
+                        certs.Add(new OpenSslX509CertificateReader(Interop.libcrypto.X509_dup(certPtr)));
+                    }
+                }
+            }
+
+            if (_x509Handle != null && !_x509Handle.IsInvalid)
+            {
+                // The certificate and (if applicable) private key handles will be given over
+                // to the OpenSslX509CertificateReader, and the fields here are thus nulled out to
+                // prevent double-Dispose.
+                OpenSslX509CertificateReader reader = new OpenSslX509CertificateReader(_x509Handle);
+                _x509Handle = null;
+
+                certs.Add(reader);
+            }
+
+            return certs;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -120,6 +120,12 @@ namespace Internal.Cryptography.Pal
                 OpenSslX509CertificateReader reader = new OpenSslX509CertificateReader(_x509Handle);
                 _x509Handle = null;
 
+                if (_evpPkeyHandle != null && !_evpPkeyHandle.IsInvalid)
+                {
+                    reader.SetPrivateKey(_evpPkeyHandle);
+                    _evpPkeyHandle = null;
+                }
+
                 certs.Add(reader);
             }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -35,41 +35,6 @@ namespace Internal.Cryptography.Pal
             _cert = handle;
         }
 
-        internal unsafe OpenSslX509CertificateReader(byte[] data)
-        {
-            SafeX509Handle cert;
-
-            // If the first byte is a hyphen then this is likely PEM-encoded,
-            // otherwise it's DER-encoded (or not a certificate).
-            if (data[0] == '-')
-            {
-                using (SafeBioHandle bio = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
-                {
-                    Interop.libcrypto.CheckValidOpenSslHandle(bio);
-
-                    Interop.libcrypto.BIO_write(bio, data, data.Length);
-                    cert = Interop.libcrypto.PEM_read_bio_X509_AUX(bio, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-                }
-            }
-            else
-            {
-                cert = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_X509, data);
-            }
-
-            Interop.libcrypto.CheckValidOpenSslHandle(cert);
-
-            // X509_check_purpose has the effect of populating the sha1_hash value,
-            // and other "initialize" type things.
-            bool init = Interop.libcrypto.X509_check_purpose(cert, -1, 0);
-
-            if (!init)
-            {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
-            }
-
-            _cert = cert;
-        }
-
         public bool HasPrivateKey
         {
             get { return false; }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -40,11 +40,6 @@ namespace Internal.Cryptography.Pal
             get { return false; }
         }
 
-        public AsymmetricAlgorithm PrivateKey
-        {
-            get { return null; }
-        }
-
         public IntPtr Handle
         {
             get { return _cert == null ? IntPtr.Zero : _cert.DangerousGetHandle(); }
@@ -233,9 +228,9 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        public void SetPrivateKey(AsymmetricAlgorithm privateKey, AsymmetricAlgorithm publicKey)
+        public RSA GetRSAPrivateKey()
         {
-            throw new NotImplementedException();
+            return null;
         }
 
         public string GetNameInfo(X509NameType nameType, bool forIssuer)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
 {
@@ -18,7 +19,17 @@ namespace Internal.Cryptography.Pal
 
         public static IStorePal FromBlob(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
         {
-            throw new NotImplementedException();
+            OpenSslPkcs12Reader pfx;
+
+            if (OpenSslPkcs12Reader.TryRead(rawData, out pfx))
+            {
+                using (pfx)
+                {
+                    return PfxToCollection(pfx, password);
+                }
+            }
+
+            return null;
         }
 
         public static IStorePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
@@ -77,6 +88,20 @@ namespace Internal.Cryptography.Pal
 
             // TODO (#2207): Support the rest of the stores, or throw PlatformNotSupportedException.
             throw new NotImplementedException();
+        }
+
+        private static IStorePal PfxToCollection(OpenSslPkcs12Reader pfx, string password)
+        {
+            pfx.Decrypt(password);
+
+            X509Certificate2Collection coll = new X509Certificate2Collection();
+
+            foreach (OpenSslX509CertificateReader certPal in pfx.ReadCertificates())
+            {
+                coll.Add(new X509Certificate2(certPal));
+            }
+
+            return new OpenSslX509StoreProvider(coll);
         }
 
         private static IStorePal CloneStore(X509Certificate2Collection seed)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -34,7 +34,22 @@ namespace Internal.Cryptography.Pal
 
         public static IStorePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
         {
-            throw new NotImplementedException();
+            using (SafeBioHandle fileBio = Interop.libcrypto.BIO_new_file(fileName, "rb"))
+            {
+                Interop.libcrypto.CheckValidOpenSslHandle(fileBio);
+
+                OpenSslPkcs12Reader pfx;
+
+                if (OpenSslPkcs12Reader.TryRead(fileBio, out pfx))
+                {
+                    using (pfx)
+                    {
+                        return PfxToCollection(pfx, password);
+                    }
+                }
+            }
+
+            return null;
         }
 
         public static IStorePal FromCertificate(ICertificatePal cert)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -2,21 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
-using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.InteropServices;
-
-using Internal.NativeCrypto;
-using Internal.Cryptography;
-using Internal.Cryptography.Pal.Native;
-
-using FILETIME = Internal.Cryptography.Pal.Native.FILETIME;
-
-using CryptographicUnexpectedOperationException = System.Security.Cryptography.CryptographicException;
-
 using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
+
+using Internal.Cryptography.Pal.Native;
 
 namespace Internal.Cryptography.Pal
 {
@@ -30,104 +19,15 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        public AsymmetricAlgorithm PrivateKey
+        public RSA GetRSAPrivateKey()
         {
-            get
-            {
-                CspParameters cspParameters = GetPrivateKey();
-                if (cspParameters == null)
-                    return null;
+            CspParameters cspParameters = GetPrivateKey();
+            if (cspParameters == null)
+                return null;
 
-                // We never want to stomp over certificate private keys.
-                cspParameters.Flags |= CspProviderFlags.UseExistingKey;
-
-                int algId = OidInfo.FindOidInfo(CryptOidInfoKeyType.CRYPT_OID_INFO_OID_KEY, KeyAlgorithm, OidGroup.PublicKeyAlgorithm, fallBackToAllGroups: true).AlgId;
-                switch (algId)
-                {
-                    case AlgId.CALG_RSA_KEYX:
-                    case AlgId.CALG_RSA_SIGN:
-                        return new RSACryptoServiceProvider(cspParameters);
-
-                    case AlgId.CALG_DSS_SIGN:
-                        return new DSACryptoServiceProvider(cspParameters);
-
-                    default:
-                        throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Set the private key object. The additional "publicKey" argument is used to validate that the private key corresponds to the existing publicKey.
-        /// </summary>
-        public void SetPrivateKey(AsymmetricAlgorithm privateKey, AsymmetricAlgorithm publicKey)
-        {
-            if (privateKey == null)
-            {
-                unsafe
-                {
-                    if (!Interop.crypt32.CertSetCertificateContextProperty(_certContext, CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, CertSetPropertyFlags.None, (CRYPT_KEY_PROV_INFO*)null))
-                        throw new CryptographicException(Marshal.GetLastWin32Error());
-                }
-            }
-            else
-            {
-                // we do not support keys in non-CAPI storage for now.
-                ICspAsymmetricAlgorithm asymmetricAlgorithm = privateKey as ICspAsymmetricAlgorithm;
-                if (asymmetricAlgorithm == null)
-                    throw new NotSupportedException(SR.NotSupported_InvalidKeyImpl);
-                if (asymmetricAlgorithm.CspKeyContainerInfo == null)
-                    throw new ArgumentException("CspKeyContainerInfo");
-
-                // check that the public key in the certificate corresponds to the private key passed in.
-                // 
-                // note that it should be legal to set a key which matches in every aspect but the usage
-                // i.e. to use a CALG_RSA_KEYX private key to match a CALG_RSA_SIGN public key. A
-                // PUBLICKEYBLOB is defined as:
-                //
-                //  BLOBHEADER publickeystruc
-                //  RSAPUBKEY rsapubkey
-                //  BYTE modulus[rsapubkey.bitlen/8]
-                //  
-                // To allow keys which differ by key usage only, we skip over the BLOBHEADER of the key,
-                // and start comparing bytes at the RSAPUBKEY structure.
-                unsafe
-                {
-                    // This cast is safe because via our contract with our caller, "publicKey" is the Key property of a PublicKey object that this Pal class manufactured in the first place.
-                    // Since we manufactured the PublicKey, we know the real types of the object.
-                    ICspAsymmetricAlgorithm cspPublicKey = (ICspAsymmetricAlgorithm)publicKey;
-                    byte[] array1 = cspPublicKey.ExportCspBlob(false);
-                    byte[] array2 = asymmetricAlgorithm.ExportCspBlob(false);
-                    if (array1 == null || array2 == null || array1.Length != array2.Length || array1.Length <= sizeof(BLOBHEADER))
-                        throw new CryptographicUnexpectedOperationException(SR.Cryptography_X509_KeyMismatch);
-                    for (int index = sizeof(BLOBHEADER); index < array1.Length; index++)
-                    {
-                        if (array1[index] != array2[index])
-                            throw new CryptographicUnexpectedOperationException(SR.Cryptography_X509_KeyMismatch);
-                    }
-                }
-
-                unsafe
-                {
-                    CspKeyContainerInfo keyContainerInfo = asymmetricAlgorithm.CspKeyContainerInfo;
-                    fixed (char* pKeyContainerName = keyContainerInfo.KeyContainerName, pProviderName = keyContainerInfo.ProviderName)
-                    {
-                        CRYPT_KEY_PROV_INFO keyProvInfo = new CRYPT_KEY_PROV_INFO()
-                        {
-                            pwszContainerName = pKeyContainerName,
-                            pwszProvName = pProviderName,
-                            dwProvType = keyContainerInfo.ProviderType,
-                            dwFlags = keyContainerInfo.MachineKeyStore ? CryptAcquireContextFlags.CRYPT_MACHINE_KEYSET : CryptAcquireContextFlags.None,
-                            cProvParam = 0,
-                            rgProvParam = IntPtr.Zero,
-                            dwKeySpec = (int)(keyContainerInfo.KeyNumber),
-                        };
-
-                        if (!Interop.crypt32.CertSetCertificateContextProperty(_certContext, CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, CertSetPropertyFlags.None, &keyProvInfo))
-                            throw new CryptographicException(Marshal.GetLastWin32Error());
-                    }
-                }
-            }
+            // We never want to stomp over certificate private keys.
+            cspParameters.Flags |= CspProviderFlags.UseExistingKey;
+            return new RSACryptoServiceProvider(cspParameters);
         }
 
         private CspParameters GetPrivateKey()

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -129,6 +129,7 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="Internal\Cryptography\Pal.Unix\CertificatePal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\ChainPal.cs" />
+    <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslPkcs12Reader.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslX509CertificateReader.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslX509ChainProcessor.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslX509Encoder.cs" />
@@ -156,8 +157,17 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EvpPkey.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.EvpPkey.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EvpPkey.Rsa.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.EvpPkey.Rsa.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Initialization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Pkcs12.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.Pkcs12.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Rsa.cs</Link>
@@ -179,6 +189,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpPkeyHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpPkeyHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             // When the CNG contract comes online this needs to return an RsaCng on Windows, unless CNG reports
             // an error, then try falling back to CAPI (for CAPI-only smartcards).
-            return (RSA)certificate.Pal.PrivateKey;
+            return certificate.Pal.GetRSAPrivateKey();
         }
 
         private static bool IsRSA(X509Certificate2 certificate)

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -9,16 +9,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class CertTests
     {
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void X509CertTest()
         {
-            const string CertSubject =
-                @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
+            string certSubject = TestData.NormalizeX500String(
+                @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com");
 
             using (X509Certificate cert = new X509Certificate(Path.Combine("TestData", "microsoft.cer")))
             {
-                Assert.Equal(CertSubject, cert.Subject);
-                Assert.Equal(CertSubject, cert.Issuer);
+                Assert.Equal(certSubject, cert.Subject);
+                Assert.Equal(certSubject, cert.Issuer);
 
                 int snlen = cert.GetSerialNumber().Length;
                 Assert.Equal(16, snlen);
@@ -49,19 +49,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void X509Cert2Test()
         {
-            const string CertName =
-                @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US";
+            string certName = TestData.NormalizeX500String(
+                @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US");
 
             DateTime notBefore = new DateTime(1999, 7, 12, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
             DateTime notAfter = new DateTime(2009, 7, 9, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
 
             using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.cer")))
             {
-                Assert.Equal(CertName, cert2.IssuerName.Name);
-                Assert.Equal(CertName, cert2.SubjectName.Name);
+                Assert.Equal(certName, cert2.IssuerName.Name);
+                Assert.Equal(certName, cert2.SubjectName.Name);
 
                 Assert.Equal("ABA.ECOM Root CA", cert2.GetNameInfo(X509NameType.DnsName, true));
 
@@ -147,7 +147,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2CreateFromPfxFile()
         {
             using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "DummyTcpServer.pfx")))
@@ -158,7 +157,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2CreateFromPfxWithPassword()
         {
             using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.pfx"), "test"))

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -154,7 +154,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportPfx()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -175,6 +175,43 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void ImportFullChainPfx()
+        {
+            X509Certificate2Collection certs = new X509Certificate2Collection();
+            certs.Import(Path.Combine("TestData", "test.pfx"), "test", X509KeyStorageFlags.DefaultKeySet);
+            int count = certs.Count;
+            Assert.Equal(3, count);
+
+            // Verify that the read ordering is consistent across the platforms
+            string[] expectedSubjects =
+            {
+                "MS Passport Test Sub CA",
+                "MS Passport Test Root CA",
+                "test.local",
+            };
+
+            string[] actualSubjects = certs.OfType<X509Certificate2>().
+                Select(cert => cert.GetNameInfo(X509NameType.SimpleName, false)).
+                ToArray();
+
+            Assert.Equal(expectedSubjects, actualSubjects);
+            
+            // And verify that we have private keys when we expect them
+            bool[] expectedHasPrivateKeys =
+            {
+                false,
+                false,
+                true,
+            };
+
+            bool[] actualHasPrivateKeys = certs.OfType<X509Certificate2>().
+                Select(cert => cert.HasPrivateKey).
+                ToArray();
+
+            Assert.Equal(expectedHasPrivateKeys, actualHasPrivateKeys);
+        }
+
+        [Fact]
         [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportStoreSavedAsCerData()
         {
@@ -267,7 +304,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportFromFileTests()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -152,7 +152,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         private static X509Certificate2 LoadCertificateFromFile()
         {
-            string path = Path.Combine("TestData", "Ms.cer");
+            string path = Path.Combine("TestData", "MS.cer");
             if (!File.Exists(path))
                 throw new Exception(string.Format("Test infrastructure failure: Expected to find file \"{0}\".", path));
             byte[] data = File.ReadAllBytes(path);

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -10,7 +10,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class LoadFromFileTests
     {
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestIssuer()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -18,13 +17,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 string issuer = c.Issuer;
 
                 Assert.Equal(
-                    "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    TestData.NormalizeX500String("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
                     issuer);
             }
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSubject()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -32,13 +30,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 string subject = c.Subject;
 
                 Assert.Equal(
-                    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    TestData.NormalizeX500String("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
                     subject);
             }
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestSerial()
         {
             byte[] expectedSerial = "b00000000100dd9f3bd08b0aaf11b000000033".HexToByteArray();
@@ -51,7 +48,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestThumbprint()
         {
             byte[] expectedThumbPrint = "108e2ba23632620c427c570b6d9db51ac31387fe".HexToByteArray();
@@ -64,7 +60,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetFormat()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -75,7 +70,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetKeyAlgorithm()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -86,7 +80,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetKeyAlgorithmParameters()
         {
             string expected = "0500";
@@ -101,7 +94,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestGetPublicKey()
         {
             byte[] expectedPublicKey = (

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -57,7 +57,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestPrivateKey()
         {
             using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -10,7 +10,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class PfxTests
     {
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestConstructor()
         {
             byte[] expectedThumbprint = "71cb4e2b02738ad44f8b382c93bd17ba665f9914".HexToByteArray();
@@ -25,7 +24,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestRawData()
         {
             byte[] expectedRawData = (


### PR DESCRIPTION
With this change the following things now work on Unix systems:
* Reading a DER-encoded PKCS12 (PFX) `byte[]` via `X509Certificate2` constructors
* Reading a DER-encoded PKCS12 (PFX) `byte[]` via `X509Certificate2Collection.Import`
* Reading a DER-encoded PKCS12 (PFX) file identified by `string filename` via `X509Certificate2` 
constructors
* Reading a DER-encoded PKCS12 (PFX) file identified by `string filename` via `X509Certificate2Collection.Import`
* Reading a DER-encoded X509 (.cer) file identified by `string filename` via `X509Certificate2` 
constructors
* Reading a PEM-encoded X509 (.cer) file identified by `string filename` via `X509Certificate2` 
constructors
* Instantiating an `RSAOpenSsl` based off of having an `IntPtr` to an existing OpenSSL `RSA*` (which enables people on Unix systems to make use of hardware security keys)

The file paths and the byte[] paths don't share as much code as I would have liked, but the `BIO_s_mem` BIO didn't seem to support seeking back to the start when it read down the wrong path.

15 tests get [ActiveIssue] removed, two changed to a more specific number, and one new test was added.

Fixes #2449.