### PR TITLE
Fix TODO in CapiHelper around Encoding.ASCII

### DIFF
--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -409,18 +409,7 @@ namespace Internal.NativeCrypto
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, pb, ref cb, CryptGetProvParamFlags.PP_UNIQUE_CONTAINER);
                         pb = new byte[cb];
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, pb, ref cb, CryptGetProvParamFlags.PP_UNIQUE_CONTAINER);
-                        //ToDO : I am getting compilation error when trying to use ASCII
-                        // 'System.Text.Encoding' does not contain a definition for 'ASCII'
-                        //If we don't support ASCII then for loop below should do the work.
-                        //Otherwise remove the for loop and keep the commented code below
-                        //char[] ch = Encoding.ASCII.GetChars(pb);
-
-                        char[] ch = new char[cb];
-                        for (int i = 0; i < cb; i++)
-                        {
-                            ch[i] = (char)pb[i];
-                        }
-                        retStr = new string(ch);
+                        retStr = Encoding.ASCII.GetString(pb);
                     }
                     break;
                 default:

--- a/src/System.Security.Cryptography.Csp/src/project.json
+++ b/src/System.Security.Cryptography.Csp/src/project.json
@@ -7,6 +7,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "System.Runtime.InteropServices": "4.0.20",
+    "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.10"
   },
   "frameworks": {

--- a/src/System.Security.Cryptography.Csp/src/project.lock.json
+++ b/src/System.Security.Cryptography.Csp/src/project.lock.json
@@ -132,12 +132,15 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.0": {
+      "System.Text.Encoding/4.0.10": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
       "System.Threading/4.0.10": {
@@ -567,19 +570,17 @@
         "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
-    "System.Text.Encoding/4.0.0": {
-      "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
+    "System.Text.Encoding/4.0.10": {
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "files": [
-        "License.rtf",
-        "System.Text.Encoding.4.0.0.nupkg",
-        "System.Text.Encoding.4.0.0.nupkg.sha512",
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
         "System.Text.Encoding.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net45/_._",
-        "lib/win8/_._",
-        "lib/wp80/_._",
-        "lib/wpa81/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/System.Text.Encoding.dll",
@@ -595,23 +596,10 @@
         "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net45/_._",
-        "ref/netcore50/System.Text.Encoding.dll",
-        "ref/netcore50/System.Text.Encoding.xml",
-        "ref/netcore50/de/System.Text.Encoding.xml",
-        "ref/netcore50/es/System.Text.Encoding.xml",
-        "ref/netcore50/fr/System.Text.Encoding.xml",
-        "ref/netcore50/it/System.Text.Encoding.xml",
-        "ref/netcore50/ja/System.Text.Encoding.xml",
-        "ref/netcore50/ko/System.Text.Encoding.xml",
-        "ref/netcore50/ru/System.Text.Encoding.xml",
-        "ref/netcore50/zh-hans/System.Text.Encoding.xml",
-        "ref/netcore50/zh-hant/System.Text.Encoding.xml",
-        "ref/win8/_._",
-        "ref/wp80/_._",
-        "ref/wpa81/_._",
+        "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
     "System.Threading/4.0.10": {
@@ -704,6 +692,7 @@
       "System.Runtime >= 4.0.20",
       "System.Runtime.Extensions >= 4.0.10",
       "System.Runtime.InteropServices >= 4.0.20",
+      "System.Text.Encoding >= 4.0.10",
       "System.Threading >= 4.0.10"
     ],
     "DNXCore,Version=v5.0": []


### PR DESCRIPTION
The new System.Security.Cryptography.Csp assembly was depending on the older System.Text.Encoding 4.0.0 contract, which lacks Encoding.ASCII.  Updated it to use 4.0.10, which does contain Encoding.ASCII, and fixed an associated TODO.

cc: @AtsushiKan, @bartonjs, @ericstj