### PR TITLE
Boost RuntimeInformation code coverage to 100%

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
@@ -71,9 +71,11 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.False(winObj != winProp);
 
             Assert.True(winObj.Equals(winProp));
+            Assert.True(winObj.Equals((object)winProp));
             Assert.True(conObj.Equals(defaultObj));
 
             Assert.False(defaultObj.Equals(winProp));
+            Assert.False(defaultObj.Equals((object)winProp));
             Assert.False(winObj.Equals(null));
             Assert.False(winObj.Equals("something"));
 


### PR DESCRIPTION
Scratching an itch; very small addition to get System.Runtime.InteropServices.RuntimeInformation's line and branch code coverage up to 100%.

cc: @Priya91