### PR TITLE
Fix UnixFileSystem.MaxDirectoryName to be MaxPath

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -15,7 +14,7 @@ namespace System.IO
     {
         public override int MaxPath { get { return Interop.libc.MaxPath; } }
 
-        public override int MaxDirectoryPath { get { return Interop.libc.MaxName; } }
+        public override int MaxDirectoryPath { get { return Interop.libc.MaxPath; } }
 
         public override FileStreamBase Open(string fullPath, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options, FileStream parent)
         {

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -233,7 +233,6 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
-        [ActiveIssue(645)]
         public void UnixPathLongerThan256_Allowed()
         {
             DirectoryInfo testDir = Create(GetTestFilePath());
@@ -245,11 +244,14 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
-        public void UnixPathLongerThan256_Throws()
+        public void UnixPathWithDeeplyNestedDirectories()
         {
-            DirectoryInfo testDir = Create(GetTestFilePath());
-            PathInfo path = IOServices.GetPath(testDir.FullName, 257, IOInputs.MaxComponent);
-            Assert.Throws<PathTooLongException>(() => Create(path.FullPath));
+            DirectoryInfo parent = Create(GetTestFilePath());
+            for (int i = 1; i <= 100; i++) // 100 == arbitrarily large number of directories
+            {
+                parent = Create(Path.Combine(parent.FullName, "dir" + i));
+                Assert.True(Directory.Exists(parent.FullName));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
UnixFileSystem's override of MaxDirectoryName was assuming the property meant the maximum size of the file name of a directory, i.e. the component length, not the full path length of everything from the beginning of the root.  As a result, checks against MaxDirectoryName, such as in CreateDirectory, were failing incorrectly with longer path lengths.

The fix is just to return MaxPath from MaxDirectoryName; there's no difference on Unix.  I also added a test to cover this case, included a previously excluded test, and deleted a faulty test.

Fixes #2627