### PR TITLE
Enable System.IO.Pipes test disabled against Issue#1840

### DIFF
--- a/src/System.IO.Pipes/tests/AnonymousPipesSimpleTest.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipesSimpleTest.cs
@@ -199,7 +199,6 @@ public class AnonymousPipesSimpleTest
     }
 
     [Fact]
-    [ActiveIssue(1840, PlatformID.Windows)]
     public static async Task ClientPInvokeChecks()
     {
         using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.In, System.IO.HandleInheritability.None, 4096))

--- a/src/System.IO.Pipes/tests/NamedPipesSimpleTest.cs
+++ b/src/System.IO.Pipes/tests/NamedPipesSimpleTest.cs
@@ -355,7 +355,6 @@ public class NamedPipesSimpleTest
     }
 
     [Fact]
-    [ActiveIssue(1840)]
     [PlatformSpecific(PlatformID.Windows)]
     public static void ClientServerMessages()
     {
@@ -407,7 +406,6 @@ public class NamedPipesSimpleTest
     }
 
     [Fact]
-    [ActiveIssue(1840, PlatformID.Windows)]
     public static async Task ServerCloneTests()
     {
         const string pipeName = "fooclone";
@@ -439,7 +437,6 @@ public class NamedPipesSimpleTest
     }
 
     [Fact]
-    [ActiveIssue(1840, PlatformID.Windows)]
     public static async Task ClientCloneTests()
     {
         const string pipeName = "fooClientclone";


### PR DESCRIPTION
System.IO.Pipes dependended on some new APISets introduced in WIndows10.
Since the OS was still under development, it was not available on all the images, making the tests flaky.
Now that the things are stable, enabling the tests again.