### PR TITLE
Implement System.Security.Cryptography.RSACng

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/SafeUnicodeStringHandle.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/SafeUnicodeStringHandle.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+
+namespace Internal.Cryptography
+{
+    /// <summary>
+    ///     Holds a managed string marshaled as a LPCWSTR. 
+    /// </summary>
+    internal sealed class SafeUnicodeStringHandle : SafeHandle
+    {
+        /// <summary>
+        ///     Marshal a String to a native LPCWSTR. It is permitted to pass "null" for the string.
+        /// </summary>
+        public SafeUnicodeStringHandle(string s)
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+            handle = Marshal.StringToHGlobalUni(s);
+        }
+
+        public sealed override bool IsInvalid
+        {
+            get
+            {
+                return handle == IntPtr.Zero;
+            }
+        }
+
+        protected sealed override bool ReleaseHandle()
+        {
+            Marshal.FreeHGlobal(handle);
+            return true;
+        }
+    }
+}
+
+

--- a/src/System.Security.Cryptography.Cng/src/Interop/BCrypt/Interop.AsymmetricEncryption.Types.cs
+++ b/src/System.Security.Cryptography.Cng/src/Interop/BCrypt/Interop.AsymmetricEncryption.Types.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    /// <summary>
+    /// BCrypt types related to asymmetric encryption algorithms
+    /// </summary>
+    internal partial class BCrypt
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BCRYPT_OAEP_PADDING_INFO
+        {
+            /// <summary>
+            ///     Null-terminated Unicode string that identifies the hashing algorithm used to create the padding.
+            /// </summary>
+            internal IntPtr pszAlgId;
+
+            /// <summary>
+            ///     Address of a buffer that contains the data used to create the padding.
+            /// </summary>
+            internal IntPtr pbLabel;
+
+            /// <summary>
+            ///     Number of bytes in the pbLabel buffer.
+            /// </summary>
+            internal int cbLabel;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BCRYPT_PKCS1_PADDING_INFO
+        {
+            /// <summary>
+            ///     Null-terminated Unicode string that identifies the hashing algorithm used to create the padding.
+            /// </summary>
+            internal IntPtr pszAlgId;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BCRYPT_PSS_PADDING_INFO
+        {
+            /// <summary>
+            ///     Null-terminated Unicode string that identifies the hashing algorithm used to create the padding.
+            /// </summary>
+            internal IntPtr pszAlgId;
+
+            /// <summary>
+            ///     The size, in bytes, of the random salt to use for the padding.
+            /// </summary>
+            internal int cbSalt;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/Interop/BCrypt/Interop.Blobs.cs
+++ b/src/System.Security.Cryptography.Cng/src/Interop/BCrypt/Interop.Blobs.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    //
+    // These structures define the layout of CNG key blobs passed to NCryptImportKey 
+    //
+    internal partial class BCrypt
+    {
+        /// <summary>
+        ///     Magic numbers identifying blob types
+        /// </summary>
+        internal enum KeyBlobMagicNumber : int
+        {
+            BCRYPT_ECDH_PUBLIC_P256_MAGIC = 0x314B4345,
+            BCRYPT_ECDH_PUBLIC_P384_MAGIC = 0x334B4345,
+            BCRYPT_ECDH_PUBLIC_P521_MAGIC = 0x354B4345,
+            BCRYPT_ECDSA_PUBLIC_P256_MAGIC = 0x31534345,
+            BCRYPT_ECDSA_PUBLIC_P384_MAGIC = 0x33534345,
+            BCRYPT_ECDSA_PUBLIC_P521_MAGIC = 0x35534345,
+            BCRYPT_RSAPUBLIC_MAGIC = 0x31415352,
+            BCRYPT_RSAPRIVATE_MAGIC = 0x32415352,
+            BCRYPT_RSAFULLPRIVATE_MAGIC = 0x33415352,   
+            BCRYPT_KEY_DATA_BLOB_MAGIC = 0x4d42444b,
+        }
+
+
+        /// <summary>
+        ///     Well known key blob types
+        /// </summary>
+        internal static class KeyBlobType
+        {
+            internal const string BCRYPT_RSAFULLPRIVATE_BLOB = "RSAFULLPRIVATEBLOB";    
+            internal const string BCRYPT_RSAPRIVATE_BLOB = "RSAPRIVATEBLOB";            
+            internal const string BCRYPT_PUBLIC_KEY_BLOB = "RSAPUBLICBLOB";             
+        }
+
+
+        /// <summary>
+        ///     The BCRYPT_RSAKEY_BLOB structure is used as a header for an RSA public key or private key BLOB in memory.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BCRYPT_RSAKEY_BLOB
+        {
+            internal KeyBlobMagicNumber Magic;
+            internal int BitLength;
+            internal int cbPublicExp;
+            internal int cbModulus;
+            internal int cbPrime1;
+            internal int cbPrime2;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/Interop/NCrypt/NCrypt.cs
+++ b/src/System.Security.Cryptography.Cng/src/Interop/NCrypt/NCrypt.cs
@@ -44,6 +44,18 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
         internal static extern ErrorCode NCryptFinalizeKey(SafeNCryptKeyHandle hKey, int dwFlags);
 
+        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, [In] byte[] pbInput, int cbInput, void* pPaddingInfo, [Out] byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, [In] byte[] pbInput, int cbInput, void* pPaddingInfo, [Out] byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, [In] byte[] pbHashValue, int cbHashValue, [Out] byte[] pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void *pPaddingInfo, [In] byte[] pbHashValue, int cbHashValue, [In] byte[] pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
+
         /// <summary>
         ///     Result codes from NCrypt APIs
         /// </summary>
@@ -68,5 +80,14 @@ internal static partial class Interop
             public IntPtr pszFriendlyName;
             public IntPtr pszDescription;
         }
+
+        internal enum AsymmetricPaddingMode : int
+        {
+            NCRYPT_NO_PADDING_FLAG = 0x00000001,
+            NCRYPT_PAD_PKCS1_FLAG = 0x00000002,    // NCryptEncrypt/Decrypt or NCryptSignHash/VerifySignature
+            NCRYPT_PAD_OAEP_FLAG = 0x00000004,     // NCryptEncrypt/Decrypt
+            NCRYPT_PAD_PSS_FLAG = 0x00000008,      // NCryptSignHash/VerifySignature
+        }
     }
 }
+ 

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -132,6 +132,9 @@
   <data name="Cryptography_ArgRSAaRequiresRSAKey" xml:space="preserve">
     <value>Keys used with the RSACng algorithm must have an algorithm group of RSA.</value>
   </data>
+  <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
+    <value>The hash algorithm name cannot be null or empty.</value>
+  </data>
   <data name="Cryptography_InvalidAlgorithmGroup" xml:space="preserve">
     <value>The algorithm group '{0}' is invalid.</value>
   </data>
@@ -182,5 +185,8 @@
   </data>
   <data name="WorkInProgress" xml:space="preserve">
     <value>WorkInProgress.</value>
+  </data>
+  <data name="WorkInProgress_UnsupportedHash" xml:space="preserve">
+    <value>Unsupported hash algorithm. RSACng currently supports only MD5, SHA1, SHA256, SHA384 and SHA512.</value>
   </data>
 </root>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -52,15 +52,23 @@
      <Compile Include="System\Security\Cryptography\CngUIPolicy.cs" />
      <Compile Include="System\Security\Cryptography\CngUIProtectionLevels.cs" />
      <Compile Include="System\Security\Cryptography\RSACng.cs" />
+     <Compile Include="System\Security\Cryptography\RSACng.EncryptDecrypt.cs" />
+     <Compile Include="System\Security\Cryptography\RSACng.HashData.cs" />
+     <Compile Include="System\Security\Cryptography\RSACng.ImportExport.cs" />
+     <Compile Include="System\Security\Cryptography\RSACng.Key.cs" />
+     <Compile Include="System\Security\Cryptography\RSACng.SignVerify.cs" />
 
      <Compile Include="Microsoft\Win32\SafeHandles\NCryptSafeHandles.cs" />
 
      <Compile Include="Internal\Cryptography\Helpers.cs" />
      <Compile Include="Internal\Cryptography\KeyPropertyName.cs" />
      <Compile Include="Internal\Cryptography\ProviderPropertyName.cs" />
+     <Compile Include="Internal\Cryptography\SafeUnicodeStringHandle.cs" />
 
      <Compile Include="Interop\Interop.Libraries.cs" />
      <Compile Include="Interop\NCrypt\NCrypt.cs" />
+     <Compile Include="Interop\BCrypt\Interop.Blobs.cs" />
+     <Compile Include="Interop\BCrypt\Interop.AsymmetricEncryption.Types.cs" />
 
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+using Microsoft.Win32.SafeHandles;
+
+using Internal.Cryptography;
+
+using ErrorCode = Interop.NCrypt.ErrorCode;
+using AsymmetricPaddingMode = Interop.NCrypt.AsymmetricPaddingMode;
+using BCRYPT_OAEP_PADDING_INFO = Interop.BCrypt.BCRYPT_OAEP_PADDING_INFO;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class RSACng : RSA
+    {
+        /// <summary>
+        ///     Encrypts data using the public key.
+        /// </summary>
+        public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
+        {
+            unsafe
+            {
+                return EncryptOrDecrypt(data, padding, Interop.NCrypt.NCryptEncrypt);
+            }
+        }
+
+        /// <summary>
+        ///     Decrypts data using the private key.
+        /// </summary>
+        public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
+        {
+            unsafe
+            {
+                return EncryptOrDecrypt(data, padding, Interop.NCrypt.NCryptDecrypt);
+            }
+        }
+
+        //
+        // Conveniently, Encrypt() and Decrypt() are identical save for the actual P/Invoke call to CNG. Thus, both
+        // api's invoke this common helper with the "transform" parameter determining whether encryption or decryption is done.
+        //
+        private byte[] EncryptOrDecrypt(byte[] data, RSAEncryptionPadding padding, EncryptOrDecryptAction encryptOrDecrypt)
+        {
+            if (data == null)
+                throw new ArgumentNullException("data");
+
+            if (padding == null)
+                throw new ArgumentNullException("padding");
+
+            unsafe
+            {
+                SafeNCryptKeyHandle keyHandle = Key.Handle;
+                switch (padding.Mode)
+                {
+                    case RSAEncryptionPaddingMode.Pkcs1:
+                        return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encryptOrDecrypt);
+
+                    case RSAEncryptionPaddingMode.Oaep:
+                        {
+                            using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(padding.OaepHashAlgorithm.Name))
+                            {
+                                BCRYPT_OAEP_PADDING_INFO paddingInfo = new BCRYPT_OAEP_PADDING_INFO()
+                                {
+                                    pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
+
+                                    // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
+                                    pbLabel = IntPtr.Zero,
+                                    cbLabel = 0, 
+                                };
+                                return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encryptOrDecrypt);
+                            }
+                        }
+
+                    default:
+                        throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                }
+            }
+        }
+
+        //
+        // Now that the padding mode and information have been marshaled to their native counterparts, perform the encryption or decryption.
+        //
+        private static unsafe byte[] EncryptOrDecrypt(SafeNCryptKeyHandle key, byte[] input, AsymmetricPaddingMode paddingMode, void* paddingInfo, EncryptOrDecryptAction encryptOrDecrypt)
+        {
+            int numBytesNeeded;
+            ErrorCode errorCode = encryptOrDecrypt(key, input, input.Length, paddingInfo, null, 0, out numBytesNeeded, paddingMode);
+            if (errorCode != ErrorCode.ERROR_SUCCESS)
+                throw errorCode.ToCryptographicException();
+
+            byte[] output = new byte[numBytesNeeded];
+            errorCode = encryptOrDecrypt(key, input, input.Length, paddingInfo, output, numBytesNeeded, out numBytesNeeded, paddingMode);
+            if (errorCode != ErrorCode.ERROR_SUCCESS)
+                throw errorCode.ToCryptographicException();
+
+            return output;
+        }
+
+        // Delegate binds to either NCryptEncrypt() or NCryptDecrypt() depending on which api was called.
+        private unsafe delegate ErrorCode EncryptOrDecryptAction(SafeNCryptKeyHandle hKey, byte[] pbInput, int cbInput, void* pPaddingInfo, byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+    }
+}
+

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.HashData.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.HashData.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class RSACng : RSA
+    {
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+        {
+            // we're sealed and the base should have checked this already.
+            Debug.Assert(data != null);
+            Debug.Assert(offset >= 0 && offset <= data.Length);
+            Debug.Assert(count >= 0 && count <= data.Length);
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+
+            HashAlgorithm hasher = GetHasher(hashAlgorithm);
+            byte[] hash = hasher.ComputeHash(data, offset, count);
+            return hash;
+        }
+
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+        {
+            // We're sealed and the base should have checked these already.
+            Debug.Assert(data != null);
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+
+            HashAlgorithm hasher = GetHasher(hashAlgorithm);
+            byte[] hash = hasher.ComputeHash(data);
+            return hash;
+        }
+
+        private static HashAlgorithm GetHasher(HashAlgorithmName hashAlgorithm)
+        {
+            // @todo B#1208349:  This is a temporary implementation that should nevertheless handle most real-world cases. To fully implement this method,
+            //   it needs to be able to handle arbitrary hash algorithms on the local CNG primitive provider's menu. There are some interop-cleanup/layering decisions
+            //   that need to made first.
+
+            if (hashAlgorithm == HashAlgorithmName.MD5)
+                return MD5.Create();
+
+            if (hashAlgorithm == HashAlgorithmName.SHA1)
+                return SHA1.Create();
+
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
+                return SHA256.Create();
+
+            if (hashAlgorithm == HashAlgorithmName.SHA384)
+                return SHA384.Create();
+
+            if (hashAlgorithm == HashAlgorithmName.SHA512)
+                return SHA512.Create();
+
+            throw new NotImplementedException(SR.WorkInProgress_UnsupportedHash);   // Can't handle arbitrary CNG hash algorithms yet.
+        }
+    }
+}
+

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+using Internal.Cryptography;
+
+using ErrorCode = Interop.NCrypt.ErrorCode;
+using KeyBlobMagicNumber = Interop.BCrypt.KeyBlobMagicNumber;
+using BCRYPT_RSAKEY_BLOB = Interop.BCrypt.BCRYPT_RSAKEY_BLOB;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class RSACng : RSA
+    {
+        /// <summary>
+        ///     <para>
+        ///         ImportParameters will replace the existing key that RSACng is working with by creating a
+        ///         new CngKey for the parameters structure. If the parameters structure contains only an
+        ///         exponent and modulus, then only a public key will be imported. If the parameters also
+        ///         contain P and Q values, then a full key pair will be imported.
+        ///     </para>        
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        ///     if <paramref name="parameters" /> contains neither an exponent nor a modulus.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///     if <paramref name="parameters" /> is not a valid RSA key or if <paramref name="parameters"
+        ///     /> is a full key pair and the default KSP is used.
+        /// </exception>        
+        public override void ImportParameters(RSAParameters parameters)
+        {
+            unsafe
+            {
+                if (parameters.Exponent == null || parameters.Modulus == null)
+                    throw new ArgumentException(SR.Cryptography_InvalidRsaParameters);
+
+                bool includePrivate = parameters.P != null && parameters.Q != null;
+
+                //
+                // We need to build a key blob structured as follows:
+                //
+                //     BCRYPT_RSAKEY_BLOB   header
+                //     byte[cbPublicExp]    publicExponent      - Exponent
+                //     byte[cbModulus]      modulus             - Modulus
+                //     -- Only if "includePrivate" is true --
+                //     byte[cbPrime1]       prime1              - P
+                //     byte[cbPrime2]       prime2              - Q
+                //     ------------------
+                //
+
+                int blobSize = sizeof(BCRYPT_RSAKEY_BLOB) +
+                               parameters.Exponent.Length +
+                               parameters.Modulus.Length;
+                if (includePrivate)
+                {
+                    blobSize += parameters.P.Length + 
+                                parameters.Q.Length;
+                }
+
+                byte[] rsaBlob = new byte[blobSize];
+                fixed (byte* pRsaBlob = rsaBlob)
+                {
+                    // Build the header
+                    BCRYPT_RSAKEY_BLOB* pBcryptBlob = (BCRYPT_RSAKEY_BLOB*)pRsaBlob;
+                    pBcryptBlob->Magic = includePrivate ? KeyBlobMagicNumber.BCRYPT_RSAPRIVATE_MAGIC : KeyBlobMagicNumber.BCRYPT_RSAPUBLIC_MAGIC;
+                    pBcryptBlob->BitLength = parameters.Modulus.Length * 8;
+                    pBcryptBlob->cbPublicExp = parameters.Exponent.Length;
+                    pBcryptBlob->cbModulus = parameters.Modulus.Length;
+
+                    if (includePrivate)
+                    {
+                        pBcryptBlob->cbPrime1 = parameters.P.Length;
+                        pBcryptBlob->cbPrime2 = parameters.Q.Length;
+                    }
+
+                    int offset = sizeof(BCRYPT_RSAKEY_BLOB);
+
+                    Emit(rsaBlob, ref offset, parameters.Exponent);
+                    Emit(rsaBlob, ref offset, parameters.Modulus);
+
+                    if (includePrivate)
+                    {
+                        Emit(rsaBlob, ref offset, parameters.P);
+                        Emit(rsaBlob, ref offset, parameters.Q);
+                    }
+
+                    // We better have computed the right allocation size above!
+                    Debug.Assert(offset == blobSize, "offset == blobSize");
+                }
+                CngKeyBlobFormat blobFormat = includePrivate ? s_rsaPrivateBlob : s_rsaPublicBlob;
+                Key = CngKey.Import(rsaBlob, blobFormat);
+            }
+        }
+
+        /// <summary>
+        ///     Append "value" to the data already in "rsaBlob". 
+        /// </summary>
+        private static void Emit(byte[] rsaBlob, ref int offset, byte[] value)
+        {
+            Buffer.BlockCopy(value, 0, rsaBlob, offset, value.Length);
+            offset += value.Length;
+        }
+
+        /// <summary>
+        ///     Exports the key used by the RSA object into an RSAParameters object.
+        /// </summary>        
+        public override RSAParameters ExportParameters(bool includePrivateParameters)
+        {
+            byte[] rsaBlob = Key.Export(includePrivateParameters ? s_rsaFullPrivateBlob : s_rsaPublicBlob);
+            RSAParameters rsaParams = new RSAParameters();
+
+            //
+            // We now have a buffer laid out as follows:
+            //     BCRYPT_RSAKEY_BLOB   header
+            //     byte[cbPublicExp]    publicExponent      - Exponent
+            //     byte[cbModulus]      modulus             - Modulus
+            //     -- Private only --
+            //     byte[cbPrime1]       prime1              - P
+            //     byte[cbPrime2]       prime2              - Q
+            //     byte[cbPrime1]       exponent1           - DP
+            //     byte[cbPrime2]       exponent2           - DQ
+            //     byte[cbPrime1]       coefficient         - InverseQ
+            //     byte[cbModulus]      privateExponent     - D
+            //
+            byte[] tempMagic = new byte[4];
+            tempMagic[0] = rsaBlob[0]; tempMagic[1] = rsaBlob[1]; tempMagic[2] = rsaBlob[2]; tempMagic[3] = rsaBlob[3];
+            KeyBlobMagicNumber magic = (KeyBlobMagicNumber)BitConverter.ToInt32(tempMagic, 0);
+
+            // Check the magic value in the key blob header. If the blob does not have the required magic,
+            // then throw a CryptographicException.
+            CheckMagicValueOfKey(magic, includePrivateParameters);
+
+            unsafe
+            {
+                // Fail-fast if a rogue provider gave us a blob that isn't even the size of the blob header.
+                if (rsaBlob.Length < sizeof(BCRYPT_RSAKEY_BLOB))
+                    throw ErrorCode.E_FAIL.ToCryptographicException();
+
+                fixed (byte* pRsaBlob = rsaBlob)
+                {
+                    BCRYPT_RSAKEY_BLOB* pBcryptBlob = (BCRYPT_RSAKEY_BLOB*)pRsaBlob;
+
+                    int offset = sizeof(BCRYPT_RSAKEY_BLOB);
+
+                    // Read out the exponent
+                    rsaParams.Exponent = Consume(rsaBlob, ref offset, pBcryptBlob->cbPublicExp);
+                    rsaParams.Modulus = Consume(rsaBlob, ref offset, pBcryptBlob->cbModulus);
+
+                    if (includePrivateParameters)
+                    {
+                        rsaParams.P = Consume(rsaBlob, ref offset, pBcryptBlob->cbPrime1);
+                        rsaParams.Q = Consume(rsaBlob, ref offset, pBcryptBlob->cbPrime2);
+                        rsaParams.DP = Consume(rsaBlob, ref offset, pBcryptBlob->cbPrime1);
+                        rsaParams.DQ = Consume(rsaBlob, ref offset, pBcryptBlob->cbPrime2);
+                        rsaParams.InverseQ = Consume(rsaBlob, ref offset, pBcryptBlob->cbPrime1);
+                        rsaParams.D = Consume(rsaBlob, ref offset, pBcryptBlob->cbModulus);
+                    }
+                }
+            }
+
+            return rsaParams;
+        }
+
+        /// <summary>
+        ///     This function checks the magic value in the key blob header
+        /// </summary>
+        /// <param name="includePrivateParameters">Private blob if true else public key blob</param>
+        private static void CheckMagicValueOfKey(KeyBlobMagicNumber magic, bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+            {
+                if (magic != KeyBlobMagicNumber.BCRYPT_RSAPRIVATE_MAGIC && magic != KeyBlobMagicNumber.BCRYPT_RSAFULLPRIVATE_MAGIC)
+                {
+                    throw new CryptographicException(SR.Cryptography_NotValidPrivateKey);
+                }
+            }
+            else
+            {
+                if (magic != KeyBlobMagicNumber.BCRYPT_RSAPUBLIC_MAGIC)
+                {
+                    // Private key magic is permissible too since the public key can be derived from the private key blob.
+                    if (magic != KeyBlobMagicNumber.BCRYPT_RSAPRIVATE_MAGIC && magic != KeyBlobMagicNumber.BCRYPT_RSAFULLPRIVATE_MAGIC)
+                    {
+                        throw new CryptographicException(SR.Cryptography_NotValidPublicOrPrivateKey);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Peel off the next "count" bytes in "rsaBlob" and return them in a byte array. 
+        /// </summary>
+        private static byte[] Consume(byte[] rsaBlob, ref int offset, int count)
+        {
+            byte[] value = new byte[count];
+            Buffer.BlockCopy(rsaBlob, offset, value, 0, count);
+            offset += count;
+            return value;
+        }
+
+        // CngKeyBlob formats for RSA key blobs
+        private static readonly CngKeyBlobFormat s_rsaFullPrivateBlob = new CngKeyBlobFormat(Interop.BCrypt.KeyBlobType.BCRYPT_RSAFULLPRIVATE_BLOB);
+        private static readonly CngKeyBlobFormat s_rsaPrivateBlob = new CngKeyBlobFormat(Interop.BCrypt.KeyBlobType.BCRYPT_RSAPRIVATE_BLOB);
+        private static readonly CngKeyBlobFormat s_rsaPublicBlob = new CngKeyBlobFormat(Interop.BCrypt.KeyBlobType.BCRYPT_PUBLIC_KEY_BLOB);
+    }
+}
+

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.Key.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class RSACng : RSA
+    {
+        /// <summary>
+        ///     Gets the key that will be used by the RSA object for any cryptographic operation that it uses.
+        ///     This key object will be disposed if the key is reset, for instance by changing the KeySize
+        ///     property, using ImportParamers to create a new key, or by Disposing of the parent RSA object.
+        ///     Therefore, you should make sure that the key object is no longer used in these scenarios. This
+        ///     object will not be the same object as the CngKey passed to the RSACng constructor if that
+        ///     constructor was used, however it will point at the same CNG key.
+        /// </summary>
+        public CngKey Key
+        {
+            get
+            {
+                // If our key size was changed from the key we're using, we need to generate a new key.
+                if (_lazyKey != null && _lazyKey.KeySize != KeySize)
+                {
+                    _lazyKey.Dispose();
+                    _lazyKey = null;
+                }
+
+                // If we don't have a key yet, we need to generate a random one now.
+                if (_lazyKey == null)
+                {
+                    CngKeyCreationParameters creationParameters = new CngKeyCreationParameters();
+                    CngProperty keySizeProperty = new CngProperty(KeyPropertyName.Length, BitConverter.GetBytes(KeySize), CngPropertyOptions.None);
+                    creationParameters.Parameters.Add(keySizeProperty);
+                    _lazyKey = CngKey.Create(CngAlgorithm.Rsa, null, creationParameters);
+                }
+
+                return _lazyKey;
+            }
+
+            private set
+            {
+                Debug.Assert(value != null, "value != null");
+                if (value.AlgorithmGroup != CngAlgorithmGroup.Rsa)
+                    throw new ArgumentException(SR.Cryptography_ArgRSAaRequiresRSAKey, "value");
+
+                // If we already have a key, clear it out.
+                if (_lazyKey != null)
+                {
+                    _lazyKey.Dispose();
+                }
+
+                _lazyKey = value;
+                KeySize = _lazyKey.KeySize;
+            }
+        }
+    }
+}
+

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+using Microsoft.Win32.SafeHandles;
+
+using Internal.Cryptography;
+
+using ErrorCode = Interop.NCrypt.ErrorCode;
+using AsymmetricPaddingMode = Interop.NCrypt.AsymmetricPaddingMode;
+using BCRYPT_PKCS1_PADDING_INFO = Interop.BCrypt.BCRYPT_PKCS1_PADDING_INFO;
+using BCRYPT_PSS_PADDING_INFO = Interop.BCrypt.BCRYPT_PSS_PADDING_INFO;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class RSACng : RSA
+    {
+        /// <summary>
+        ///     Computes the signature of a hash that was produced by the hash algorithm specified by "hashAlgorithm."
+        /// </summary>
+        public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            if (hash == null)
+                throw new ArgumentNullException("hash");
+
+            unsafe
+            {
+                byte[] signature = null;
+                SignOrVerify(padding, hashAlgorithm, hash,
+                    delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
+                    {
+                        SafeNCryptKeyHandle keyHandle = Key.Handle;
+                        int numBytesNeeded;
+                        ErrorCode errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, null, 0, out numBytesNeeded, paddingMode);
+                        if (errorCode != ErrorCode.ERROR_SUCCESS)
+                            throw errorCode.ToCryptographicException();
+
+                        signature = new byte[numBytesNeeded];
+                        errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out numBytesNeeded, paddingMode);
+                        if (errorCode != ErrorCode.ERROR_SUCCESS)
+                            throw errorCode.ToCryptographicException();
+                    }
+                );
+                return signature;
+            }
+        }
+
+        /// <summary>
+        ///     Verifies that alleged signature of a hash is, in fact, a valid signature of that hash.
+        /// </summary>
+        public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            if (hash == null)
+                throw new ArgumentNullException("hash");
+            if (signature == null)
+                throw new ArgumentNullException("signature");
+
+            unsafe
+            {
+                bool verified = false;
+                SignOrVerify(padding, hashAlgorithm, hash,
+                    delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
+                    {
+                        SafeNCryptKeyHandle keyHandle = Key.Handle;
+                        ErrorCode errorCode = Interop.NCrypt.NCryptVerifySignature(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, paddingMode);
+                        if (errorCode == ErrorCode.ERROR_SUCCESS)
+                            verified = true;
+                        else if (errorCode == ErrorCode.NTE_BAD_SIGNATURE)
+                            verified = false;
+                        else
+                            throw errorCode.ToCryptographicException();
+                    }
+                );
+                return verified;
+            }
+        }
+
+        //
+        // Common helper for SignHash() and VerifyHash(). Creates the necessary PADDING_INFO structure based on the chosen padding mode and then passes it
+        // to "signOrVerify" which performs the actual signing or verification.
+        //
+        private static unsafe void SignOrVerify(RSASignaturePadding padding, HashAlgorithmName hashAlgorithm, byte[] hash, SignOrVerifyAction signOrVerify)
+        {
+            string hashAlgorithmName = hashAlgorithm.Name;
+            if (string.IsNullOrEmpty(hashAlgorithmName))
+                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
+
+            if (padding == null)
+                throw new ArgumentNullException("padding");
+
+            switch (padding.Mode)
+            {
+                case RSASignaturePaddingMode.Pkcs1:
+                    {
+                        using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(hashAlgorithmName))
+                        {
+                            BCRYPT_PKCS1_PADDING_INFO paddingInfo = new BCRYPT_PKCS1_PADDING_INFO()
+                            {
+                                pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
+                            };
+                            signOrVerify(AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &paddingInfo);
+                        }
+                        break;
+                    }
+
+                case RSASignaturePaddingMode.Pss:
+                    {
+                        using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(hashAlgorithmName))
+                        {
+                            BCRYPT_PSS_PADDING_INFO paddingInfo = new BCRYPT_PSS_PADDING_INFO()
+                            {
+                                pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
+                                cbSalt = hash.Length,
+                            };
+                            signOrVerify(AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &paddingInfo);
+                        }
+                        break;
+                    }
+
+                default:
+                    throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+            }
+        }
+
+        private unsafe delegate void SignOrVerifyAction(AsymmetricPaddingMode paddingMode, void* pPaddingInfo);
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.cs
@@ -3,76 +3,71 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 
 namespace System.Security.Cryptography
 {
-    public sealed class RSACng : RSA
+    public sealed partial class RSACng : RSA
     {
+        /// <summary>
+        ///     Create an RSACng algorithm with a random 2048 bit key pair.
+        /// </summary>
         public RSACng()
+            : this(2048)
         {
-            throw new NotImplementedException(SR.WorkInProgress);
         }
 
+        /// <summary>
+        ///     Creates a new RSACng object that will use a randomly generated key of the specified size.
+        ///     Valid key sizes range from 512 to 16384 bits, in increments of 64 bits. It is suggested that a
+        ///     minimum size of 2048 bits be used for all keys.
+        /// </summary>
+        /// <param name="keySize">Size of the key to generate, in bits.</param>
+        /// <exception cref="CryptographicException">if <paramref name="keySize" /> is not valid</exception>
         public RSACng(int keySize)
         {
-            throw new NotImplementedException(SR.WorkInProgress);
+            _legalKeySizesValue = s_legalKeySizes;
+            KeySize = keySize;
         }
 
+        /// <summary>
+        ///     Creates a new RSACng object that will use the specified key. The key's
+        ///     <see cref="CngKey.AlgorithmGroup" /> must be Rsa. This constructor
+        ///     creates a copy of the key. Hence, the caller can safely dispose of the 
+        ///     passed in key and continue using the RSACng object. 
+        /// </summary>
+        /// <param name="key">Key to use for RSA operations</param>
+        /// <exception cref="ArgumentException">if <paramref name="key" /> is not an RSA key</exception>
+        /// <exception cref="ArgumentNullException">if <paramref name="key" /> is null.</exception>
         public RSACng(CngKey key)
         {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
+            if (key == null)
+                throw new ArgumentNullException("key");
 
-        public CngKey Key
-        {
-            get { throw new NotImplementedException(SR.WorkInProgress); }
-        }
+            if (key.AlgorithmGroup != CngAlgorithmGroup.Rsa)
+                throw new ArgumentException(SR.Cryptography_ArgRSAaRequiresRSAKey, "key");
 
-        public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
+            _legalKeySizesValue = s_legalKeySizes;
+            Key = CngKey.Open(key.Handle, key.IsEphemeral ? CngKeyHandleOpenOptions.EphemeralKey : CngKeyHandleOpenOptions.None);
         }
 
         protected override void Dispose(bool disposing)
         {
-            throw new NotImplementedException(SR.WorkInProgress);
+            if (disposing && _lazyKey != null)
+            {
+                _lazyKey.Dispose();
+            }
         }
 
-        public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
+        // Key handle
+        private CngKey _lazyKey;
 
-        public override RSAParameters ExportParameters(bool includePrivateParameters)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
-
-        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
-
-        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
-
-        public override void ImportParameters(RSAParameters parameters)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
-
-        public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
-
-        public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
-        {
-            throw new NotImplementedException(SR.WorkInProgress);
-        }
+        // See https://msdn.microsoft.com/en-us/library/windows/desktop/bb931354(v=vs.85).aspx
+        private static readonly KeySizes[] s_legalKeySizes = 
+            new KeySizes[] 
+            {
+                // All values are in bits.
+                new KeySizes(minSize: 512, maxSize: 16384, skipSize: 64), 
+            }; 
     }
 }
 

--- a/src/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
@@ -1,0 +1,283 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Cng.Tests
+{
+    public static class RsaCngTests
+    {
+        [Fact]
+        public static void EncryptDecryptRoundtrip()
+        {
+            {
+                byte[] plainText = "87abc91203fa927823".HexToByteArray();
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.Pkcs1, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA1, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA256, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA384, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA512, 0x100);
+            }
+            {
+                byte[] plainText = "1298999adbbc".HexToByteArray();
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.Pkcs1, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA1, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA256, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA384, 0x100);
+                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA512, 0x100);
+            }
+        }
+
+        private static void TestEncryptDecryptRoundTrip(byte[] plainText, RSAEncryptionPadding paddingMode, int expectedCipherSize)
+        {
+            using (RSA rsaCng = new RSACng())
+            {
+                byte[] cipher = rsaCng.Encrypt(plainText, paddingMode);
+
+                // RSACng.Encrypt() is intentionally non-deterministic so we can verify that we got back a cipher of the right length
+                // but nothing about the contents.
+                Assert.Equal(expectedCipherSize, cipher.Length);
+
+                // But we can test to see that it decrypts back to the original.
+                byte[] plainTextAgain = rsaCng.Decrypt(cipher, paddingMode);
+                Assert.Equal<byte>(plainText, plainTextAgain);
+            }
+        }
+
+        [Fact]
+        public static void DecryptPkcs1()
+        {
+            byte[] cipher =
+                ("49d4247afc62226a48c8fc0983fe5c774dcffa57a2d44f68bbcd40af0111ab5b9e8683f994f89bdd1c295e276666f810e343"
+               + "583882acad9349810368204c5e3e24e196f7fc3fc1621e8c2843006e7b80732043faaa4ef873941a626e716943f2f5addd3e"
+               + "5b3d39c6e856bdca84d7040b711315794b612808a51b587df244d539").HexToByteArray();
+
+            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
+            {
+                byte[] expectedPlainText = "87abc91203fa927823".HexToByteArray();
+                byte[] actualPlainText = rsa.Decrypt(cipher, RSAEncryptionPadding.Pkcs1);
+                Assert.Equal<byte>(expectedPlainText, actualPlainText);
+            }
+        }
+
+        [Fact]
+        public static void DecryptOaepSHA1()
+        {
+            byte[] cipher =
+                ("0b9293720a2d171c3c0754611a83180086199cff3531e4849eb3da4ce5e9a19fc1de619cceae2b5eb341e2311b4651baa01a"
+               + "8ecdd9b1e5c5baf0181bf31595407f2730e24a952ebef506ee7812d17658ac13de37033a8c94aef2839d3c528f438f5f5e3b"
+               + "290d1a12af586c64073f99d1fbd4a406cdae46f7059ee4300d334855").HexToByteArray();
+
+            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
+            {
+                byte[] expectedPlainText = "87abc91203fa927823".HexToByteArray();
+                byte[] actualPlainText = rsa.Decrypt(cipher, RSAEncryptionPadding.OaepSHA1);
+                Assert.Equal<byte>(expectedPlainText, actualPlainText);
+            }
+        }
+
+        [Fact]
+        public static void SignVerifyHashRoundTrip()
+        {
+            {
+                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+                byte[] hash = SHA1.Create().ComputeHash(message);
+                TestSignVerifyHashRoundTrip(hash, HashAlgorithmName.SHA1, RSASignaturePadding.Pss, 0x100);
+            }
+
+            {
+                byte[] message = "abcd992377".HexToByteArray();
+                byte[] hash = SHA256.Create().ComputeHash(message);
+                TestSignVerifyHashRoundTrip(hash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, 0x100);
+            }
+        }
+
+        private static void TestSignVerifyHashRoundTrip(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding paddingMode, int expectedSignatureLength)
+        {
+            using (RSA rsa = new RSACng())
+            {
+                byte[] signature = rsa.SignHash(hash, hashAlgorithm, paddingMode);
+
+                // RSACng.SignHash() is intentionally non-deterministic so we can verify that we got back a signature of the right length
+                // but nothing about the contents.
+                Assert.Equal(expectedSignatureLength, signature.Length);
+
+                bool verified = rsa.VerifyHash(hash, signature, hashAlgorithm, paddingMode);
+                Assert.True(verified);
+            }
+        }
+
+        [Fact]
+        public static void SignVerifyDataRoundTrip()
+        {
+            {
+                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+                TestSignVerifyDataRoundTrip(message, HashAlgorithmName.SHA1, RSASignaturePadding.Pss, 0x100);
+            }
+
+            {
+                byte[] message = "abcd992377".HexToByteArray();
+                TestSignVerifyDataRoundTrip(message, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, 0x100);
+            }
+        }
+
+        private static void TestSignVerifyDataRoundTrip(byte[] message, HashAlgorithmName hashAlgorithm, RSASignaturePadding paddingMode, int expectedSignatureLength)
+        {
+            using (RSA rsa = new RSACng())
+            {
+                byte[] signature = rsa.SignData(message, hashAlgorithm, paddingMode);
+
+                // RSACng.SignHash() is intentionally non-deterministic so we can verify that we got back a signature of the right length
+                // but nothing about the contents.
+                Assert.Equal(expectedSignatureLength, signature.Length);
+
+                bool verified = rsa.VerifyData(message, signature, hashAlgorithm, paddingMode);
+                Assert.True(verified);
+            }
+        }
+
+        [Fact]
+        public static void VerifyHashPkcs1()
+        {
+            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
+            {
+                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+                byte[] hash = ("aecc72ccc8e3c3ff28ffd7acac7d3065225aa24e").HexToByteArray();
+                byte[] signature =
+                    ("a35477a7db1f5d47fdca660eb7ab31520a6267b45498c5fb52b9a0a634545f96d289da27f8f8f21cee71271fecfb1d013ed9"
+                   + "6f12f1a17fbb29190bf1bb4bbeb14f6eb7c4703982ac9c3ad355f30064596cfebc5c2dae59962035fbbaa073af4bf2774195"
+                   + "74a2937736ccdec4c9b6f6b930f9787ca5be9e8edfe493473903e965").HexToByteArray();
+
+                bool verified = rsa.VerifyHash(hash, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                Assert.True(verified);
+            }
+        }
+
+        [Fact]
+        public static void VerifyHashPss()
+        {
+            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
+            {
+                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+                byte[] hash = ("aecc72ccc8e3c3ff28ffd7acac7d3065225aa24e").HexToByteArray();
+                byte[] signature =
+                    ("3bde39974a884c4ecbc7296063a2a96edc778435b7b277b594a0712dcc0ddcd00b2970473b2f1359c98535dbae41fe2fb9e7"
+                   + "42f77e1849c9746fd05c58d2e3f06c7290d96bbe53882391d76a73fd5f0650f1e46d5a81c83e617f05203f9ad6416957d06e"
+                   + "49fe98a3d97359a3b7c1b80593b75265daa1a670aabf287d31a2f441").HexToByteArray();
+
+                bool verified = rsa.VerifyHash(hash, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pss);
+                Assert.True(verified);
+            }
+        }
+
+        [Fact]
+        public static void VerifyData()
+        {
+            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
+            {
+                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+                byte[] signature =
+                    ("a35477a7db1f5d47fdca660eb7ab31520a6267b45498c5fb52b9a0a634545f96d289da27f8f8f21cee71271fecfb1d013ed9"
+                   + "6f12f1a17fbb29190bf1bb4bbeb14f6eb7c4703982ac9c3ad355f30064596cfebc5c2dae59962035fbbaa073af4bf2774195"
+                   + "74a2937736ccdec4c9b6f6b930f9787ca5be9e8edfe493473903e965").HexToByteArray();
+
+                bool verified = rsa.VerifyData(message, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                Assert.True(verified);
+
+
+            }
+        }
+
+        [Fact]
+        public static void SignAndVerifyDataFromStream()
+        {
+            TestSignAndVerifyDataFromStream(100);
+            TestSignAndVerifyDataFromStream(4096);
+            TestSignAndVerifyDataFromStream(4097);
+            TestSignAndVerifyDataFromStream(4096 * 2);
+            TestSignAndVerifyDataFromStream(4096 * 2 + 1);
+            TestSignAndVerifyDataFromStream(0);
+        }
+
+        private static void TestSignAndVerifyDataFromStream(int messageSize)
+        {
+            RSASignaturePadding padding = RSASignaturePadding.Pkcs1;
+            byte[] message = new byte[messageSize];
+            byte b = 5;
+            for (int i = 0; i < message.Length; i++)
+            {
+                message[i] = b;
+                b = (byte)((b << 4) | (i & 0xf));
+            }
+
+            byte[] hash = SHA1.Create().ComputeHash(message);
+            Stream stream = new MemoryStream(message);
+
+            using (RSA rsa = new RSACng())
+            {
+                byte[] signature = rsa.SignData(stream, HashAlgorithmName.SHA1, padding);
+
+                // Since the unique codepath being tested here is HashData(Stream...), the interesting test is to see if HashData(Stream...)
+                // computed the right hash. The easiest way to test that is to compute the hash ourselves and call VerifyHash.
+                bool verified = rsa.VerifyHash(hash, signature, HashAlgorithmName.SHA1, padding);
+                Assert.True(verified);
+
+                stream = new MemoryStream(message);
+                verified = rsa.VerifyData(stream, signature, HashAlgorithmName.SHA1, padding);
+                Assert.True(verified);
+            }
+        }
+
+        [Fact]
+        public static void ImportExport()
+        {
+            using (RSA rsa = new RSACng())
+            {
+                rsa.ImportParameters(TestData.TestRsaKeyPair);
+                RSAParameters reExported;
+
+                // This is the current 4.6 behavior.
+                Assert.Throws<CryptographicException>(() => reExported = rsa.ExportParameters(includePrivateParameters: true));
+                //AssertRSAParametersEquals(TestData.TestRsaKeyPair, reExported);
+            }
+        }
+
+        [Fact]
+        public static void ImportExportPublicOnly()
+        {
+            using (RSA rsa = new RSACng())
+            {
+                rsa.ImportParameters(TestData.TestRsaKeyPair);
+                RSAParameters reExported = rsa.ExportParameters(includePrivateParameters: false);
+                Assert.Null(reExported.D);
+                Assert.Null(reExported.DP);
+                Assert.Null(reExported.DQ);
+                Assert.Null(reExported.InverseQ);
+                Assert.Null(reExported.P);
+                Assert.Null(reExported.Q);
+                Assert.Equal<byte>(TestData.TestRsaKeyPair.Exponent, reExported.Exponent);
+                Assert.Equal<byte>(TestData.TestRsaKeyPair.Modulus, reExported.Modulus);
+            }
+        }
+
+        private static void AssertRSAParametersEquals(RSAParameters expected, RSAParameters actual)
+        {
+            Assert.Equal<byte>(expected.D, actual.D);
+            Assert.Equal<byte>(expected.DP, actual.DP);
+            Assert.Equal<byte>(expected.DQ, actual.DQ);
+            Assert.Equal<byte>(expected.Exponent, actual.Exponent);
+            Assert.Equal<byte>(expected.InverseQ, actual.InverseQ);
+            Assert.Equal<byte>(expected.Modulus, actual.Modulus);
+            Assert.Equal<byte>(expected.P, actual.P);
+            Assert.Equal<byte>(expected.Q, actual.Q);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -15,6 +15,10 @@
       <Project>{4C1BD451-6A99-45E7-9339-79C77C42EE9E}</Project>
       <Name>System.Security.Cryptography.Cng</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\src\System.Security.Cryptography.Algorithms.csproj">
+      <Project>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</Project>
+      <Name>System.Security.Cryptography.Algorithms</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\System.Security.Cryptography.Primitives\src\System.Security.Cryptography.Primitives.csproj">
       <Project>{D04A73AE-E418-4ACD-A132-7688435BE8B5}</Project>
       <Name>System.Security.Cryptography.Primitives</Name>
@@ -26,6 +30,7 @@
     <Compile Include="OpenTests.cs" />
     <Compile Include="ImportExportTests.cs" />
     <Compile Include="PropertyTests.cs" />
+    <Compile Include="RSACngTests.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\ByteUtils.cs">
       <Link>CommonTest\Cryptography\ByteUtils.cs</Link>

--- a/src/System.Security.Cryptography.Cng/tests/TestData.cs
+++ b/src/System.Security.Cryptography.Cng/tests/TestData.cs
@@ -19,6 +19,46 @@ namespace System.Security.Cryptography.Cng.Tests
         // AllowExport|AllowPlainTextExport,  CngKeyCreationOptions.NOne, UIPolicy(CngUIProtectionLevels.None), CngKeyUsages.Decryption
         public static byte[] Key_ECDiffieHellmanP256 =
            ("45434b3120000000d679ed064a01dacd012d24495795d4a3272fb6f6bd3d9baf8b40c0db26a81dfb8b4919d5477a07ae5c4b"
-          + "4b577f2221be085963abc7515bbbf6998919a34baefe").HexToByteArray(); 
+          + "4b577f2221be085963abc7515bbbf6998919a34baefe").HexToByteArray();
+
+        public static RSA CreateRsaCng(this RSAParameters rsaParameters)
+        {
+            RSA rsa = new RSACng();
+            rsa.ImportParameters(rsaParameters);
+            return rsa;
+        }
+
+        public static RSAParameters TestRsaKeyPair;
+
+        static TestData()
+        {
+            RSAParameters rp = new RSAParameters();
+            rp.D = ("2806880f41dfba6ea9cb91f141c07e09cc0def786030162e1947c50d427d21dc5c0779ded52c50e570665884ba0ba32977c6"
+                  + "3019da0d255de458c9f421f0a17cd70bc21ea1e97152d3ded5ef1f17927bf2c03f83a72534033baacc670443d4e9c80e2d87"
+                  + "e206a3c3094ee5b20c3a1edf99c275f8f63cd4de7cdea326050cb151").HexToByteArray();
+
+            rp.DP = ("0aa6fc0436a24aa03c7a4d0b4cb84b75b9475eb0410ffaaa2a2c6d4dd8d4c3a5ac815bdeb93245babef613f983e4770d63d0"
+                   + "d931e33f0509019a1e431e6b5911").HexToByteArray();
+
+            rp.DQ = ("b7944d4d4846708c33adb0ad964623ad0e55d7c5bbd6475d25b12fbb39ab8c75794fdc977d67f54833ba59acbec8f3d91ddb"
+                   + "f29d0e780d52f8c656cad787fad5").HexToByteArray();
+
+            rp.Exponent = ("010001").HexToByteArray();
+
+            rp.InverseQ = ("8fdd8821b7fcc6e907436bc33d7311f9344ee18a3af36429c550f34f83c4c93fd0429f63bdc502db9cc03d3d857a6354e98b"
+                         + "db7c76b3ab54c32cdae75c539f2c").HexToByteArray();
+
+            rp.Modulus = ("c7b5012552672f812a015bf3356abdfe4964cfe2ae35b8aba819120c58ffa2f1fc0f512e76fd22e6d32646ceea78829a9cbb"
+                        + "2dbe5c66d14390e1bcef05afbababfe1f5ca07983b1f688a01b2beef8886b05df9e9420e65a1c0dc605ccfa2e27d84b39433"
+                        + "ffcd07441ef5be8ab80497bc553fce022c7620922d1d624b6e3babe1").HexToByteArray();
+
+            rp.P = ("c7eb601fdd49b22eda5b9a5ccb2fcfc35a660bb3bd2872857c864432e32916c2231e3b3da8afddc3efa38d04f9b1a08a08ab"
+                  + "08b4603ff28345ba32d24de3cfa5").HexToByteArray();
+
+            rp.Q = ("ffba608710355472b48b41e57eadd19a3f1a5d2fc1baa3d6210520c95694f11a065a16354827abdb06a59c3616f5ff2c5ca3"
+                  + "be835f1278e9a9e9f0373027b68d").HexToByteArray();
+
+            TestRsaKeyPair = rp;
+        }
     }
 }


### PR DESCRIPTION
RSACng implemented with one open issue (tracked internally as 1208349) - SignData and VerifyData throw NI for any hash algorithm other than MD5/SHA1/SHA256/SHA384/SHA512. I want to peel that off for a later commit as it's likely to create a lot of debate over how/if to share the CNG hash provider code with SSC.Algorithms (these also involve the only P/Invokes that any assembly outside of SSC.Cng has any reasonable excuse to call.) 

Since the rest of the class is in good shape, I'd like to get it put away as I'll probably be randomized next week.


