### PR TITLE
Use Array.Copy in ImmutableArray.Builder

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -269,11 +269,7 @@ namespace System.Collections.Immutable
                 var offset = this.Count;
                 this.Count += items.Length;
 
-                var nodes = _elements;
-                for (int i = 0; i < items.Length; i++)
-                {
-                    nodes[offset + i] = items[i];
-                }
+                Array.Copy(items, 0, _elements, offset, items.Length);
             }
 
             /// <summary>
@@ -287,11 +283,7 @@ namespace System.Collections.Immutable
                 var offset = this.Count;
                 this.Count += items.Length;
 
-                var nodes = _elements;
-                for (int i = 0; i < items.Length; i++)
-                {
-                    nodes[offset + i] = items[i];
-                }
+                Array.Copy(items, 0, _elements, offset, items.Length);
             }
 
             /// <summary>
@@ -302,16 +294,12 @@ namespace System.Collections.Immutable
             public void AddRange(T[] items, int length)
             {
                 Requires.NotNull(items, "items");
-                Requires.Range(length >= 0, "length");
+                Requires.Range(length >= 0 && length <= items.Length, "length");
 
                 var offset = this.Count;
                 this.Count += length;
 
-                var nodes = _elements;
-                for (int i = 0; i < length; i++)
-                {
-                    nodes[offset + i] = items[i];
-                }
+                Array.Copy(items, 0, _elements, offset, length);
             }
 
             /// <summary>
@@ -420,14 +408,9 @@ namespace System.Collections.Immutable
             /// </summary>
             public T[] ToArray()
             {
-                var tmp = new T[this.Count];
-                var elements = _elements;
-                for (int i = 0; i < tmp.Length; i++)
-                {
-                    tmp[i] = elements[i];
-                }
-
-                return tmp;
+                T[] result = new T[this.Count];
+                Array.Copy(_elements, 0, result, 0, this.Count);
+                return result;
             }
 
             /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -133,7 +133,7 @@ namespace System.Collections.Immutable.Test
             Assert.Throws<ArgumentNullException>(() => builder1.AddRange((int[])null));
             Assert.Throws<ArgumentNullException>(() => builder1.AddRange(null, 42));
             Assert.Throws<ArgumentOutOfRangeException>(() => builder1.AddRange(new int[0], -1));
-            Assert.Throws<IndexOutOfRangeException>(() => builder1.AddRange(new int[0], 42));
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder1.AddRange(new int[0], 42));
 
             Assert.Throws<ArgumentNullException>(() => builder1.AddRange((ImmutableArray<int>.Builder)null));
             Assert.Throws<ArgumentNullException>(() => builder1.AddRange((IEnumerable<int>)null));


### PR DESCRIPTION
Replaced some for-loops I found with Array.Copy and Array.Clone.

I couldn't optimize the `AddRange(IEnumerable<T>)` overload because it requires use of the extension method made in PR #2643, so I'll submit a new commit there soon.