### PR TITLE
Adding new Unit Tests to validate the more complex FileSystemWatcher scenarios

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.inotify.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.inotify.cs
@@ -53,6 +53,7 @@ internal static partial class Interop
             IN_Q_OVERFLOW  = 0x00004000,
             IN_IGNORED     = 0x00008000,
             IN_ONLYDIR     = 0x01000000,
+            IN_DONT_FOLLOW = 0x02000000,
             IN_EXCL_UNLINK = 0x04000000,
             IN_ISDIR       = 0x40000000,
         }

--- a/src/Common/src/Interop/Unix/System.IO.Native/Interop.NativeIO.cs
+++ b/src/Common/src/Interop/Unix/System.IO.Native/Interop.NativeIO.cs
@@ -43,5 +43,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.IOInterop, SetLastError = true)]
         internal static extern int Stat(string path, out FileStats output);
+
+        [DllImport(Libraries.IOInterop, SetLastError = true)]
+        internal static extern int LStat(string path, out FileStats output);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.poll.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.poll.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [Flags]
+        internal enum PollFlags : short
+        {
+            POLLIN      = 0x0001,       /* any readable data available */
+            POLLERR     = 0x0008,       /* some poll error occurred */
+            POLLHUP     = 0x0010,       /* file descriptor was "hung up" */
+            POLLNVAL    = 0x0020,       /* requested events "invalid" */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct pollfd
+        {
+            internal int fd;            /* file descriptor to poll*/
+            internal PollFlags events;  /* events to poll for */
+            internal PollFlags revents; /* events received from polling */
+        }
+
+        /// <summary>
+        /// Polls a set of file descriptors for signals and returns what signals have been set
+        /// </summary>
+        /// <param name="fds">A pointer to pollfd structs to look for</param>
+        /// <param name="count">The number of entries in fds</param>
+        /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
+        /// <returns>
+        /// Returns a positive number (which is the number of structures with nonzero revent files), 0 for a timeout or no 
+        /// descriptors were ready, or -1 on error.
+        /// </returns>
+        [DllImport(Libraries.Libc, SetLastError = true)]
+        private static unsafe extern int poll(pollfd* fds, uint count, int timeout);
+
+        /// <summary>
+        /// Polls a File Descriptor for the passed in flags.
+        /// </summary>
+        /// <param name="fd">The descriptor to poll</param>
+        /// <param name="flags">The flags to poll for</param>
+        /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
+        /// <param name="resultFlags">The flags that were returned by the poll call</param>
+        /// <returns>
+        /// Returns a positive number (which is the number of structures with nonzero revent files), 0 for a timeout or no 
+        /// descriptors were ready, or -1 on error.
+        /// </returns>
+        internal unsafe static int poll(int fd, PollFlags flags, int timeout, out PollFlags resultFlags)
+        {
+            pollfd pfd = default(pollfd);
+            pfd.fd = fd;
+            pfd.events = flags;
+            int result = poll(&pfd, 1, timeout);
+            resultFlags = pfd.revents;
+            return result;
+        }
+    }
+}

--- a/src/Native/System.IO.Native/nativeio.cpp
+++ b/src/Native/System.IO.Native/nativeio.cpp
@@ -10,9 +10,11 @@
 #if HAVE_STAT64
 #    define stat_ stat64
 #    define fstat_ fstat64
+#    define lstat_ lstat64
 #else
 #   define stat_ stat
 #   define fstat_ fstat
+#   define lstat_ lstat
 #endif
 
 static void ConvertFileStats(const struct stat_& src, FileStats* dst)
@@ -51,6 +53,19 @@ extern "C"
     {
         struct stat_ result;
         int ret = fstat_(fileDescriptor, &result);
+
+        if (ret == 0)
+        {
+            ConvertFileStats(result, output);
+        }
+
+        return ret; // TODO: errno conversion
+    }
+
+    int32_t LStat(const char* path, struct FileStats* output)
+    {
+        struct stat_ result;
+        int ret = lstat_(path, &result);
 
         if (ret == 0)
         {

--- a/src/Native/System.IO.Native/nativeio.h
+++ b/src/Native/System.IO.Native/nativeio.h
@@ -41,5 +41,12 @@ extern "C"
      * Returns 0 for success, -1 for failure. Sets errno on failure.
      */
     int32_t Stat(const char* path, FileStats* output);
+
+    /**
+    * Get file stats from a full path. Implemented as shim to lstat(2).
+    *
+    * Returns 0 for success, -1 for failure. Sets errno on failure.
+    */
+    int32_t LStat(const char* path, FileStats* output);
 }
 

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -66,6 +66,12 @@
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Errors.cs">
       <Link>Common\Interop\Linux\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.poll.cs">
+      <Link>Common\Interop\Unix\Interop.poll.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.IO.Native\Interop.NativeIO.cs">
+      <Link>Common\Interop\Unix\Interop.NativeIO.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="System\IO\FileSystemWatcher.OSX.cs" />

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -229,7 +229,7 @@ namespace System.IO
             FSEventStreamEventId[] eventIds)
         {
             Debug.Assert((numEvents.ToInt32() == eventPaths.Length) && (numEvents.ToInt32() == eventFlags.Length) && (numEvents.ToInt32() == eventIds.Length));
-            
+
             // Since renames come in pairs, when we find the first we need to search for the next one. Once we find it, we'll add it to this
             // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.
             List<FSEventStreamEventId> handledRenameEvents = null;
@@ -310,19 +310,21 @@ namespace System.IO
                     }
                     else
                     {
-                        // Note: we keep the same order (Create, delete, modify) as *nix but since OS X does some coalescing on it's own, we need to
-                        //       fire multiple events for the same item (potentially).
-                        if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated))
+                        // OS X is wonky where it can give back kFSEventStreamEventFlagItemCreated and kFSEventStreamEventFlagItemRemoved
+                        // for the same item. The only option we have is to stat and see if the item exists; if so send created, otherwise send deleted.
+                        if ((IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated)) ||
+                            (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved)))
                         {
-                            // Next look for creates since a create + modification coalesced could confuse apps since a file they haven't heard of yet would get a mod event
-                            NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
+                            if (DoesItemExist(eventPaths[i], IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)))
+                            {
+                                NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
+                            }
+                            else
+                            {
+                                NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
+                            }
                         }
-                        
-                        if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved))
-                        {
-                            NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
-                        }
-                        
+
                         if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemInodeMetaMod) ||
                             IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemModified) ||
                             IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemFinderInfoMod) ||

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
@@ -118,4 +118,142 @@ public partial class FileSystemWatcher_4000_Tests
         },
         NotifyFilters.DirectoryName | NotifyFilters.LastAccess | NotifyFilters.FileName);
     }
+
+    [Fact]
+    public static void FileSystemWatcher_Changed_FileDataChange()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+
+            // Attach the FSW to the existing structure
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.Size;
+
+            using (var file = File.Create(Path.Combine(dir.Path, "testfile.txt")))
+            {
+                watcher.EnableRaisingEvents = true;
+
+                // Change the nested file and verify we get the changed event
+                byte[] bt = new byte[4096];
+                file.Write(bt, 0, bt.Length);
+                file.Flush();
+            }
+
+            Utility.ExpectEvent(eventOccured, "file changed");
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void FileSystemWatcher_Changed_PreSeededNestedStructure(bool includeSubdirectories)
+    {
+        // Make a nested structure before the FSW is setup
+        using (var dir = Utility.CreateTestDirectory())
+        using (var watcher = new FileSystemWatcher())
+        using (var dir1 = Utility.CreateTestDirectory(Path.Combine(dir.Path, "dir1")))
+        using (var dir2 = Utility.CreateTestDirectory(Path.Combine(dir1.Path, "dir2")))
+        using (var dir3 = Utility.CreateTestDirectory(Path.Combine(dir2.Path, "dir3")))
+        {
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            byte[] bt = new byte[4096];
+
+            using (var file = File.Create(Path.Combine(dir3.Path, "testfile.txt")))
+            {
+                // Attach the FSW to the existing structure
+                watcher.Path = Path.GetFullPath(dir.Path);
+                watcher.Filter = "*";
+                watcher.NotifyFilter = NotifyFilters.Attributes | NotifyFilters.CreationTime | NotifyFilters.DirectoryName | NotifyFilters.FileName | NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.Security | NotifyFilters.Size;
+                watcher.IncludeSubdirectories = includeSubdirectories;
+                watcher.EnableRaisingEvents = true;
+
+                // Change the nested file and verify we get (or do not get, depending on the parameter) the changed event 
+                file.Write(bt, 0, bt.Length);
+                file.Flush();
+            }
+
+            if (includeSubdirectories)
+                Utility.ExpectEvent(eventOccured, "file changed");
+            else
+                Utility.ExpectNoEvent(eventOccured, "file changed");
+
+            // Stop the FSW
+            watcher.EnableRaisingEvents = false;
+
+            using (var file2 = File.Create(Path.Combine(dir3.Path, "testfile2.txt")))
+            {
+                // Start the FSW, write to the file, expect (or don't get, depending on the parameter) to pick up the write
+                watcher.EnableRaisingEvents = true;
+                file2.Write(bt, 0, bt.Length);
+                file2.Flush();
+            }
+
+            if (includeSubdirectories)
+                Utility.ExpectEvent(eventOccured, "second file change");
+            else
+                Utility.ExpectNoEvent(eventOccured, "second file change");
+        }
+    }
+
+    [Fact, ActiveIssue(1477, PlatformID.Windows)]
+    public static void FileSystemWatcher_Changed_SymLinkFileDoesntFireEvent()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent are = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+
+            // Setup the watcher
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.Size;
+
+            using (var file = Utility.CreateTestFile(Path.GetTempFileName()))
+            {
+                Utility.CreateSymLink(file.Path, Path.Combine(dir.Path, "link"), false);
+                watcher.EnableRaisingEvents = true;
+
+                // Changing the temp file should not fire an event through the symlink
+                byte[] bt = new byte[4096];
+                file.Write(bt, 0, bt.Length);
+                file.Flush();
+            }
+
+            Utility.ExpectNoEvent(are, "symlink'd file change");
+        }
+    }
+
+    [Fact, ActiveIssue(1477, PlatformID.Windows)]
+    public static void FileSystemWatcher_Changed_SymLinkFolderDoesntFireEvent()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var tempDir = Utility.CreateTestDirectory(Path.Combine(Path.GetTempPath(), "FooBar")))
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent are = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+
+            // Setup the watcher
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.Size;
+            watcher.IncludeSubdirectories = true;
+
+            using (var file = Utility.CreateTestFile(Path.Combine(tempDir.Path, "test")))
+            {
+                // Create the symlink first
+                Utility.CreateSymLink(tempDir.Path, Path.Combine(dir.Path, "link"), true);
+                watcher.EnableRaisingEvents = true;
+
+                // Changing the temp file should not fire an event through the symlink
+                byte[] bt = new byte[4096];
+                file.Write(bt, 0, bt.Length);
+                file.Flush();
+            }
+
+            Utility.ExpectNoEvent(are, "symlink'd file change");
+        }
+    }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Xunit;
@@ -119,5 +120,93 @@ public partial class FileSystemWatcher_4000_Tests
                 Utility.ExpectEvent(are, "nested file created", 1000 * 30);
             }
         });
+    }
+
+    // This can potentially fail, depending on where the test is run from, due to 
+    // the MAX_PATH limitation. When issue 645 is closed, this shouldn't be a problem
+    [Fact, ActiveIssue(645, PlatformID.Any)]
+    public static void FileSystemWatcher_Created_DeepDirectoryStructure()
+    {
+        // List of created directories
+        List<TemporaryTestDirectory> lst = new List<TemporaryTestDirectory>();
+
+        try
+        {
+            using (var dir = Utility.CreateTestDirectory())
+            using (var watcher = new FileSystemWatcher())
+            {
+                AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+
+                // put everything in our own directory to avoid collisions
+                watcher.Path = Path.GetFullPath(dir.Path);
+                watcher.Filter = "*.*";
+                watcher.IncludeSubdirectories = true;
+                watcher.EnableRaisingEvents = true;
+
+                // Priming directory
+                TemporaryTestDirectory priming = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir"));
+                lst.Add(priming);
+                Utility.ExpectEvent(eventOccured, "priming create");
+
+                // Create a deep directory structure and expect things to work
+                for (int i = 1; i < 20; i++)
+                {
+                    lst.Add(new TemporaryTestDirectory(Path.Combine(lst[i - 1].Path, String.Format("dir{0}", i))));
+                    Utility.ExpectEvent(eventOccured, lst[i].Path + " create");
+                }
+
+                // Put a file at the very bottom and expect it to raise an event
+                using (var file = new TemporaryTestFile(Path.Combine(lst[lst.Count - 1].Path, "temp file")))
+                {
+                    Utility.ExpectEvent(eventOccured, "temp file create");
+                }
+            }
+        }
+        finally
+        {
+            // Cleanup
+            foreach (TemporaryTestDirectory d in lst)
+                d.Dispose();
+        }
+    }
+
+    [Fact, ActiveIssue(1477, PlatformID.Windows)]
+    public static void FileSystemWatcher_Created_WatcherDoesntFollowSymLinkToFile()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var temp = Utility.CreateTestFile(Path.GetTempFileName()))
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+
+            // put everything in our own directory to avoid collisions
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.EnableRaisingEvents = true;
+
+            // Make the symlink in our path (to the temp file) and make sure an event is raised
+            Utility.CreateSymLink(Path.GetFullPath(temp.Path), Path.Combine(dir.Path, Path.GetFileName(temp.Path)), false);
+            Utility.ExpectEvent(eventOccured, "symlink created");
+        }
+    }
+
+    [Fact, ActiveIssue(1477, PlatformID.Windows)]
+    public static void FileSystemWatcher_Created_WatcherDoesntFollowSymLinkToFolder()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var temp = Utility.CreateTestDirectory(Path.Combine(Path.GetTempPath(), "FooBar")))
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+
+            // put everything in our own directory to avoid collisions
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.EnableRaisingEvents = true;
+
+            // Make the symlink in our path (to the temp folder) and make sure an event is raised
+            Utility.CreateSymLink(Path.GetFullPath(temp.Path), Path.Combine(dir.Path, Path.GetFileName(temp.Path)), true);
+            Utility.ExpectEvent(eventOccured, "symlink created");
+        }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
@@ -67,4 +67,152 @@ public partial class FileSystemWatcher_4000_Tests
             Utility.ExpectEvent(are, "renamed");
         });
     }
+
+    [Fact]
+    public static void FileSystemWatcher_Renamed_FileInNestedDirectory()
+    {
+        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Renamed | WatcherChangeTypes.Created, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
+        {
+            using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
+            {
+                Utility.ExpectEvent(are, "file created", Utility.WaitForCreationTimeoutInMs);
+                nestedFile.Move(nestedFile.Path + "_2");
+                Utility.ExpectEvent(are, "renamed");
+            }
+        });
+    }
+
+    [Fact]
+    // Note: Can't use the TestNestedDirectoriesHelper since we need access to the root
+    public static void FileSystemWatcher_Moved_NestedDirectoryRoot()
+    {
+        // Create a test root with our watch dir and a temp directory since, on the default Ubuntu install, the system
+        // temp directory is on a different mount point and Directory.Move does not work across mount points.
+        using (var root = Utility.CreateTestDirectory())
+        using (var dir = Utility.CreateTestDirectory(Path.Combine(root.Path, "test_root")))
+        using (var temp = Utility.CreateTestDirectory(Path.Combine(root.Path, "temp")))
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent deletedOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.IncludeSubdirectories = true;
+            watcher.EnableRaisingEvents = true;
+
+            using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
+            {
+                Utility.ExpectEvent(createdOccured, "dir1 created", Utility.WaitForCreationTimeoutInMs);
+
+                using (var dir2 = new TemporaryTestDirectory(Path.Combine(dir1.Path, "dir2")))
+                {
+                    Utility.ExpectEvent(createdOccured, "dir2 created", Utility.WaitForCreationTimeoutInMs);
+
+                    using (var file = Utility.CreateTestFile(Path.Combine(dir2.Path, "test file"))) { };
+
+                    // Move the directory out of the watched folder and expect that we get a deleted event
+                    string original = dir1.Path;
+                    string target = Path.Combine(temp.Path, Path.GetFileName(dir1.Path));
+                    dir1.Move(target);
+                    Utility.ExpectEvent(deletedOccured, "dir1 moved out");
+
+                    // Move the directory back and expect a created event
+                    dir1.Move(original);
+                    Utility.ExpectEvent(createdOccured, "dir1 moved back");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    // Note: Can't use the TestNestedDirectoriesHelper since we need access to the root
+    public static void FileSystemWatcher_Moved_NestedDirectoryRootWithoutSubdirectoriesFlag()
+    {
+        // Create a test root with our watch dir and a temp directory since, on the default Ubuntu install, the system
+        // temp directory is on a different mount point and Directory.Move does not work across mount points.
+        using (var root = Utility.CreateTestDirectory())
+        using (var dir = Utility.CreateTestDirectory(Path.Combine(root.Path, "test_root")))
+        using (var temp = Utility.CreateTestDirectory(Path.Combine(root.Path, "temp")))
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent deletedOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.IncludeSubdirectories = false;
+            watcher.EnableRaisingEvents = true;
+
+            using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
+            {
+                Utility.ExpectEvent(createdOccured, "dir1 created", Utility.WaitForCreationTimeoutInMs);
+
+                using (var dir2 = new TemporaryTestDirectory(Path.Combine(dir1.Path, "dir2")))
+                {
+                    Utility.ExpectNoEvent(createdOccured, "dir2 created", Utility.WaitForCreationTimeoutInMs);
+
+                    using (var file = Utility.CreateTestFile(Path.Combine(dir2.Path, "test file"))) { };
+
+                    // Move the directory out of the watched folder and expect that we get a deleted event
+                    string original = dir1.Path;
+                    string target = Path.Combine(temp.Path, Path.GetFileName(dir1.Path));
+                    dir1.Move(target);
+                    Utility.ExpectEvent(deletedOccured, "dir1 moved out");
+
+                    // Move the directory back and expect a created event
+                    dir1.Move(original);
+                    Utility.ExpectEvent(createdOccured, "dir1 moved back");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    // Note: Can't use the TestNestedDirectoriesHelper since we need access to the root
+    public static void FileSystemWatcher_Moved_NestedDirectoryTreeMoveFileAndFolder()
+    {
+        using (var root = Utility.CreateTestDirectory())
+        using (var dir = Utility.CreateTestDirectory(Path.Combine(root.Path, "test_root")))
+        using (var temp = Utility.CreateTestDirectory(Path.Combine(root.Path, "temp")))
+        using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
+        using (var watcher = new FileSystemWatcher())
+        {
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted | WatcherChangeTypes.Changed);
+
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.IncludeSubdirectories = true;
+            watcher.EnableRaisingEvents = true;
+
+            string filePath = Path.Combine(dir1.Path, "test_file");
+            using (var file = File.Create(filePath))
+            {
+                // Wait for the file to be created then make a change to validate that we get a change
+                Utility.ExpectEvent(eventOccured, "test file created");
+                byte[] buffer = new byte[4096];
+                file.Write(buffer, 0, buffer.Length);
+                file.Flush();
+            }
+            Utility.ExpectEvent(eventOccured, "test file changed");
+
+            // Move the nested dir out of scope and validate that we get a single deleted event
+            string original = dir1.Path;
+            string target = Path.Combine(temp.Path, "dir1");
+            dir1.Move(target);
+            Utility.ExpectEvent(eventOccured, "nested dir deleted");
+
+            // Move the dir (and child file) back into scope and validate that we get a created event
+            dir1.Move(original);
+            Utility.ExpectEvent(eventOccured, "nested dir created");
+
+            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Write))
+            {
+                byte[] buffer = new byte[4096];
+                fs.Write(buffer, 0, buffer.Length);
+                fs.Flush();
+            }
+            Utility.ExpectEvent(eventOccured, "test file changed");
+        }
+    }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
@@ -6,13 +6,21 @@ using System.IO;
 using System.Threading;
 using System.Runtime.CompilerServices;
 using Xunit;
+using System.Runtime.InteropServices;
 
 public static class Utility
 {
+    // These pinvokes are used only for tests and not by the src
+    [DllImport("Kernel32.dll", EntryPoint = "CreateSymbolicLinkW", SetLastError = true)]
+    private static extern byte CreateSymbolicLink(string linkName, string targetFileName, int flags);
+    [DllImport("libc", SetLastError = true)]
+    private static extern int symlink(string oldPath, string newPath);
+
     // events are reported asynchronously by the OS, so allow an amount of time for
     // them to arrive before testing an assertion.
     public const int Timeout = 500;
     public const int WaitForCreationTimeoutInMs = 1000 * 30;
+    private const int SYMBOLIC_LINK_FLAG_DIRECTORY = 0x1;
 
     public static TemporaryTestFile CreateTestFile([CallerMemberName] string path = null)
     {
@@ -129,6 +137,20 @@ public static class Utility
                     action(eventOccured, nestedDir);
                 }
             }
+        }
+    }
+
+    public static void CreateSymLink(String sourceItem, String symlinkPath, bool isDirectory)
+    {
+        if (global::Interop.IsWindows)
+        {
+            Assert.True(CreateSymbolicLink(sourceItem, symlinkPath, (isDirectory ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0)) > 0,
+                        String.Format("Failed to create symlink with {0}", Marshal.GetLastWin32Error()));
+        }
+        else
+        {
+            Assert.True(symlink(sourceItem, symlinkPath) == 0,
+                        String.Format("Failed to create symlink with {0}", Marshal.GetLastWin32Error()));
         }
     }
 }


### PR DESCRIPTION
Adding new Unit Tests to validate the more complex FileSystemWatcher scenarios: symlinks, deep directory structures, and preseeded directories.