### PR TITLE
Bug fix: When decoding a modified type it was throwing a BadImageForm…

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -382,10 +382,10 @@ namespace System.Reflection.Metadata.Decoding
             var modifier = new CustomModifier<TType>(type, isRequired);
 
             ImmutableArray<CustomModifier<TType>> modifiers;
-            SignatureTypeCode typeCode = blobReader.ReadSignatureTypeCode();
+            int typeCode = blobReader.ReadCompressedInteger();
 
-            isRequired = typeCode == SignatureTypeCode.RequiredModifier;
-            if (!isRequired && typeCode != SignatureTypeCode.OptionalModifier)
+            isRequired = typeCode == (int)SignatureTypeCode.RequiredModifier;
+            if (!isRequired && typeCode != (int)SignatureTypeCode.OptionalModifier)
             {
                 // common case: 1 modifier.
                 modifiers = ImmutableArray.Create(modifier);
@@ -401,13 +401,13 @@ namespace System.Reflection.Metadata.Decoding
                     type = DecodeTypeHandle(ref blobReader, provider, null);
                     modifier = new CustomModifier<TType>(type, isRequired);
                     builder.Add(modifier);
-                    typeCode = blobReader.ReadSignatureTypeCode();
-                    isRequired = typeCode == SignatureTypeCode.RequiredModifier;
-                } while (isRequired || typeCode == SignatureTypeCode.OptionalModifier);
+                    typeCode = blobReader.ReadCompressedInteger();
+                    isRequired = typeCode == (int)SignatureTypeCode.RequiredModifier;
+                } while (isRequired || typeCode == (int)SignatureTypeCode.OptionalModifier);
 
                 modifiers = builder.ToImmutable();
             }
-            TType unmodifiedType = DecodeType(ref blobReader, (int)typeCode, provider);
+            TType unmodifiedType = DecodeType(ref blobReader, typeCode, provider);
             return provider.GetModifiedType(unmodifiedType, modifiers);
         }
 


### PR DESCRIPTION
…atException, the previous change to get the valuetype and class prefix flag broke that because didn't update DecodeModifiedType to read a compressed integer instead of reading a SignatureTypeCode.