### PR TITLE
Remove [PlatformSpecific] from the Windows-only CSP library

### DIFF
--- a/src/System.Security.Cryptography.Csp/tests/ImportExportCspBlob.cs
+++ b/src/System.Security.Cryptography.Csp/tests/ImportExportCspBlob.cs
@@ -9,7 +9,6 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class ImportExportCspBlob
     {
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public static void ExportImportPublicOnly()
         {
             byte[] expectedExport = ByteUtils.HexToByteArray(
@@ -42,7 +41,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public static void ExportImportPublicPrivate()
         {
             // This blob contains the private key of TestData.CspTestKey. The guidelines for the TestData class


### PR DESCRIPTION
The library is marked as being unsupported for platforms other than Windows, the [PlatformSpecific] attributes were holdovers from when this was in the former unified RSA library.

Fixes #2626.