### PR TITLE
Delete 'Assert.None' helper methods

### DIFF
--- a/src/Common/tests/System/Diagnostics/AssertWithCallerAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/AssertWithCallerAttributes.cs
@@ -274,27 +274,6 @@ internal static class Assert
         catch (Exception e) { throw WrapException(e, path, line); }
     }
 
-    public static void None(IEnumerable collection, object expected,
-        [CallerFilePath] string path = null, [CallerLineNumber] int line = 0)
-    {
-        try { Xunit.Assert.DoesNotContain(expected, (IEnumerable<object>)collection); }
-        catch (Exception e) { throw WrapException(e, path, line); }
-    }
-
-    public static void None<T>(IEnumerable<T> collection, Predicate<T> predicate,
-        [CallerFilePath] string path = null, [CallerLineNumber] int line = 0)
-    {
-        try { Xunit.Assert.DoesNotContain(collection, predicate); }
-        catch (Exception e) { throw WrapException(e, path, line); }
-    }
-
-    public static void None<T>(IEnumerable<T> collection, T expected,
-        [CallerFilePath] string path = null, [CallerLineNumber] int line = 0)
-    {
-        try { Xunit.Assert.DoesNotContain(expected, collection); }
-        catch (Exception e) { throw WrapException(e, path, line); }
-    }
-
     public static void NotEmpty(IEnumerable collection,
         [CallerFilePath] string path = null, [CallerLineNumber] int line = 0)
     {


### PR DESCRIPTION
This helper class contains wrappers for all of the assert methods. "None" was removed in the latest version of xUnit because it was identical to "DoesNotContain". To fix our helper code here, I just switched the calls to "DoesNotContain". Instead, it makes more sense to just get rid of the "None" helpers altogether and only wrap "DoesNotContain."

EDIT: I just removed them, all of the "DoesNotcontain" overloads are covered by existing wrappers.