### PR TITLE
Fix casing to unblock Linux native builds

### DIFF
--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.Unit.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.Unit.Tests.csproj
@@ -28,8 +28,8 @@
     <Compile Include="..\..\src\System\Net\CookieContainer.cs" >
       <Link>ProductionCode\System\Net\CookieContainer.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\System\Net\cookiecollection.cs" >
-      <Link>ProductionCode\System\Net\cookiecollection.cs</Link>
+    <Compile Include="..\..\src\System\Net\CookieCollection.cs" >
+      <Link>ProductionCode\System\Net\CookieCollection.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\CookieException.cs" >
       <Link>ProductionCode\System\Net\CookieException.cs</Link>


### PR DESCRIPTION
I had hoped that this was going to be fixed by PR #2591, but that PR appears to be on hold for the moment.  
This change fixes the casing in the proj file so that native Linux builds will pass.