### PR TITLE
Fix FileSystemWatcher test race and allow process exit time == start time

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTests.cs
@@ -137,7 +137,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.Throws<InvalidOperationException>(() => p.ExitTime);
             p.Kill();
             Assert.True(p.WaitForExit(WaitInMS));
-            Assert.True(p.ExitTime.ToUniversalTime() > timeBeforeProcessStart, "TestExitTime is incorrect.");
+            Assert.True(p.ExitTime.ToUniversalTime() >= timeBeforeProcessStart, "TestExitTime is incorrect.");
         }
 
         [Fact]

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
@@ -101,7 +102,14 @@ public partial class FileSystemWatcher_4000_Tests
                 testFile.Flush();
 
                 // renaming a directory
-                testDir.Move(testDir.Path + "_rename");
+                //
+                // We don't do this on Linux because depending on the timing of MOVED_FROM and MOVED_TO events,
+                // a rename can trigger delete + create as a deliberate handling of an edge case, and this
+                // test is checking that no create events are raised.
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    testDir.Move(testDir.Path + "_rename");
+                }
 
                 // deleting a file & directory by leaving the using block
             }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
@@ -70,9 +71,16 @@ public partial class FileSystemWatcher_4000_Tests
                 testFile.Flush();
 
                 // renaming a directory
-                testDir.Move(testDir.Path + "_rename");
+                //
+                // We don't do this on Linux because depending on the timing of MOVED_FROM and MOVED_TO events,
+                // a rename can trigger delete + create as a deliberate handling of an edge case, and this
+                // test is checking that no delete events are raised.
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    testDir.Move(testDir.Path + "_rename");
+                }
 
-                Utility.ExpectNoEvent(eventOccured, "changed");
+                Utility.ExpectNoEvent(eventOccured, "deleted");
             }
         }
     }


### PR DESCRIPTION
Addressing the issue that was hit by PR #2606 trying to get through CI.

cc @stephentoub @sokket 

On Linux, we can sometimes generate delete and create
instead of rename, depending on the timing of events.
As such, we can't perform renames and test that no
create or delete is raised when we're running on Linux.

The issue had so far only arisen on the negative create
test and not the negative delete test, which turned out
to be because the negative delete test was using the wrong
event name.