### PR TITLE
Add the common RSA tests to RSACng.Test.

### DIFF
--- a/src/Common/tests/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
 {
-    public class ImportExport
+    public partial class ImportExport
     {
         [Fact]
         public static void ExportAutoKey()
@@ -38,33 +38,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        public static void PaddedExport()
-        {
-            // OpenSSL's numeric type for the storage of RSA key parts disregards zero-valued
-            // prefix bytes.
-            //
-            // The .NET 4.5 RSACryptoServiceProvider type verifies that all of the D breakdown
-            // values (P, DP, Q, DQ, InverseQ) are exactly half the size of D (which is itself
-            // the same size as Modulus).
-            //
-            // These two things, in combination, suggest that we ensure that all .NET
-            // implementations of RSA export their keys to the fixed array size suggested by their
-            // KeySize property.
-            RSAParameters diminishedDPParamaters = TestData.DiminishedDPParamaters;
-            RSAParameters exported;
-
-            using (RSA rsa = RSAFactory.Create())
-            {
-                rsa.ImportParameters(diminishedDPParamaters);
-                exported = rsa.ExportParameters(true);
-            }
-
-            // DP is the most likely to fail, the rest just otherwise ensure that Export
-            // isn't losing data.
-            AssertKeyEquals(ref diminishedDPParamaters, ref exported);
-        }
-
-        [Fact]
         public static void LargeKeyImportExport()
         {
             RSAParameters imported = TestData.RSA16384Params;
@@ -91,30 +64,6 @@ namespace System.Security.Cryptography.Rsa.Tests
 
                 AssertKeyEquals(ref imported, ref exported);
             }
-        }
-
-        [Fact]
-        public static void UnusualExponentImportExport()
-        {
-            // Most choices for the Exponent value in an RSA key use a Fermat prime.
-            // Since a Fermat prime is 2^(2^m) + 1, it always only has two bits set, and
-            // frequently has the form { 0x01, [some number of 0x00s], 0x01 }, which has the same
-            // representation in both big- and little-endian.
-            //
-            // The only real requirement for an Exponent value is that it be coprime to (p-1)(q-1).
-            // So here we'll use the (non-Fermat) prime value 433 (0x01B1) to ensure big-endian export.
-            RSAParameters unusualExponentParameters = TestData.UnusualExponentParameters;
-            RSAParameters exported;
-
-            using (RSA rsa = RSAFactory.Create())
-            {
-                rsa.ImportParameters(unusualExponentParameters);
-                exported = rsa.ExportParameters(true);
-            }
-
-            // Exponent is the most likely to fail, the rest just otherwise ensure that Export
-            // isn't losing data.
-            AssertKeyEquals(ref unusualExponentParameters, ref exported);
         }
 
         [Fact]

--- a/src/Common/tests/Cryptography/AlgorithmImplementations/RSA/ImportExportUnusual.cs
+++ b/src/Common/tests/Cryptography/AlgorithmImplementations/RSA/ImportExportUnusual.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Rsa.Tests
+{
+    //
+    // These tests currently do not work against CNG and thus are split off so we can exclude them.
+    //
+    public partial class ImportExport
+    {
+        [Fact]
+        public static void PaddedExport()
+        {
+            // OpenSSL's numeric type for the storage of RSA key parts disregards zero-valued
+            // prefix bytes.
+            //
+            // The .NET 4.5 RSACryptoServiceProvider type verifies that all of the D breakdown
+            // values (P, DP, Q, DQ, InverseQ) are exactly half the size of D (which is itself
+            // the same size as Modulus).
+            //
+            // These two things, in combination, suggest that we ensure that all .NET
+            // implementations of RSA export their keys to the fixed array size suggested by their
+            // KeySize property.
+            RSAParameters diminishedDPParamaters = TestData.DiminishedDPParamaters;
+            RSAParameters exported;
+
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(diminishedDPParamaters);
+                exported = rsa.ExportParameters(true);
+            }
+
+            // DP is the most likely to fail, the rest just otherwise ensure that Export
+            // isn't losing data.
+            AssertKeyEquals(ref diminishedDPParamaters, ref exported);
+        }
+
+        [Fact]
+        public static void UnusualExponentImportExport()
+        {
+            // Most choices for the Exponent value in an RSA key use a Fermat prime.
+            // Since a Fermat prime is 2^(2^m) + 1, it always only has two bits set, and
+            // frequently has the form { 0x01, [some number of 0x00s], 0x01 }, which has the same
+            // representation in both big- and little-endian.
+            //
+            // The only real requirement for an Exponent value is that it be coprime to (p-1)(q-1).
+            // So here we'll use the (non-Fermat) prime value 433 (0x01B1) to ensure big-endian export.
+            RSAParameters unusualExponentParameters = TestData.UnusualExponentParameters;
+            RSAParameters exported;
+
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(unusualExponentParameters);
+                exported = rsa.ExportParameters(true);
+            }
+
+            // Exponent is the most likely to fail, the rest just otherwise ensure that Export
+            // isn't losing data.
+            AssertKeyEquals(ref unusualExponentParameters, ref exported);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -139,6 +139,19 @@ namespace Internal.Cryptography
                 return value;
             }
         }
+
+        /// <summary>
+        ///     Modify a CNG key's export policy.
+        /// </summary>
+        public static void SetExportPolicy(this SafeNCryptKeyHandle keyHandle, CngExportPolicies exportPolicy)
+        {
+            unsafe
+            {
+                ErrorCode errorCode = Interop.NCrypt.NCryptSetProperty(keyHandle, KeyPropertyName.ExportPolicy, &exportPolicy, sizeof(CngExportPolicies), CngPropertyOptions.Persist);
+                if (errorCode != ErrorCode.ERROR_SUCCESS)
+                    throw errorCode.ToCryptographicException();
+            }
+        }
     }
 }
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Create.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Create.cs
@@ -67,16 +67,14 @@ namespace System.Security.Cryptography
         /// <summary>
         ///     Setup the key properties specified in the key creation parameters
         /// </summary>
-        private static void InitializeKeyProperties(SafeNCryptHandle keyHandle, CngKeyCreationParameters creationParameters)
+        private static void InitializeKeyProperties(SafeNCryptKeyHandle keyHandle, CngKeyCreationParameters creationParameters)
         {
             unsafe
             {
                 if (creationParameters.ExportPolicy.HasValue)
                 {
                     CngExportPolicies exportPolicy = creationParameters.ExportPolicy.Value;
-                    ErrorCode errorCode = Interop.NCrypt.NCryptSetProperty(keyHandle, KeyPropertyName.ExportPolicy, &exportPolicy, sizeof(CngExportPolicies), CngPropertyOptions.Persist);
-                    if (errorCode != ErrorCode.ERROR_SUCCESS)
-                        throw errorCode.ToCryptographicException();
+                    keyHandle.SetExportPolicy(exportPolicy);
                 }
 
                 if (creationParameters.KeyUsage.HasValue)
@@ -119,7 +117,7 @@ namespace System.Security.Cryptography
         /// <summary>
         ///     Setup the UIPolicy key properties specified in the key creation parameters
         /// </summary>
-        private static void InitializeKeyUiPolicyProperties(SafeNCryptHandle keyHandle, CngUIPolicy uiPolicy)
+        private static void InitializeKeyUiPolicyProperties(SafeNCryptKeyHandle keyHandle, CngUIPolicy uiPolicy)
         {
             unsafe
             {

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -64,6 +64,11 @@ namespace System.Security.Cryptography
                 CngExportPolicies policy = (CngExportPolicies)_keyHandle.GetPropertyAsDword(KeyPropertyName.ExportPolicy, CngPropertyOptions.None);
                 return policy;
             }
+
+            internal set
+            {
+                _keyHandle.SetExportPolicy(value);
+            }
         }
 
         /// <summary>

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.Key.cs
@@ -32,7 +32,11 @@ namespace System.Security.Cryptography
                 // If we don't have a key yet, we need to generate a random one now.
                 if (_lazyKey == null)
                 {
-                    CngKeyCreationParameters creationParameters = new CngKeyCreationParameters();
+                    CngKeyCreationParameters creationParameters = new CngKeyCreationParameters()
+                    {
+                        ExportPolicy = CngExportPolicies.AllowPlaintextExport,
+                    };
+
                     CngProperty keySizeProperty = new CngProperty(KeyPropertyName.Length, BitConverter.GetBytes(KeySize), CngPropertyOptions.None);
                     creationParameters.Parameters.Add(keySizeProperty);
                     _lazyKey = CngKey.Create(CngAlgorithm.Rsa, null, creationParameters);

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -65,12 +65,7 @@ namespace System.Security.Cryptography
                     {
                         SafeNCryptKeyHandle keyHandle = Key.Handle;
                         ErrorCode errorCode = Interop.NCrypt.NCryptVerifySignature(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, paddingMode);
-                        if (errorCode == ErrorCode.ERROR_SUCCESS)
-                            verified = true;
-                        else if (errorCode == ErrorCode.NTE_BAD_SIGNATURE)
-                            verified = false;
-                        else
-                            throw errorCode.ToCryptographicException();
+                        verified = (errorCode == ErrorCode.ERROR_SUCCESS);  // For consistency with other RSA classes, return "false" for any error code rather than making the caller catch an exception.
                     }
                 );
                 return verified;

--- a/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Security.Cryptography.Rsa.Tests
+{
+    public class RSACngProvider : IRSAProvider
+    {
+        public RSA Create()
+        {
+            return new RSACng();
+        }
+
+        public RSA Create(int keySize)
+        {
+            return new RSACng(keySize);
+        }
+    }
+
+    public partial class RSAFactory
+    {
+        private static readonly IRSAProvider s_provider = new RSACngProvider();
+    }
+}

--- a/src/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
@@ -16,88 +16,11 @@ namespace System.Security.Cryptography.Cng.Tests
     public static class RsaCngTests
     {
         [Fact]
-        public static void EncryptDecryptRoundtrip()
-        {
-            {
-                byte[] plainText = "87abc91203fa927823".HexToByteArray();
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.Pkcs1, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA1, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA256, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA384, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA512, 0x100);
-            }
-            {
-                byte[] plainText = "1298999adbbc".HexToByteArray();
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.Pkcs1, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA1, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA256, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA384, 0x100);
-                TestEncryptDecryptRoundTrip(plainText, RSAEncryptionPadding.OaepSHA512, 0x100);
-            }
-        }
-
-        private static void TestEncryptDecryptRoundTrip(byte[] plainText, RSAEncryptionPadding paddingMode, int expectedCipherSize)
-        {
-            using (RSA rsaCng = new RSACng())
-            {
-                byte[] cipher = rsaCng.Encrypt(plainText, paddingMode);
-
-                // RSACng.Encrypt() is intentionally non-deterministic so we can verify that we got back a cipher of the right length
-                // but nothing about the contents.
-                Assert.Equal(expectedCipherSize, cipher.Length);
-
-                // But we can test to see that it decrypts back to the original.
-                byte[] plainTextAgain = rsaCng.Decrypt(cipher, paddingMode);
-                Assert.Equal<byte>(plainText, plainTextAgain);
-            }
-        }
-
-        [Fact]
-        public static void DecryptPkcs1()
-        {
-            byte[] cipher =
-                ("49d4247afc62226a48c8fc0983fe5c774dcffa57a2d44f68bbcd40af0111ab5b9e8683f994f89bdd1c295e276666f810e343"
-               + "583882acad9349810368204c5e3e24e196f7fc3fc1621e8c2843006e7b80732043faaa4ef873941a626e716943f2f5addd3e"
-               + "5b3d39c6e856bdca84d7040b711315794b612808a51b587df244d539").HexToByteArray();
-
-            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
-            {
-                byte[] expectedPlainText = "87abc91203fa927823".HexToByteArray();
-                byte[] actualPlainText = rsa.Decrypt(cipher, RSAEncryptionPadding.Pkcs1);
-                Assert.Equal<byte>(expectedPlainText, actualPlainText);
-            }
-        }
-
-        [Fact]
-        public static void DecryptOaepSHA1()
-        {
-            byte[] cipher =
-                ("0b9293720a2d171c3c0754611a83180086199cff3531e4849eb3da4ce5e9a19fc1de619cceae2b5eb341e2311b4651baa01a"
-               + "8ecdd9b1e5c5baf0181bf31595407f2730e24a952ebef506ee7812d17658ac13de37033a8c94aef2839d3c528f438f5f5e3b"
-               + "290d1a12af586c64073f99d1fbd4a406cdae46f7059ee4300d334855").HexToByteArray();
-
-            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
-            {
-                byte[] expectedPlainText = "87abc91203fa927823".HexToByteArray();
-                byte[] actualPlainText = rsa.Decrypt(cipher, RSAEncryptionPadding.OaepSHA1);
-                Assert.Equal<byte>(expectedPlainText, actualPlainText);
-            }
-        }
-
-        [Fact]
         public static void SignVerifyHashRoundTrip()
         {
-            {
-                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
-                byte[] hash = SHA1.Create().ComputeHash(message);
-                TestSignVerifyHashRoundTrip(hash, HashAlgorithmName.SHA1, RSASignaturePadding.Pss, 0x100);
-            }
-
-            {
-                byte[] message = "abcd992377".HexToByteArray();
-                byte[] hash = SHA256.Create().ComputeHash(message);
-                TestSignVerifyHashRoundTrip(hash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, 0x100);
-            }
+            byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+            byte[] hash = SHA1.Create().ComputeHash(message);
+            TestSignVerifyHashRoundTrip(hash, HashAlgorithmName.SHA1, RSASignaturePadding.Pss, 0x100);
         }
 
         private static void TestSignVerifyHashRoundTrip(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding paddingMode, int expectedSignatureLength)
@@ -118,15 +41,8 @@ namespace System.Security.Cryptography.Cng.Tests
         [Fact]
         public static void SignVerifyDataRoundTrip()
         {
-            {
-                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
-                TestSignVerifyDataRoundTrip(message, HashAlgorithmName.SHA1, RSASignaturePadding.Pss, 0x100);
-            }
-
-            {
-                byte[] message = "abcd992377".HexToByteArray();
-                TestSignVerifyDataRoundTrip(message, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, 0x100);
-            }
+            byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
+            TestSignVerifyDataRoundTrip(message, HashAlgorithmName.SHA1, RSASignaturePadding.Pss, 0x100);
         }
 
         private static void TestSignVerifyDataRoundTrip(byte[] message, HashAlgorithmName hashAlgorithm, RSASignaturePadding paddingMode, int expectedSignatureLength)
@@ -140,23 +56,6 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal(expectedSignatureLength, signature.Length);
 
                 bool verified = rsa.VerifyData(message, signature, hashAlgorithm, paddingMode);
-                Assert.True(verified);
-            }
-        }
-
-        [Fact]
-        public static void VerifyHashPkcs1()
-        {
-            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
-            {
-                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
-                byte[] hash = ("aecc72ccc8e3c3ff28ffd7acac7d3065225aa24e").HexToByteArray();
-                byte[] signature =
-                    ("a35477a7db1f5d47fdca660eb7ab31520a6267b45498c5fb52b9a0a634545f96d289da27f8f8f21cee71271fecfb1d013ed9"
-                   + "6f12f1a17fbb29190bf1bb4bbeb14f6eb7c4703982ac9c3ad355f30064596cfebc5c2dae59962035fbbaa073af4bf2774195"
-                   + "74a2937736ccdec4c9b6f6b930f9787ca5be9e8edfe493473903e965").HexToByteArray();
-
-                bool verified = rsa.VerifyHash(hash, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
                 Assert.True(verified);
             }
         }
@@ -176,108 +75,6 @@ namespace System.Security.Cryptography.Cng.Tests
                 bool verified = rsa.VerifyHash(hash, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pss);
                 Assert.True(verified);
             }
-        }
-
-        [Fact]
-        public static void VerifyData()
-        {
-            using (RSA rsa = TestData.TestRsaKeyPair.CreateRsaCng())
-            {
-                byte[] message = "781021abcd982139a8bc91387870ac01".HexToByteArray();
-                byte[] signature =
-                    ("a35477a7db1f5d47fdca660eb7ab31520a6267b45498c5fb52b9a0a634545f96d289da27f8f8f21cee71271fecfb1d013ed9"
-                   + "6f12f1a17fbb29190bf1bb4bbeb14f6eb7c4703982ac9c3ad355f30064596cfebc5c2dae59962035fbbaa073af4bf2774195"
-                   + "74a2937736ccdec4c9b6f6b930f9787ca5be9e8edfe493473903e965").HexToByteArray();
-
-                bool verified = rsa.VerifyData(message, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
-                Assert.True(verified);
-
-
-            }
-        }
-
-        [Fact]
-        public static void SignAndVerifyDataFromStream()
-        {
-            TestSignAndVerifyDataFromStream(100);
-            TestSignAndVerifyDataFromStream(4096);
-            TestSignAndVerifyDataFromStream(4097);
-            TestSignAndVerifyDataFromStream(4096 * 2);
-            TestSignAndVerifyDataFromStream(4096 * 2 + 1);
-            TestSignAndVerifyDataFromStream(0);
-        }
-
-        private static void TestSignAndVerifyDataFromStream(int messageSize)
-        {
-            RSASignaturePadding padding = RSASignaturePadding.Pkcs1;
-            byte[] message = new byte[messageSize];
-            byte b = 5;
-            for (int i = 0; i < message.Length; i++)
-            {
-                message[i] = b;
-                b = (byte)((b << 4) | (i & 0xf));
-            }
-
-            byte[] hash = SHA1.Create().ComputeHash(message);
-            Stream stream = new MemoryStream(message);
-
-            using (RSA rsa = new RSACng())
-            {
-                byte[] signature = rsa.SignData(stream, HashAlgorithmName.SHA1, padding);
-
-                // Since the unique codepath being tested here is HashData(Stream...), the interesting test is to see if HashData(Stream...)
-                // computed the right hash. The easiest way to test that is to compute the hash ourselves and call VerifyHash.
-                bool verified = rsa.VerifyHash(hash, signature, HashAlgorithmName.SHA1, padding);
-                Assert.True(verified);
-
-                stream = new MemoryStream(message);
-                verified = rsa.VerifyData(stream, signature, HashAlgorithmName.SHA1, padding);
-                Assert.True(verified);
-            }
-        }
-
-        [Fact]
-        public static void ImportExport()
-        {
-            using (RSA rsa = new RSACng())
-            {
-                rsa.ImportParameters(TestData.TestRsaKeyPair);
-                RSAParameters reExported;
-
-                // This is the current 4.6 behavior.
-                Assert.Throws<CryptographicException>(() => reExported = rsa.ExportParameters(includePrivateParameters: true));
-                //AssertRSAParametersEquals(TestData.TestRsaKeyPair, reExported);
-            }
-        }
-
-        [Fact]
-        public static void ImportExportPublicOnly()
-        {
-            using (RSA rsa = new RSACng())
-            {
-                rsa.ImportParameters(TestData.TestRsaKeyPair);
-                RSAParameters reExported = rsa.ExportParameters(includePrivateParameters: false);
-                Assert.Null(reExported.D);
-                Assert.Null(reExported.DP);
-                Assert.Null(reExported.DQ);
-                Assert.Null(reExported.InverseQ);
-                Assert.Null(reExported.P);
-                Assert.Null(reExported.Q);
-                Assert.Equal<byte>(TestData.TestRsaKeyPair.Exponent, reExported.Exponent);
-                Assert.Equal<byte>(TestData.TestRsaKeyPair.Modulus, reExported.Modulus);
-            }
-        }
-
-        private static void AssertRSAParametersEquals(RSAParameters expected, RSAParameters actual)
-        {
-            Assert.Equal<byte>(expected.D, actual.D);
-            Assert.Equal<byte>(expected.DP, actual.DP);
-            Assert.Equal<byte>(expected.DQ, actual.DQ);
-            Assert.Equal<byte>(expected.Exponent, actual.Exponent);
-            Assert.Equal<byte>(expected.InverseQ, actual.InverseQ);
-            Assert.Equal<byte>(expected.Modulus, actual.Modulus);
-            Assert.Equal<byte>(expected.P, actual.P);
-            Assert.Equal<byte>(expected.Q, actual.Q);
         }
     }
 }

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -32,10 +32,35 @@
     <Compile Include="PropertyTests.cs" />
     <Compile Include="RSACngTests.cs" />
     <Compile Include="TestData.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RSACngProvider.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\ByteUtils.cs">
       <Link>CommonTest\Cryptography\ByteUtils.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\TestData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Streams\PositionValueStream.cs">
+      <Link>CommonTest\Streams\PositionValueStream.cs</Link>
+    </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -37,6 +37,9 @@
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\ImportExportUnusual.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\ImportExportUnusual.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -35,6 +35,9 @@
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\ImportExportUnusual.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\ImportExportUnusual.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
     </Compile>


### PR DESCRIPTION
This required some fixes to RSACng that will need to be
ported to 4.6.

- Set the export policies so that ImportParameters(true)
  works.

- Throw the right (or wrong, depending on your pov)
  exception if ImportParameters() is given an
  RSAParameters with null fields.

- VerifyHash(). Don't throw CryptographicException
  if the hash doesn't verify. Just return false like
  the nice docs say.

We have two tests that still fail and are being
investigated with the Win Crypto guys. Since it is
likely the bug is on their side, we'll split these
off into their own file so that RSACng can exclude them.