### PR TITLE
Fixed AccessTime, WriteTime, and CreationTime to return a DateTime object with properly set DateTimeKind

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -260,7 +260,7 @@ namespace System.IO
         public static DateTime GetCreationTime(String path)
         {
             String fullPath = PathHelpers.GetFullPathInternal(path);
-            return FileSystem.Current.GetCreationTime(fullPath).DateTime;
+            return FileSystem.Current.GetCreationTime(fullPath).LocalDateTime;
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -286,7 +286,7 @@ namespace System.IO
         public static DateTime GetLastAccessTime(String path)
         {
             String fullPath = PathHelpers.GetFullPathInternal(path);
-            return FileSystem.Current.GetLastAccessTime(fullPath).DateTime;
+            return FileSystem.Current.GetLastAccessTime(fullPath).LocalDateTime;
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -312,7 +312,7 @@ namespace System.IO
         public static DateTime GetLastWriteTime(String path)
         {
             String fullPath = PathHelpers.GetFullPathInternal(path);
-            return FileSystem.Current.GetLastWriteTime(fullPath).DateTime;
+            return FileSystem.Current.GetLastWriteTime(fullPath).LocalDateTime;
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystemObject.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystemObject.cs
@@ -193,7 +193,7 @@ namespace System.IO
                 get
                 {
                     EnsureStatInitialized();
-                    return DateTimeOffset.FromUnixTimeSeconds(_fileinfo.atime);
+                    return DateTimeOffset.FromUnixTimeSeconds(_fileinfo.atime).ToLocalTime();
                 }
                 set { SetAccessWriteTimes((IntPtr)value.ToUnixTimeSeconds(), null); }
             }
@@ -203,7 +203,7 @@ namespace System.IO
                 get
                 {
                     EnsureStatInitialized();
-                    return DateTimeOffset.FromUnixTimeSeconds(_fileinfo.mtime);
+                    return DateTimeOffset.FromUnixTimeSeconds(_fileinfo.mtime).ToLocalTime();
                 }
                 set { SetAccessWriteTimes(null, (IntPtr)value.ToUnixTimeSeconds()); }
             }

--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -72,7 +72,10 @@ namespace System.IO.FileSystem.Tests
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testDir.FullName, dt);
-                Assert.Equal(dt, tuple.Item2(testDir.FullName));
+                var result = tuple.Item2(testDir.FullName);
+                Assert.Equal(dt, result);
+                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
+                Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
             });
         }
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -52,7 +52,10 @@ namespace System.IO.FileSystem.Tests
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testDir, dt);
-                Assert.Equal(dt, tuple.Item2(testDir));
+                var result = tuple.Item2(testDir);
+                Assert.Equal(dt, result);
+                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
+                Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
             });
         }
 

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -73,7 +73,10 @@ namespace System.IO.FileSystem.Tests
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testFile.FullName, dt);
-                Assert.Equal(dt, tuple.Item2(testFile.FullName));
+                var result = tuple.Item2(testFile.FullName);
+                Assert.Equal(dt, result);
+                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
+                Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
             });
         }
 

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -53,7 +53,10 @@ namespace System.IO.FileSystem.Tests
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testFile, dt);
-                Assert.Equal(dt, tuple.Item2(testFile));
+                var result = tuple.Item2(testFile);
+                Assert.Equal(dt, result);
+                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
+                Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
             });
         }
 


### PR DESCRIPTION
- The implementations of GetLastAccessTime, GetCreationTime, and GetLastWriteTime were not properly converting the read values to LocalTime for either Windows or Unix.
- Resolves #2603, #2610