### PR TITLE
Allow extended long path directories

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.MaxLengths.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MaxLengths.cs
@@ -6,7 +6,21 @@ internal partial class Interop
     internal partial class mincore
     {
         internal const int MAX_PATH = 260;
-        internal const int MAX_DIRECTORY_PATH = 248; // cannot create directories greater than 248 characters
+
+        // Technically the maximum file/directory name is whatever GetVolumeInformation tells you in
+        // MaximumComponentLength. For most file systems this is 255 (UDF is the notable exception at
+        // 254).
+        //
+        // CreateDirectory will refuse directories that are over MAX_PATH - 12 (8.3 filename length).
+        // This count includes the drive and NULL. This limitation existed to allow "del *.*" to work
+        // successfully and now appears to be moot as you can create files in a directory that is over
+        // 248 (up to MAX_PATH) and "del *.*" on them on both FAT and NTFS.
+        //
+        // Using extended syntax (\\?\) will allow creation of directory names that are full length
+        // (e.g. 255 characters). MKDIR/MD, however, does not check extended syntax and will fail out
+        // ANY string that is longer than OR equal to MAX_PATH. This effectively makes the longest
+        // directory you can create 252 characters, excluding the prefix and drive (\\?\C:\).
+        internal const int MAX_DIRECTORY_PATH = 248;
         internal const int CREDUI_MAX_USERNAME_LENGTH = 513;
     }
 }

--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -41,5 +41,22 @@ namespace System.IO
             Debug.Assert(Path.DirectorySeparatorChar == Path.AltDirectorySeparatorChar);
             return c == Path.DirectorySeparatorChar;
         }
+
+
+        /// <summary>
+        /// Returns true if the path is too long
+        /// </summary>
+        internal static bool IsPathTooLong(string fullPath)
+        {
+            return fullPath.Length >= Interop.libc.MaxPath;
+        }
+
+        /// <summary>
+        /// Returns true if the directory is too long
+        /// </summary>
+        internal static bool IsDirectoryTooLong(string fullPath)
+        {
+            return fullPath.Length >= Interop.libc.MaxPath;
+        }
     }
 }

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -13,6 +13,9 @@ namespace System.IO
         internal const string UncPathPrefix = @"\\";
         internal const string UncExtendedPrefixToInsert = @"?\UNC\";
         internal const string UncExtendedPathPrefix = @"\\?\UNC\";
+        internal const int MaxShortPath = 260;
+        internal const int MaxShortDirectoryPath = 248;
+        internal const int MaxExtendedPath = short.MaxValue;
 
         internal static readonly char[] InvalidPathChars =
         {
@@ -31,6 +34,40 @@ namespace System.IO
             (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
             (char)31, '*', '?'
         };
+
+        /// <summary>
+        /// Returns true if the path is too long
+        /// </summary>
+        internal static bool IsPathTooLong(string fullPath)
+        {
+            if (IsExtended(fullPath))
+            {
+                return fullPath.Length >= MaxExtendedPath;
+            }
+            else
+            {
+                // Will need to be updated with #2581 to allow all paths to MaxExtendedPath
+                // minus legth of extended local or UNC prefix.
+                return fullPath.Length >= MaxShortPath;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the directory is too long
+        /// </summary>
+        internal static bool IsDirectoryTooLong(string fullPath)
+        {
+            if (IsExtended(fullPath))
+            {
+                return fullPath.Length >= MaxExtendedPath;
+            }
+            else
+            {
+                // Will need to be updated with #2581 to allow all paths to MaxExtendedPath
+                // minus legth of extended local or UNC prefix.
+                return fullPath.Length >= MaxShortDirectoryPath;
+            }
+        }
 
         /// <summary>
         /// Adds the extended path prefix (\\?\) if not already present.

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -52,6 +52,27 @@
     <Compile Include="..\src\System\IO\PathInternal.CaseInsensitive.cs">
       <Link>Common\System\IO\PathInternal.CaseInsensitive.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.pathconf.cs">
+      <Link>Common\Interop\Unix\Interop.pathconf.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.PathConfNames.cs">
+      <Link>Common\Interop\Linux\Interop.PathConfNames.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.PathConfNames.cs">
+      <Link>Common\Interop\OSX\Interop.PathConfNames.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\FreeBSD\libc\Interop.PathConfNames.cs">
+      <Link>Common\Interop\FreeBSD\Interop.PathConfNames.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -99,6 +99,9 @@
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.pathconf.cs">
+      <Link>Common\Interop\Unix\Interop.pathconf.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mountpoints.cs">
       <Link>Common\Interop\Unix\Interop.mountpoints.cs</Link>
     </Compile>
@@ -123,6 +126,9 @@
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
       <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.PathConfNames.cs">
+      <Link>Common\Interop\Linux\Interop.PathConfNames.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsBSD)' == 'true' ">
     <Compile Include="System\IO\DriveInfo.BSD.cs" />
@@ -137,6 +143,9 @@
     <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.statfs.cs">
       <Link>Common\Interop\OSX\Interop.statfs.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.PathConfNames.cs">
+      <Link>Common\Interop\OSX\Interop.PathConfNames.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\FreeBSD\libc\Interop.statfs.cs">
@@ -144,6 +153,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\FreeBSD\Interop.Libraries.cs">
       <Link>Common\Interop\FreeBSD\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\FreeBSD\libc\Interop.PathConfNames.cs">
+      <Link>Common\Interop\FreeBSD\Interop.PathConfNames.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -519,7 +519,7 @@ namespace System.IO
             if (path.Length == 0)
                 throw new ArgumentException(SR.Argument_PathEmpty, "path");
             Contract.EndContractBlock();
-            if (path.Length >= FileSystem.Current.MaxPath)
+            if (PathInternal.IsPathTooLong(path))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
             String fulldestDirName = PathHelpers.GetFullPathInternal(path);
@@ -544,13 +544,12 @@ namespace System.IO
             String fullsourceDirName = PathHelpers.GetFullPathInternal(sourceDirName);
             String sourcePath = EnsureTrailingDirectorySeparator(fullsourceDirName);
 
-            int maxDirectoryPath = FileSystem.Current.MaxDirectoryPath;
-            if (sourcePath.Length >= maxDirectoryPath)
+            if (PathInternal.IsDirectoryTooLong(sourcePath))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
             String fulldestDirName = PathHelpers.GetFullPathInternal(destDirName);
             String destPath = EnsureTrailingDirectorySeparator(fulldestDirName);
-            if (destPath.Length >= maxDirectoryPath)
+            if (PathInternal.IsDirectoryTooLong(destPath))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
             StringComparison pathComparison = PathInternal.GetComparison();

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -392,11 +392,10 @@ namespace System.IO
             else
                 fullSourcePath = FullPath + PathHelpers.DirectorySeparatorCharAsString;
 
-            int maxDirectoryPath = FileSystem.Current.MaxDirectoryPath;
-            if (fullSourcePath.Length >= maxDirectoryPath)
+            if (PathInternal.IsDirectoryTooLong(fullSourcePath))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
-            if (fullDestDirName.Length >= maxDirectoryPath)
+            if (PathInternal.IsDirectoryTooLong(fullDestDirName))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
             StringComparison pathComparison = PathInternal.GetComparison();

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -105,7 +105,7 @@ namespace System.IO
             {
                 String name = stackDir[stackDir.Count - 1];
                 stackDir.RemoveAt(stackDir.Count - 1);
-                if (name.Length >= Interop.mincore.MAX_DIRECTORY_PATH)
+                if (PathInternal.IsDirectoryTooLong(name))
                     throw new PathTooLongException(SR.IO_PathTooLong);
                 r = Interop.mincore.CreateDirectory(name, ref secAttrs);
                 if (!r && (firstError == 0))

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -124,7 +124,7 @@ namespace System.IO.FileSystem.Tests
             var components = IOInputs.GetValidPathComponentNames();
             Assert.All(components, (component) =>
             {
-                string path = @"\\?\" + IOServices.AddTrailingSlashIfNeeded(Path.Combine(testDir.FullName, component));
+                string path = IOInputs.ExtendedPrefix + IOServices.AddTrailingSlashIfNeeded(Path.Combine(testDir.FullName, component));
                 DirectoryInfo result = Create(path);
 
                 Assert.Equal(path, result.FullName);
@@ -221,6 +221,17 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
+        public void ExtendedDirectoryLongerThanLegacyMaxPathSucceeds()
+        {
+            var paths = IOInputs.GetPathsLongerThanMaxPath(useExtendedSyntax: true, includeExtendedMaxPath: false);
+            Assert.All(paths, (path) =>
+            {
+                Assert.True(Create(path).Exists);
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_ThrowsPathTooLongException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxDirectory();
@@ -304,7 +315,7 @@ namespace System.IO.FileSystem.Tests
             {
                 foreach (var path in paths)
                 {
-                    string extendedPath = Path.Combine(@"\\?\" + directory.Path, path);
+                    string extendedPath = Path.Combine(IOInputs.ExtendedPrefix + directory.Path, path);
                     Directory.CreateDirectory(extendedPath);
                     Assert.True(Directory.Exists(extendedPath), extendedPath);
                 }
@@ -360,7 +371,7 @@ namespace System.IO.FileSystem.Tests
             {
                 Assert.All(paths, (path) =>
                 {
-                    Assert.True(Create(@"\\?\" + Path.Combine(directory.Path, path)).Exists, path);
+                    Assert.True(Create(IOInputs.ExtendedPrefix + Path.Combine(directory.Path, path)).Exists, path);
                 });
             }
         }

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -94,10 +94,19 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void WindowsExtendedDirectoryWithSubdirectories()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(@"\\?\" + GetTestFilePath());
+            DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
             testDir.CreateSubdirectory(GetTestFileName());
             Assert.Throws<IOException>(() => Delete(testDir.FullName));
             Assert.True(testDir.Exists);
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void WindowsLongPathExtendedDirectory()
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);
+            Delete(testDir.FullName);
+            Assert.False(testDir.Exists);
         }
 
         [Fact]
@@ -115,7 +124,7 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void WindowsDeleteExtendedReadOnlyDirectory()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(@"\\?\" + GetTestFilePath());
+            DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
             testDir.Attributes = FileAttributes.ReadOnly;
             Assert.Throws<IOException>(() => Delete(testDir.FullName));
             Assert.True(testDir.Exists);
@@ -146,7 +155,7 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void WindowsShouldBeAbleToDeleteExtendedHiddenDirectory()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(@"\\?\" + GetTestFilePath());
+            DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
             testDir.Attributes = FileAttributes.Hidden;
             Delete(testDir.FullName);
             Assert.False(testDir.Exists);

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -123,7 +123,7 @@ namespace System.IO.FileSystem.Tests
         {
             Assert.All((IOInputs.GetValidPathComponentNames()), (component) =>
             {
-                string path = @"\\?\" + Path.Combine(TestDirectory, "extended", component);
+                string path = IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, "extended", component);
                 DirectoryInfo testDir = Directory.CreateDirectory(path);
                 Assert.True(Exists(path));
             });
@@ -133,7 +133,7 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void ExtendedPathAlreadyExistsAsFile()
         {
-            string path = @"\\?\" + GetTestFilePath();
+            string path = IOInputs.ExtendedPrefix + GetTestFilePath();
             File.Create(path).Dispose();
 
             Assert.False(Exists(IOServices.RemoveTrailingSlash(path)));
@@ -145,7 +145,7 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void ExtendedPathAlreadyExistsAsDirectory()
         {
-            string path = @"\\?\" + GetTestFilePath();
+            string path = IOInputs.ExtendedPrefix + GetTestFilePath();
             DirectoryInfo testDir = Directory.CreateDirectory(path);
 
             Assert.True(Exists(IOServices.RemoveTrailingSlash(path)));
@@ -203,13 +203,13 @@ namespace System.IO.FileSystem.Tests
             {
                 string path = testDir.FullName + component;
                 Assert.True(Exists(path), path); // string concat in case Path.Combine() trims whitespace before Exists gets to it
-                Assert.False(Exists(@"\\?\" + path), path);
+                Assert.False(Exists(IOInputs.ExtendedPrefix + path), path);
             });
 
             Assert.All(IOInputs.GetSimpleWhiteSpace(), (component) =>
             {
                 string path = GetTestFilePath(memberName: "Extended") + component;
-                testDir = Directory.CreateDirectory(@"\\?\" + path);
+                testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + path);
                 Assert.False(Exists(path), path);
                 Assert.True(Exists(testDir.FullName));
             });

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -201,11 +201,11 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void ExtendedPathSubdirectory()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(@"\\?\" + GetTestFilePath());
+            DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
             Assert.True(testDir.Exists);
             DirectoryInfo subDir = testDir.CreateSubdirectory("Foo");
             Assert.True(subDir.Exists);
-            Assert.StartsWith(@"\\?\", subDir.FullName);
+            Assert.StartsWith(IOInputs.ExtendedPrefix, subDir.FullName);
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -59,8 +59,23 @@ namespace System.IO.FileSystem.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void ValidCreation_ExtendedSyntax()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(@"\\?\" + GetTestFilePath());
-            Assert.StartsWith(@"\\?\", testDir.FullName);
+            DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
+            Assert.StartsWith(IOInputs.ExtendedPrefix, testDir.FullName);
+            string testFile = Path.Combine(testDir.FullName, GetTestFileName());
+            using (FileStream stream = Create(testFile))
+            {
+                Assert.True(File.Exists(testFile));
+                Assert.Equal(0, stream.Length);
+                Assert.Equal(0, stream.Position);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void ValidCreation_LongPathExtendedSyntax()
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);
+            Assert.StartsWith(IOInputs.ExtendedPrefix, testDir.FullName);
             string testFile = Path.Combine(testDir.FullName, GetTestFileName());
             using (FileStream stream = Create(testFile))
             {

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -93,13 +93,20 @@ internal class IOServices
         return null;
     }
 
-
-    public static PathInfo GetPath(int characterCount)
+    public static PathInfo GetPath(int characterCount, bool extended = false)
     {
-        return GetPath(Path.GetPathRoot(Directory.GetCurrentDirectory()), characterCount, IOInputs.MaxComponent);
+        string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+        if (extended)
+            root = IOInputs.ExtendedPrefix + root;
+        return GetPath(root, characterCount);
     }
 
-    public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent)
+    public static PathInfo GetExtendedPath(int characterCount)
+    {
+        return GetPath(characterCount, extended: true);
+    }
+
+    public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent = IOInputs.MaxComponent)
     {
         List<string> paths = new List<string>();
         rootPath = rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);


### PR DESCRIPTION
Add methods for checking max length as it varies on path format.

Most code paths hit PathTooLong with GetFullPath- directories are a special
case as Win32 apis have a special limit (248) for directory creation.

#2581, #2411, #2579
@stephentoub, @mmitche, @weshaggard 