### PR TITLE
Use CopyTo where possible in InsertRange

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -549,6 +549,9 @@ namespace System.Collections.Immutable
                 return ImmutableArray.CreateRange(items);
             }
 
+            // If items is not any of the interfaces below, it will
+            // be 'captured' in a List<T> here and travel
+            // down the ICollection<T> path.
             int count = ImmutableExtensions.GetCount(ref items);
             if (count == 0)
             {
@@ -556,13 +559,11 @@ namespace System.Collections.Immutable
             }
 
             T[] tmp = new T[self.Length + count];
-            Array.Copy(self.array, 0, tmp, 0, index);
-            int sequenceIndex = index;
-            foreach (var item in items)
-            {
-                tmp[sequenceIndex++] = item;
-            }
 
+            // CopyTo first in case bad interface impl
+            // tries to modify other parts of tmp
+            items.CopyTo(tmp, index);
+            Array.Copy(self.array, 0, tmp, 0, index);
             Array.Copy(self.array, index, tmp, index + count, self.Length - index);
             return new ImmutableArray<T>(tmp);
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -87,6 +87,41 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
+        /// Copies part of an <see cref="IEnumerable{T}"/> to an array, starting at the specified index.
+        /// </summary>
+        /// <typeparam name="T">The type of element.</typeparam>
+        /// <param name="sequence">The sequence of elements you want to copy.</param>
+        /// <param name="dest">The destination array.</param>
+        /// <param name="index">The index in the array to start copying to.</param>
+        internal static void CopyTo<T>(this IEnumerable<T> sequence, T[] dest, int index)
+        {
+            Requires.NotNull(sequence, "sequence");
+            Requires.NotNull(dest, "dest");
+            Requires.Range(index >= 0 && index < dest.Length, "index");
+            
+            var collectionOfT = sequence as ICollection<T>;
+            if (collectionOfT != null)
+            {
+                collectionOfT.CopyTo(dest, index);
+                return;
+            }
+            
+            var collection = sequence as ICollection;
+            if (collection != null)
+            {
+                collection.CopyTo(dest, index);
+                return;
+            }
+            
+            // Fallback to manual iteration over dest and sequence
+            int sequenceIndex = index;
+            foreach (var item in sequence)
+            {
+                dest[sequenceIndex++] = item;
+            }
+        }
+
+        /// <summary>
         /// Gets a copy of a sequence as an array.
         /// </summary>
         /// <typeparam name="T">The type of element.</typeparam>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1375,9 +1375,46 @@ namespace System.Collections.Immutable.Test
             Assert.Throws<NotSupportedException>(() => c.SyncRoot);
         }
 
+        ////[Fact] // Perf test
+        public void InsertRange_Perf_Arrays()
+        {
+            TestInsertRangePerfWith(Enumerable.Range(1, 10000).ToArray());
+        }
+        
+        ////[Fact] // Perf test
+        public void InsertRange_Perf_ListOfT()
+        {
+            TestInsertRangePerfWith(Enumerable.Range(1, 10000).ToList());
+        }
+        
+        ////[Fact] // Perf test
+        public void InsertRange_Perf_NonCollectionEnumerable()
+        {
+            // IEnumerable being tested here must not inherit from
+            // ICollection<T>, ICollection, or IReadOnlyCollection<T>.
+            
+            TestInsertRangePerfWith(Enumerable.Range(1, 10000));
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             return ImmutableArray.Create(contents);
+        }
+
+        private static void TestInsertRangePerfWith<T>(IEnumerable<T> toInsert)
+        {
+            var iarray = ImmutableArray<T>.Empty;
+            
+            var watch = new Stopwatch();
+            
+            for (int i = 0; i < 3; i++)
+            {
+                watch.Start();
+                iarray = iarray.InsertRange(0, toInsert);
+                watch.Stop();
+                Debug.WriteLine(watch.Elapsed);
+                watch.Reset();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This has been separated from PR #2397: Optimizations for ImmutableArray.

The logic has been changed to use `CopyTo` for enumerables that impl `ICollection` and `ICollection<T>`, which includes arrays. This also affects enumerables that don't inherit from them, since while getting the count of an `IEnumerable` we capture it into a `List<T>` (which impls `ICollection<T>`) to avoid enumerating over it more than once.