### PR TITLE
Change System.IO.FileSystem.Tests to use FileCleanupTestBase

### DIFF
--- a/src/Common/tests/System/IO/FileCleanupTestBase.cs
+++ b/src/Common/tests/System/IO/FileCleanupTestBase.cs
@@ -6,13 +6,17 @@ using System.Runtime.CompilerServices;
 namespace System.IO
 {
     /// <summary>Base class for test classes the use temporary files that need to be cleaned up.</summary>
-    public abstract class TemporaryFilesCleanupTestBase : IDisposable
+    public abstract class FileCleanupTestBase : IDisposable
     {
-        /// <summary>Initialize the test class base.</summary>
-        protected TemporaryFilesCleanupTestBase()
+        /// <summary>Initialize the test class base.  This creates the associated test directory.</summary>
+        protected FileCleanupTestBase()
         {
-            // Use a unique test directory per test class
-            TestDirectory = Path.Combine(Path.GetTempPath(), GetType().Name + "_" + Guid.NewGuid().ToString("N"));
+            // Use a unique test directory per test class.  The test directory lives in the user's temp directory,
+            // and includes both the name of the test class and a random string.  The test class name is included 
+            // so that it can be easily correlated if necessary, and the random string to helps avoid conflicts if
+            // the same test should be run concurrently with itself (e.g. if a [Fact] method lives on a base class) 
+            // or if some stray files were left over from a previous run.
+            TestDirectory = Path.Combine(Path.GetTempPath(), GetType().Name + "_" + Path.GetRandomFileName());
             try
             {
                 Directory.CreateDirectory(TestDirectory);
@@ -24,38 +28,49 @@ namespace System.IO
             }
         }
 
-        ~TemporaryFilesCleanupTestBase()
+        /// <summary>Delete the associated test directory.</summary>
+        ~FileCleanupTestBase()
         {
             Dispose(false);
         }
 
+        /// <summary>Delete the associated test directory.</summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        protected void Dispose(bool disposing)
+        /// <summary>Delete the associated test directory.</summary>
+        protected virtual void Dispose(bool disposing)
         {
-            // No managed resources to clean up.
+            // No managed resources to clean up, so disposing is ignored.
 
             try { Directory.Delete(TestDirectory, recursive: true); }
-            catch { } // avoid exceptions from Dispose
+            catch { } // avoid exceptions escaping Dispose
         }
 
         /// <summary>Gets the test directory into which all files and directories created by tests should be stored.</summary>
         protected string TestDirectory { get; private set; }
 
-        /// <summary>Generates a test file full path that is unique to the call site.</summary>
-        protected string GetTestFilePath([CallerMemberName]string fileName = null, [CallerLineNumber] int lineNumber = 0)
+        /// <summary>Gets a test file full path that is associated with the call site.</summary>
+        /// <param name="index">An optional index value to use as a suffix on the file name.  Typically a loop index.</param>
+        /// <param name="memberName">The member name of the function calling this method.</param>
+        /// <param name="lineNumber">The line number of the function calling this method.</param>
+        protected string GetTestFilePath(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
-            return Path.Combine(TestDirectory, GetTestFileName(fileName, lineNumber));
+            return Path.Combine(TestDirectory, GetTestFileName(index, memberName, lineNumber));
         }
 
-        /// <summary>Generates a test file name that is unique to the call site.</summary>
-        protected string GetTestFileName([CallerMemberName]string fileName = null, [CallerLineNumber] int lineNumber = 0)
+        /// <summary>Gets a test file name that is associated with the call site.</summary>
+        /// <param name="index">An optional index value to use as a suffix on the file name.  Typically a loop index.</param>
+        /// <param name="memberName">The member name of the function calling this method.</param>
+        /// <param name="lineNumber">The line number of the function calling this method.</para
+        protected string GetTestFileName(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
-            return string.Format("{0}_{1}", fileName ?? "TestBase", lineNumber);
+            return string.Format(
+                index.HasValue ? "{0}_{1}_{2}" : "{0}_{1}",
+                memberName ?? "TestBase", lineNumber, index.GetValueOrDefault());
         }
     }
 }

--- a/src/Scenarios/tests/InterProcessCommunication/IpcTestBase.cs
+++ b/src/Scenarios/tests/InterProcessCommunication/IpcTestBase.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace InterProcessCommunication.Tests
 {
     /// <summary>Base class used for all inter-process communication tests.</summary>
-    public abstract class IpcTestBase : TemporaryFilesCleanupTestBase
+    public abstract class IpcTestBase : FileCleanupTestBase
     {
         /// <summary>The CoreCLR host used to host the test console app.</summary>
         private const string HostRunner = "corerun";

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -208,7 +208,7 @@ namespace System.IO.FileSystem.Tests
 
             Assert.All(IOInputs.GetSimpleWhiteSpace(), (component) =>
             {
-                string path = GetTestFilePath("Extended") + component;
+                string path = GetTestFilePath(memberName: "Extended") + component;
                 testDir = Directory.CreateDirectory(@"\\?\" + path);
                 Assert.False(Exists(path), path);
                 Assert.True(Exists(testDir.FullName));

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot.cs
@@ -24,28 +24,28 @@ namespace System.IO.FileSystem.Tests
         public void RelativeDirectory()
         {
             string root = Directory.GetDirectoryRoot(Path.DirectorySeparatorChar + "testDir");
-            Assert.Equal(Path.GetPathRoot(TestDirectory), root);
+            Assert.Equal(Path.GetPathRoot(Directory.GetCurrentDirectory()), root);
         }
 
         [Fact]
         public void NestedDirectories()
         {
             string root = Directory.GetDirectoryRoot(Path.Combine("a", "a", "a", "b") + Path.DirectorySeparatorChar);
-            Assert.Equal(Path.GetPathRoot(TestDirectory), root);
+            Assert.Equal(Path.GetPathRoot(Directory.GetCurrentDirectory()), root);
         }
 
         [Fact]
         public void DotPaths()
         {
             string root = Directory.GetDirectoryRoot(Path.Combine("Test1", ".", "test2", "..", "test3"));
-            Assert.Equal(Path.GetPathRoot(TestDirectory), root);
+            Assert.Equal(Path.GetPathRoot(Directory.GetCurrentDirectory()), root);
         }
 
         [Fact]
         public void WhitespacePaths()
         {
             string root = Directory.GetDirectoryRoot(Path.Combine("T es t1", "te s  t2", "t  est 3"));
-            Assert.Equal(Path.GetPathRoot(TestDirectory), root);
+            Assert.Equal(Path.GetPathRoot(Directory.GetCurrentDirectory()), root);
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
@@ -66,7 +66,7 @@ namespace System.IO.FileSystem.Tests
             using (File.Create(testFile1))
             using (File.Create(testFile2))
             {
-                string[] results = GetEntries(Directory.GetCurrentDirectory(), Path.Combine(new DirectoryInfo(TestDirectory).Name, "*"), SearchOption.AllDirectories);
+                string[] results = GetEntries(Directory.GetParent(TestDirectory).FullName, Path.Combine(Path.GetFileName(TestDirectory), "*"), SearchOption.AllDirectories);
                 if (TestFiles)
                 {
                     Assert.Contains(testFile1, results);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Root.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Root.cs
@@ -34,7 +34,7 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void UNCShares()
         {
-            string root = Path.GetPathRoot(TestDirectory);
+            string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
             string path = Path.DirectorySeparatorChar + Path.Combine("Machine", "Test");
             Assert.Equal(root, new DirectoryInfo(path).Root.FullName);
 

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -1,72 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-
 namespace System.IO.FileSystem.Tests
 {
-    public abstract class FileSystemTest : IDisposable
+    public abstract class FileSystemTest : FileCleanupTestBase
     {
         public static readonly byte[] TestBuffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-
-        public string TestDirectory { get; private set; }
-
-        public FileSystemTest()
-        {
-            // Use a unique test directory per test class
-            TestDirectory = Path.Combine(Directory.GetCurrentDirectory(), GetType().Name);
-
-            try
-            {
-                Directory.CreateDirectory(TestDirectory);
-            }
-            catch
-            {
-                // Don't want this to crash the test, we'll fail appropriately in other test 
-                // cases if Directory.Create is broken.
-            }
-        }
-
-        // Generates a test file path to use that is unique name per test case / call
-        public string GetTestFilePath([CallerMemberName]string memberName = null, [CallerLineNumber] int lineNumber = 0)
-        {
-            return Path.Combine(TestDirectory, String.Format("{0}_{1}", memberName ?? "testFile", lineNumber));
-        }
-
-        // Generates a test file path to use that is unique name per test case / call with an additional
-        // variable to specify a trailing identifier
-        public string GetTestFilePath(int index, [CallerMemberName]string memberName = null, [CallerLineNumber] int lineNumber = 0)
-        {
-            return Path.Combine(TestDirectory, String.Format("{0}_{1}_{2}", memberName ?? "testFile", lineNumber, index));
-        }
-
-        // Generates a test file name to use that is unique name per test case / call
-        public string GetTestFileName([CallerMemberName]string memberName = null, [CallerLineNumber] int lineNumber = 0)
-        {
-            return String.Format("{0}_{1}", memberName ?? "testFile", lineNumber);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected void Dispose(bool disposing)
-        {
-            // if (disposing)  no managed resources
-
-            // clean up non-managed resources
-            try
-            {
-                Directory.Delete(TestDirectory, true);
-            }
-            catch
-            {
-                // Don't throw during dispose
-            }
-        }
     }
 }

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -157,6 +157,9 @@
     <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs">
       <Link>Common\Interop\Interop.PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace System.IO.MemoryMappedFiles.Tests
 {
     /// <summary>Base class from which all of the memory mapped files test classes derive.</summary>
-    public abstract class MemoryMappedFilesTestBase : TemporaryFilesCleanupTestBase
+    public abstract class MemoryMappedFilesTestBase : FileCleanupTestBase
     {
         /// <summary>Gets whether named maps are supported by the current platform.</summary>
         protected static bool MapNamesSupported { get { return Interop.IsWindows; } }
@@ -66,7 +66,7 @@ namespace System.IO.MemoryMappedFiles.Tests
             if (MapNamesSupported)
             {
                 yield return MemoryMappedFile.CreateNew(CreateUniqueMapName(), capacity, access);
-                yield return MemoryMappedFile.CreateFromFile(GetTestFilePath(fileName, lineNumber), FileMode.CreateNew, CreateUniqueMapName(), capacity, access);
+                yield return MemoryMappedFile.CreateFromFile(GetTestFilePath(null, fileName, lineNumber), FileMode.CreateNew, CreateUniqueMapName(), capacity, access);
             }
         }
 


### PR DESCRIPTION
When I rewrote the MemoryMappedFiles tests, I cribbed from the
System.IO.FileSystem test's base class and created a Common base class
that could be used by test projects that had temporary files to be cleaned up.
At the time, however, FileSystem's tests were undergoing heavy changes and
so I didn't update FileSystem's tests to use the common base.  Now that
things have quieted down, I've made that change.

In doing so, I made a few tweaks to the FileSystem tests, where tests were
assuming that the test directory was always in the current directory, and
the consolidated base class puts temporary files in the user's temporary
directory instead.