### PR TITLE
Support ICollection with [MaxLength] and [MinLength] data annotations

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Globalization;
 
 namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
-    ///     Specifies the maximum length of array/string data allowed in a property.
+    ///     Specifies the maximum length of collection/string data allowed in a property.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter,
         AllowMultiple = false)]
@@ -18,7 +19,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     Initializes a new instance of the <see cref="MaxLengthAttribute" /> class.
         /// </summary>
         /// <param name="length">
-        ///     The maximum allowable length of array/string data.
+        ///     The maximum allowable length of collection/string data.
         ///     Value must be greater than zero.
         /// </param>
         public MaxLengthAttribute(int length)
@@ -38,7 +39,7 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         /// <summary>
-        ///     Gets the maximum allowable length of the array/string data.
+        ///     Gets the maximum allowable length of the collection/string data.
         /// </summary>
         public int Length { get; private set; }
 
@@ -77,8 +78,18 @@ namespace System.ComponentModel.DataAnnotations
             }
             else
             {
-                // We expect a cast exception if a non-{string|array} property was passed in.
-                length = ((Array)value).Length;
+                ICollection collection = value as ICollection;
+
+                if (collection != null)
+                {
+                    length = collection.Count;
+                }
+                else
+                {
+                    // A cast exception previously occurred if a non-{string|array} property was passed
+                    // in so preserve this behavior if the value does not implement ICollection
+                    length = ((Array)value).Length;
+                }
             }
 
             return MaxAllowableLength == Length || length <= Length;

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Globalization;
 
 namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
-    ///     Specifies the minimum length of array/string data allowed in a property.
+    ///     Specifies the minimum length of collection/string data allowed in a property.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter,
         AllowMultiple = false)]
@@ -16,7 +17,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     Initializes a new instance of the <see cref="MinLengthAttribute" /> class.
         /// </summary>
         /// <param name="length">
-        ///     The minimum allowable length of array/string data.
+        ///     The minimum allowable length of collection/string data.
         ///     Value must be greater than or equal to zero.
         /// </param>
         public MinLengthAttribute(int length)
@@ -26,7 +27,7 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         /// <summary>
-        ///     Gets the minimum allowable length of the array/string data.
+        ///     Gets the minimum allowable length of the collection/string data.
         /// </summary>
         public int Length { get; private set; }
 
@@ -61,8 +62,18 @@ namespace System.ComponentModel.DataAnnotations
             }
             else
             {
-                // We expect a cast exception if a non-{string|array} property was passed in.
-                length = ((Array)value).Length;
+                ICollection collection = value as ICollection;
+
+                if (collection != null)
+                {
+                    length = collection.Count;
+                }
+                else
+                {
+                    // A cast exception previously occurred if a non-{string|array} property was passed
+                    // in so preserve this behavior if the value does not implement ICollection
+                    length = ((Array)value).Length;
+                }
             }
 
             return length >= Length;

--- a/src/System.ComponentModel.Annotations/tests/MaxLengthAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/MaxLengthAttributeTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations
@@ -64,6 +67,26 @@ namespace System.ComponentModel.DataAnnotations
             Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(16).GetValidationResult(new string[16], s_testValidationContext));
             Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(-1).GetValidationResult(new object[500], s_testValidationContext));
             Assert.NotNull((new MaxLengthAttribute(12).GetValidationResult(new byte[13], s_testValidationContext)).ErrorMessage);
+        }
+
+        [Fact]
+        public static void GetValidationResult_validates_collection_length()
+        {
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute().GetValidationResult(new Collection<int>(new int[500]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(15).GetValidationResult(new Collection<string>(new string[14]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(16).GetValidationResult(new Collection<string>(new string[16]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(-1).GetValidationResult(new Collection<object>(new object[500]), s_testValidationContext));
+            Assert.NotNull((new MaxLengthAttribute(12).GetValidationResult(new Collection<byte>(new byte[13]), s_testValidationContext)).ErrorMessage);
+        }
+
+        [Fact]
+        public static void GetValidationResult_validates_list_length()
+        {
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute().GetValidationResult(new List<int>(new int[500]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(15).GetValidationResult(new List<string>(new string[14]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(16).GetValidationResult(new List<string>(new string[16]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MaxLengthAttribute(-1).GetValidationResult(new List<object>(new object[500]), s_testValidationContext));
+            Assert.NotNull((new MaxLengthAttribute(12).GetValidationResult(new List<byte>(new byte[13]), s_testValidationContext)).ErrorMessage);
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/MinLengthAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/MinLengthAttributeTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations
@@ -56,6 +59,24 @@ namespace System.ComponentModel.DataAnnotations
             Assert.Equal(ValidationResult.Success, new MinLengthAttribute(12).GetValidationResult(new int[13], s_testValidationContext));
             Assert.Equal(ValidationResult.Success, new MinLengthAttribute(16).GetValidationResult(new string[16], s_testValidationContext));
             Assert.NotNull((new MinLengthAttribute(15).GetValidationResult(new byte[14], s_testValidationContext)).ErrorMessage);
+        }
+
+        [Fact]
+        public static void GetValidationResult_validates_collection_length()
+        {
+            Assert.Equal(ValidationResult.Success, new MinLengthAttribute(0).GetValidationResult(new Collection<int>(new int[0]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MinLengthAttribute(12).GetValidationResult(new Collection<int>(new int[13]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MinLengthAttribute(16).GetValidationResult(new Collection<string>(new string[16]), s_testValidationContext));
+            Assert.NotNull((new MinLengthAttribute(15).GetValidationResult(new Collection<byte>(new byte[14]), s_testValidationContext)).ErrorMessage);
+        }
+
+        [Fact]
+        public static void GetValidationResult_validates_list_length()
+        {
+            Assert.Equal(ValidationResult.Success, new MinLengthAttribute(0).GetValidationResult(new List<int>(new int[0]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MinLengthAttribute(12).GetValidationResult(new List<int>(new int[13]), s_testValidationContext));
+            Assert.Equal(ValidationResult.Success, new MinLengthAttribute(16).GetValidationResult(new List<string>(new string[16]), s_testValidationContext));
+            Assert.NotNull((new MinLengthAttribute(15).GetValidationResult(new List<byte>(new byte[14]), s_testValidationContext)).ErrorMessage);
         }
     }
 }


### PR DESCRIPTION
This PR adds support for the use of the ```[MaxLength]``` and ```[MaxLength]``` data annotation attributes on properties whose type implements ```ICollection``` so that they can be used on more properties than just those which are strings and arrays, such as ```List<T>``` and ```ICollection<T>```.

This would then allow models such as the one below to use the attributes successfully without an ```InvalidCastException``` being thrown:

```
using System.Collections.Generic;
using System.ComponentModel.DataAnnotations;

namespace MyNamespace
{
    public class MyDataModel
    {
        [MinLength(1)]
        public ICollection<string> MySet { get; set; }
    }
}
```

If the value is not of type ```string``` or ```ICollection``` then the existing code is executed so that the exception behavior from before ```ICollection``` support was added is retained.
