### PR TITLE
Avoid char buffer allocations in System.IO.Compression

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -453,7 +453,7 @@ namespace System.IO.Compression
                 readEntryNameEncoding = Encoding.UTF8;
             }
 
-            return new string(readEntryNameEncoding.GetChars(entryNameBytes)); //readEntryNameEncoding.GetString(entryNameBytes);
+            return readEntryNameEncoding.GetString(entryNameBytes);
         }
 
         private Byte[] EncodeEntryName(String entryName, out bool isUTF8)


### PR DESCRIPTION
These changes avoid creating an intermediate `char[]` buffer when creating a string.