### PR TITLE
More char buffer elimination in CapiHelper

### DIFF
--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -409,18 +409,8 @@ namespace Internal.NativeCrypto
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, pb, ref cb, CryptGetProvParamFlags.PP_UNIQUE_CONTAINER);
                         pb = new byte[cb];
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, pb, ref cb, CryptGetProvParamFlags.PP_UNIQUE_CONTAINER);
-                        //ToDO : I am getting compilation error when trying to use ASCII
-                        // 'System.Text.Encoding' does not contain a definition for 'ASCII'
-                        //If we don't support ASCII then for loop below should do the work.
-                        //Otherwise remove the for loop and keep the commented code below
-                        //char[] ch = Encoding.ASCII.GetChars(pb);
 
-                        char[] ch = new char[cb];
-                        for (int i = 0; i < cb; i++)
-                        {
-                            ch[i] = (char)pb[i];
-                        }
-                        retStr = new string(ch);
+                        retStr = Encoding.ASCII.GetString(pb);
                     }
                     break;
                 default:


### PR DESCRIPTION
The comment said the compiler wouldn't recognize `Encoding.ASCII`, but when I hover over it in VS it appears to work fine.