### PR TITLE
Replace ContainsKey with TryGetValue in Regex

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -362,10 +362,8 @@ namespace System.Text.RegularExpressions
             {
                 if (_caps != null)
                 {
-                    if (!_caps.ContainsKey(i))
+                    if (!_caps.TryGetValue(i, out i))
                         return String.Empty;
-
-                    i = _caps[i];
                 }
 
                 if (i >= 0 && i < _capslist.Length)
@@ -395,10 +393,10 @@ namespace System.Text.RegularExpressions
             // look up name if we have a hashtable of names
             if (_capnames != null)
             {
-                if (!_capnames.ContainsKey(name))
+                if (!_capnames.TryGetValue(name, out result))
                     return -1;
 
-                return _capnames[name];
+                return result;
             }
 
             // convert to an int if it looks like a number


### PR DESCRIPTION
I did a recursive search for `".ContainsKey("` and sifted though the matches; unfortunately, the only places I could optimize were `WinRTFileSystem` and `Regex`. Here is the PR.

That being said, many of the matches I found looked like `if (!dict.ContainsKey(key) dict.Add(key, value)`. If we [add a `TryAdd` method](https://github.com/dotnet/corefx/issues/1942) like we have for ConcurrentDictionary, around ~40 different places could be optimized.