### PR TITLE
Fix TestUserCredentialsPropertiesOnWindows without admin privileges

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Interop.cs
@@ -93,7 +93,7 @@ namespace System.Diagnostics.ProcessTests
         [DllImport("advapi32.dll")]
         internal static extern bool GetTokenInformation(SafeProcessHandle TokenHandle, uint TokenInformationClass, IntPtr TokenInformation, int TokenInformationLength, ref int ReturnLength);
 
-        internal static bool NetUserAdd(string username, string password)
+        internal static void NetUserAdd(string username, string password)
         {
             USER_INFO_1 userInfo = new USER_INFO_1();
             userInfo.usri1_name = username;
@@ -103,12 +103,12 @@ namespace System.Diagnostics.ProcessTests
             uint parm_err;
             uint result = NetUserAdd(null, 1, ref userInfo, out parm_err);
 
-            if (result != 0)
+            if (result != 0) // NERR_Success
             {
-                throw new Win32Exception();
+                // most likely result == ERROR_ACCESS_DENIED 
+                // due to running without elevated privileges
+                throw new Win32Exception((int)result);
             }
-
-            return true;
         }
 
         internal static bool ProcessTokenToSid(SafeProcessHandle token, out SecurityIdentifier sid)


### PR DESCRIPTION
The System.Diagnostics.Process test TestUserCredentialsPropertiesOnWindows has two problems:
1) It requires admin privileges, and it looks like the intention was to silently bail from the test if such privileges weren't available, but instead it's causing the test to fail, which means outer loop tests fail when run without admin privileges.
2) When the exception is thrown, it's getting the error code from the wrong location: NetUserAdd returns the error code rather than having it available from GetLastWin32Error.

This commit addresses (2) simply by passing the result to Win32Exception, and it addresses (1) by catching the exception and returning instead of allowing it to propagate.

Eventually we'll need a better solution for such tests, but for now this should suffice.