### PR TITLE
Disable ProcessThreadTests.TestStartTimeProperty test on Linux

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -56,6 +56,7 @@ namespace System.Diagnostics.ProcessTests
         }
 
         [Fact]
+        [ActiveIssue(2613, PlatformID.Linux)]
         public void TestStartTimeProperty()
         {
             DateTime timeBeforeCreatingProcess = DateTime.UtcNow;


### PR DESCRIPTION
#2613

@Priya91, I think the tests are just expecting more precision than is actually available.  As with #2680, I'll let you investigate a real fix; for now I'm just disabling the test.