### PR TITLE
When building other platforms, skip tests

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -236,6 +236,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Don't run tests if we're building another platform's binaries on Windows -->
+    <SkipTests Condition="'$(SkipTests)'=='' and ('$(OsEnvironment)'=='Windows_NT' and '$(TargetsWindows)'!='true')">true</SkipTests>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Work around known Dev14 bug - see
          https://connect.microsoft.com/VisualStudio/feedback/details/1000796/connect-file-uap-props-not-found-cant-build-a-portable-lib-on-vs14
     -->


### PR DESCRIPTION
When building other platforms on Windows, skip tests.

@weshaggard, @stephentoub