### PR TITLE
Modified the Unix implementation of FileMove and fixed the corresponding broken FileSystemWatcher tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -99,9 +99,6 @@ public partial class FileSystemWatcher_4000_Tests
                 testFile.WriteByte(0xFF);
                 testFile.Flush();
 
-                // rename a file in the same directory
-                testFile.Move(testFile.Path + "_rename");
-
                 // renaming a directory
                 testDir.Move(testDir.Path + "_rename");
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
@@ -45,7 +45,6 @@ public partial class FileSystemWatcher_4000_Tests
         }
     }
 
-
     [Fact]
     public static void FileSystemWatcher_Deleted_Negative()
     {
@@ -69,9 +68,6 @@ public partial class FileSystemWatcher_4000_Tests
                 // change a file
                 testFile.WriteByte(0xFF);
                 testFile.Flush();
-
-                // rename a file in the same directory
-                testFile.Move(testFile.Path + "_rename");
 
                 // renaming a directory
                 testDir.Move(testDir.Path + "_rename");

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MoveFile.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MoveFile.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+public partial class FileSystemWatcher_4000_Tests
+{
+    #region WindowsTests
+
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, false)]
+    [InlineData(WatcherChangeTypes.Deleted, false)]
+    [InlineData(WatcherChangeTypes.Renamed, true)]
+    [PlatformSpecific(PlatformID.Windows)]
+    public static void Windows_File_Move_To_Same_Directory_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_SameDirectory(eventType, moveRaisesEvent);
+    }
+
+    [Theory]
+    [OuterLoop]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, false)]
+    [InlineData(WatcherChangeTypes.Deleted, false)]
+    [InlineData(WatcherChangeTypes.Renamed, true)]
+    [PlatformSpecific(PlatformID.Windows)]
+    public static void Windows_File_Move_To_Different_Directory_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_DifferentDirectory(eventType, moveRaisesEvent);
+    }
+
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed, true)]
+    [InlineData(WatcherChangeTypes.Created, true)]
+    [InlineData(WatcherChangeTypes.Deleted, false)]
+    [InlineData(WatcherChangeTypes.Renamed, true)]
+    [PlatformSpecific(PlatformID.Windows)]
+    public static void Windows_File_Move_In_Nested_Directory_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_NestedDirectory(eventType, moveRaisesEvent);
+    }
+
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, false)]
+    [InlineData(WatcherChangeTypes.Deleted, false)]
+    [InlineData(WatcherChangeTypes.Renamed, true)]
+    [PlatformSpecific(PlatformID.Windows)]
+    public static void Windows_File_Move_With_Set_NotifyFilter_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_WithNotifyFilter(eventType, moveRaisesEvent);
+    }
+
+    #endregion
+
+    #region UnixTests
+
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, true)]
+    [InlineData(WatcherChangeTypes.Deleted, true)]
+    [InlineData(WatcherChangeTypes.Renamed, false)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public static void Unix_File_Move_To_Same_Directory_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_SameDirectory(eventType, moveRaisesEvent);
+    }
+
+    [Theory]
+    [OuterLoop]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, true)]
+    [InlineData(WatcherChangeTypes.Deleted, true)]
+    [InlineData(WatcherChangeTypes.Renamed, false)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public static void Unix_File_Move_To_Different_Directory_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_DifferentDirectory(eventType, moveRaisesEvent);
+
+    }
+
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, true)]
+    [InlineData(WatcherChangeTypes.Deleted, true)]
+    [InlineData(WatcherChangeTypes.Renamed, false)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public static void Unix_File_Move_In_Nested_Directory_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_NestedDirectory(eventType, moveRaisesEvent);
+    }
+
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed, false)]
+    [InlineData(WatcherChangeTypes.Created, false)]
+    [InlineData(WatcherChangeTypes.Deleted, true)]
+    [InlineData(WatcherChangeTypes.Renamed, false)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public static void Unix_File_Move_With_Set_NotifyFilter_Triggers_Event(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        MoveAndCheck_WithNotifyFilter(eventType, moveRaisesEvent);
+    }
+
+    #endregion
+
+    #region TestHelpers
+
+    /// <summary>
+    /// Sets up watchers for the type given before performing a File.Move operation and checking for
+    /// events. If moveRaisesEvent is true, we make sure that the given event type is observed. If false,
+    /// we ensure that it is not observed.
+    /// 
+    /// This test will move the source file to a destination file in the same directory i.e. rename it
+    /// </summary>
+    private static void MoveAndCheck_SameDirectory(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        using (var dir = Utility.CreateTestDirectory(Guid.NewGuid().ToString()))
+        using (var watcher = new FileSystemWatcher())
+        {
+            // put everything in our own directory to avoid collisions
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*.*";
+
+            // create a file
+            using (var testFile = new TemporaryTestFile(Path.Combine(dir.Path, "file")))
+            {
+                watcher.EnableRaisingEvents = true;
+                AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, eventType);
+
+                // Move the testFile to a different name in the same directory
+                testFile.Move(testFile.Path + "_" + eventType.ToString());
+
+                // Test that the event is observed or not observed
+                if (moveRaisesEvent)
+                    Utility.ExpectEvent(eventOccured, eventType.ToString());
+                else
+                    Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets up watchers for the type given before performing a File.Move operation and checking for
+    /// events. If moveRaisesEvent is true, we make sure that the given event type is observed. If false,
+    /// we ensure that it is not observed.
+    /// 
+    /// This test checks for when the file being moved has a destination directory that is outside of
+    /// the path of the FileSystemWatcher.
+    /// </summary>
+    private static void MoveAndCheck_DifferentDirectory(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        using (var dir = Utility.CreateTestDirectory(Guid.NewGuid().ToString()))
+        using (var dir_unwatched = new TemporaryTestDirectory(Path.GetRandomFileName()))
+        using (var watcher = new FileSystemWatcher())
+        {
+            // put everything in our own directory to avoid collisions
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*.*";
+
+            // create a file
+            using (var testFile = new TemporaryTestFile(Path.Combine(dir.Path, "file")))
+            {
+                watcher.EnableRaisingEvents = true;
+                AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, eventType);
+
+                // Move the testFile to a different name in the same directory
+                testFile.Move(Path.Combine(dir_unwatched.Path, testFile.Name + "_" + eventType.ToString()));
+
+                // Test which events are thrown
+                if (moveRaisesEvent)
+                    Utility.ExpectEvent(eventOccured, eventType.ToString());
+                else
+                    Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets up watchers for the type given before performing a File.Move operation and checking for
+    /// events. If moveRaisesEvent is true, we make sure that the given event type is observed. If false,
+    /// we ensure that it is not observed.
+    /// 
+    /// This test will move the source file of a file within a nested directory
+    /// </summary>
+    private static void MoveAndCheck_NestedDirectory(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        Utility.TestNestedDirectoriesHelper(eventType, (AutoResetEvent eventOccured, TemporaryTestDirectory ttd) =>
+        {
+            using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile" + eventType.ToString())))
+            {
+                nestedFile.Move(nestedFile.Path + "_2");
+                if (moveRaisesEvent)
+                    Utility.ExpectEvent(eventOccured, eventType.ToString());
+                else
+                    Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+            }
+        });
+    }
+
+    /// <summary>
+    /// Sets up watchers for the type given before performing a File.Move operation and checking for
+    /// events. If moveRaisesEvent is true, we make sure that the given event type is observed. If false,
+    /// we ensure that it is not observed.
+    /// 
+    /// This test will use the NotifyFilter attribute of the FileSystemWatcher before the move and subsequent
+    /// checks are made.
+    /// </summary>
+    private static void MoveAndCheck_WithNotifyFilter(WatcherChangeTypes eventType, bool moveRaisesEvent)
+    {
+        using (var file = Utility.CreateTestFile(Guid.NewGuid().ToString()))
+        using (var watcher = new FileSystemWatcher("."))
+        {
+            watcher.NotifyFilter = NotifyFilters.FileName;
+            watcher.Filter = Path.GetFileName(file.Path);
+            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, eventType);
+
+            string newName = file.Path + "_" + eventType.ToString();
+            Utility.EnsureDelete(newName);
+
+            watcher.EnableRaisingEvents = true;
+
+            file.Move(newName);
+
+            if (moveRaisesEvent)
+                Utility.ExpectEvent(eventOccured, eventType.ToString());
+            else
+                Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+        }
+    }
+
+    #endregion
+}

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.NotifyFilter.cs
@@ -72,26 +72,6 @@ public partial class FileSystemWatcher_4000_Tests
         }
     }
 
-    [Fact]
-    public static void FileSystemWatcher_NotifyFilter_FileName()
-    {
-        using (var file = Utility.CreateTestFile())
-        using (var watcher = new FileSystemWatcher("."))
-        {
-            watcher.NotifyFilter = NotifyFilters.FileName;
-            watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
-
-            string newName = file.Path + "_rename";
-            Utility.EnsureDelete(newName);
-
-            watcher.EnableRaisingEvents = true;
-
-            file.Move(newName);
-
-            Utility.ExpectEvent(eventOccured, "changed");
-        }
-    }
 
     [Fact]
     [ActiveIssue(2011, PlatformID.OSX)]
@@ -253,13 +233,6 @@ public partial class FileSystemWatcher_4000_Tests
 
             // None of these should trigger any events
             Utility.ExpectNoEvent(eventOccured, "any");
-
-            // finally, change name and expect a name change
-            eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
-
-            file.Move(newName);
-
-            Utility.ExpectEvent(eventOccured, "changed");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
@@ -8,27 +8,6 @@ using Xunit;
 public partial class FileSystemWatcher_4000_Tests
 {
     [Fact]
-    public static void FileSystemWatcher_Renamed_File()
-    {
-        using (var file = Utility.CreateTestFile())
-        using (var watcher = new FileSystemWatcher("."))
-        {
-            watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
-
-            string newName = file.Path + "_rename";
-            Utility.EnsureDelete(newName);
-
-            watcher.EnableRaisingEvents = true;
-
-            file.Move(newName);
-
-            Utility.ExpectEvent(eventOccured, "renamed");
-        }
-    }
-
-
-    [Fact]
     public static void FileSystemWatcher_Renamed_Directory()
     {
         using (var dir = Utility.CreateTestDirectory())
@@ -86,19 +65,6 @@ public partial class FileSystemWatcher_4000_Tests
         {
             ttd.Move(ttd.Path + "_2");
             Utility.ExpectEvent(are, "renamed");
-        });
-    }
-
-    [Fact]
-    public static void FileSystemWatcher_Renamed_FileInNestedDirectory()
-    {
-        Utility.TestNestedDirectoriesHelper(WatcherChangeTypes.Renamed, (AutoResetEvent are, TemporaryTestDirectory ttd) =>
-        {
-            using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
-            {
-                nestedFile.Move(nestedFile.Path + "_2");
-                Utility.ExpectEvent(are, "renamed");
-            }
         });
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="FileSystemWatcher.InternalBufferSize.cs" />
     <Compile Include="FileSystemWatcher.NotifyFilter.cs" />
     <Compile Include="FileSystemWatcher.Renamed.cs" />
+    <Compile Include="FileSystemWatcher.MoveFile.cs" />
     <Compile Include="Utility\TemporaryTestDirectory.cs" />
     <Compile Include="Utility\TemporaryTestFile.cs" />
     <Compile Include="Utility\TestFileSystemWatcher.cs" />

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
@@ -106,7 +106,7 @@ public static class Utility
         Action<AutoResetEvent, TemporaryTestDirectory> action,
         NotifyFilters changeFilers = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName)
     {
-        using (var dir = Utility.CreateTestDirectory())
+        using (var dir = Utility.CreateTestDirectory(Guid.NewGuid().ToString()))
         using (var watcher = new FileSystemWatcher())
         {
             AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -54,13 +54,9 @@ namespace System.IO
         {
             // The desired behavior for Move(source, dest) is to not overwrite the destination file
             // if it exists. Since rename(source, dest) will replace the file at 'dest' if it exists,
-            // a check is added before rename is called. Note that this is a race condition. Possible
-            // better solutions would be to use link/unlink or platform specific functions instead of
-            // rename(source, dest). Regardless of the implementation, an IOException should be thrown if 
-            // 'dest' refers to a file that already exists.
-            if (File.Exists(destFullPath))
-                throw new IOException(SR.GetResourceString(SR.IO_AlreadyExists_Name, destFullPath));
-            while (Interop.libc.rename(sourceFullPath, destFullPath) < 0)
+            // link/unlink are used instead. Note that the Unix FileSystemWatcher will treat a Move 
+            // as a Creation and Deletion instead of a Rename and thus differ from Windows.
+            while (Interop.libc.link(sourceFullPath, destFullPath) < 0)
             {
                 int errno = Marshal.GetLastWin32Error();
                 if (errno == Interop.Errors.EINTR) // interrupted; try again
@@ -72,7 +68,6 @@ namespace System.IO
                     CopyFile(sourceFullPath, destFullPath, overwrite: false);
                     break;
                 }
-                //else if (errno == Interop.Errors.ENOENT && (!Directory.Exists(Path.GetDirectoryName(sourceFullPath)) || !Directory.Exists(Path.GetDirectoryName(destFullPath)))) // The parent directory for either source or dest can't be found
                 else if (errno == Interop.Errors.ENOENT && !Directory.Exists(Path.GetDirectoryName(destFullPath))) // The parent directory of destFile can't be found
                 {
                     // Windows distinguishes between whether the directory or the file isn't found,
@@ -89,6 +84,7 @@ namespace System.IO
                     throw Interop.GetExceptionForIoErrno(errno);
                 }
             }
+            DeleteFile(sourceFullPath);
         }
 
         public override void DeleteFile(string fullPath)


### PR DESCRIPTION
- Resolves #2460 
- Changed the way the UnixFileSystem does File moving; it was previously implemented using the rename syscall but now uses a combination of link and unlink. The side effect of this change is that the FileSystemWatcher will now treat File.Move as a deletion.
- Removed all tests from FileSystemWatcher that made calls to File.Move and consolidated them into a new file: FileSystemWatcher.MoveFile.cs. This new file separates tests into Windows and Unix categories and uses Theories to supply the input WatcherChangeType and whether a move should trigger an event for the given type. If we later decide to change the Unix behavior of MoveFile, changing the FileSystemWatcher tests will be a simple matter of flipping the boolean values for the affected tests.