### PR TITLE
ZipFile: Reduce allocations in IsDirEmpty

### DIFF
--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
@@ -569,10 +570,8 @@ namespace System.IO.Compression
 
         private static Boolean IsDirEmpty(DirectoryInfo possiblyEmptyDir)
         {
-            foreach (FileSystemInfo fi in possiblyEmptyDir.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
-                return false;
-
-            return true;
+            using (IEnumerator<String> enumerator = Directory.EnumerateFileSystemEntries(possiblyEmptyDir.FullName).GetEnumerator())
+                return !enumerator.MoveNext();
         }
     }  // class ZipFile
 }  // namespace


### PR DESCRIPTION
- Use `Directory.EnumerateFileSystemEntries` to avoid the extra allocations associated with the `FileInfo`/`DirectoryInfo` instance created by `DirectoryInfo.EnumerateFileSystemInfos`.

- Use the default overload of `EnumerateFileSystemEntries`, which uses `SearchOption.TopDirectoryOnly`, as `SearchOption.AllDirectories` is not necessary here and `AllDirectories` currently has more allocations than `TopDirectoryOnly` on Windows.

- Use the enumerator directly to avoid the unnecessary call to `Current`.

(Use of uppercase `String` is deliberate to match the other formatting in this file.)