### PR TITLE
Remove unneeded llvm-ranlib dependency

### DIFF
--- a/src/Native/gen-buildsys-clang.sh
+++ b/src/Native/gen-buildsys-clang.sh
@@ -88,8 +88,6 @@ llvm_link="$(locate_llvm_exec link)"
 [[ $? -eq 0 ]] || { echo "Unable to locate llvm-link"; exit 1; }
 llvm_nm="$(locate_llvm_exec nm)"
 [[ $? -eq 0 ]] || { echo "Unable to locate llvm-nm"; exit 1; }
-llvm_ranlib="$(locate_llvm_exec ranlib)"
-[[ $? -eq 0 ]] || { echo "Unable to locate llvm-ranlib"; exit 1; }
 if [ $OS = "Linux" -o $OS = "FreeBSD" -o $OS = "OpenBSD" -o $OS = "NetBSD" ]; then
   llvm_objdump="$(locate_llvm_exec objdump)"
   [[ $? -eq 0 ]] || { echo "Unable to locate llvm-objdump"; exit 1; }


### PR DESCRIPTION
Unavailable on openSuSE 13.2

/cc @nguerrera 