### PR TITLE
Added Some Async Methods in XmlBaseWriter Required by WCF.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -597,6 +597,9 @@
   <data name="XmlArrayTooSmallOutput" xml:space="preserve">
     <value>Array too small.  Must be able to hold at least {0}.</value>
   </data>
+  <data name="XmlAsyncIsRunningException" xml:space="preserve">
+    <value>An asynchronous operation is already in progress.</value>
+  </data>
   <data name="XmlInvalidBase64Length" xml:space="preserve">
     <value>Base64 sequence length ({0}) not valid. Must be a multiple of 4.</value>
   </data>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -77,6 +77,8 @@
     <Compile Include="$(RuntimeSerializationSources)\XmlObjectSerializerWriteContextComplex.cs" Condition="$(NetNative) Or $(MergeDcjs)" />
     <Compile Include="$(RuntimeSerializationSources)\BitFlagsGenerator.cs" Condition="!$(NetNative) And $(MergeDcjs)" />
     <Compile Include="$(XmlSources)\ArrayHelper.cs" />
+    <Compile Include="$(XmlSources)\BytesWithOffset.cs" />
+    <Compile Include="$(XmlSources)\XmlDictionaryAsyncCheckWriter.cs" />
     <Compile Include="$(XmlSources)\IStreamProvider.cs" />
     <Compile Include="$(XmlSources)\IXmlDictionary.cs" />
     <Compile Include="$(XmlSources)\PrefixHandle.cs" />

--- a/src/System.Private.DataContractSerialization/src/System/Xml/BytesWithOffset.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/BytesWithOffset.cs
@@ -1,0 +1,30 @@
+﻿namespace System.Xml
+{
+    internal struct BytesWithOffset
+    {
+        private readonly byte[] _bytes;
+        private readonly int _offset;
+
+        public BytesWithOffset(byte[] bytes, int offset)
+        {
+            _bytes = bytes;
+            _offset = offset;
+        }
+
+        public byte[] Bytes
+        {
+            get
+            {
+                return _bytes;
+            }
+        }
+
+        public int Offset
+        {
+            get
+            {
+                return _offset;
+            }
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
@@ -1,0 +1,695 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Xml
+{
+    internal class XmlDictionaryAsyncCheckWriter : XmlDictionaryWriter
+    {
+        private readonly XmlDictionaryWriter _coreWriter = null;
+        private Task _lastTask;
+
+        public XmlDictionaryAsyncCheckWriter(XmlDictionaryWriter writer)
+        {
+            _coreWriter = writer;
+        }
+
+        internal XmlDictionaryWriter CoreWriter
+        {
+            get
+            {
+                return _coreWriter;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CheckAsync()
+        {
+            if (_lastTask != null && !_lastTask.IsCompleted)
+            {
+                throw new InvalidOperationException(SR.XmlAsyncIsRunningException);
+            }
+        }
+
+        private Task SetLastTask(Task task)
+        {
+            _lastTask = task;
+            return task;
+        }
+
+        public override XmlWriterSettings Settings
+        {
+            get
+            {
+                CheckAsync();
+                return CoreWriter.Settings;
+            }
+        }
+
+        public override WriteState WriteState
+        {
+            get
+            {
+                CheckAsync();
+                return CoreWriter.WriteState;
+            }
+        }
+
+        public override string XmlLang
+        {
+            get
+            {
+                CheckAsync();
+                return CoreWriter.XmlLang;
+            }
+        }
+
+        public override XmlSpace XmlSpace
+        {
+            get
+            {
+                CheckAsync();
+                return CoreWriter.XmlSpace;
+            }
+        }
+
+        public override void Flush()
+        {
+            CheckAsync();
+            CoreWriter.Flush();
+        }
+
+        public override Task FlushAsync()
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.FlushAsync());
+        }
+
+        public override string LookupPrefix(string ns)
+        {
+            CheckAsync();
+            return CoreWriter.LookupPrefix(ns);
+        }
+
+        public override void WriteAttributes(XmlReader reader, bool defattr)
+        {
+            CheckAsync();
+            CoreWriter.WriteAttributes(reader, defattr);
+        }
+
+        public override Task WriteAttributesAsync(XmlReader reader, bool defattr)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteAttributesAsync(reader, defattr));
+        }
+
+        public override void WriteBase64(byte[] buffer, int index, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteBase64(buffer, index, count);
+        }
+
+        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteBase64Async(buffer, index, count));
+        }
+
+        public override void WriteBinHex(byte[] buffer, int index, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteBinHex(buffer, index, count);
+        }
+
+        public override Task WriteBinHexAsync(byte[] buffer, int index, int count)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteBinHexAsync(buffer, index, count));
+        }
+
+        public override void WriteCData(string text)
+        {
+            CheckAsync();
+            CoreWriter.WriteCData(text);
+        }
+
+        public override Task WriteCDataAsync(string text)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteCDataAsync(text));
+        }
+
+        public override void WriteCharEntity(char ch)
+        {
+            CheckAsync();
+            CoreWriter.WriteCharEntity(ch);
+        }
+
+        public override Task WriteCharEntityAsync(char ch)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteCharEntityAsync(ch));
+        }
+
+        public override void WriteChars(char[] buffer, int index, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteChars(buffer, index, count);
+        }
+
+        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteCharsAsync(buffer, index, count));
+        }
+
+        public override void WriteComment(string text)
+        {
+            CheckAsync();
+            CoreWriter.WriteComment(text);
+        }
+
+        public override Task WriteCommentAsync(string text)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteCommentAsync(text));
+        }
+
+        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        {
+            CheckAsync();
+            CoreWriter.WriteDocType(name, pubid, sysid, subset);
+        }
+
+        public override Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteDocTypeAsync(name, pubid, sysid, subset));
+        }
+
+        public override void WriteEndAttribute()
+        {
+            CheckAsync();
+            CoreWriter.WriteEndAttribute();
+        }
+
+        public override void WriteEndDocument()
+        {
+            CheckAsync();
+            CoreWriter.WriteEndDocument();
+        }
+
+        public override Task WriteEndDocumentAsync()
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteEndDocumentAsync());
+        }
+
+        public override void WriteEndElement()
+        {
+            CheckAsync();
+            CoreWriter.WriteEndElement();
+        }
+
+        public override Task WriteEndElementAsync()
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteEndElementAsync());
+        }
+
+        public override void WriteEntityRef(string name)
+        {
+            CheckAsync();
+            CoreWriter.WriteEntityRef(name);
+        }
+
+        public override Task WriteEntityRefAsync(string name)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteEntityRefAsync(name));
+        }
+
+        public override void WriteFullEndElement()
+        {
+            CheckAsync();
+            CoreWriter.WriteFullEndElement();
+        }
+
+        public override Task WriteFullEndElementAsync()
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteFullEndElementAsync());
+        }
+
+        public override void WriteName(string name)
+        {
+            CheckAsync();
+            CoreWriter.WriteName(name);
+        }
+
+        public override Task WriteNameAsync(string name)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteNameAsync(name));
+        }
+
+        public override void WriteNmToken(string name)
+        {
+            CheckAsync();
+            CoreWriter.WriteNmToken(name);
+        }
+
+        public override Task WriteNmTokenAsync(string name)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteNmTokenAsync(name));
+        }
+
+        public override void WriteNode(XmlReader reader, bool defattr)
+        {
+            CheckAsync();
+            CoreWriter.WriteNode(reader, defattr);
+        }
+
+        public override Task WriteNodeAsync(XmlReader reader, bool defattr)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteNodeAsync(reader, defattr));
+        }
+
+        public override void WriteProcessingInstruction(string name, string text)
+        {
+            CheckAsync();
+            CoreWriter.WriteProcessingInstruction(name, text);
+        }
+
+        public override Task WriteProcessingInstructionAsync(string name, string text)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteProcessingInstructionAsync(name, text));
+        }
+
+        public override void WriteQualifiedName(string localName, string ns)
+        {
+            CheckAsync();
+            CoreWriter.WriteQualifiedName(localName, ns);
+        }
+
+        public override Task WriteQualifiedNameAsync(string localName, string ns)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteQualifiedNameAsync(localName, ns));
+        }
+
+        public override void WriteRaw(string data)
+        {
+            CheckAsync();
+            CoreWriter.WriteRaw(data);
+        }
+
+        public override void WriteRaw(char[] buffer, int index, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteRaw(buffer, index, count);
+        }
+
+        public override Task WriteRawAsync(string data)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteRawAsync(data));
+        }
+
+        public override Task WriteRawAsync(char[] buffer, int index, int count)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteRawAsync(buffer, index, count));
+        }
+
+        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        {
+            CheckAsync();
+            CoreWriter.WriteStartAttribute(prefix, localName, ns);
+        }
+
+        public override void WriteStartDocument()
+        {
+            CheckAsync();
+            CoreWriter.WriteStartDocument();
+        }
+
+        public override void WriteStartDocument(bool standalone)
+        {
+            CheckAsync();
+            CoreWriter.WriteStartDocument(standalone);
+        }
+
+        public override Task WriteStartDocumentAsync()
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteStartDocumentAsync());
+        }
+
+        public override Task WriteStartDocumentAsync(bool standalone)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteStartDocumentAsync(standalone));
+        }
+
+        public override void WriteStartElement(string prefix, string localName, string ns)
+        {
+            CheckAsync();
+            CoreWriter.WriteStartElement(prefix, localName, ns);
+        }
+
+        public override Task WriteStartElementAsync(string prefix, string localName, string ns)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteStartElementAsync(prefix, localName, ns));
+        }
+
+        public override void WriteString(string text)
+        {
+            CheckAsync();
+            CoreWriter.WriteString(text);
+        }
+
+        public override Task WriteStringAsync(string text)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteStringAsync(text));
+        }
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar)
+        {
+            CheckAsync();
+            CoreWriter.WriteSurrogateCharEntity(lowChar, highChar);
+        }
+
+        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteSurrogateCharEntityAsync(lowChar, highChar));
+        }
+
+        public override void WriteValue(string value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(double value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(int value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(long value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(object value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(float value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(decimal value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(DateTimeOffset value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(bool value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteWhitespace(string ws)
+        {
+            CheckAsync();
+            CoreWriter.WriteWhitespace(ws);
+        }
+
+        public override Task WriteWhitespaceAsync(string ws)
+        {
+            CheckAsync();
+            return SetLastTask(CoreWriter.WriteWhitespaceAsync(ws));
+        }
+
+        public override void WriteStartElement(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri)
+        {
+            CheckAsync();
+            CoreWriter.WriteStartElement(prefix, localName, namespaceUri);
+        }
+
+        public override void WriteStartAttribute(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri)
+        {
+            CheckAsync();
+            CoreWriter.WriteStartAttribute(prefix, localName, namespaceUri);
+        }
+
+        public override void WriteXmlnsAttribute(string prefix, string namespaceUri)
+        {
+            CheckAsync();
+            CoreWriter.WriteXmlnsAttribute(prefix, namespaceUri);
+        }
+
+        public override void WriteXmlnsAttribute(string prefix, XmlDictionaryString namespaceUri)
+        {
+            CheckAsync();
+            CoreWriter.WriteXmlnsAttribute(prefix, namespaceUri);
+        }
+
+        public override void WriteXmlAttribute(string localName, string value)
+        {
+            CheckAsync();
+            CoreWriter.WriteXmlAttribute(localName, value);
+        }
+
+        public override void WriteXmlAttribute(XmlDictionaryString localName, XmlDictionaryString value)
+        {
+            CheckAsync();
+            CoreWriter.WriteXmlAttribute(localName, value);
+        }
+
+        public override void WriteString(XmlDictionaryString value)
+        {
+            CheckAsync();
+            CoreWriter.WriteString(value);
+        }
+
+        public override void WriteQualifiedName(XmlDictionaryString localName, XmlDictionaryString namespaceUri)
+        {
+            CheckAsync();
+            CoreWriter.WriteQualifiedName(localName, namespaceUri);
+        }
+
+        public override void WriteValue(XmlDictionaryString value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(UniqueId value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(Guid value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override void WriteValue(TimeSpan value)
+        {
+            CheckAsync();
+            CoreWriter.WriteValue(value);
+        }
+
+        public override bool CanCanonicalize
+        {
+            get
+            {
+                CheckAsync();
+                return CoreWriter.CanCanonicalize;
+            }
+        }
+
+        public override void StartCanonicalization(Stream stream, bool includeComments, string[] inclusivePrefixes)
+        {
+            CheckAsync();
+            CoreWriter.StartCanonicalization(stream, includeComments, inclusivePrefixes);
+        }
+
+        public override void EndCanonicalization()
+        {
+            CheckAsync();
+            CoreWriter.EndCanonicalization();
+        }
+
+        public override void WriteNode(XmlDictionaryReader reader, bool defattr)
+        {
+            CheckAsync();
+            CoreWriter.WriteNode(reader, defattr);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, bool[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, bool[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, Int16[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int16[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, Int32[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int32[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, Int64[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int64[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, float[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, float[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, double[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, double[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, decimal[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, decimal[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, DateTime[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, DateTime[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, Guid[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Guid[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, string localName, string namespaceUri, TimeSpan[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, TimeSpan[] array, int offset, int count)
+        {
+            CheckAsync();
+            CoreWriter.WriteArray(prefix, localName, namespaceUri, array, offset, count);
+        }
+
+        public override void Close()
+        {
+            CheckAsync();
+            CoreWriter.Close();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            CheckAsync();
+            CoreWriter.Dispose();
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -57,7 +57,8 @@ namespace System.Xml
 #if NET_NATIVE || MERGE_DCJS
             XmlUTF8TextWriter writer = new XmlUTF8TextWriter();
             writer.SetOutput(stream, encoding, ownsStream);
-            return writer;
+            var asyncWriter = new XmlDictionaryAsyncCheckWriter(writer);
+            return asyncWriter;
 #else
             XmlWriterSettings settings = new XmlWriterSettings();
             if (s_UTF8Encoding.WebName == encoding.WebName)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlNodeWriter.cs
@@ -10,25 +10,41 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
-
+using System.Threading.Tasks;
 
 namespace System.Xml
 {
     internal abstract class XmlNodeWriter
     {
         public abstract void Flush();
+        public virtual Task FlushAsync()
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
+        }
         public abstract void Close();
         public abstract void WriteDeclaration();
         public abstract void WriteComment(string text);
         public abstract void WriteCData(string text);
         public abstract void WriteStartElement(string prefix, string localName);
+        public virtual Task WriteStartElementAsync(string prefix, string localName)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
+        }
         public virtual void WriteStartElement(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength)
         {
             WriteStartElement(Encoding.UTF8.GetString(prefixBuffer, prefixOffset, prefixLength), Encoding.UTF8.GetString(localNameBuffer, localNameOffset, localNameLength));
         }
         public abstract void WriteStartElement(string prefix, XmlDictionaryString localName);
         public abstract void WriteEndStartElement(bool isEmpty);
+        public virtual Task WriteEndStartElementAsync(bool isEmpty)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
+        }
         public abstract void WriteEndElement(string prefix, string localName);
+        public virtual Task WriteEndElementAsync(string prefix, string localName)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
+        }
         public virtual void WriteEndElement(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength)
         {
             WriteEndElement(Encoding.UTF8.GetString(prefixBuffer, prefixOffset, prefixLength), Encoding.UTF8.GetString(localNameBuffer, localNameOffset, localNameLength));
@@ -46,6 +62,10 @@ namespace System.Xml
         }
         public abstract void WriteStartAttribute(string prefix, XmlDictionaryString localName);
         public abstract void WriteEndAttribute();
+        public virtual Task WriteEndAttributeAsync()
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
+        }
         public abstract void WriteCharEntity(int ch);
         public abstract void WriteEscapedText(string value);
         public abstract void WriteEscapedText(XmlDictionaryString value);
@@ -70,6 +90,10 @@ namespace System.Xml
         public abstract void WriteListSeparator();
         public abstract void WriteEndListText();
         public abstract void WriteBase64Text(byte[] trailBuffer, int trailCount, byte[] buffer, int offset, int count);
+        public virtual Task WriteBase64TextAsync(byte[] trailBuffer, int trailCount, byte[] buffer, int offset, int count)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
+        }
         public abstract void WriteQualifiedName(string prefix, XmlDictionaryString localName);
     }
 }

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="DataContractSerializer.cs" />
     <Compile Include="DataContractSerializerTestData.cs" />
     <Compile Include="MyResolver.cs" />
+    <Compile Include="XmlDictionaryWriterTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Console.cs">

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+public static class XmlDictionaryWriterTest
+{
+    [Fact]
+    public static void XmlBaseWriter_WriteBase64Async()
+    {
+        string actual;
+        int byteSize = 1024;
+        byte[] bytes = GetByteArray(byteSize);
+        string expect = GetExpectString(bytes, byteSize);
+        using (var ms = new AsyncMemoryStream())
+        {
+            var writer = XmlDictionaryWriter.CreateTextWriter(ms);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("data");
+            var task = writer.WriteBase64Async(bytes, 0, byteSize);
+            task.Wait();
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+            writer.Flush();
+            ms.Position = 0;
+            var sr = new StreamReader(ms);
+            actual = sr.ReadToEnd();
+        }
+
+        Assert.StrictEqual(expect, actual);
+    }
+
+    [Fact]
+    public static void XmlBaseWriter_FlushAsync()
+    {
+        string actual;
+        int byteSize = 1024;
+        byte[] bytes = GetByteArray(byteSize);
+        string expect = GetExpectString(bytes, byteSize);
+        using (var ms = new AsyncMemoryStream())
+        {
+            var writer = XmlDictionaryWriter.CreateTextWriter(ms);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("data");
+            writer.WriteBase64(bytes, 0, byteSize);
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+            var task = writer.FlushAsync();
+            task.Wait();
+            ms.Position = 0;
+            var sr = new StreamReader(ms);
+            actual = sr.ReadToEnd();
+        }
+
+        Assert.StrictEqual(expect, actual);
+    }
+
+    [Fact]
+    public static void XmlBaseWriter_WriteStartEndElementAsync()
+    {
+        string actual;
+        int byteSize = 1024;
+        byte[] bytes = GetByteArray(byteSize);
+        string expect = GetExpectString(bytes, byteSize);
+        using (var ms = new AsyncMemoryStream())
+        {
+            var writer = XmlDictionaryWriter.CreateTextWriter(ms);
+            writer.WriteStartDocument();
+            // NOTE: the async method has only one overload that takes 3 params
+            var t1 = writer.WriteStartElementAsync(null, "data", null);
+            t1.Wait();
+            writer.WriteBase64(bytes, 0, byteSize);
+            var t2 = writer.WriteEndElementAsync();
+            t2.Wait();
+            writer.WriteEndDocument();
+            writer.Flush();
+            ms.Position = 0;
+            var sr = new StreamReader(ms);
+            actual = sr.ReadToEnd();
+        }
+
+        Assert.StrictEqual(expect, actual);
+    }
+
+    [Fact]
+    public static void XmlBaseWriter_CheckAsync_ThrowInvalidOperationException()
+    {
+        int byteSize = 1024;
+        byte[] bytes = GetByteArray(byteSize);
+        using (var ms = new MemoryStreamWithBlockAsync())
+        {
+            var writer = XmlDictionaryWriter.CreateTextWriter(ms);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("data");
+
+            ms.blockAsync(true);
+            var t1 = writer.WriteBase64Async(bytes, 0, byteSize);
+            var t2 = Assert.ThrowsAsync<InvalidOperationException>(() => writer.WriteBase64Async(bytes, 0, byteSize));
+
+            InvalidOperationException e = t2.Result;
+            Assert.StrictEqual(e.Message, "An asynchronous operation is already in progress.");
+
+            // let the first task complete
+            ms.blockAsync(false);
+            t1.Wait();
+        }
+    }
+
+    private static byte[] GetByteArray(int byteSize)
+    {
+        var bytes = new byte[byteSize];
+        for (int i = 0; i < byteSize; i++)
+        {
+            bytes[i] = 8;
+        }
+
+        return bytes;
+    }
+
+    private static string GetExpectString(byte[] bytes, int byteSize)
+    {
+        using (var ms = new MemoryStream())
+        {
+            var writer = XmlDictionaryWriter.CreateTextWriter(ms);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("data");
+            writer.WriteBase64(bytes, 0, byteSize);
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+            writer.Flush();
+            ms.Position = 0;
+            var sr = new StreamReader(ms);
+            return sr.ReadToEnd();
+        }
+
+    }
+
+    public class AsyncMemoryStream : MemoryStream
+    {
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(1).ConfigureAwait(false);
+            await base.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+    }
+
+    public class MemoryStreamWithBlockAsync : MemoryStream
+    {
+        private bool _blockAsync;
+        public void blockAsync(bool blockAsync)
+        {
+            _blockAsync = blockAsync;
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            while (_blockAsync)
+            {
+                await Task.Delay(10).ConfigureAwait(false);
+            }
+
+            await base.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
WCF want to use some of XmlDictionaryWriter's async methods, which were not yet implemented. The PR made these async methods available (in XmlBaseWriter) for WCF to use.

Fixes #2502 
Fixes #2504