### PR TITLE
Update BuildTools version to uptake _AssemblyInfo.cs changes

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00069</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00070</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-12101</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00069" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00070" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-12101" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00069" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00070" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>


### PR DESCRIPTION
Update the BuildTools version in CoreFx to pick up the changes to the
generation of _AssemblyInfo.cs which, are necessary for the localization
work.