### PR TITLE
Eliminate char buffer allocations in ConsolePal.Unix

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -321,32 +321,6 @@ namespace System
             }
         }
 
-        /// <summary>Creates a string from an array of ASCII bytes.</summary>
-        /// <param name="buffer">The byte buffer.</param>
-        /// <param name="offset">The starting location in the buffer from which to begin the string.</param>
-        /// <param name="length">The length of the resulting string.</param>
-        /// <returns>
-        /// A string containing characters copied from the buffer, one character per byte starting
-        /// from <paramref name="offset"/> and going for <paramref name="length"/> bytes.
-        /// </returns>
-        private static string StringFromAsciiBytes(byte[] buffer, int offset, int length)
-        {
-            // Special-case for empty strings
-            if (length == 0)
-            {
-                return string.Empty;
-            }
-
-            // new string(sbyte*, ...) doesn't exist in the targeted reference assembly,
-            // so we first copy to an array of chars, and then create a string from that.
-            char[] chars = new char[length];
-            for (int i = 0, j = offset; i < length; i++, j++)
-            {
-                chars[i] = (char)buffer[j];
-            }
-            return new string(chars);
-        }
-
         /// <summary>Provides a stream to use for Unix console input or output.</summary>
         private sealed class UnixConsoleStream : ConsoleStream
         {
@@ -710,7 +684,7 @@ namespace System
                     {
                         findNullEnding++;
                     }
-                    return StringFromAsciiBytes(buffer, pos, findNullEnding - pos);
+                    return Encoding.ASCII.GetString(buffer, pos, findNullEnding - pos);
                 }
             }
 
@@ -1054,7 +1028,7 @@ namespace System
                             throw new InvalidOperationException(SR.InvalidOperation_PrintF);
                         }
                     }
-                    return StringFromAsciiBytes(bytes, 0, neededLength);
+                    return Encoding.ASCII.GetString(bytes, 0, neededLength);
                 }
 
                 /// <summary>Gets the lazily-initialized dynamic or static variables collection, based on the supplied variable name.</summary>


### PR DESCRIPTION
Instead of creating an intermediary `char[]` buffer, we now call `GetString`. This internally calls `string.CreateStringFromEncoding`, copying the characters directly into the string.