### PR TITLE
Localize Microsoft.CSharp with machine translations

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00079</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00080</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-12101</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00079" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00080" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-12101" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00079" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00080" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="de" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Unerwartete Ausnahme beim Binden eines dynamischen Vorgangs</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ein Aufruf ohne aufrufendes Objekt kann nicht gebunden werden.</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Fehler bei der Überladungsauflösung</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Binäre Operatoren müssen mit zwei Argumenten aufgerufen werden.</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Unäre Operatoren müssen mit einem Argument aufgerufen werden.</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Name "{0}" ist an eine Methode gebunden und kann nicht wie eine Eigenschaft verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Das Ereignis "{0}" kann nur verwendet werden, auf der linken Seite des +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ein Nichtdelegattyp kann nicht aufgerufen werden.</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine implizite Konvertierung akzeptiert genau ein Argument.</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine explizite Konvertierung akzeptiert genau ein Argument.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Binäre Operatoren können nicht mit einem Argument aufgerufen werden.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Für einen NULL-Verweis kann keine Memberzuweisung ausgeführt werden.</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Laufzeitbindung kann für einen NULL-Verweis nicht ausgeführt werden.</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die {0}-Methode kann nicht dynamisch aufgerufen werden, da sie ein Conditional-Attribut enthält.</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Typ "void" kann nicht implizit in "object" konvertiert werden.</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Operator kann nicht auf Operanden vom Typ "{1}" und "{2}" angewendet werden.</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Division durch Konstante NULL</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine Indizierung mit [] kann nicht auf einen Ausdruck vom Typ "{0}" angewendet werden.</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Falsche Indexanzahl in []. {0} wurde erwartet</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Operator kann nicht auf einen Operanden vom Typ "{1}" angewendet werden.</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Typ kann nicht implizit in {1} konvertiert werden.</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Typ kann nicht in {1} konvertiert werden.</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Konstantenwert "{0}" kann nicht in {1} konvertiert werden.</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Operator ist bei Operanden vom Typ "{1}" und "{2}" mehrdeutig.</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Operator ist für einen Operanden vom Typ "{1}" mehrdeutig.</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">NULL kann nicht in {0} konvertiert werden, da dieser Werttyp nicht auf NULL festgelegt werden kann.</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Auf einen nicht statischen Member des äußeren {0}-Typs kann nicht über den geschachtelten {1}-Typ zugegriffen werden.</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} enthält keine Definition für {1}.</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Für das nicht statische Feld, die Methode oder die Eigenschaft "{0}" ist ein Objektverweis erforderlich.</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Aufruf unterscheidet nicht eindeutig zwischen den folgenden Methoden oder Eigenschaften: {0} und {1}</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Zugriff auf "{0}" ist aufgrund des Schutzgrads nicht möglich.</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Keine Überladung für {0} stimmt mit dem Delegaten "{1}" überein.</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die linke Seite einer Zuweisung muss eine Variable, eine Eigenschaft oder ein Indexer sein.</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Für den {0}-Typ sind keine Konstruktoren definiert.</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Delegat "{0}" enthält keinen gültigen Konstruktor.</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Eigenschaft oder der Indexer "{0}" kann in diesem Kontext nicht verwendet werden, weil der get-Accessor fehlt.</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Auf den Member "{0}" kann nicht mit einem Instanzverweis zugegriffen werden. Qualifizieren Sie ihn stattdessen mit einem Typnamen.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Einem schreibgeschützten Feld kann nichts zugewiesen werden (außer in einem Konstruktor oder Variableninitialisierer).</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Einem schreibgeschützten Feld kann kein Verweis und keine Ausgabe übergeben werden (außer in einem Konstruktor).</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Einem statischen, schreibgeschützten Feld kann nichts zugewiesen werden (außer in einem statischen Konstruktor oder einem Variableninitialisierer).</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Einem statischen, schreibgeschützten Feld kann kein Verweis und keine Ausgabe übergeben werden (außer in einem statischen Konstruktor)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Für die Eigenschaft oder den Indexer "{0}" ist eine Zuweisung nicht möglich -- sie sind schreibgeschützt.</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ein abstrakter Basismember kann nicht aufgerufen werden: '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine Eigenschaft oder ein Indexer kann nicht als out- oder ref-Parameter übergeben werden.</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Es ist nicht möglich, einen Zeiger für den verwalteten Typ ({0}) zu deklarieren oder dessen Adresse oder Größe abzurufen.</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Sie können nicht die fixed-Anweisung verwenden, um die Adresse eines bereits festen Ausdrucks abzurufen.</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dynamische Aufrufe können nicht in Verbindung mit Zeigern verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Um als Kurzschlussoperator anwendbar zu sein, muss der Rückgabetyp eines benutzerdefinierten logischen Operators ({0}) mit dem Typ seiner zwei Parameter übereinstimmen.</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Typ ({0}) muss Deklarationen des True- und des False-Operators enthalten.</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Vorgangsüberlauf zur Kompilierzeit im aktivierten Modus.</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Konstantenwert "{0}" kann nicht in {1} konvertiert werden (verwenden Sie zum Außerkraftsetzen die unchecked-Syntax).</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Mehrdeutigkeit zwischen {0} und {1}</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} enthält keine vordefinierte Größe, sizeof kann daher nur in einem ungeschützten Kontext verwendet werden (verwenden Sie ggf. System.Runtime.InteropServices.Marshal.SizeOf).</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ein Feldinitialisierer kann nicht auf das nicht statische Feld bzw. die nicht statische Methode oder Eigenschaft "{0}" verweisen.</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Destruktoren und object.Finalize können nicht direkt aufgerufen werden. Rufen Sie IDisposable.Dispose auf, sofern verfügbar.</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Rufen Sie die Finalize-Methode Ihrer Basisklasse nicht direkt auf, da sie automatisch vom Destruktor aufgerufen wird.</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die rechte Seite einer fixed-Anweisungszuweisung darf kein Umwandlungsausdruck sein.</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Typ kann nicht implizit in {1} konvertiert werden. Es ist bereits eine explizite Konvertierung vorhanden (möglicherweise fehlt eine Umwandlung).</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Eigenschaft oder der Indexer "{0}" kann in diesem Kontext nicht verwendet werden, da nicht auf den get-Accessor zugegriffen werden kann.</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Eigenschaft oder der Indexer "{0}" kann in diesem Kontext nicht verwendet werden, da nicht auf den set-Accessor zugegriffen werden kann.</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Verwendung von {1} "{0}" (generisch) erfordert {2}-Typargumente.</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Typ "{0}" darf nicht als Typargument verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} "{0}" kann nicht mit Typargumenten verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} "{0}" ist nicht generisch und kann daher nicht mit Typargumenten verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{2} muss ein nicht abstrakter Typ mit einem öffentlichen parameterlosen Konstruktor sein, um im generischen Typ oder in der generischen {0}-Methode als {1}-Parameter verwendet werden zu können.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Es ist keine implizite Verweiskonvertierung von {3} in {1} vorhanden.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Der {3}-Typ, der NULL-Werte zulässt, entspricht nicht der Einschränkung von {1}.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Der {3}-Typ, der NULL-Werte zulässt, entspricht nicht der Einschränkung von {1}. Typen, die NULL-Werte zulassen, können Schnittstelleneinschränkungen nicht entsprechen.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Es ist keine Boxing-Konvertierung oder Typparameterkonvertierung von {3} in {1} vorhanden.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Es ist keine Boxing-Konvertierung von {3} in {1} vorhanden.</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">NULL kann nicht in den {0}-Typparameter konvertiert werden, da dieser Werttyp möglicherweise nicht auf NULL festgelegt werden kann. Verwenden Sie stattdessen ggf. default({0}).</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Rückgabetyp von {1} {0} ist falsch.</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Typargumente der {0}-Methode können nicht per Rückschluss aus der Syntax abgeleitet werden. Geben Sie die Typargumente explizit an.</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die {0}-Methodengruppe kann nicht in den Nichtdelegattyp "{1}" konvertiert werden. Wollten Sie die Methode aufrufen?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {2}-Typ muss ein Referenztyp sein, damit er als {1}-Parameter im generischen Typ oder in der generischen {0}-Methode verwendet werden kann.</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {2}-Typ darf keine NULL-Werte zulassen, wenn er als {1}-Parameter im generischen Typ oder in der generischen {0}-Methode verwendet werden soll.</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Einschränkungsringabhängigkeit zwischen {0} und {1}</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {0}-Typparameter erbt die in Konflikt stehenden Einschränkungen "{1}" und "{2}"</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der {1}-Typparameter enthält die Einschränkung "struct". {1} kann daher nicht als Einschränkung für {0} verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Mehrdeutige benutzerdefinierte Konvertierungen von {0} und {1} bei der Konvertierung von {2} in {3}</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der vordefinierte {0}-Typ ist nicht definiert oder importiert.</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der vordefinierte {0}-Typ wurde falsch deklariert.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} wird von der Sprache nicht unterstützt.</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0}: Der Operator oder Accessor kann nicht explizit aufgerufen werden.</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} ist ein Typ, der von der Sprache nicht unterstützt wird.</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der vom Compiler angeforderte Member "{0}.{1}" fehlt.</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Literale vom Typ "double" können nicht implizit in den {1}-Typ konvertiert werden. Verwenden Sie ein {0}-Suffix, um ein Literal mit diesem Typ zu erstellen.</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} kann nicht gleichzeitig {1} und {2} implementieren, da diese für einige Typparameterersetzungen zusammengeführt werden können.</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Konvertierung in den statischen {0}-Typ ist nicht möglich.</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0}: Statische Typen können nicht als Typargumente verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Aus der {0}-Methode kann kein Delegat erstellt werden, da es sich um eine partielle Methode ohne implementierende Deklaration handelt.</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Operand eines Inkrement- oder Dekrementoperators muss eine Variable, eine Eigenschaft oder ein Indexer sein.</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} enthält keine Definition für {1}, und es konnte keine {1}-Erweiterungsmethode gefunden werden, die ein erstes Argument vom Typ "{0}" akzeptiert (möglicherweise fehlt eine Using-Direktive oder ein Assemblyverweis).</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die im {1}-Werttyp definierten {0}-Erweiterungsmethoden können nicht zum Erstellen von Delegaten verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Keine Überladung für die {0}-Methode nimmt {1}-Argumente an.</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die beste Übereinstimmung für die überladene {0}-Methode enthält einige ungültige Argumente.</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0}-Argument: Die Konvertierung von {1} in {2} ist nicht möglich.</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ein ref- oder out-Argument muss eine zuweisbare Variable sein.</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Auf den geschützten Member "{0}" kann nicht über einen Qualifizierer vom Typ "{1}" zugegriffen werden. Der Qualifizierer muss vom Typ "{2}" (oder von ihm abgeleitet) sein.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Eigenschaft, der Indexer oder das Ereignis "{0}" wird von der Sprache nicht unterstützt. Rufen Sie die {1}- oder {2}-Accessormethoden direkt auf.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Eigenschaft, der Indexer oder das Ereignis "{0}" wird von der Sprache nicht unterstützt. Rufen Sie die {1}-Accessormethode direkt auf.</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Delegat "{0}" akzeptiert {1}-Argumente nicht.</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Delegat "{0}" enthält einige ungültige Argumente.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} ist schreibgeschützt. Eine Zuweisung ist daher nicht möglich.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} ist schreibgeschützt und kann daher nicht als ref- oder out-Argument übergeben werden.</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Rückgabewert von {0} ist keine Variable und kann daher nicht geändert werden.</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Das {0}-Argument darf nicht mit dem {1}-Schlüsselwort übergeben werden.</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Das {0}-Argument muss mit dem {1}-Schlüsselwort übergeben werden.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Member des schreibgeschützten Felds "{0}" können nicht geändert werden (außer in einem Konstruktor oder Variableninitialisierer).</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">An Member des schreibgeschützten Felds "{0}" können keine ref- oder out-Argumente übergeben werden (außer in einem Konstruktor).</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Für Felder eines statischen schreibgeschützten Felds "{0}" ist eine Zuweisung nicht möglich (außer in einem statischen Konstruktor oder einem Variableninitialisierer).</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">An Felder des schreibgeschützten Felds "{0}" können keine ref- oder out-Argumente übergeben werden (außer in einem Konstruktor).</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} ist ein(e) {1}. Eine Zuweisung ist daher nicht möglich.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} ist ein(e) {1} und kann daher nicht als ref- oder out-Argument übergeben werden.</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Anonyme Methoden, lambda-Ausdrücke und Abfrageausdrücke innerhalb von Strukturen können nicht auf Instanzmember von "this" zugreifen. Kopieren Sie "this" in eine lokale Variable außerhalb der anonymen Methode, des lambda-Ausdrucks oder des Abfrageausdrucks, und verwenden Sie die lokale Variable.</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Kann Delegaten "{0}" keine Bindung an weil es ein Mitglied von "System.Nullable<it id="1" pos="open">&lt;T&gt;</it>ist"</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" enthält keinen Konstruktor, der {1}-Argumente akzeptiert.</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" enthält keine Definition für {1}, und die Überladung der optimalen {2}-Erweiterungsmethode enthält einige ungültige Argumente.</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Instanzenargument: Konvertierung von {0} in {1} ist nicht möglich.</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die beste Übereinstimmung für die überladene {0}-Methode für den Auflistungsinitialisierer enthält einige ungültige Argumente.</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die beste Übereinstimmung für die überladene {0}-Methode für das Auflistungsinitialisiererelement kann nicht verwendet werden. Die Add-Methoden von Auflistungsinitialisierern dürfen keine ref- oder out-Parameter enthalten.</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der nicht aufrufbare Member "{0}" kann nicht wie eine Methode verwendet werden.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Spezifikationen für benannte Argumente müssen nach Angabe aller festen Argumente angezeigt werden.</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die beste Überladung für {0} enthält keinen Parameter mit dem Namen "{1}".</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Delegat "{0}" enthält keinen Parameter mit dem Namen "{1}".</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Das benannte {0}-Argument kann nicht mehrmals angegeben werden.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Das benannte {0}-Argument legt einen Parameter fest, für den bereits ein positionelles Argument angegeben wurde.</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="es" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Excepción inesperada al enlazar una operación dinámica.</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede enlazar la llamada sin un objeto de llamada.</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Error en la resolución de sobrecarga.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se pueden invocar operadores binarios con dos argumentos.</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Los operadores unarios deben invocarse con un argumento.</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El nombre '{0}' está enlazado a un método y no se puede usar como propiedad.</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">El evento '{0}' sólo puede aparecer en el lado izquierdo de +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede invocar un tipo no delegado.</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversión implícita toma exactamente un argumento.</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversión explícita toma exactamente un argumento.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se pueden invocar operadores binarios con un argumento.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede realizar la asignación de miembros en una referencia NULL.</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede realizar enlace en tiempo de ejecución en una referencia NULL.</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede invocar dinámicamente el método '{0}' porque tiene un atributo Conditional.</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir implícitamente el tipo 'void' en 'object'.</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El operador '{0}' no se puede aplicar a operandos del tipo '{1}' y '{2}'</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">División por cero constante</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede aplicar la indización con [] a una expresión del tipo '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Número incorrecto de índices dentro de []; se esperaba '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El operador '{0}' no se puede aplicar al operando del tipo '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir implícitamente el tipo '{0}' en '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">No se puede convertir el tipo '{0}' en '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El valor constante '{0}' no se puede convertir en '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El operador '{0}' es ambiguo en operandos del tipo '{1}' y '{2}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El operador '{0}' es ambiguo con un operando del tipo '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir NULL en '{0}' porque es un tipo de valor que no acepta valores NULL.</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede obtener acceso a un miembro no estático de tipo externo '{0}' mediante el tipo anidado '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no contiene una definición para '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Se requiere una referencia de objeto para el campo, método o propiedad no estáticos '{0}'.</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La llamada es ambigua entre los métodos o propiedades siguientes: '{0}' y '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no es accesible debido a su nivel de protección</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ninguna sobrecarga correspondiente a '{0}' coincide con el '{1}' delegado</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La parte izquierda de una asignación debe ser una variable, una propiedad o un indizador</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{0}' no tiene constructores definidos.</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El delegado '{0}' no tiene un constructor válido</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La propiedad o el indizador '{0}' no se puede usar en este contexto porque carece del descriptor de acceso get.</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede obtener acceso al miembro '{0}' con una referencia de instancia; califíquelo con un nombre de tipo en su lugar.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede asignar un campo de sólo lectura (excepto en un constructor o inicializador de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede pasar out o ref a un campo de sólo lectura (excepto en un constructor)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede asignar un campo de sólo lectura estático (excepto en un constructor estático o inicializador de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede pasar out o ref a un campo estático de sólo lectura (excepto en un constructor estático)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede asignar a la propiedad o el indizador '{0}' porque es de solo lectura</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede llamar a un miembro base abstracto: '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Una propiedad o un indizador no se puede pasar como parámetro out o ref</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede adquirir la dirección, obtener el tamaño ni declarar un puntero a un tipo administrado ('{0}')</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede utilizar la instrucción fixed para adquirir la dirección de una expresión de tipo fixed</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se pueden usar llamadas dinámicas en combinación con los punteros.</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Para que se pueda aplicar un operador de cortocircuito, el operador lógico definido por el usuario ('{0}') debe tener el mismo tipo de valor devuelto que sus dos parámetros</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo ('{0}') debe incluir declaraciones de operador true y operador false.</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">La operación se desborda en tiempo de compilación en modo comprobado</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El valor constante '{0}' no se puede convertir en '{1}' (use la sintaxis 'unchecked' para invalidar el valor)</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ambigüedad entre '{0}' y '{1}'</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no tiene un tamaño predefinido; por tanto, sizeof sólo se puede usar en un contexto no seguro (use System.Runtime.InteropServices.Marshal.SizeOf).</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un inicializador de campo no puede hacer referencia al campo, método o propiedad no estáticos '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Los destructores y object.Finalize no se pueden llamar directamente. Llame a IDisposable.Dispose si está disponible.</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No llame directamente al método Finalize de la clase base. Se llama automáticamente desde el destructor.</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El lado derecho de una asignación de instrucción fixed puede no ser una expresión de conversión</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir implícitamente el tipo '{0}' en '{1}'. Ya existe una conversión explícita (compruebe si le falta una conversión).</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La propiedad o indizador '{0}' no se puede usar en este contexto porque el descriptor de acceso get es inaccesible</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La propiedad o indizador '{0}' no se puede usar en este contexto porque el descriptor de acceso set es inaccesible</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Uso de {1} de tipo genérico ('{0}'): requiere '{2}' argumentos de tipo</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{0}' no se puede usar como argumento de tipo</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} '{0}' no se puede usar con argumentos de tipo.</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Uso de {1} '{0}' de tipo no genérico: no se puede usar con argumentos de tipo</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}' debe ser un tipo no abstracto con un constructor público sin parámetros para poder usarlo como parámetro '{1}' en el tipo o método genérico '{0}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. No hay ninguna conversión de referencia implícita de '{3}' a '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. El tipo que acepta valores NULL '{3}' no cumple la restricción de '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. El tipo que acepta valores NULL '{3}' no cumple la restricción de '{1}'. Los tipos que aceptan valores NULL no pueden cumplir restricciones de interfaz.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. No hay conversión boxing ni conversión de parámetro de tipo de '{3}' a '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. No hay conversión boxing de '{3}' a '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir NULL en el parámetro de tipo '{0}' porque podría ser un tipo de valor que no acepta valores NULL. Use 'default({0})' en su lugar.</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1} {0}' es un tipo de valor devuelto equivocado</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Los argumentos de tipo para el método '{0}' no se pueden inferir a partir del uso. Intente especificar los argumentos de tipo explícitamente.</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir el grupo de métodos '{0}' en tipo no delegado '{1}'. ¿Intentó invocar el método?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{2}' debe ser un tipo de referencia para poder usarlo como parámetro '{1}' en el tipo o método genérico '{0}'.</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo '{2}' debe ser un tipo de valor que no acepte valores NULL para poder usarlo como parámetro '{1}' en el tipo o método genérico '{0}'.</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dependencia de restricción circular que implica '{0}' y '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El parámetro de tipo '{0}' hereda las restricciones conflictivas '{1}' y '{2}'</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El parámetro de tipo '{1}' tiene la restricción 'struct'; por tanto,  '{1}' no se puede usar como restricción para  '{0}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Conversiones ambiguas definidas por el usuario '{0}' y '{1}' al convertir de '{2}' a '{3}'</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El tipo predefinido '{0}' no está definido ni importado.</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Tipo predefinido '{0}' declarado incorrectamente.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no es compatible con el lenguaje</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': no se puede llamar explícitamente al operador o al descriptor de acceso</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se admite el tipo '{0}' para este lenguaje</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Falta el miembro '{0}.{1}' que requiere el compilador.</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El literal de tipo double no se puede convertir implícitamente en el tipo '{1}'; use un sufijo '{0}' para crear un literal de este tipo</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no puede implementar tanto '{1}' como '{2}' porque se pueden unificar para algunas sustituciones de parámetros de tipo.</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir en el tipo estático '{0}'</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': los tipos estáticos no se pueden usar como argumentos de tipo</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede crear un delegado a partir del método '{0}' porque es un método parcial sin una declaración de implementación.</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El operando de un operador de incremento o decremento debe ser una variable, una propiedad o un indizador</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no contiene una definición para '{1}' ni se encuentra ningún método de extensión '{1}' que acepte un primer argumento del tipo '{0}' (¿falta una directiva de uso o una referencia de ensamblado?).</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Los métodos de extensión '{0}' definidos en el tipo de valor '{1}' no se pueden usar para crear delegados.</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ninguna sobrecarga del método '{0}' toma argumentos '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La mejor coincidencia de método sobrecargado para '{0}' tiene algunos argumentos no válidos</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Argumento '{0}': no se puede convertir de '{1}' a '{2}'</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un argumento out o ref debe ser una variable asignable</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede obtener acceso al miembro protegido '{0}' mediante un calificador del tipo '{1}'; el calificador debe ser del tipo '{2}' (o derivado de éste)</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El lenguaje no admite la propiedad, el indizador o el evento '{0}'; intente llamar directamente a los métodos de descriptor de acceso '{1}' o '{2}'</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El lenguaje no admite la propiedad, el indizador o el evento '{0}'; intente llamar directamente al método de descriptor de acceso '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El delegado '{0}' no toma '{1}' argumentos</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El delegado '{0}' tiene algunos argumentos no válidos</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede asignar a '{0}' porque es de solo lectura</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede pasar '{0}' como argumento out o ref porque es de solo lectura.</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede modificar el valor devuelto de '{0}' porque no es una variable.</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se debe pasar el argumento '{0}' con la palabra clave '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El argumento '{0}' se debe pasar con la palabra clave '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Los miembros del campo de solo lectura '{0}' no se pueden modificar (excepto en un constructor o inicializador de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede pasar out o ref a los miembros del campo de solo lectura '{0}' (excepto en un constructor).</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede asignar a los campos del campo estático de solo lectura '{0}' (excepto en un constructor estático o un inicializador de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede pasar out o ref a los campos del campo estático de solo lectura '{0}' (excepto en un constructor estático).</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede asignar a '{0}' porque es '{1}'</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede pasar '{0}' como argumento out o ref porque es '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Los métodos anónimos, las expresiones lambda y las expresiones de consulta incluidos en structs no pueden obtener acceso a miembros de instancia de 'this'. Copie 'this' en una variable local fuera del método anónimo, la expresión lambda o la expresión de consulta y use la variable local en su lugar.</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">No se puede enlazar el delegado para '{0}' porque es un miembro de 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no contiene un constructor que tome '{1}' argumentos</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no contiene una definición para '{1}' y la mejor sobrecarga del método de extensión '{2}' tiene algunos argumentos no válidos</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Argumento de instancia: no se puede convertir de '{0}' a '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El mejor método Add sobrecargado '{0}' del inicializador de colección tiene algunos argumentos no válidos</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La mejor coincidencia de método sobrecargado '{0}' para el elemento inicializador de la colección no se puede usar. Los métodos 'Add' inicializadores de colección no pueden tener parámetros out o ref.</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede usar como método el miembro '{0}' no invocable.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Las especificaciones de argumento con nombre deben aparecer después de haber especificado todos los argumentos fijos.</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La mejor sobrecarga para '{0}' no tiene un parámetro denominado '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El delegado '{0}' no tiene un parámetro denominado '{1}'</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El argumento con nombre '{0}' no se puede especificar varias veces</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">El argumento con nombre '{0}' especifica un parámetro para el que ya se ha proporcionado un argumento posicional.</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="fr" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Une exception inattendue s'est produite lors de la liaison d'une opération dynamique</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de lier l'appel sans objet appelant</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Échec de la résolution de surcharge</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Les opérateurs binaires doivent être appelés avec deux arguments</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Les opérateurs unaires doivent être appelés à l'aide d'un seul argument</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le nom '{0}' est lié à une méthode et ne peut pas être utilisé comme une propriété</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">L'événement « {0} » ne peut apparaître sur le côté gauche de +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler un type non-délégué</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversion implicite n'accepte qu'un seul argument</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversion explicite n'accepte qu'un seul argument</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler les opérateurs binaires avec un argument</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'effectuer une assignation de membre sur une référence null</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'effectuer une liaison au moment de l'exécution sur une référence null</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler dynamiquement la méthode '{0}' car elle a un attribut Conditional</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir implicitement le type 'void' en 'object'</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appliquer l'opérateur '{0}' aux opérandes de type '{1}' et '{2}'</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Division par zéro constant</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appliquer l'indexation à l'aide de [] à une expression de type '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Nombre d'index incorrects dans [], '{0}' attendu</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appliquer l'opérateur '{0}' à un opérande de type '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir implicitement le type '{0}' en '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Impossible de convertir le type « {0} » pour « {1} »</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir la valeur de constante '{0}' en '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'opérateur '{0}' est ambigu pour des opérandes de type '{1}' et '{2}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'opérateur '{0}' est ambigu pour un opérande de type '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir null en '{0}', car il s'agit d'un type valeur qui n'autorise pas les valeurs null</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'accéder à un membre non statique de type externe '{0}' par l'intermédiaire du type imbriqué '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' ne contient pas de définition pour '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Une référence d'objet est requise pour la propriété, la méthode ou le champ non statique '{0}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'appel est ambigu entre les méthodes ou propriétés suivantes : '{0}' et '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' est inaccessible en raison de son niveau de protection</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Aucune surcharge pour '{0}' ne correspond au délégué '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La partie gauche d'une assignation doit être une variable, une propriété ou un indexeur</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Aucun constructeur n'est défini pour le type '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le délégué '{0}' n'a pas de constructeur valide</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser la propriété ou l'indexeur '{0}' dans ce contexte, car il lui manque l'accesseur get</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le membre '{0}' est inaccessible avec une référence d'instance ; qualifiez-le avec un nom de type</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un champ readonly ne peut pas être assigné (sauf s'il appartient à un constructeur ou un initialiseur de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un champ readonly ne peut pas être passé en ref ou out (sauf s'il appartient à un constructeur)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un champ readonly statique ne peut pas être assigné (sauf s'il appartient à un constructeur statique ou un initialiseur de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un champ readonly statique ne peut pas être passé en ref ou out (sauf s'il appartient à un constructeur statique)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'assigner la propriété ou l'indexeur '{0}' -- il est en lecture seule</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler un membre de base abstrait : '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Une propriété ou un indexeur ne peut pas être passé en tant que paramètre de sortie (out) ni de référence (ref)</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de prendre l'adresse, d'obtenir la taille ou de déclarer un pointeur vers un type managé ('{0}')</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Vous ne pouvez pas utiliser l'instruction fixed pour prendre l'adresse d'une expression qui est déjà fixed</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser des appels dynamiques avec des pointeurs</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Pour être applicable en tant qu'opérateur de court-circuit, un opérateur logique défini par l'utilisateur '{0}') doit avoir le même type de retour que le type de ses 2 paramètres</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le type ('{0}') doit contenir les déclarations de l'opérateur true et de l'opérateur false</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">L'opération déborde au moment de la compilation en mode activé</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir la valeur de constante '{0}' en '{1}' (utilisez la syntaxe 'unchecked)</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ambiguïté entre '{0}' et '{1}'</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' n'a pas de taille prédéfinie ; c'est pourquoi sizeof ne peut être utilisé que dans un contexte unsafe (utilisez System.Runtime.InteropServices.Marshal.SizeOf)</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un initialiseur de champ ne peut pas faire référence au champ, à la méthode ou à la propriété non statique '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler directement des destructeurs et object.Finalize. Appelez IDisposable.Dispose s'il est disponible.</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ne pas appeler directement votre méthode Finalize de la classe de base. La méthode est automatiquement appelée à partir de votre destructeur.</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La partie droite d'une assignation d'instruction fixed peut ne pas être une expression de cast</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir implicitement le type '{0}' en '{1}'. Une conversion explicite existe (un cast est-il manquant ?)</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser la propriété ou l'indexeur '{0}' dans ce contexte, car l'accesseur get n'est pas accessible</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser la propriété ou l'indexeur '{0}' dans ce contexte, car l'accesseur set n'est pas accessible</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'utilisation du {1} '{0}' générique requiert les arguments de type '{2}'</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le type '{0}' ne peut pas être utilisé comme argument de type</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le {1} '{0}' avec des arguments de type</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le {1} '{0}' non générique avec des arguments de type</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}' doit être un type non abstrait avec un constructeur sans paramètre public afin de l'utiliser comme paramètre '{1}' dans le type ou la méthode générique '{0}'</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Il n'y a pas de conversion de référence implicite de '{3}' en '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Le type Nullable '{3}' ne satisfait pas la contrainte de '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Le type Nullable '{3}' ne satisfait pas la contrainte de '{1}'. Les types Nullable ne peuvent pas satisfaire les contraintes d'interface.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Il n'y a pas de conversion boxing ou de conversion de paramètre de type de '{3}' en '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Il n'y a pas de conversion boxing de '{3}' en '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir null en paramètre de type '{0}' car il peut s'agir d'un type valeur qui n'autorise pas les valeurs null. Utilisez 'default({0})' à la place.</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1} {0}' n'a pas le type de retour correct</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de déduire les arguments de type pour la méthode '{0}' à partir de l'utilisation. Essayez de spécifier les arguments de type de façon explicite.</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir le groupe de méthodes '{0}' en type non-délégué '{1}'. Souhaitiez-vous appeler la méthode ?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le type '{2}' doit être un type référence afin d'être utilisé comme paramètre '{1}' dans le type ou la méthode générique '{0}'</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le type '{2}' doit être un type valeur non Nullable afin d'être utilisé comme paramètre '{1}' dans le type ou la méthode générique '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dépendance de contrainte circulaire utilisant '{0}' et '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le paramètre de type '{0}' hérite des contraintes en conflit '{1}' et '{2}'</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le paramètre de type '{1}' a la contrainte 'struct', donc '{1}' ne peut pas être utilisé comme contrainte pour '{0}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Conversions définies par l'utilisateur ambiguës '{0}' et '{1}' lors de la conversion de '{2}' en '{3}'</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le type prédéfini '{0}' n'est pas défini ou importé</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le type prédéfini '{0}' n'est pas déclaré correctement</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' n'est pas pris en charge par le langage</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' : impossible d'appeler explicitement un opérateur ou un accesseur</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' est un type qui n'est pas pris en charge par le langage</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Membre requis par le compilateur '{0}.{1}' manquant</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir implicitement un littéral de type double en type '{1}' ; utilisez un suffixe '{0}' pour créer un littéral de ce type</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' ne peut pas implémenter '{1}' et '{2}', car ils peuvent être réunis pour des substitutions de paramètre de type</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir en type static '{0}'</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' : impossible d'utiliser les types static en tant qu'arguments de type</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de créer un délégué à partir de la méthode '{0}', car il s'agit d'une méthode partielle sans déclaration d'implémentation</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'opérande d'un opérateur d'incrémentation ou de décrémentation doit être une variable, une propriété ou un indexeur</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' ne contient pas de définition pour '{1}' et aucune méthode d'extension '{1}' acceptant un premier argument de type '{0}' n'a été trouvée (une directive using ou une référence d'assembly est-elle manquante ?)</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser les méthodes d'extension '{0}' définies dans un type valeur '{1}' pour créer des délégués</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Aucune surcharge pour la méthode '{0}' ne prend d'arguments '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La méthode surchargée correspondant le mieux à '{0}' a des arguments non valides</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Argument '{0}' : impossible de convertir de '{1}' en '{2}'</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un argument ref ou out doit être une variable qui peut être assignée</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'accéder au membre protégé '{0}' par l'intermédiaire d'un qualificateur de type '{1}' ; le qualificateur doit être de type '{2}' (ou dérivé de celui-ci)</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La propriété, l'indexeur ou l'événement '{0}' n'est pas pris en charge par le langage ; essayez d'appeler directement les méthodes d'accesseur '{1}' ou '{2}'</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La propriété, l'indexeur ou l'événement '{0}' n'est pas pris en charge par le langage ; essayez d'appeler directement la méthode d'accesseur '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le délégué '{0}' ne prend pas les arguments '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le délégué '{0}' utilise des arguments non valides</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'assigner à '{0}', car il est en lecture seule</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de passer '{0}' comme argument ref ou out, car il est en lecture seule</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de modifier la valeur de retour de '{0}' car il ne s'agit pas d'une variable</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'argument '{0}' ne doit pas être passé avec le mot clé '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'argument '{0}' doit être passé avec le mot clé '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de modifier les membres d'un champ readonly '{0}' (sauf s'ils appartiennent à un constructeur ou un initialiseur de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de passer les membres d'un champ readonly '{0}' en ref ou out (sauf s'ils appartiennent à un constructeur)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'assigner les champs du champ readonly statique '{0}' (sauf s'ils appartiennent à un constructeur statique ou un initialiseur de variable)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de passer les champs d'un champ readonly statique '{0}' en ref ou out (sauf s'ils appartiennent à un constructeur statique)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'assigner à '{0}', car il s'agit d'un '{1}'</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de passer '{0}' en tant qu'argument ref ou out, car il s'agit d'un '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Les méthodes anonymes, les expressions lambda et les expressions de requête dans des structs ne peuvent pas accéder aux membres d'instance de 'this'. Copiez 'this' dans une variable locale en dehors de la méthode anonyme, de l'expression lambda ou de l'expression de requête et utilisez la variable locale à la place.</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Impossible de lier délégué à « {0} » parce que c'est un membre de « System.Nullable<it id="1" pos="open">&lt;T&gt;</it>»</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' ne contient pas de constructeur qui accepte des arguments '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' ne contient pas de définition pour '{1}' et la meilleure surcharge de la méthode d'extension '{2}' contient des arguments non valides</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Argument d'instance : impossible de convertir '{0}' en '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La méthode Add surchargée '{0}' correspondant le mieux à l'initialiseur de collection a des arguments non valides</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La méthode surchargée '{0}' correspondant le mieux à l'élément de l'initialiseur de collection ne peut pas être utilisée. Les méthodes 'Add' de l'initialiseur de collection ne peuvent pas avoir de paramètres ref ou out.</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser un membre '{0}' ne pouvant pas être appelé comme une méthode.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Les spécifications d'argument nommé doivent s'afficher après la spécification de tous les arguments fixes</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La meilleure surcharge pour '{0}' n'a pas de paramètre nommé '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le délégué '{0}' n'a pas de paramètre nommé '{1}'</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de spécifier plusieurs fois l'argument nommé '{0}'</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'argument nommé '{0}' spécifie un paramètre pour lequel un paramètre positionnel a déjà été donné</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="it" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eccezione imprevista durante l'associazione di un'operazione dinamica</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile associare la chiamata senza oggetto chiamante</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Risoluzione dell'overload non riuscita</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Gli operatori binari devono essere richiamati con due argomenti</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Gli operatori unari devono essere richiamati con un solo argomento</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il nome '{0}' è associato a un metodo e non può essere utilizzato come una proprietà</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">L'evento '{0}' può trovarsi soltanto sul lato sinistro di +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile richiamare un tipo non delegato</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Per la conversione implicita viene accettato un solo argomento</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Per la conversione esplicita viene accettato un solo argomento</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile richiamare operatori binari con un solo argomento</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile eseguire un'assegnazione membro su un riferimento Null</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile eseguire un'associazione di runtime su un riferimento Null</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile richiamare in modo dinamico il metodo '{0}' perché contiene un attributo Conditional</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire il tipo 'void' in 'object' in modo implicito</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile applicare l'operatore '{0}' su operandi di tipo '{1}' e '{2}'</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Divisione per zero costante</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile applicare l'indicizzazione con [] a un'espressione di tipo '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Numero di indici errato in [], previsto '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile applicare l'operatore '{0}' sull'operando di tipo '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire in modo implicito il tipo '{0}' in '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Impossibile convertire il tipo '{0}' a '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire il valore costante '{0}' in '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'operatore '{0}' è ambiguo su operandi di tipo '{1}' e '{2}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'operatore '{0}' è ambiguo su un operando di tipo '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire Null in '{0}' perché è un tipo di valore non nullable</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile accedere a un membro non statico di tipo outer '{0}' tramite il tipo annidato '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non contiene una definizione per '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">È necessario specificare un riferimento a un oggetto per la proprietà, il metodo o il campo non statico '{0}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Chiamata ambigua tra i seguenti metodi o proprietà: '{0}' e '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' è inaccessibile a causa del livello di protezione.</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Nessun overload per '{0}' corrisponde al delegato '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La parte sinistra di un'assegnazione deve essere una variabile, una proprietà o un indicizzatore</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Per il tipo '{0}' non sono definiti costruttori</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il delegato '{0}' non presenta un costruttore valido</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare la proprietà o l'indicizzatore '{0}' in questo contesto perché manca la funzione di accesso get.</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile accedere al membro '{0}' con un riferimento a un'istanza. Qualificarlo con un nome di tipo</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un campo readonly non può essere assegnato (tranne che in un costruttore o in un inizializzatore di variabile).</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un campo readonly non può essere passato a un parametro ref o out (tranne che in un costruttore)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile effettuare un'assegnazione a un campo statico in sola lettura (tranne che in un costruttore statico o in un inizializzatore di variabile).</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile passare un parametro ref o out a un campo statico in sola lettura (tranne che in un costruttore statico).</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile assegnare un valore alla proprietà o all'indicizzatore '{0}' perché è di sola lettura</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile chiamare un membro di base astratto: '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Una proprietà o un indicizzatore non può essere passato come parametro out o ref</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile accettare l'indirizzo di un tipo gestito ('{0}'), recuperarne la dimensione o dichiarare un puntatore a esso</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare l'istruzione fixed per accettare l'indirizzo di un'espressione già di tipo fixed</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare le chiamate dinamiche insieme ai puntatori</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Per essere utilizzato come operatore di corto circuito, un operatore logico definito dall'utente ('{0}') deve avere lo stesso tipo restituito dei 2 parametri</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il tipo ('{0}') deve contenere dichiarazioni di operatore true e operatore false.</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">L'operazione di overflow in fase di compilazione in modalità checked</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il valore costante '{0}' non può essere convertito in '{1}' (utilizzare la sintassi 'unchecked' per eseguire l'override).</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ambiguità tra '{0}' e '{1}'</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non ha una dimensione predefinita, quindi sizeof può essere utilizzato solo in un contesto di tipo unsafe. Si consiglia di utilizzare System.Runtime.InteropServices.Marshal.SizeOf.</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un inizializzatore di campo non può fare riferimento alla proprietà, al metodo o al campo non statico '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile chiamare direttamente i distruttori e object.Finalize. Provare a chiamare IDisposable.Dispose se disponibile.</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Non chiamare direttamente il metodo Finalize della classe base. Viene chiamato automaticamente dal distruttore.</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La parte destra dell'assegnazione di un'istruzione fixed non può essere un'espressione cast</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire in modo implicito il tipo '{0}' in '{1}'. È presente una conversione esplicita. Probabile cast mancante.</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare la proprietà o l'indicizzatore '{0}' in questo contesto perché la funzione di accesso get è inaccessibile.</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare la proprietà o l'indicizzatore '{0}' in questo contesto perché la funzione di accesso set è inaccessibile.</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'utilizzo del {1} generico '{0}' richiede argomenti di tipo '{2}'</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il tipo '{0}' non può essere utilizzato come argomento di tipo</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare {1} '{0}' insieme ad argomenti di tipo</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare {1} non generico '{0}' insieme ad argomenti di tipo</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}' deve essere un tipo non astratto con un costruttore pubblico senza parametri per essere utilizzato come parametro '{1}' nel tipo o nel metodo generico '{0}'</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Nessuna conversione implicita di riferimenti da '{3}' a '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel tipo o metodo generico '{0}'. Il tipo nullable '{3}' non soddisfa il vincolo di '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel tipo o metodo generico '{0}'. Il tipo nullable '{3}' non soddisfa il vincolo di '{1}'. I tipi nullable non soddisfano i vincoli di interfaccia.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Nessuna conversione boxing o conversione di parametri di tipo da '{3}' a '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Nessuna conversione boxing da '{3}' a '{1}'.</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire il valore Null nel parametro di tipo '{0}' perché potrebbe essere un tipo di valore non nullable. Si consiglia di utilizzare 'default({0})'.</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il tipo restituito di '{1} {0}' è errato</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile dedurre gli argomenti di tipo per il metodo '{0}' dall'utilizzo. Provare a specificare gli argomenti di tipo in modo esplicito.</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire il gruppo di metodi '{0}' nel tipo non delegato '{1}'. Si desiderava richiamare il metodo?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">È necessario che il tipo '{2}' sia un tipo di riferimento per essere utilizzato come parametro '{1}' nel tipo generico o nel metodo '{0}'</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il tipo '{2}' deve essere un tipo di valore non nullable per poter essere utilizzato come parametro '{1}' nel metodo o nel tipo generico '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dipendenza di vincolo circolare che comprende '{0}' e '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il parametro di tipo '{0}' eredita i vincoli in conflitto '{1}' e '{2}'</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il parametro di tipo '{1}' ha il vincolo 'struct'. Non è pertanto possibile utilizzare '{1}' come vincolo per '{0}'.</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Conversioni '{0}' e '{1}' ambigue definite dall'utente durante la conversione da '{2}' a '{3}'</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il tipo predefinito '{0}' non è definito né importato</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il tipo predefinito '{0}' è dichiarato in modo non corretto</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non è supportato dal linguaggio</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': impossibile chiamare in modo esplicito l'operatore o la funzione di accesso</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' è un tipo non supportato dal linguaggio</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Manca il membro '{0}.{1}', necessario per il compilatore.</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire in modo implicito il valore letterale di tipo double nel tipo '{1}'. Utilizzare un suffisso '{0}' per creare un valore letterale di questo tipo</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non può implementare sia '{1}' che '{2}' perché potrebbero unificarsi per alcune sostituzioni di parametro di tipo.</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire nel tipo statico '{0}'</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': i tipi statici non possono essere utilizzati come argomenti di tipi</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile creare un delegato dal metodo '{0}' perché è un metodo parziale senza una dichiarazione di implementazione</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'operando di un operatore di incremento o decremento deve essere una variabile, una proprietà o un indicizzatore</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non contiene una definizione per '{1}' e non è stato trovato alcun metodo di estensione '{1}' che accetta un primo argomento di tipo '{0}'. Probabilmente manca una direttiva using o un riferimento a un assembly.</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare i metodi di estensione '{0}' definiti nel tipo di valore '{1}' per creare delegati</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Nessun overload del metodo '{0}' accetta argomenti '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La corrispondenza migliore del metodo di overload per '{0}' presenta alcuni argomenti non validi</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Argomento '{0}': impossibile eseguire la conversione da '{1}' a '{2}'</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Un argomento ref o out deve essere una variabile assegnabile.</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile accedere al membro protetto '{0}' tramite un qualificatore di tipo '{1}'. Il qualificatore deve essere di tipo '{2}' o derivato da esso.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La proprietà, l'indicizzatore o l'evento '{0}' non è supportato dal linguaggio. Provare a chiamare direttamente il metodo '{1}' o '{2}' della funzione di accesso</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">La proprietà, l'indicizzatore o l'evento '{0}' non è supportato dal linguaggio. Provare a chiamare direttamente il metodo '{1}' della funzione di accesso</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il delegato '{0}' non accetta argomenti '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il delegato '{0}' presenta alcuni argomenti non validi</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile assegnare a '{0}' perché è di sola lettura</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile passare '{0}' come argomento ref o out perché è di sola lettura</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile modificare il valore restituito da '{0}' perché non è una variabile</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'argomento '{0}' non deve essere passato con la parola chiave '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'argomento '{0}' deve essere passato con la parola chiave '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile modificare i membri del campo di sola lettura '{0}' (tranne che in un costruttore o in un inizializzatore di variabile)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile passare i membri del campo di sola lettura '{0}' come argomento ref o out (tranne che in un costruttore)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile effettuare un'assegnazione ai campi di un campo statico di sola lettura '{0}' (tranne che in un costruttore statico o in un inizializzatore di variabile)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile passare un argomento ref o out ai campi di un campo statico di sola lettura '{0}' (tranne che in un costruttore statico)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile assegnare a '{0}' perché è '{1}'</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile passare '{0}' come argomento ref o out perché è '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">I metodi anonimi, le espressioni lambda e le espressioni di query all'interno delle strutture non possono accedere ai membri di istanza di 'this'. Si consiglia di copiare 'this' in una variabile locale all'esterno del metodo anonimo, dell'espressione lambda o dell'espressione di query e di utilizzare tale variabile locale.</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Non è possibile associare il delegato a '{0}' perché è un membro di 'System. Nullable<it id="1" pos="open">&lt;T&gt;</it>'</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non contiene un costruttore che accetta argomenti '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non contiene una definizione per '{1}' e l'overload migliore del metodo di estensione '{2}' presenta alcuni argomenti non validi</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Argomento dell'istanza: impossibile eseguire la conversione da '{0}' a '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il miglior metodo Add di overload '{0}' per l'inizializzatore di raccolta presenta alcuni argomenti non validi</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare la corrispondenza migliore del metodo di overload '{0}' per l'elemento inizializzatore della raccolta. I metodi 'Add' dell'inizializzatore di raccolta non possono includere parametri ref o out.</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il membro non richiamabile '{0}' come metodo.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Le specifiche di argomenti denominati devono trovarsi dopo tutti gli argomenti fissi specificati</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il miglior overload per '{0}' non contiene un parametro denominato '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il delegato '{0}' non dispone di un parametro denominato '{1}'</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile specificare l'argomento denominato '{0}' più volte</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">L'argomento denominato '{0}' specifica un parametro per cui è già stato fornito un argomento posizionale</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="ja" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">動的な操作をバインド中に、予期しない例外が発生しました</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">呼び出し元オブジェクトのない呼び出しはバインドできません</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">オーバーロードの解決に失敗しました</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">二項演算子は 2 つの引数を指定して呼び出す必要があります</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">単項演算子は 1 つの引数を指定して呼び出す必要があります</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">名前 '{0}' はメソッドにバインドされており、プロパティのように使用することはできません</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">イベント '{0}' することができますの左側にのみ表示されます +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">非デリゲート型を呼び出すことはできません</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">暗黙の型変換では 1 つの引数のみ受け取ります</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">明示的な変換では 1 つの引数のみ受け取ります</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">1 つの引数を指定して二項演算子を呼び出すことはできません</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">null 参照に対してメンバー割り当てを実行することはできません</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">null 参照に対して実行時バインディングを実行することはできません</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">条件付き属性があるため、メソッド '{0}' を動的に呼び出すことはできません</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 'void' を 'object' に暗黙的に変換することはできません</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">演算子 '{0}' を '{1}' と '{2}' 型のオペランドに適用することはできません</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">定数 0 で除算</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">角かっこ [] 付きインデックスを '{0}' 型の式に適用することはできません</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">角かっこ [] 内のインデックス数が正しくありません。正しい数は '{0}' です</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">演算子 '{0}' は '{1}' 型のオペランドに適用できません</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{0}' を '{1}' に暗黙的に変換できません</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">型 '{0}' を '{1}' に変換できません。</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">定数値 '{0}' を '{1}' に変換できません</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{1}' および '{2}' のオペランドの演算子 '{0}' があいまいです</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">演算子 '{0}' は型 '{1}' のオペランドに対してあいまいです</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Null 非許容の値型であるため、Null を '{0}' に変換できません</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">入れ子にされた型 '{1}' を経由して、外の型 '{0}' の静的でないメンバーにアクセスすることはできません</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' に '{1}' の定義がありません</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">静的でないフィールド、メソッド、またはプロパティ '{0}' で、オブジェクト参照が必要です</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">次のメソッドまたはプロパティ間で呼び出しが不適切です: '{0}' と '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' はアクセスできない保護レベルになっています</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">デリゲート '{1}' に一致する '{0}' のオーバーロードはありません</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">代入式の左辺には変数、プロパティ、またはインデクサーを指定してください。</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{0}' のコンストラクターが定義されていません</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">デリゲート '{0}' には有効なコンストラクターがありません</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">get アクセサーがないため、プロパティまたはインデクサー '{0}' をこのコンテキストで使用することはできません</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">インスタンス参照でメンバー '{0}' にアクセスできません。代わりに型名を使用してください</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用フィールドに割り当てることはできません (コンストラクター、変数初期化子では可 )。</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用フィールドに ref または out を渡すことはできません (コンストラクターでは可 )。</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">静的読み取り専用フィールドへの割り当てはできません (静的コンストラクターまたは変数初期化子では可)。</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用フィールドに ref または out を渡すことはできません (静的コンストラクターでは可)。</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">プロパティまたはインデクサー '{0}' は読み取り専用であるため、割り当てることはできません</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">抽象基本メンバーを呼び出すことはできません: '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">プロパティまたはインデクサーを out か ref のパラメーターとして渡すことはできません。</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">マネージ型 ('{0}') のアドレスの取得、サイズの取得、またはそのマネージ型へのポインターの宣言が実行できません</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">既に fixed が使用されている式のアドレスを取得するために、fixed ステートメントを使用することはできません。</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">動的な呼び出しはポインターと共に使用できません</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">short circuit 演算子として適用するためには、ユーザー定義の論理演算子 ('{0}') がその 2 つのパラメーターと同じ戻り値の型を持つ必要があります</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 ('{0}') に演算子 true および演算子 false の宣言が含まれている必要があります</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">操作はチェック モードでコンパイル時にオーバーフローします。</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">定数値 '{0}' は '{1}' に変換できません (unchecked 構文を使ってオーバーライドしてください)</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' と '{1}' 間があいまいです</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' には定義済みのサイズが指定されていないため、sizeof は unsafe コンテキストでのみ使用できます (System.Runtime.InteropServices.Marshal.SizeOf の使用をお勧めします)</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">フィールド初期化子は、静的でないフィールド、メソッド、またはプロパティ '{0}' を参照できません</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">デストラクター と object.Finalize を直接呼び出すことはできません。使用可能であれば IDisposable.Dispose を呼び出してください。</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">基本クラスの Finalize メソッドを直接呼び出さないでください。デストラクターから自動的に呼び出されます。</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">固定ステートメントの代入式の右辺はキャスト式ではない可能性があります。</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{0}' を '{1}' に暗黙的に変換できません。明示的な変換が存在します (cast が不足していないかどうかを確認してください)</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">get アクセサーにアクセスできないため、プロパティまたはインデクサー '{0}' はこのコンテキストでは使用できません。</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">set アクセサーにアクセスできないため、プロパティまたはインデクサー '{0}' はこのコンテキストでは使用できません。</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ジェネリック {1} '{0}' の使用には、'{2}' 型の引数が必要です</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">型 '{0}' は型引数としては使えません</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} '{0}' は型引数と一緒には使用できません</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">非ジェネリック {1} '{0}' は型引数と一緒には使用できません。</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}' は、ジェネリック型またはメソッド '{0}' 内でパラメーター '{1}' として使用するために、パブリック パラメーターなしのコンストラクターを持つ非抽象型でなければなりません</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。'{3}' から '{1}' への暗黙的な参照変換がありません。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。Null 許容型 '{3}' は、'{1}' の制約を満たしていません。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。Null 許容型 '{3}' は、'{1}' の制約を満たしていません。Null 許容型はインターフェイス制約を満たすことはできません。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。'{3}' から '{1}' へのボックス変換または型パラメーター変換がありません。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。'{3}' から '{1}' へのボックス変換がありません。</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Null 非許容の値型である可能性があるため、Null を型パラメーター '{0}' に変換できません。'default({0})' を使用してください。</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1} {0}' には、不適切な戻り値の型が指定されています</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">メソッド '{0}' の型引数を使い方から推論することはできません。型引数を明示的に指定してください。</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">メソッド グループ '{0}' を非デリゲート型 '{1}' に変換することはできません。このメソッドを呼び出しますか?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{2}' は、ジェネリック型のパラメーター '{1}'、またはメソッド '{0}' として使用するために、参照型でなければなりません</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 '{2}' は、ジェネリック型のパラメーター '{1}'、またはメソッド '{0}' として使用するために、Null 非許容の値型でなければなりません</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' と '{1}' を含む、循環制約の依存関係です</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型パラメーター '{0}' は、競合する制約 '{1}' および '{2}' を継承します</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型パラメーター '{1}' は 'struct' 制約を含むので、'{0}' の制約として '{1}' を使用することはできません</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}' から '{3}' へ変換するときの、あいまいなユーザー定義の変換 '{0}' および '{1}' です</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">定義済みの型 '{0}' は定義、またはインポートされていません</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">定義済みの型 '{0}' が不適切に宣言されています</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' はこの言語でサポートされていません</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 演算子またはアクセサーを明示的に呼び出すことはできません</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' はこの言語でサポートされていない型です</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">コンパイラが必要とするメンバー '{0}.{1}' がありません</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 double のリテラルを暗黙的に型 '{1}' に変換することはできません。'{0}' サフィックスを使用して、この型のリテラルを作成してください</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型パラメーターの代用に対して統合している可能性があるため、'{0}' は '{1}' と '{2}' の両方を実装することはできません</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">スタティック型 '{0}' へ変換できません</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': スタティック型を型引数として使用することはできません</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">メソッド '{0}' は実装宣言がない部分メソッドであるため、このメソッドからデリゲートを作成できません</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">インクリメント演算子またはデクリメント演算子のオペランドには、変数、プロパティ、またはインデクサーを指定してください。</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' に '{1}' の定義が含まれておらず、型 '{0}' の最初の引数を受け付ける拡張メソッド '{1}' が見つかりませんでした。using ディレクティブまたはアセンブリ参照が不足しています</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">値の型 '{1}' で定義された拡張メソッド '{0}' は、デリゲートを作成するために使用できません</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">引数を '{1}' 個指定できる、メソッド '{0}' のオーバーロードはありません</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' に最も適しているオーバーロード メソッドには無効な引数がいくつか含まれています</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">引数 '{0}': '{1}' から '{2}' へ変換できません</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref または out 引数は、割り当て可能な変数でなければなりません。</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}' 型の修飾子をとおしてプロテクト メンバー '{0}' にアクセスすることはできません。修飾子は '{2}' 型、またはそれから派生したものでなければなりません</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">プロパティ、インデクサー、またはイベント '{0}' はこの言語でサポートされていません。アクセサー メソッドの '{1}' または '{2}' を直接呼び出してください</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">プロパティ、インデクサー、またはイベント '{0}' はこの言語でサポートされていません。アクセサー メソッドの '{1}' を直接呼び出してください</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">デリゲート '{0}' に '{1}' 個の引数を指定することはできません</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">デリゲート '{0}' に無効な引数があります</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用であるため '{0}' に割り当てできません</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用なので '{0}' は ref または out 引数として渡せません</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">変数ではないため、'{0}' の戻り値を変更できません</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">引数 '{0}' を '{1}' キーワードと共に渡すことはできません</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">引数 '{0}' は '{1}' キーワードと共に渡されなければなりません</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用フィールド '{0}' のメンバーは変更できません (コンストラクターまたは変数初期化子では可)。</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">読み取り専用フィールド '{0}' のメンバーに ref または out を渡すことはできません (コンストラクターでは可)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">静的読み取り専用フィールド '{0}' のフィールドへの割り当てはできません (静的コンストラクターまたは変数初期化子では可)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">静的読み取り専用フィールド '{0}' には、静的コンストラクター内を除き、ref または out を渡すことはできません</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' は '{1}' であるため、割り当てることはできません</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}' であるため、'{0}' は ref または out 引数として渡せません</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">構造体内部の匿名メソッド、ラムダ式、またはクエリ式は、'this' のインスタンス メンバーにアクセスできません。'this' を匿名メソッド、ラムダ式、またはクエリ式の外部のローカル変数にコピーして、そのローカルを使用してください。</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>' のメンバーであるために、'{0}' のデリゲートをバインドできません。</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' に、引数を '{1}' 個指定できるコンストラクターがありません</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' に '{1}' の定義が含まれておらず、最も適している拡張メソッド オーバーロード '{2}' には無効な引数がいくつか含まれています</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">インスタンス引数: '{0}' から '{1}' へ変換できません</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">コレクション初期化子に最も適しているオーバーロード Add メソッド '{0}' には無効な引数がいくつか含まれています</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">コレクション初期化子要素の '{0}' に最も適しているオーバーロード メソッドは使用できません。コレクション初期化子 'Add' メソッドには、ref パラメーターまたは out パラメーターを使用できません。</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">実行不可能なメンバー '{0}' をメソッドのように使用することはできません。</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">名前付き引数は、すべての固定引数を指定した後で指定する必要があります</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' に最も適しているオーバーロードには '{1}' という名前のパラメーターがありません</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">デリゲート '{0}' には '{1}' という名前のパラメーターがありません</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' という名前付き引数が複数指定されました</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">名前付き引数 '{0}' は、場所引数が既に指定されているパラメーターを指定します</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="ko" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">동적 작업을 바인딩하는 동안 예기치 않은 예외가 발생했습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">호출 개체가 없으면 호출을 바인딩할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">오버로드 확인에 실패했습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">이항 연산자를 호출하려면 인수 두 개를 사용해야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">단항 연산자를 호출하려면 인수 한 개를 사용해야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">이름 '{0}'은(는) 메서드에 바인딩되어 있으며 속성처럼 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">이벤트 ' (0) '의 왼쪽에만 나타날 수 있습니다 +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">비대리자 형식을 호출할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">암시적 변환에서는 정확히 하나의 인수를 사용합니다.</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">명시적 변환에서는 정확히 하나의 인수를 사용합니다.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">하나의 인수를 사용하여 이항 연산자를 호출할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">null 참조에 대해 멤버 할당을 수행할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">null 참조에 대해 런타임 바인딩을 수행할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 메서드는 Conditional 특성이 있으므로 동적으로 호출할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">암시적으로 'void' 형식을 'object' 형식으로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 연산자는 '{1}' 및 '{2}' 형식의 피연산자에 적용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">상수 0으로 나누기</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">[]을 사용하는 인덱싱을 '{0}' 형식의 식에 적용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">[] 내부의 인덱스 수가 잘못되었습니다. '{0}'개가 필요합니다.</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 연산자는 '{1}' 형식의 피연산자에 적용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">암시적으로 '{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">상수 값 '{0}'을(를) '{1}'(으)로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 연산자가 모호하여 '{1}' 및 '{2}' 형식의 피연산자에 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 연산자가 모호하여 '{1}' 형식의 피연산자에 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) null을 허용하지 않는 값 형식이므로 null을 이 형식으로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">중첩 형식 '{1}'을(를) 통해 외부 형식 '{0}'의 static이 아닌 멤버에 액세스할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 '{1}'에 대한 정의가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">static이 아닌 필드, 메서드 또는 속성 '{0}'에 개체 참조가 필요합니다.</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">다음 메서드 또는 속성 사이의 호출이 모호합니다. '{0}'과(와) '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">보호 수준 때문에 '{0}'에 액세스할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}' 대리자와 일치하는 '{0}'에 대한 오버로드가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">할당식의 왼쪽은 변수, 속성 또는 인덱서여야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 형식에 정의된 생성자가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 대리자에 올바른 생성자가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 속성 또는 인덱서는 get 접근자가 없으므로 이 컨텍스트에서 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 멤버는 인스턴스 참조를 사용하여 액세스할 수 없습니다. 대신 형식 이름을 사용하여 한정하십시오.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">읽기 전용 필드에는 할당할 수 없습니다. 단 생성자 또는 변수 이니셜라이저에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">읽기 전용 필드는 ref 또는 out으로 전달할 수 없습니다. 단 생성자에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">정적 읽기 전용 필드에는 할당할 수 없습니다. 단 정적 생성자 또는 변수 이니셜라이저에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">정적 읽기 전용 필드는 ref 또는 out으로 전달할 수 없습니다. 단 정적 생성자에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 속성 또는 인덱서는 읽기 전용이므로 할당할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">추상 기본 멤버를 호출할 수 없습니다. '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">속성 또는 인덱서는 out 또는 ref 매개 변수로 전달할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">관리되는 형식('{0}')의 주소 또는 크기를 가져오거나 해당 형식에 대한 포인터를 선언할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">이미 고정된 식의 주소를 가져오는 데 fixed 문을 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">동적 호출을 포인터와 함께 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">사용자 정의 논리 연산자('{0}')를 단락(short circuit) 연산자로 사용하려면 연산자의 두 매개 변수와 같은 형식을 반환해야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 형식에는 true 및 false 연산자 선언이 있어야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">작업 선택된 모드에서 컴파일 타임에 오버플로</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">상수 값 '{0}'을(를) '{1}'(으)로 변환할 수 없습니다. 재정의하려면 'unchecked' 구문을 사용하십시오.</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'과(와) '{1}' 사이에 모호성이 있습니다.</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 미리 정의된 크기가 없으므로 sizeof는 안전하지 않은 컨텍스트에서만 사용할 수 있습니다. System.Runtime.InteropServices.Marshal.SizeOf를 사용하십시오.</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">필드 이니셜라이저는 static이 아닌 필드, 메서드 또는 속성 '{0}'을(를) 참조할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">소멸자 및 object.Finalize는 직접 호출할 수 없습니다. 가능한 경우 IDisposable.Dispose를 호출하십시오.</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">기본 클래스 Finalize 메서드를 직접 호출하지 마십시오. 이 메서드는 소멸자에서 자동으로 호출됩니다.</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">fixed 문의 오른쪽에는 캐스트 식을 할당할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">암시적으로 '{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다. 명시적 변환이 있습니다. 캐스트가 있는지 확인하십시오.</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">get 접근자에 액세스할 수 없으므로 '{0}' 속성 또는 인덱서는 이 컨텍스트에서 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">set 접근자에 액세스할 수 없으므로 '{0}' 속성 또는 인덱서는 이 컨텍스트에서 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">제네릭 {1} '{0}'을(를) 사용하려면 '{2}' 형식 인수가 필요합니다.</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 형식은 형식 인수로 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} '{0}'은(는) 형식 인수와 함께 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">제네릭이 아닌 {1} '{0}'은(는) 형식 인수와 함께 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">제네릭 형식 또는 메서드 '{0}'에서 '{1}' 매개 변수로 사용하려면 '{2}'이(가) 매개 변수가 없는 public 생성자를 사용하는 비추상 형식이어야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. '{3}'에서 '{1}'(으)로의 암시적 참조 변환이 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. nullable 형식 '{3}'이(가) '{1}' 제약 조건을 충족하지 않습니다.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. nullable 형식 '{3}'이(가) '{1}' 제약 조건을 충족하지 않습니다. nullable 형식은 어떠한 인터페이스 제약 조건도 만족할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. '{3}'에서 '{1}'(으)로의 boxing 변환 또는 형식 매개 변수 변환이 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. '{3}'에서 '{1}'(으)로의 boxing 변환이 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">null을 허용하지 않는 값 형식일 수 있으므로 null을 형식 매개 변수 '{0}'(으)로 변환할 수 없습니다. 대신 'default({0})'를 사용하십시오.</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1} {0}'에 잘못된 반환 형식이 있습니다.</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 메서드의 형식 인수를 유추할 수 없습니다. 형식 인수를 명시적으로 지정하십시오.</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 메서드 그룹을 비대리자 형식 '{1}'(으)로 변환할 수 없습니다. 메서드를 호출하시겠습니까?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">제네릭 형식 또는 메서드 '{0}'에서 '{2}' 형식을 '{1}' 매개 변수로 사용하려면 해당 형식이 참조 형식이어야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">제네릭 형식 또는 메서드 '{0}'에서 '{2}' 형식을 '{1}' 매개 변수로 사용하려면 해당 형식이 null을 허용하지 않는 값 형식이어야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 및 '{1}'과(와) 관련된 순환 제약 조건 종속성입니다.</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">형식 매개 변수 '{0}'이(가) 상속하는 '{1}' 및 '{2}' 제약 조건이 충돌합니다.</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">형식 매개 변수 '{1}'에 'struct' 제약 조건이 있으므로 '{1}'은(는) '{0}'에 대한 제약 조건으로 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}'에서 '{3}(으)로 변환하는 동안 모호한 사용자 정의 변환 '{0}' 및 '{1}'이(가) 발생했습니다.</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">미리 정의된 형식 '{0}'을(를) 정의하지 않았거나 가져오지 않았습니다.</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">미리 정의된 형식 '{0}'이(가) 잘못 선언되었습니다.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) 언어에서 지원되지 않습니다.</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 연산자나 접근자를 명시적으로 호출할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) 언어에서 지원하는 형식이 아닙니다.</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}.{1}' 멤버를 필요로 하는 컴파일러가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">double 형식의 리터럴을 암시적으로 '{1}' 형식으로 변환할 수 없습니다. 이 형식의 리터럴을 만들려면 '{0}' 접미사를 사용하십시오.</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}'과(와) '{2}'은(는) 일부 형식 매개 변수를 대체할 때 통합될 수 있으므로 '{0}'에서 둘 다 구현할 수는 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 정적 형식으로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 정적 형식은 형식 인수로 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) 구현 선언이 없는 부분 메서드(Partial Method)이므로 이 메서드로부터 대리자를 만들 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">증가 연산자 또는 감소 연산자의 피연산자는 변수, 속성 또는 인덱서여야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 '{1}'에 대한 정의가 없고 '{0}' 형식의 첫 번째 인수를 허용하는 확장 메서드 '{1}'을(를) 찾을 수 없습니다. using 지시문 또는 어셈블리 참조가 있는지 확인하십시오.</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">값 형식 '{1}'에 정의된 확장 메서드 '{0}'은(는) 대리자를 만드는 데 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}'개의 인수를 사용하는 '{0}' 메서드에 대한 오버로드가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 가장 일치하는 오버로드된 메서드에 잘못된 인수가 있습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 인수: '{1}'에서 '{2}'(으)로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 또는 out 인수는 할당 가능한 변수여야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}' 형식의 한정자를 통해 보호된 멤버 '{0}'에 액세스할 수 없습니다. 한정자는 '{2}' 형식이거나 여기에서 파생된 형식이어야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 속성, 인덱서 또는 이벤트는 이 언어에서 지원되지 않습니다. '{1}' 또는 '{2}' 접근자 메서드를 직접 호출해 보십시오.</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 속성, 인덱서 또는 이벤트는 이 언어에서 지원되지 않습니다. '{1}' 접근자 메서드를 직접 호출해 보십시오.</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 대리자에는 '{1}'개의 인수를 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 대리자에 잘못된 인수가 있습니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">읽기 전용인 '{0}'에는 할당할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) 읽기 전용이므로 ref 또는 out 인수로 전달할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) 변수가 아니므로 해당 반환 값을 수정할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 인수는 '{1}' 키워드와 함께 전달할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 인수는 '{1}' 키워드와 함께 전달해야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">읽기 전용 필드 '{0}'의 멤버는 수정할 수 없습니다. 단 생성자 또는 변수 이니셜라이저에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">읽기 전용 필드 '{0}'의 멤버는 ref 또는 out으로 전달할 수 없습니다. 단 생성자에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">static 읽기 전용 필드 '{0}'의 필드에는 할당할 수 없습니다. 단 static 생성자 또는 변수 이니셜라이저에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">static 읽기 전용 필드 '{0}'의 필드는 ref 또는 out으로 전달할 수 없습니다. 단 static 생성자에서는 예외입니다.</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1}'인 '{0}'에는 할당할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) '{1}'이므로 ref 또는 out 인수로 전달할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">구조체 안의 무명 메서드, 람다 식 및 쿼리 식은 'this'의 인스턴스 멤버에 액세스할 수 없습니다. 'this'를 무명 메서드, 람다 식 또는 쿼리 식 외부에 있는 지역 변수에 복사한 다음 이 지역 변수를 대신 사용하십시오.</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">그것 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'의 멤버 이므로 ' (0) '에 대리자를 바인딩할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 '{1}'개의 인수를 사용하는 생성자가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 '{1}'에 대한 정의가 없으며 가장 적합한 확장 메서드 오버로드 '{2}'에 잘못된 인수가 있습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">인스턴스 인수: '{0}'에서 '{1}'(으)로 변환할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">오버로드된 Add 메서드 중 해당 컬렉션 이니셜라이저에 가장 적합한 '{0}'에 잘못된 인수가 있습니다.</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">컬렉션 이니셜라이저에 대해 '{0}'에 가장 일치하는 오버로드된 메서드를 사용할 수 없습니다. 컬렉션 이니셜라이저 'Add' 메서드에는 ref 또는 out 매개 변수를 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">호출할 수 없는 멤버인 '{0}'은(는) 메서드처럼 사용할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">명명된 인수 사양은 모든 고정 인수를 지정한 다음에 와야 합니다.</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 가장 적합한 오버로드에 '{1}' 매개 변수가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 대리자에 '{1}' 매개 변수가 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">명명된 인수 '{0}'을(를) 여러 번 지정할 수 없습니다.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">명명된 인수 '{0}'은(는) 위치 인수가 이미 지정된 매개 변수를 지정합니다.</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="ru" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Возникло непредвиденное исключение при выполнении привязки динамической операции</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно выполнить привязку вызова к невызывающему объекту</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Сбой при разрешении перегрузки</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Бинарные операторы должны вызываться с использованием двух аргументов</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Унарные операторы должны быть вызваны с использованием одного аргумента</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для имени "{0}" выполнена привязка к методу. Невозможно использовать его как свойство</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Событие «{0}» может появляться только на стороне левой руки +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удалось вызвать тип, не являющийся делегатом</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для неявного преобразования нужен строго один аргумент</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для явного преобразования нужен строго один аргумент</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно вызвать бинарные операторы с использованием одного аргумента</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается выполнить присваивание члена по нулевой ссылке</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается выполнить привязки исполняющей среды по нулевой ссылке</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается динамически вызвать метод "{0}", так как у него есть условный атрибут</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Нельзя неявно преобразовать тип "void" to "object"</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается применить оператор "{0}" к операндам типа "{1}" и "{2}"</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Деление на ноль постоянной</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно применить индексирование через [] к выражению типа "{0}"</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Неверное количество индексов внутри []; ожидалось "{0}"</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается применить операнд "{0}" типа "{1}"</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается неявно преобразовать тип "{0}" в "{1}"</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно преобразовать тип "{0}" в "{1}"</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Постоянное значение "{0}" не может быть преобразовано в "{1}"</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Оператор "{0}" является неоднозначным по отношению к операндам типа "{1}" и "{2}"</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Оператор "{0}" является неоднозначным по отношению к операнду типа "{1}"</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Cannot convert null to "{0}" because it is a non-nullable value type</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно получить доступ к нестатическому члену внешнего типа "{0}" через вложенный тип "{1}"</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" не содержит определения для "{1}"</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для нестатического поля, метода или свойства "{0}" требуется ссылка на объект</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Понятие "вызов" трактуется неоднозначно в следующих методах или свойствах: "{0}" и "{1}"</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" недоступен из-за его уровня защиты</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Нет перегрузки для "{0}", соответствующей делегату "{1}"</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Левая часть выражения присваивания должна быть переменной, свойством или индексатором</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для типа "{0}" нет определенных конструкторов</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Делегат "{0}" не имеет допустимого конструктора</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">The property or indexer "{0}" cannot be used in this context because it lacks the get accessor</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Доступ к члену "{0}" через ссылку на экземпляр невозможен; вместо этого уточните его, указав имя типа</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Присваивание значений доступному только для чтения полю допускается только в конструкторе и в инициализаторе переменных</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Доступное только для чтения поле может передаваться как параметр с ключевым словом ref или out только в конструкторе</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Присваивание значений доступному только для чтения статическому полю допускается только в статическом конструкторе и в инициализаторе переменных</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Доступное только для чтения статическое поле может передаваться как параметр с ключевым словом ref или out только в статическом конструкторе</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно присвоить значение свойству или индексатору "{0}" -- доступ только для чтения</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается вызвать абстрактный член базового класса: "{0}"</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Свойства и индексаторы не могут передаваться как параметры с ключевыми словами out и ref</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно получить адрес, определить размер или объявить указатель на управляемый тип ("{0}")</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Получить адрес фиксированного выражения с помощью оператора fixed невозможно</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Динамические вызовы нельзя использовать в сопряжении с указателями</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для использования в качестве логического оператора краткой записи тип возвращаемого значения пользовательского логического оператора ("{0}") должен быть аналогичен типам двух его параметров</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Тип ("{0}") должен содержать объявления оператора true и оператора false</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Операция вызывает переполнение во время компиляции в проверяемом режиме</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Постоянное значение "{0}" не может быть преобразовано в "{1}" (для обхода используйте синтаксис "unchecked")</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Неоднозначность между "{0}" и "{1}"</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Инициализатор поля не может обращаться к нестатическому полю, методу или свойству "{0}"</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Непосредственный вызов деструкторов и функций object.Finalize запрещен. Рекомендуется вызов IDisposable.Dispose, если она доступна.</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не вызывайте метод Finalize базового класса напрямую. Он вызывается автоматически из деструктора.</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Правая часть присваивания оператора fixed не может быть выражением приведения типа</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается неявно преобразовать тип "{0}" в "{1}". Существует явное преобразование (требуется приведение типа?)</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Свойство или индексатор "{0}" невозможно использовать в данном контексте, поскольку метод доступа get недоступен</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Свойство или индексатор "{0}" невозможно использовать в данном контексте, поскольку метод доступа set недоступен</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Использование универсального {1} "{0}" требует аргументов типа "{2}"</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Тип '{0}' не может использоваться в качестве аргумента типа</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} "{0}" не может использоваться с аргументами типа</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Неуниверсальный {1} "{0}" не может использоваться с аргументами типа</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"Для использования в качестве параметра "{1}" в универсальном типе или методе "{0}" тип "{2}" должен быть неабстрактным и иметь открытый конструктор без параметров</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Нет неявного преобразования ссылки из "{3}" в "{1}".</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Для типа "{3}", допускающего значение null, не выполняется ограничение "{1}".</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Для типа "{3}", допускающего значение null, не выполняется ограничение "{1}". Типы, допускающие значение null, не могут удовлетворять ни одному интерфейсному ограничению.</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Нет преобразования-упаковки или преобразования типа параметра из "{3}" в "{1}".</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Нет преобразования-упаковки из "{3}" в "{1}".</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Cannot convert null to type parameter "{0}" because it could be a non-nullable value type. Вместо этого рекомендуется использовать "default({0})".</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{1} {0}" имеет неправильный возвращаемый тип</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">The type arguments for method "{0}" cannot be inferred from the usage. Попытайтесь явно определить аргументы-типы.</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается преобразовать группу методов "{0}" в тип, не являющийся делегатом "{1}". Предполагается ли вызывать этот метод?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для использования в качестве параметра "{1}" в универсальном типе или методе "{0}" тип "{2}" должен быть ссылочным типом</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для использования в качестве параметра "{1}" в универсальном типе или методе "{0}" тип "{2}" должен быть типом значения, не допускающим значения NULL</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Циклическая зависимость ограничения, включающая "{0}" и "{1}"</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Параметр типа "{0}" наследует конфликтующие ограничения "{1}" и "{2}"</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Параметр типа "{1}" имеет ограничение "struct", поэтому "{1}" не может использоваться в качестве ограничения для "{0}"</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Неоднозначные пользовательские преобразования "{0}" и "{1}" при преобразовании из "{2}" в "{3}"</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Предопределенный тип "{0}" не определен и не импортирован</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Предопределенный тип "{0}" объявлен неправильно</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" не поддерживается языком</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}": явный вызов оператора или метода доступа невозможен</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" является типом, который не поддерживается в данном языке</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Отсутствует обязательный для компилятора член "{0}.{1}"</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Литерал с типом double не может быть неявно преобразован к типу "{1}"; для создания литерала этого типа следует воспользоваться суффиксом "{0}"</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" не в состоянии реализовать как "{1}", так и "{2}", поскольку они могут быть идентичными для некоторых подстановок параметров-типов</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается выполнить преобразование к статическому типу "{0}"</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}": нельзя использовать статические типы в качестве аргументов-типов</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно создать делегат на основе метода "{0}", поскольку он является разделяемым методом без реализующего объявления</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Операндом оператора инкремента или декремента должна быть переменная, свойство или индексатор</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" не содержит определения для "{1}", а найти метод расширения "{1}", принимающий первый аргумент типа "{0}", не удалось (возможно, пропущена директива using или ссылка на сборку)</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Методы расширения "{0}", определенные для типа значения "{1}", не могут применяться для создания делегатов</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Отсутствие перегрузки для метода "{0}" принимает"{1}" аргументы</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Наиболее подходящий перегруженный метод для "{0}" имеет несколько недопустимых аргументов</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Аргумент "{0}": невозможно преобразовать из "{1}" в "{2}"</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Аргумент с ключевым словом ref или out должен быть переменной, которой можно присвоить значение</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается получить доступ к защищенному члену "{0}" через квалификатор типа "{1}"; квалификатор должен иметь тип "{2}" (или производный от него)</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Свойство, индексатор или событие "{0}" не поддерживается в данном языке; попробуйте вызвать метод доступа "{1}" или "{2}"</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Свойство, индексатор или событие "{0}" не поддерживается в данном языке; попробуйте вызвать метод доступа "{1}" или "{2}"</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Делегат "{0}" не принимает аргументы "{1}"</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Делегат "{0}" имеет недопустимые аргументы</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается выполнить присвоение параметру "{0}", так как он доступен только для чтения</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Cannot pass "{0}" as a ref or out argument because it is read-only</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Cannot modify the return value of "{0}" because it is not a variable</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Аргумент "{0}" должен быть передан с ключевым словом "{1}"</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Аргумент "{0}" должен быть передан с ключевым словом "{1}"</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Члены поля "{0}", предназначенного только для чтения, могут быть изменены только в конструкторе или инициализаторе переменных</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Members of readonly field "{0}" cannot be passed ref or out (except in a constructor)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Присваивание значений полям доступного только для чтения статического поля "{0}" допускается только в статическом конструкторе и в инициализаторе переменных</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Fields of static readonly field "{0}" cannot be passed ref or out (except in a static constructor)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается выполнить присвоение параметру "{0}", так как он является "{1}"</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удалось передать "{0}" как ссылку или аргумент out, так как это "{1}"</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Анонимные методы, лямбда-выражения и выражения запроса внутри структуры не имеет доступа к членам экземпляра "this". Возможно, следует скопировать "this" в локальную переменную за пределами анонимного метода, лямбда-выражения или выражения запроса и использовать эту локальную переменную.</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Не удается привязать делегат '{0}', потому что он является членом «System.Nullable<it id="1" pos="open">&lt;T&gt;</it>»</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" не содержит конструктор, принимающий аргументов: {1}</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" не содержит определения для "{1}", наилучшая перегрузка метода расширения "{2}" имеет такие же недопустимые аргументы</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Instance argument: невозможно преобразовать из "{0}" в "{1}"</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Наиболее подходящий перегруженный метод Add "{0}" для инициализатора коллекции содержит недопустимые аргументы</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Наиболее подходящий перегруженный метод, соответствующий "{0}" для элемента инициализации коллекции не может быть использован. Методы инициализации коллекции "Add" не имеют ссылочных и выходных параметров.</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невызываемый член "{0}" не может использоваться как метод.</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Спецификации именованного аргумента должны появляться во всех указанных фиксированных аргументах</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Наиболее подходящий перегруженный метод для "{0}" не имеет параметра "{1}"</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Делегат "{0}" не имеет параметра "{1}"</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается задать именованный аргумент "{0}" несколько раз</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Именованный аргумент "{0}" задает параметр, для которого уже был установлен позиционный аргумент.</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="zh-Hans" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">绑定动态操作时出现异常</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法在没有调用对象的情况下绑定调用</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">重载决策失败</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">必须使用两个参数调用二元运算符</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">必须使用一个参数调用一元运算符</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">名称“{0}”已绑定到某个方法，无法像属性一样使用</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">事件 '{0}' 只能出现在左边的 +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法调用非委托类型</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">隐式转换采用一个且仅一个参数</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">显式转换采用一个且仅一个参数</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用一个参数调用二元运算符</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法对 null 引用执行成员赋值</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法对 null 引用执行运行时绑定</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法动态调用方法“{0}”，因为它具有 Conditional 特性</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将类型“void”隐式转换为“object”</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">运算符“{0}”无法应用于“{1}”和“{2}”类型的操作数</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">常数零做除数</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将带 [] 的索引应用于“{0}”类型的表达式</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">[] 内的索引数错误；应为“{0}”</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">运算符“{0}”无法应用于“{1}”类型的操作数</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将类型“{0}”隐式转换为“{1}”</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">不能转换类型 '{0}' 到 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">常量值“{0}”无法转换为“{1}”</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">运算符“{0}”对于“{1}”和“{2}”类型的操作数具有二义性</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">运算符“{0}”对于“{1}”类型的操作数具有二义性</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将 null 转换为“{0}”，因为后者是不可以为 null 的值类型</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法通过嵌套类型“{1}”来访问外部类型“{0}”的非静态成员</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”未包含“{1}”的定义</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">对象引用对于非静态的字段、方法或属性“{0}”是必需的</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">以下方法或属性之间的调用具有二义性:“{0}”和“{1}”</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”不可访问，因为它具有一定的保护级别</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”没有与委托“{1}”匹配的重载</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">赋值号左边必须是变量、属性或索引器</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{0}”未定义构造函数</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委托“{0}”没有有效的构造函数</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">属性或索引器“{0}”不能用在此上下文中，因为它缺少 get 访问器</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用实例引用来访问成员“{0}”；请改用类型名来限定它</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法对只读的字段赋值(构造函数或变量初始值指定项中除外)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">对只读字段无法传递 ref 或 out 参数(构造函数中除外)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法对静态只读字段赋值(静态构造函数或变量初始值设定项中除外)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法向静态只读字段传递 ref 或 out 参数(静态构造函数中除外)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为属性或索引器“{0}”赋值 - 它是只读的</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法调用抽象基成员:“{0}”</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">属性或索引器不得作为 out 或 ref 参数传递</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法获取托管类型(“{0}”)的地址和大小，或者声明指向它的指针</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不能使用 fixed 语句来获取已固定的表达式的地址</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">动态调用不能与指针一起使用</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">为了可以像短路运算符一样应用，用户定义的逻辑运算符(“{0}”)的返回类型必须与它的两个参数的类型相同</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型(“{0}”)必须包含运算符 True 和运算符 False 的声明</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">操作在检查模式下编译时溢出</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">常量值“{0}”无法转换为“{1}”(使用“unchecked”语法重写)</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">在“{0}”和“{1}”之间具有二义性</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”没有预定义的大小，因此 sizeof 只能在不安全的上下文中使用(请考虑使用 System.Runtime.InteropServices.Marshal.SizeOf)</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">字段初始值设定项无法引用非静态字段、方法或属性“{0}”</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法直接调用析构函数和 object.Finalize。如果可用，请考虑调用 IDisposable.Dispose。</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不要直接调用基类 Finalize 方法。它将从析构函数中自动调用。</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">fixed 语句赋值的右边不能是强制转换表达式</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将类型“{0}”隐式转换为“{1}”。存在一个显式转换(是否缺少强制转换?)</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">属性或索引器“{0}”不能用在此上下文中，因为 get 访问器不可访问</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">属性或索引器“{0}”不能用在此上下文中，因为 set 访问器不可访问</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">使用泛型 {1}“{0}”需要“{2}”个类型参数</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">类型"{0}"不可能用作类型参数</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1}“{0}”不能与类型参数一起使用</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">非泛型 {1}“{0}”不能与类型参数一起使用</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{2}”必须是具有公共的无参数构造函数的非抽象类型，才能用作泛型类型或方法“{0}”中的参数“{1}”</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。没有从“{3}”到“{1}”的隐式引用转换。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。可以为 null 的类型“{3}”不满足“{1}”的约束。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。可以为 null 的类型“{3}”不满足“{1}”的约束。可以为 null 的类型不能满足任何接口约束。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。没有从“{3}”到“{1}”的装箱转换或类型参数转换。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。没有从“{3}”到“{1}”的装箱转换。</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将 null 转换为类型参数“{0}”，因为它可能是不可以为 null 的值类型。请考虑改用“default({0})”。</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{1} {0}”的返回类型错误</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法从用法中推断出方法“{0}”的类型参数。请尝试显式指定类型参数。</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将方法组“{0}”转换为非委托类型“{1}”。是否希望调用此方法?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{2}”必须是引用类型才能用作泛型类型或方法“{0}”中的参数“{1}”</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型“{2}”必须是不可以为 null 值的类型，才能用作泛型类型或方法“{0}”中的参数“{1}”</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">涉及“{0}”和“{1}”的循环约束依赖项</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型参数“{0}”继承了彼此冲突的“{1}”和“{2}”约束</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">类型参数“{1}”具有“struct”约束，因此“{1}”不能用作“{0}”的约束</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">从“{2}”转换为“{3}”时，用户定义的转换“{0}”和“{1}”具有二义性</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">预定义类型“{0}”未定义或导入</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">预定义类型“{0}”未正确声明</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">现用语言不支持“{0}”</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”: 无法显式调用运算符或访问器</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”不是现用语言支持的类型</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">缺少编译器要求的成员“{0}.{1}”</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将 Double 类型隐式转换为“{1}”类型；请使用“{0}”后缀创建此类型</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”不能同时实现“{1}”和“{2}”，原因是它们可以统一以进行某些类型参数替换</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法转换为静态类型“{0}”</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”: 静态类型不能用作类型参数</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法通过方法“{0}”创建委托，因为该方法是没有实现声明的分部方法</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">递增或递减运算符的操作数必须是变量、属性或索引器</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”未包含“{1}”的定义，并且找不到可接受第一个“{0}”类型参数的扩展方法“{1}”(是否缺少 using 指令或程序集引用?)</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用值类型“{1}”定义的扩展方法“{0}”来创建委托</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”方法没有采用“{1}”个参数的重载</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">与“{0}”最匹配的重载方法具有一些无效参数</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">参数“{0}”: 无法从“{1}”转换为“{2}”</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 或 out 参数必须是可以赋值的变量</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法通过“{1}”类型的限定符访问受保护的成员“{0}”；限定符必须是“{2}”类型(或者从该类型派生)</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">属性、索引器或事件“{0}”不受现用语言支持；请尝试直接调用访问器方法“{1}”或“{2}”</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">属性、索引器或事件“{0}”不受现用语言支持；请尝试直接调用访问器方法“{1}”</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委托“{0}”未采用“{1}”个参数</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委托“{0}”有一些无效参数</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为“{0}”赋值，因为它是只读的</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将“{0}”作为 ref 或 out 参数传递，因为它是只读的</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法修改“{0}”的返回值，因为它不是变量</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">参数“{0}”不应使用关键字“{1}”传递</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">参数“{0}”必须使用关键字“{1}”传递</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法修改只读字段“{0}”的成员(在构造函数或变量初始值设定项中除外)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为只读字段“{0}”的成员传递 ref 或 out (在构造函数中除外)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为静态只读字段“{0}”的字段赋值(在静态构造函数或变量初始值设定项中除外)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为静态只读字段“{0}”的字段传递 ref 或 out (在静态构造函数中除外)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为“{0}”赋值，因为它是“{1}”</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”是一个“{1}”，无法作为 ref 或 out 参数进行传递</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">结构内部的匿名方法、lambda 表达式和查询表达式无法访问“this”的实例成员。请考虑将“this”复制到匿名方法、lambda 表达式或查询表达式外部的某个局部变量并改用该局部变量。</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">不能将委托绑定到 '{0}'，因为它是 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>' 成员</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”不包含采用“{1}”个参数的构造函数</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”不包含“{1}”的定义，并且最佳扩展方法重载“{2}”具有一些无效参数</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">实例参数: 无法从“{0}”转换为“{1}”</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">集合初始值设定项的最佳重载 Add 方法“{0}”具有一些无效参数</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用集合初始值设定项元素的最佳重载方法匹配项“{0}”。集合初始值设定项“Add”方法不能具有 ref 或 out 参数。</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不可调用的成员“{0}”不能像方法一样使用。</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">命名参数规范必须出现在所有指定的固定参数后</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”的最佳重载没有名为“{1}”的参数</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委托“{0}”没有名为“{1}”的参数</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不能多次指定所命名的参数“{0}”。</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">命名实参“{0}”指定的形参已被赋予位置实参</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="zh-Hant" original="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1387.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="MICROSOFT.CSHARP/RESOURCES/STRINGS.RESX" datatype="resx">
+        <trans-unit id="InternalCompilerError" translate="yes" xml:space="preserve">
+          <source>An unexpected exception occurred while binding a dynamic operation</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">繫結動態作業時發生意外的例外狀況</target>
+        </trans-unit>
+        <trans-unit id="BindRequireArguments" translate="yes" xml:space="preserve">
+          <source>Cannot bind call with no calling object</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法繫結沒有呼叫物件的呼叫</target>
+        </trans-unit>
+        <trans-unit id="BindCallFailedOverloadResolution" translate="yes" xml:space="preserve">
+          <source>Overload resolution failed</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">多載解析失敗</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryOperatorRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators must be invoked with two arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">必須以兩個引數叫用二元運算子</target>
+        </trans-unit>
+        <trans-unit id="BindUnaryOperatorRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Unary operators must be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">必須以一個引數叫用一元運算子</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedMethodGroup" translate="yes" xml:space="preserve">
+          <source>The name '{0}' is bound to a method and cannot be used like a property</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">名稱 '{0}' 已繫結至一個方法，因此不能當成屬性使用</target>
+        </trans-unit>
+        <trans-unit id="BindPropertyFailedEvent" translate="yes" xml:space="preserve">
+          <source>The event '{0}' can only appear on the left hand side of +</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">事件 '{0}' 只能出現在左邊的 +</target>
+        </trans-unit>
+        <trans-unit id="BindInvokeFailedNonDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot invoke a non-delegate type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法叫用非委派型別</target>
+        </trans-unit>
+        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Implicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">隱含轉換只接受一個引數</target>
+        </trans-unit>
+        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
+          <source>Explicit conversion takes exactly one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">明確轉換只接受一個引數</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
+          <source>Binary operators cannot be invoked with one argument</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法以一個引數叫用二元運算子</target>
+        </trans-unit>
+        <trans-unit id="BindBinaryAssignmentFailedNullReference" translate="yes" xml:space="preserve">
+          <source>Cannot perform member assignment on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法對 null 參考進行成員指派</target>
+        </trans-unit>
+        <trans-unit id="NullReferenceOnMemberException" translate="yes" xml:space="preserve">
+          <source>Cannot perform runtime binding on a null reference</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法對 null 參考進行執行階段繫結</target>
+        </trans-unit>
+        <trans-unit id="BindCallToConditionalMethod" translate="yes" xml:space="preserve">
+          <source>Cannot dynamically invoke method '{0}' because it has a Conditional attribute</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法以動態方式叫用方法 '{0}'，因為它有 Conditional 屬性</target>
+        </trans-unit>
+        <trans-unit id="BindToVoidMethodButExpectResult" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type 'void' to 'object'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將 'void' 型別隱含轉換為 'object' 型別</target>
+        </trans-unit>
+        <trans-unit id="BadBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將運算子 '{0}' 套用至型別 '{1}' 和 '{2}' 的運算元</target>
+        </trans-unit>
+        <trans-unit id="IntDivByZero" translate="yes" xml:space="preserve">
+          <source>Division by constant zero</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">常數零做除數</target>
+        </trans-unit>
+        <trans-unit id="BadIndexLHS" translate="yes" xml:space="preserve">
+          <source>Cannot apply indexing with [] to an expression of type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法套用有 [] 的索引至型別 '{0}' 的運算式</target>
+        </trans-unit>
+        <trans-unit id="BadIndexCount" translate="yes" xml:space="preserve">
+          <source>Wrong number of indices inside []; expected '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">[] 內的索引數目錯誤; 必須是 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="BadUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' cannot be applied to operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將運算子 '{0}' 套用至型別 '{1}' 的運算元</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將型別 '{0}' 隱含轉換為 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="NoExplicitConv" translate="yes" xml:space="preserve">
+          <source>Cannot convert type '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">不能轉換類型 '{0}' 到 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRange" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將常數值 '{0}' 轉換為 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigBinaryOps" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">運算子 '{0}' 用在型別 '{1}' 和 '{2}' 的運算元上時其意義會模稜兩可</target>
+        </trans-unit>
+        <trans-unit id="AmbigUnaryOp" translate="yes" xml:space="preserve">
+          <source>Operator '{0}' is ambiguous on an operand of type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">運算子 '{0}' 用在型別 '{1}' 的運算元上時其意義會模稜兩可</target>
+        </trans-unit>
+        <trans-unit id="ValueCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to '{0}' because it is a non-nullable value type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將 null 轉換成 '{0}'，因為它是不可為 null 的實值型別</target>
+        </trans-unit>
+        <trans-unit id="WrongNestedThis" translate="yes" xml:space="preserve">
+          <source>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法透過巢狀型別 '{1}' 存取外部型別 '{0}' 的非靜態成員</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMember" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 不包含 '{1}' 的定義</target>
+        </trans-unit>
+        <trans-unit id="ObjectRequired" translate="yes" xml:space="preserve">
+          <source>An object reference is required for the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">需要有物件參考才能使用非靜態欄位、方法或屬性 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="AmbigCall" translate="yes" xml:space="preserve">
+          <source>The call is ambiguous between the following methods or properties: '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">在下列方法或屬性之間的呼叫模稜兩可: '{0}' 和 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadAccess" translate="yes" xml:space="preserve">
+          <source>'{0}' is inaccessible due to its protection level</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 的保護層級導致無法對其進行存取</target>
+        </trans-unit>
+        <trans-unit id="MethDelegateMismatch" translate="yes" xml:space="preserve">
+          <source>No overload for '{0}' matches delegate '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 沒有任何多載符合 '{1}' 委派</target>
+        </trans-unit>
+        <trans-unit id="AssgLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The left-hand side of an assignment must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">指派的左方必須為變數、屬性或索引子</target>
+        </trans-unit>
+        <trans-unit id="NoConstructors" translate="yes" xml:space="preserve">
+          <source>The type '{0}' has no constructors defined</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{0}' 沒有已定義的建構函式</target>
+        </trans-unit>
+        <trans-unit id="BadDelegateConstructor" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a valid constructor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委派 '{0}' 沒有有效的建構函式</target>
+        </trans-unit>
+        <trans-unit id="PropertyLacksGet" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because it lacks the get accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法於此內容中使用屬性或索引子 '{0}'，因為其欠缺 get 存取子</target>
+        </trans-unit>
+        <trans-unit id="ObjectProhibited" translate="yes" xml:space="preserve">
+          <source>Member '{0}' cannot be accessed with an instance reference; qualify it with a type name instead</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">成員 '{0}' 無法以執行個體參考存取; 請使用型別名稱代替</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be assigned to (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法指定唯讀欄位 (除非在建構函式或變數初始設定式)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly" translate="yes" xml:space="preserve">
+          <source>A readonly field cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 或 out 無法傳遞唯讀欄位 (除非在建構函式)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法指定靜態唯讀欄位 (除非在靜態建構函式或變數初始設定式)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic" translate="yes" xml:space="preserve">
+          <source>A static readonly field cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 或 out 無法傳遞靜態唯讀欄位 (除非在靜態建構函式)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyProp" translate="yes" xml:space="preserve">
+          <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法指派屬性或索引子 '{0}' -- 其為唯讀</target>
+        </trans-unit>
+        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
+          <source>Cannot call an abstract base member: '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法呼叫抽象基底成員: '{0}'</target>
+        </trans-unit>
+        <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
+          <source>A property or indexer may not be passed as an out or ref parameter</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將屬性或索引子當做 out 或 ref 參數傳遞</target>
+        </trans-unit>
+        <trans-unit id="ManagedAddr" translate="yes" xml:space="preserve">
+          <source>Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不能取得 Managed 型別 ('{0}') 的位址、大小，也不能宣告指向它的指標</target>
+        </trans-unit>
+        <trans-unit id="FixedNotNeeded" translate="yes" xml:space="preserve">
+          <source>You cannot use the fixed statement to take the address of an already fixed expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">您不能使用 fixed 陳述式來取得原本就是 fixed 運算式的位址</target>
+        </trans-unit>
+        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
+          <source>Dynamic calls cannot be used in conjunction with pointers</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">動態呼叫不能與指標一起使用</target>
+        </trans-unit>
+        <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
+          <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">為了可以當成最少運算 (Short Circuit) 運算子使用，使用者定義的邏輯運算子 ('{0}') 其傳回型別必須與其 2 個參數的型別相同</target>
+        </trans-unit>
+        <trans-unit id="MustHaveOpTF" translate="yes" xml:space="preserve">
+          <source>The type ('{0}') must contain declarations of operator true and operator false</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 ('{0}') 必須包含運算子 true 和運算子 false 的宣告</target>
+        </trans-unit>
+        <trans-unit id="CheckedOverflow" translate="yes" xml:space="preserve">
+          <source>The operation overflows at compile time in checked mode</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">操作在檢查模式下編譯時溢出</target>
+        </trans-unit>
+        <trans-unit id="ConstOutOfRangeChecked" translate="yes" xml:space="preserve">
+          <source>Constant value '{0}' cannot be converted to a '{1}' (use 'unchecked' syntax to override)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將常數值 '{0}' 轉換為 '{1}' (請使用 'unchecked' 語法覆寫)</target>
+        </trans-unit>
+        <trans-unit id="AmbigMember" translate="yes" xml:space="preserve">
+          <source>Ambiguity between '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 和 '{1}' 之間模稜兩可</target>
+        </trans-unit>
+        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
+          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 沒有預先定義的大小，因此 sizeof 只能使用於 unsafe 內容 (可考慮使用 System.Runtime.InteropServices.Marshal.SizeOf)</target>
+        </trans-unit>
+        <trans-unit id="FieldInitRefNonstatic" translate="yes" xml:space="preserve">
+          <source>A field initializer cannot reference the non-static field, method, or property '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">欄位初始設定式無法參考非靜態欄位、方法或屬性 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
+          <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不能直接呼叫解構函式和 object.Finalize。請考慮呼叫 IDisposable.Dispose (如果有)。</target>
+        </trans-unit>
+        <trans-unit id="CallingBaseFinalizeDeprecated" translate="yes" xml:space="preserve">
+          <source>Do not directly call your base class Finalize method. It is called automatically from your destructor.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不要直接呼叫您的基底類別 Finalize 方法。會從您的解構函式自動呼叫它。</target>
+        </trans-unit>
+        <trans-unit id="BadCastInFixed" translate="yes" xml:space="preserve">
+          <source>The right hand side of a fixed statement assignment may not be a cast expression</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">fixed 陳述式設定運算子的右邊不能是 cast 運算式</target>
+        </trans-unit>
+        <trans-unit id="NoImplicitConvCast" translate="yes" xml:space="preserve">
+          <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將型別 '{0}' 隱含轉換為 '{1}'。已有明確轉換存在 (您是否漏掉了轉型?)</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleGetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the get accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">這個內容中不能使用屬性或索引子 '{0}'，因為無法存取 get 存取子</target>
+        </trans-unit>
+        <trans-unit id="InaccessibleSetter" translate="yes" xml:space="preserve">
+          <source>The property or indexer '{0}' cannot be used in this context because the set accessor is inaccessible</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">這個內容中不能使用屬性或索引子 '{0}'，因為無法存取 set 存取子</target>
+        </trans-unit>
+        <trans-unit id="BadArity" translate="yes" xml:space="preserve">
+          <source>Using the generic {1} '{0}' requires '{2}' type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">使用泛型 {1} '{0}' 需要 '{2}' 個型別引數</target>
+        </trans-unit>
+        <trans-unit id="BadTypeArgument" translate="yes" xml:space="preserve">
+          <source>The type '{0}' may not be used as a type argument</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">類型"{0}"不可能用作類型參數</target>
+        </trans-unit>
+        <trans-unit id="TypeArgsNotAllowed" translate="yes" xml:space="preserve">
+          <source>The {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">{1} '{0}' 不能配合型別引數使用</target>
+        </trans-unit>
+        <trans-unit id="HasNoTypeVars" translate="yes" xml:space="preserve">
+          <source>The non-generic {1} '{0}' cannot be used with type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">非泛型 {1} '{0}' 不能配合型別引數使用</target>
+        </trans-unit>
+        <trans-unit id="NewConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>'{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{2}' 必須是具有公用無參數建構函式的非抽象型別，才能在泛型型別或方法 '{0}' 中做為參數 '{1}' 使用</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedRefType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。沒有從 '{3}' 到 '{1}' 的隱含參考轉換。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableEnum" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。可為 Null 的型別 '{3}' 未滿足 '{1}' 的條件約束。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedNullableInterface" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The nullable type '{3}' does not satisfy the constraint of '{1}'. Nullable types can not satisfy any interface constraints.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。可為 Null 的型別 '{3}' 未滿足 '{1}' 的條件約束。可為 Null 的型別無法滿足所有介面條件約束。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedTyVar" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。沒有從 '{3}' 到 '{1}' 的 Boxing 轉換或型別參數轉換。</target>
+        </trans-unit>
+        <trans-unit id="GenericConstraintNotSatisfiedValType" translate="yes" xml:space="preserve">
+          <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion from '{3}' to '{1}'.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。沒有從 '{3}' 到 '{1}' 的 Boxing 轉換。</target>
+        </trans-unit>
+        <trans-unit id="TypeVarCantBeNull" translate="yes" xml:space="preserve">
+          <source>Cannot convert null to type parameter '{0}' because it could be a non-nullable value type. Consider using 'default({0})' instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將 null 轉換成型別參數 '{0}'，因為它是不可為 null 的實值型別。請考慮使用 'default({0})' 代替。</target>
+        </trans-unit>
+        <trans-unit id="BadRetType" translate="yes" xml:space="preserve">
+          <source>'{1} {0}' has the wrong return type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{1} {0}' 的傳回型別錯誤</target>
+        </trans-unit>
+        <trans-unit id="CantInferMethTypeArgs" translate="yes" xml:space="preserve">
+          <source>The type arguments for method '{0}' cannot be inferred from the usage. Try specifying the type arguments explicitly.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">方法 '{0}' 的型別引數不能從使用方式推斷。請嘗試明確指定型別引數。</target>
+        </trans-unit>
+        <trans-unit id="MethGrpToNonDel" translate="yes" xml:space="preserve">
+          <source>Cannot convert method group '{0}' to non-delegate type '{1}'. Did you intend to invoke the method?</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將方法群組 '{0}' 轉換為非委派型別 '{1}'。您是否想要叫用這個方法?</target>
+        </trans-unit>
+        <trans-unit id="RefConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{2}' 必須是參考型別，才能在泛型型別或方法 '{0}' 中做為參數 '{1}' 使用</target>
+        </trans-unit>
+        <trans-unit id="ValConstraintNotSatisfied" translate="yes" xml:space="preserve">
+          <source>The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別 '{2}' 必須是不可為 null 的實值型別，才能在泛型型別或方法 '{0}' 中做為參數 '{1}' 使用</target>
+        </trans-unit>
+        <trans-unit id="CircularConstraint" translate="yes" xml:space="preserve">
+          <source>Circular constraint dependency involving '{0}' and '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">條件約束 '{0}' 和 '{1}' 循環相依; 必須移除兩者其中之一</target>
+        </trans-unit>
+        <trans-unit id="BaseConstraintConflict" translate="yes" xml:space="preserve">
+          <source>Type parameter '{0}' inherits conflicting constraints '{1}' and '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別參數 '{0}' 繼承了衝突的條件約束 '{1}' 和 '{2}'</target>
+        </trans-unit>
+        <trans-unit id="ConWithValCon" translate="yes" xml:space="preserve">
+          <source>Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">型別參數 '{1}' 有 'struct' 條件約束，因此 '{1}' 不能做為 '{0}' 的條件約束</target>
+        </trans-unit>
+        <trans-unit id="AmbigUDConv" translate="yes" xml:space="preserve">
+          <source>Ambiguous user defined conversions '{0}' and '{1}' when converting from '{2}' to '{3}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">從 '{2}' 轉換為 '{3}' 時，發現模稜兩可的使用者定義轉換 '{0}' 和 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeNotFound" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is not defined or imported</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">未定義或匯入預先定義的型別 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="PredefinedTypeBadType" translate="yes" xml:space="preserve">
+          <source>Predefined type '{0}' is declared incorrectly</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">預先定義的型別 '{0}' 宣告不正確</target>
+        </trans-unit>
+        <trans-unit id="BindToBogus" translate="yes" xml:space="preserve">
+          <source>'{0}' is not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">此語言不支援 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="CantCallSpecialMethod" translate="yes" xml:space="preserve">
+          <source>'{0}': cannot explicitly call operator or accessor</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 無法明確呼叫運算子或存取子</target>
+        </trans-unit>
+        <trans-unit id="BogusType" translate="yes" xml:space="preserve">
+          <source>'{0}' is a type not supported by the language</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">此語言不支援型別 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="MissingPredefinedMember" translate="yes" xml:space="preserve">
+          <source>Missing compiler required member '{0}.{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">遺漏編譯器所需的成員 '{0}.{1}'</target>
+        </trans-unit>
+        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
+          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">不能隱含將型別 double 的常值轉換為型別 '{1}'; 請使用 '{0}' 後置字元來建立此型別的常值</target>
+        </trans-unit>
+        <trans-unit id="UnifyingInterfaceInstantiations" translate="yes" xml:space="preserve">
+          <source>'{0}' cannot implement both '{1}' and '{2}' because they may unify for some type parameter substitutions</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 不能同時實作 '{1}' 和 '{2}'，因為它們可能對某些型別參數的替代做整合</target>
+        </trans-unit>
+        <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
+          <source>Cannot convert to static type '{0}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法轉換為靜態型別 '{0}'</target>
+        </trans-unit>
+        <trans-unit id="GenericArgIsStaticClass" translate="yes" xml:space="preserve">
+          <source>'{0}': static types cannot be used as type arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 靜態型別不能當做型別引數使用</target>
+        </trans-unit>
+        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
+          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法從方法 '{0}' 建立委派，因為它是沒有實作宣告的部分方法</target>
+        </trans-unit>
+        <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
+          <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">遞增或遞減運算子的運算元必須是變數、屬性或索引子。</target>
+        </trans-unit>
+        <trans-unit id="NoSuchMemberOrExtension" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 不包含 '{1}' 的定義，也找不到擴充方法 '{1}' 來接受型別 '{0}' 的第一個引數 (您是否遺漏 using 指示詞或組件參考?)</target>
+        </trans-unit>
+        <trans-unit id="ValueTypeExtDelegate" translate="yes" xml:space="preserve">
+          <source>Extension methods '{0}' defined on value type '{1}' cannot be used to create delegates</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">在實值型別 '{1}' 中定義的擴充方法 '{0}' 無法用來建立委派</target>
+        </trans-unit>
+        <trans-unit id="BadArgCount" translate="yes" xml:space="preserve">
+          <source>No overload for method '{0}' takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">方法 '{0}' 沒有任何多載接受 '{1}' 個引數</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypes" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match for '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">最符合的多載方法 '{0}' 有一些無效的引數</target>
+        </trans-unit>
+        <trans-unit id="BadArgType" translate="yes" xml:space="preserve">
+          <source>Argument '{0}': cannot convert from '{1}' to '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">引數 '{0}': 無法從 '{1}' 轉換為 '{2}'</target>
+        </trans-unit>
+        <trans-unit id="RefLvalueExpected" translate="yes" xml:space="preserve">
+          <source>A ref or out argument must be an assignable variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 或 out 引數必須是可指派的變數</target>
+        </trans-unit>
+        <trans-unit id="BadProtectedAccess" translate="yes" xml:space="preserve">
+          <source>Cannot access protected member '{0}' via a qualifier of type '{1}'; the qualifier must be of type '{2}' (or derived from it)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法經由型別 '{1}' 的限定詞來存取保護的成員 '{0}'; 必須經由型別 '{2}' (或從其衍生的型別) 的限定詞</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp2" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor methods '{1}' or '{2}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">此語言不支援屬性、索引子或事件 '{0}'; 請試著直接呼叫存取子方法 '{1}' 或 '{2}'</target>
+        </trans-unit>
+        <trans-unit id="BindToBogusProp1" translate="yes" xml:space="preserve">
+          <source>Property, indexer, or event '{0}' is not supported by the language; try directly calling accessor method '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">此語言不支援屬性、索引子或事件 '{0}'; 請試著直接呼叫存取子方法 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgCount" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' does not take '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委派 '{0}' 不接受 '{1}' 個引數</target>
+        </trans-unit>
+        <trans-unit id="BadDelArgTypes" translate="yes" xml:space="preserve">
+          <source>Delegate '{0}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委派 '{0}' 有一些無效的引數</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法指派給 '{0}'，因為它是唯讀的</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocal" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is read-only</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將 '{0}' 當做 ref 或 out 引數傳遞，因為它是唯讀的</target>
+        </trans-unit>
+        <trans-unit id="ReturnNotLValue" translate="yes" xml:space="preserve">
+          <source>Cannot modify the return value of '{0}' because it is not a variable</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法修改 '{0}' 的傳回值，因為它不是變數</target>
+        </trans-unit>
+        <trans-unit id="BadArgExtraRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' should not be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">傳遞引數 '{0}' 時不能包含 '{1}' 關鍵字</target>
+        </trans-unit>
+        <trans-unit id="BadArgRef" translate="yes" xml:space="preserve">
+          <source>Argument '{0}' must be passed with the '{1}' keyword</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">傳遞引數 '{0}' 時必須包含 '{1}' 關鍵字</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be modified (except in a constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">唯讀欄位 '{0}' 的成員無法修改 (除非是在建構函式或變數初始設定式)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonly2" translate="yes" xml:space="preserve">
+          <source>Members of readonly field '{0}' cannot be passed ref or out (except in a constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 或 out 無法傳遞唯讀欄位 '{0}' 的成員 (除非是在建構函式中)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法指派靜態唯讀欄位 '{0}' 的欄位 (除非是在靜態建構函式或變數初始設定式)</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyStatic2" translate="yes" xml:space="preserve">
+          <source>Fields of static readonly field '{0}' cannot be passed ref or out (except in a static constructor)</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ref 或 out 無法傳遞靜態唯讀欄位 '{0}' 的欄位 (除非是在靜態建構函式)</target>
+        </trans-unit>
+        <trans-unit id="AssgReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot assign to '{0}' because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法指派給 '{0}'，因為它是 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="RefReadonlyLocalCause" translate="yes" xml:space="preserve">
+          <source>Cannot pass '{0}' as a ref or out argument because it is a '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將 '{0}' 當做 ref 或 out 引數傳遞，因為它是 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="ThisStructNotInAnonMeth" translate="yes" xml:space="preserve">
+          <source>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">結構內部的匿名方法、Lambda 運算式和查詢運算式無法存取 'this' 的執行個體成員。請考慮將 'this' 複製到匿名方法、Lambda 運算式或查詢運算式外部的區域變數，並改用這個區域變數。</target>
+        </trans-unit>
+        <trans-unit id="DelegateOnNullable" translate="yes" xml:space="preserve">
+          <source>Cannot bind delegate to '{0}' because it is a member of 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>'</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">不能將委託綁定到 '{0}'，因為它是 'System.Nullable<it id="1" pos="open">&lt;T&gt;</it>' 成員</target>
+        </trans-unit>
+        <trans-unit id="BadCtorArgCount" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a constructor that takes '{1}' arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 不包含接受 '{1}' 個引數的建構函式</target>
+        </trans-unit>
+        <trans-unit id="BadExtensionArgTypes" translate="yes" xml:space="preserve">
+          <source>'{0}' does not contain a definition for '{1}' and the best extension method overload '{2}' has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 不包含 '{1}' 的定義，而且最佳的擴充方法多載 '{2}' 有一些無效的引數</target>
+        </trans-unit>
+        <trans-unit id="BadInstanceArgType" translate="yes" xml:space="preserve">
+          <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">執行個體引數: 無法從 '{0}' 轉換為 '{1}'</target>
+        </trans-unit>
+        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
+          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">集合初始設定式的最佳多載 Add 方法 '{0}' 有一些無效的引數</target>
+        </trans-unit>
+        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
+          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法使用集合初始設定式項目之最符合的多載方法 '{0}'。集合初始設定式 'Add' 方法不能具有 ref 或 out 參數。</target>
+        </trans-unit>
+        <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
+          <source>Non-invocable member '{0}' cannot be used like a method.</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">非可叫用 (Non-invocable) 成員 '{0}' 不能做為方法使用。</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentSpecificationBeforeFixedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument specifications must appear after all fixed arguments have been specified</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">具名引數規格必須出現在所有已指定的固定引數之後</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgument" translate="yes" xml:space="preserve">
+          <source>The best overload for '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 的最佳多載沒有一個名為 '{1}' 的參數</target>
+        </trans-unit>
+        <trans-unit id="BadNamedArgumentForDelegateInvoke" translate="yes" xml:space="preserve">
+          <source>The delegate '{0}' does not have a parameter named '{1}'</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">委派 '{0}' 沒有一個名為 '{1}' 的參數</target>
+        </trans-unit>
+        <trans-unit id="DuplicateNamedArgument" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' cannot be specified multiple times</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">具名引數 '{0}' 不可以多次指定</target>
+        </trans-unit>
+        <trans-unit id="NamedArgumentUsedInPositional" translate="yes" xml:space="preserve">
+          <source>Named argument '{0}' specifies a parameter for which a positional argument has already been given</source>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">具名引數 '{0}' 指定了已給定位置引數的參數</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>Unerwartete Ausnahme beim Binden eines dynamischen Vorgangs</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>Ein Aufruf ohne aufrufendes Objekt kann nicht gebunden werden.</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>Fehler bei der Überladungsauflösung</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>Binäre Operatoren müssen mit zwei Argumenten aufgerufen werden.</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>Unäre Operatoren müssen mit einem Argument aufgerufen werden.</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>Der Name "{0}" ist an eine Methode gebunden und kann nicht wie eine Eigenschaft verwendet werden.</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>Das Ereignis "{0}" kann nur verwendet werden, auf der linken Seite des +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>Ein Nichtdelegattyp kann nicht aufgerufen werden.</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>Eine implizite Konvertierung akzeptiert genau ein Argument.</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>Eine explizite Konvertierung akzeptiert genau ein Argument.</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>Binäre Operatoren können nicht mit einem Argument aufgerufen werden.</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>Für einen NULL-Verweis kann keine Memberzuweisung ausgeführt werden.</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>Die Laufzeitbindung kann für einen NULL-Verweis nicht ausgeführt werden.</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>Die {0}-Methode kann nicht dynamisch aufgerufen werden, da sie ein Conditional-Attribut enthält.</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>Der Typ "void" kann nicht implizit in "object" konvertiert werden.</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>Der {0}-Operator kann nicht auf Operanden vom Typ "{1}" und "{2}" angewendet werden.</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>Division durch Konstante NULL</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>Eine Indizierung mit [] kann nicht auf einen Ausdruck vom Typ "{0}" angewendet werden.</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>Falsche Indexanzahl in []. {0} wurde erwartet</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>Der {0}-Operator kann nicht auf einen Operanden vom Typ "{1}" angewendet werden.</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>Der {0}-Typ kann nicht implizit in {1} konvertiert werden.</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>Der {0}-Typ kann nicht in {1} konvertiert werden.</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>Der Konstantenwert "{0}" kann nicht in {1} konvertiert werden.</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>Der {0}-Operator ist bei Operanden vom Typ "{1}" und "{2}" mehrdeutig.</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>Der {0}-Operator ist für einen Operanden vom Typ "{1}" mehrdeutig.</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>NULL kann nicht in {0} konvertiert werden, da dieser Werttyp nicht auf NULL festgelegt werden kann.</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>Auf einen nicht statischen Member des äußeren {0}-Typs kann nicht über den geschachtelten {1}-Typ zugegriffen werden.</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>{0} enthält keine Definition für {1}.</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>Für das nicht statische Feld, die Methode oder die Eigenschaft "{0}" ist ein Objektverweis erforderlich.</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>Der Aufruf unterscheidet nicht eindeutig zwischen den folgenden Methoden oder Eigenschaften: {0} und {1}</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>Der Zugriff auf "{0}" ist aufgrund des Schutzgrads nicht möglich.</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>Keine Überladung für {0} stimmt mit dem Delegaten "{1}" überein.</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>Die linke Seite einer Zuweisung muss eine Variable, eine Eigenschaft oder ein Indexer sein.</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>Für den {0}-Typ sind keine Konstruktoren definiert.</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>Der Delegat "{0}" enthält keinen gültigen Konstruktor.</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>Die Eigenschaft oder der Indexer "{0}" kann in diesem Kontext nicht verwendet werden, weil der get-Accessor fehlt.</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>Auf den Member "{0}" kann nicht mit einem Instanzverweis zugegriffen werden. Qualifizieren Sie ihn stattdessen mit einem Typnamen.</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>Einem schreibgeschützten Feld kann nichts zugewiesen werden (außer in einem Konstruktor oder Variableninitialisierer).</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>Einem schreibgeschützten Feld kann kein Verweis und keine Ausgabe übergeben werden (außer in einem Konstruktor).</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>Einem statischen, schreibgeschützten Feld kann nichts zugewiesen werden (außer in einem statischen Konstruktor oder einem Variableninitialisierer).</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>Einem statischen, schreibgeschützten Feld kann kein Verweis und keine Ausgabe übergeben werden (außer in einem statischen Konstruktor)</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>Für die Eigenschaft oder den Indexer "{0}" ist eine Zuweisung nicht möglich -- sie sind schreibgeschützt.</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>Ein abstrakter Basismember kann nicht aufgerufen werden: '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>Eine Eigenschaft oder ein Indexer kann nicht als out- oder ref-Parameter übergeben werden.</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>Es ist nicht möglich, einen Zeiger für den verwalteten Typ ({0}) zu deklarieren oder dessen Adresse oder Größe abzurufen.</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>Sie können nicht die fixed-Anweisung verwenden, um die Adresse eines bereits festen Ausdrucks abzurufen.</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>Dynamische Aufrufe können nicht in Verbindung mit Zeigern verwendet werden.</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>Um als Kurzschlussoperator anwendbar zu sein, muss der Rückgabetyp eines benutzerdefinierten logischen Operators ({0}) mit dem Typ seiner zwei Parameter übereinstimmen.</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>Der Typ ({0}) muss Deklarationen des True- und des False-Operators enthalten.</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>Vorgangsüberlauf zur Kompilierzeit im aktivierten Modus.</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>Der Konstantenwert "{0}" kann nicht in {1} konvertiert werden (verwenden Sie zum Außerkraftsetzen die unchecked-Syntax).</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>Mehrdeutigkeit zwischen {0} und {1}</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>{0} enthält keine vordefinierte Größe, sizeof kann daher nur in einem ungeschützten Kontext verwendet werden (verwenden Sie ggf. System.Runtime.InteropServices.Marshal.SizeOf).</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>Ein Feldinitialisierer kann nicht auf das nicht statische Feld bzw. die nicht statische Methode oder Eigenschaft "{0}" verweisen.</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>Destruktoren und object.Finalize können nicht direkt aufgerufen werden. Rufen Sie IDisposable.Dispose auf, sofern verfügbar.</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>Rufen Sie die Finalize-Methode Ihrer Basisklasse nicht direkt auf, da sie automatisch vom Destruktor aufgerufen wird.</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>Die rechte Seite einer fixed-Anweisungszuweisung darf kein Umwandlungsausdruck sein.</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>Der {0}-Typ kann nicht implizit in {1} konvertiert werden. Es ist bereits eine explizite Konvertierung vorhanden (möglicherweise fehlt eine Umwandlung).</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>Die Eigenschaft oder der Indexer "{0}" kann in diesem Kontext nicht verwendet werden, da nicht auf den get-Accessor zugegriffen werden kann.</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>Die Eigenschaft oder der Indexer "{0}" kann in diesem Kontext nicht verwendet werden, da nicht auf den set-Accessor zugegriffen werden kann.</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>Die Verwendung von {1} "{0}" (generisch) erfordert {2}-Typargumente.</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>Der Typ "{0}" darf nicht als Typargument verwendet werden.</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1} "{0}" kann nicht mit Typargumenten verwendet werden.</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>{1} "{0}" ist nicht generisch und kann daher nicht mit Typargumenten verwendet werden.</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>{2} muss ein nicht abstrakter Typ mit einem öffentlichen parameterlosen Konstruktor sein, um im generischen Typ oder in der generischen {0}-Methode als {1}-Parameter verwendet werden zu können.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Es ist keine implizite Verweiskonvertierung von {3} in {1} vorhanden.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Der {3}-Typ, der NULL-Werte zulässt, entspricht nicht der Einschränkung von {1}.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Der {3}-Typ, der NULL-Werte zulässt, entspricht nicht der Einschränkung von {1}. Typen, die NULL-Werte zulassen, können Schnittstelleneinschränkungen nicht entsprechen.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Es ist keine Boxing-Konvertierung oder Typparameterkonvertierung von {3} in {1} vorhanden.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>Der {3}-Typ kann nicht als {2}-Typparameter im generischen Typ oder in der generischen {0}-Methode verwendet werden. Es ist keine Boxing-Konvertierung von {3} in {1} vorhanden.</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>NULL kann nicht in den {0}-Typparameter konvertiert werden, da dieser Werttyp möglicherweise nicht auf NULL festgelegt werden kann. Verwenden Sie stattdessen ggf. default({0}).</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>Der Rückgabetyp von {1} {0} ist falsch.</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>Die Typargumente der {0}-Methode können nicht per Rückschluss aus der Syntax abgeleitet werden. Geben Sie die Typargumente explizit an.</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>Die {0}-Methodengruppe kann nicht in den Nichtdelegattyp "{1}" konvertiert werden. Wollten Sie die Methode aufrufen?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>Der {2}-Typ muss ein Referenztyp sein, damit er als {1}-Parameter im generischen Typ oder in der generischen {0}-Methode verwendet werden kann.</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>Der {2}-Typ darf keine NULL-Werte zulassen, wenn er als {1}-Parameter im generischen Typ oder in der generischen {0}-Methode verwendet werden soll.</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>Einschränkungsringabhängigkeit zwischen {0} und {1}</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>Der {0}-Typparameter erbt die in Konflikt stehenden Einschränkungen "{1}" und "{2}"</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>Der {1}-Typparameter enthält die Einschränkung "struct". {1} kann daher nicht als Einschränkung für {0} verwendet werden.</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>Mehrdeutige benutzerdefinierte Konvertierungen von {0} und {1} bei der Konvertierung von {2} in {3}</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>Der vordefinierte {0}-Typ ist nicht definiert oder importiert.</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>Der vordefinierte {0}-Typ wurde falsch deklariert.</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>{0} wird von der Sprache nicht unterstützt.</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>{0}: Der Operator oder Accessor kann nicht explizit aufgerufen werden.</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>{0} ist ein Typ, der von der Sprache nicht unterstützt wird.</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>Der vom Compiler angeforderte Member "{0}.{1}" fehlt.</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>Literale vom Typ "double" können nicht implizit in den {1}-Typ konvertiert werden. Verwenden Sie ein {0}-Suffix, um ein Literal mit diesem Typ zu erstellen.</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>{0} kann nicht gleichzeitig {1} und {2} implementieren, da diese für einige Typparameterersetzungen zusammengeführt werden können.</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>Die Konvertierung in den statischen {0}-Typ ist nicht möglich.</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>{0}: Statische Typen können nicht als Typargumente verwendet werden.</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>Aus der {0}-Methode kann kein Delegat erstellt werden, da es sich um eine partielle Methode ohne implementierende Deklaration handelt.</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>Der Operand eines Inkrement- oder Dekrementoperators muss eine Variable, eine Eigenschaft oder ein Indexer sein.</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>{0} enthält keine Definition für {1}, und es konnte keine {1}-Erweiterungsmethode gefunden werden, die ein erstes Argument vom Typ "{0}" akzeptiert (möglicherweise fehlt eine Using-Direktive oder ein Assemblyverweis).</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>Die im {1}-Werttyp definierten {0}-Erweiterungsmethoden können nicht zum Erstellen von Delegaten verwendet werden.</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>Keine Überladung für die {0}-Methode nimmt {1}-Argumente an.</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>Die beste Übereinstimmung für die überladene {0}-Methode enthält einige ungültige Argumente.</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>{0}-Argument: Die Konvertierung von {1} in {2} ist nicht möglich.</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>Ein ref- oder out-Argument muss eine zuweisbare Variable sein.</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>Auf den geschützten Member "{0}" kann nicht über einen Qualifizierer vom Typ "{1}" zugegriffen werden. Der Qualifizierer muss vom Typ "{2}" (oder von ihm abgeleitet) sein.</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>Die Eigenschaft, der Indexer oder das Ereignis "{0}" wird von der Sprache nicht unterstützt. Rufen Sie die {1}- oder {2}-Accessormethoden direkt auf.</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>Die Eigenschaft, der Indexer oder das Ereignis "{0}" wird von der Sprache nicht unterstützt. Rufen Sie die {1}-Accessormethode direkt auf.</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>Der Delegat "{0}" akzeptiert {1}-Argumente nicht.</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>Der Delegat "{0}" enthält einige ungültige Argumente.</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>{0} ist schreibgeschützt. Eine Zuweisung ist daher nicht möglich.</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>{0} ist schreibgeschützt und kann daher nicht als ref- oder out-Argument übergeben werden.</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>Der Rückgabewert von {0} ist keine Variable und kann daher nicht geändert werden.</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>Das {0}-Argument darf nicht mit dem {1}-Schlüsselwort übergeben werden.</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>Das {0}-Argument muss mit dem {1}-Schlüsselwort übergeben werden.</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>Member des schreibgeschützten Felds "{0}" können nicht geändert werden (außer in einem Konstruktor oder Variableninitialisierer).</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>An Member des schreibgeschützten Felds "{0}" können keine ref- oder out-Argumente übergeben werden (außer in einem Konstruktor).</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>Für Felder eines statischen schreibgeschützten Felds "{0}" ist eine Zuweisung nicht möglich (außer in einem statischen Konstruktor oder einem Variableninitialisierer).</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>An Felder des schreibgeschützten Felds "{0}" können keine ref- oder out-Argumente übergeben werden (außer in einem Konstruktor).</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>{0} ist ein(e) {1}. Eine Zuweisung ist daher nicht möglich.</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>{0} ist ein(e) {1} und kann daher nicht als ref- oder out-Argument übergeben werden.</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>Anonyme Methoden, lambda-Ausdrücke und Abfrageausdrücke innerhalb von Strukturen können nicht auf Instanzmember von "this" zugreifen. Kopieren Sie "this" in eine lokale Variable außerhalb der anonymen Methode, des lambda-Ausdrucks oder des Abfrageausdrucks, und verwenden Sie die lokale Variable.</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>Kann Delegaten "{0}" keine Bindung an weil es ein Mitglied von "System.Nullable&lt;T&gt;ist"</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>"{0}" enthält keinen Konstruktor, der {1}-Argumente akzeptiert.</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>"{0}" enthält keine Definition für {1}, und die Überladung der optimalen {2}-Erweiterungsmethode enthält einige ungültige Argumente.</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>Instanzenargument: Konvertierung von {0} in {1} ist nicht möglich.</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>Die beste Übereinstimmung für die überladene {0}-Methode für den Auflistungsinitialisierer enthält einige ungültige Argumente.</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>Die beste Übereinstimmung für die überladene {0}-Methode für das Auflistungsinitialisiererelement kann nicht verwendet werden. Die Add-Methoden von Auflistungsinitialisierern dürfen keine ref- oder out-Parameter enthalten.</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>Der nicht aufrufbare Member "{0}" kann nicht wie eine Methode verwendet werden.</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>Die Spezifikationen für benannte Argumente müssen nach Angabe aller festen Argumente angezeigt werden.</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>Die beste Überladung für {0} enthält keinen Parameter mit dem Namen "{1}".</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>Der Delegat "{0}" enthält keinen Parameter mit dem Namen "{1}".</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>Das benannte {0}-Argument kann nicht mehrmals angegeben werden.</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>Das benannte {0}-Argument legt einen Parameter fest, für den bereits ein positionelles Argument angegeben wurde.</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>Excepción inesperada al enlazar una operación dinámica.</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>No se puede enlazar la llamada sin un objeto de llamada.</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>Error en la resolución de sobrecarga.</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>No se pueden invocar operadores binarios con dos argumentos.</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>Los operadores unarios deben invocarse con un argumento.</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>El nombre '{0}' está enlazado a un método y no se puede usar como propiedad.</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>El evento '{0}' sólo puede aparecer en el lado izquierdo de +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>No se puede invocar un tipo no delegado.</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>La conversión implícita toma exactamente un argumento.</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>La conversión explícita toma exactamente un argumento.</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>No se pueden invocar operadores binarios con un argumento.</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>No se puede realizar la asignación de miembros en una referencia NULL.</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>No se puede realizar enlace en tiempo de ejecución en una referencia NULL.</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>No se puede invocar dinámicamente el método '{0}' porque tiene un atributo Conditional.</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>No se puede convertir implícitamente el tipo 'void' en 'object'.</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>El operador '{0}' no se puede aplicar a operandos del tipo '{1}' y '{2}'</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>División por cero constante</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>No se puede aplicar la indización con [] a una expresión del tipo '{0}'</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>Número incorrecto de índices dentro de []; se esperaba '{0}'</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>El operador '{0}' no se puede aplicar al operando del tipo '{1}'</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>No se puede convertir implícitamente el tipo '{0}' en '{1}'.</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>No se puede convertir el tipo '{0}' en '{1}'</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>El valor constante '{0}' no se puede convertir en '{1}'</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>El operador '{0}' es ambiguo en operandos del tipo '{1}' y '{2}'</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>El operador '{0}' es ambiguo con un operando del tipo '{1}'</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>No se puede convertir NULL en '{0}' porque es un tipo de valor que no acepta valores NULL.</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>No se puede obtener acceso a un miembro no estático de tipo externo '{0}' mediante el tipo anidado '{1}'.</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>'{0}' no contiene una definición para '{1}'.</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>Se requiere una referencia de objeto para el campo, método o propiedad no estáticos '{0}'.</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>La llamada es ambigua entre los métodos o propiedades siguientes: '{0}' y '{1}'</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>'{0}' no es accesible debido a su nivel de protección</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>Ninguna sobrecarga correspondiente a '{0}' coincide con el '{1}' delegado</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>La parte izquierda de una asignación debe ser una variable, una propiedad o un indizador</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>El tipo '{0}' no tiene constructores definidos.</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>El delegado '{0}' no tiene un constructor válido</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>La propiedad o el indizador '{0}' no se puede usar en este contexto porque carece del descriptor de acceso get.</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>No se puede obtener acceso al miembro '{0}' con una referencia de instancia; califíquelo con un nombre de tipo en su lugar.</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>No se puede asignar un campo de sólo lectura (excepto en un constructor o inicializador de variable)</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>No se puede pasar out o ref a un campo de sólo lectura (excepto en un constructor)</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>No se puede asignar un campo de sólo lectura estático (excepto en un constructor estático o inicializador de variable)</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>No se puede pasar out o ref a un campo estático de sólo lectura (excepto en un constructor estático)</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>No se puede asignar a la propiedad o el indizador '{0}' porque es de solo lectura</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>No se puede llamar a un miembro base abstracto: '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>Una propiedad o un indizador no se puede pasar como parámetro out o ref</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>No se puede adquirir la dirección, obtener el tamaño ni declarar un puntero a un tipo administrado ('{0}')</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>No se puede utilizar la instrucción fixed para adquirir la dirección de una expresión de tipo fixed</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>No se pueden usar llamadas dinámicas en combinación con los punteros.</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>Para que se pueda aplicar un operador de cortocircuito, el operador lógico definido por el usuario ('{0}') debe tener el mismo tipo de valor devuelto que sus dos parámetros</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>El tipo ('{0}') debe incluir declaraciones de operador true y operador false.</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>La operación se desborda en tiempo de compilación en modo comprobado</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>El valor constante '{0}' no se puede convertir en '{1}' (use la sintaxis 'unchecked' para invalidar el valor)</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>Ambigüedad entre '{0}' y '{1}'</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>'{0}' no tiene un tamaño predefinido; por tanto, sizeof sólo se puede usar en un contexto no seguro (use System.Runtime.InteropServices.Marshal.SizeOf).</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>Un inicializador de campo no puede hacer referencia al campo, método o propiedad no estáticos '{0}'</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>Los destructores y object.Finalize no se pueden llamar directamente. Llame a IDisposable.Dispose si está disponible.</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>No llame directamente al método Finalize de la clase base. Se llama automáticamente desde el destructor.</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>El lado derecho de una asignación de instrucción fixed puede no ser una expresión de conversión</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>No se puede convertir implícitamente el tipo '{0}' en '{1}'. Ya existe una conversión explícita (compruebe si le falta una conversión).</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>La propiedad o indizador '{0}' no se puede usar en este contexto porque el descriptor de acceso get es inaccesible</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>La propiedad o indizador '{0}' no se puede usar en este contexto porque el descriptor de acceso set es inaccesible</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>Uso de {1} de tipo genérico ('{0}'): requiere '{2}' argumentos de tipo</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>El tipo '{0}' no se puede usar como argumento de tipo</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1} '{0}' no se puede usar con argumentos de tipo.</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>Uso de {1} '{0}' de tipo no genérico: no se puede usar con argumentos de tipo</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>'{2}' debe ser un tipo no abstracto con un constructor público sin parámetros para poder usarlo como parámetro '{1}' en el tipo o método genérico '{0}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. No hay ninguna conversión de referencia implícita de '{3}' a '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. El tipo que acepta valores NULL '{3}' no cumple la restricción de '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. El tipo que acepta valores NULL '{3}' no cumple la restricción de '{1}'. Los tipos que aceptan valores NULL no pueden cumplir restricciones de interfaz.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. No hay conversión boxing ni conversión de parámetro de tipo de '{3}' a '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>El tipo '{3}' no se puede usar como parámetro de tipo '{2}' en el tipo o método genérico '{0}'. No hay conversión boxing de '{3}' a '{1}'.</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>No se puede convertir NULL en el parámetro de tipo '{0}' porque podría ser un tipo de valor que no acepta valores NULL. Use 'default({0})' en su lugar.</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>'{1} {0}' es un tipo de valor devuelto equivocado</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>Los argumentos de tipo para el método '{0}' no se pueden inferir a partir del uso. Intente especificar los argumentos de tipo explícitamente.</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>No se puede convertir el grupo de métodos '{0}' en tipo no delegado '{1}'. ¿Intentó invocar el método?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>El tipo '{2}' debe ser un tipo de referencia para poder usarlo como parámetro '{1}' en el tipo o método genérico '{0}'.</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>El tipo '{2}' debe ser un tipo de valor que no acepte valores NULL para poder usarlo como parámetro '{1}' en el tipo o método genérico '{0}'.</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>Dependencia de restricción circular que implica '{0}' y '{1}'</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>El parámetro de tipo '{0}' hereda las restricciones conflictivas '{1}' y '{2}'</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>El parámetro de tipo '{1}' tiene la restricción 'struct'; por tanto,  '{1}' no se puede usar como restricción para  '{0}'</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>Conversiones ambiguas definidas por el usuario '{0}' y '{1}' al convertir de '{2}' a '{3}'</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>El tipo predefinido '{0}' no está definido ni importado.</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>Tipo predefinido '{0}' declarado incorrectamente.</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>'{0}' no es compatible con el lenguaje</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>'{0}': no se puede llamar explícitamente al operador o al descriptor de acceso</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>No se admite el tipo '{0}' para este lenguaje</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>Falta el miembro '{0}.{1}' que requiere el compilador.</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>El literal de tipo double no se puede convertir implícitamente en el tipo '{1}'; use un sufijo '{0}' para crear un literal de este tipo</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>'{0}' no puede implementar tanto '{1}' como '{2}' porque se pueden unificar para algunas sustituciones de parámetros de tipo.</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>No se puede convertir en el tipo estático '{0}'</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>'{0}': los tipos estáticos no se pueden usar como argumentos de tipo</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>No se puede crear un delegado a partir del método '{0}' porque es un método parcial sin una declaración de implementación.</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>El operando de un operador de incremento o decremento debe ser una variable, una propiedad o un indizador</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>'{0}' no contiene una definición para '{1}' ni se encuentra ningún método de extensión '{1}' que acepte un primer argumento del tipo '{0}' (¿falta una directiva de uso o una referencia de ensamblado?).</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>Los métodos de extensión '{0}' definidos en el tipo de valor '{1}' no se pueden usar para crear delegados.</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>Ninguna sobrecarga del método '{0}' toma argumentos '{1}'</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>La mejor coincidencia de método sobrecargado para '{0}' tiene algunos argumentos no válidos</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>Argumento '{0}': no se puede convertir de '{1}' a '{2}'</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>Un argumento out o ref debe ser una variable asignable</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>No se puede obtener acceso al miembro protegido '{0}' mediante un calificador del tipo '{1}'; el calificador debe ser del tipo '{2}' (o derivado de éste)</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>El lenguaje no admite la propiedad, el indizador o el evento '{0}'; intente llamar directamente a los métodos de descriptor de acceso '{1}' o '{2}'</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>El lenguaje no admite la propiedad, el indizador o el evento '{0}'; intente llamar directamente al método de descriptor de acceso '{1}'</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>El delegado '{0}' no toma '{1}' argumentos</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>El delegado '{0}' tiene algunos argumentos no válidos</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>No se puede asignar a '{0}' porque es de solo lectura</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>No se puede pasar '{0}' como argumento out o ref porque es de solo lectura.</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>No se puede modificar el valor devuelto de '{0}' porque no es una variable.</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>No se debe pasar el argumento '{0}' con la palabra clave '{1}'</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>El argumento '{0}' se debe pasar con la palabra clave '{1}'</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>Los miembros del campo de solo lectura '{0}' no se pueden modificar (excepto en un constructor o inicializador de variable)</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>No se puede pasar out o ref a los miembros del campo de solo lectura '{0}' (excepto en un constructor).</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>No se puede asignar a los campos del campo estático de solo lectura '{0}' (excepto en un constructor estático o un inicializador de variable)</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>No se puede pasar out o ref a los campos del campo estático de solo lectura '{0}' (excepto en un constructor estático).</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>No se puede asignar a '{0}' porque es '{1}'</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>No se puede pasar '{0}' como argumento out o ref porque es '{1}'.</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>Los métodos anónimos, las expresiones lambda y las expresiones de consulta incluidos en structs no pueden obtener acceso a miembros de instancia de 'this'. Copie 'this' en una variable local fuera del método anónimo, la expresión lambda o la expresión de consulta y use la variable local en su lugar.</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>No se puede enlazar el delegado para '{0}' porque es un miembro de 'System.Nullable&lt;T&gt;'</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>'{0}' no contiene un constructor que tome '{1}' argumentos</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>'{0}' no contiene una definición para '{1}' y la mejor sobrecarga del método de extensión '{2}' tiene algunos argumentos no válidos</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>Argumento de instancia: no se puede convertir de '{0}' a '{1}'</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>El mejor método Add sobrecargado '{0}' del inicializador de colección tiene algunos argumentos no válidos</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>La mejor coincidencia de método sobrecargado '{0}' para el elemento inicializador de la colección no se puede usar. Los métodos 'Add' inicializadores de colección no pueden tener parámetros out o ref.</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>No se puede usar como método el miembro '{0}' no invocable.</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>Las especificaciones de argumento con nombre deben aparecer después de haber especificado todos los argumentos fijos.</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>La mejor sobrecarga para '{0}' no tiene un parámetro denominado '{1}'</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>El delegado '{0}' no tiene un parámetro denominado '{1}'</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>El argumento con nombre '{0}' no se puede especificar varias veces</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>El argumento con nombre '{0}' especifica un parámetro para el que ya se ha proporcionado un argumento posicional.</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>Une exception inattendue s'est produite lors de la liaison d'une opération dynamique</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>Impossible de lier l'appel sans objet appelant</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>Échec de la résolution de surcharge</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>Les opérateurs binaires doivent être appelés avec deux arguments</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>Les opérateurs unaires doivent être appelés à l'aide d'un seul argument</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>Le nom '{0}' est lié à une méthode et ne peut pas être utilisé comme une propriété</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>L'événement « {0} » ne peut apparaître sur le côté gauche de +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>Impossible d'appeler un type non-délégué</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>La conversion implicite n'accepte qu'un seul argument</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>La conversion explicite n'accepte qu'un seul argument</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>Impossible d'appeler les opérateurs binaires avec un argument</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>Impossible d'effectuer une assignation de membre sur une référence null</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>Impossible d'effectuer une liaison au moment de l'exécution sur une référence null</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>Impossible d'appeler dynamiquement la méthode '{0}' car elle a un attribut Conditional</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>Impossible de convertir implicitement le type 'void' en 'object'</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>Impossible d'appliquer l'opérateur '{0}' aux opérandes de type '{1}' et '{2}'</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>Division par zéro constant</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>Impossible d'appliquer l'indexation à l'aide de [] à une expression de type '{0}'</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>Nombre d'index incorrects dans [], '{0}' attendu</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>Impossible d'appliquer l'opérateur '{0}' à un opérande de type '{1}'</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>Impossible de convertir implicitement le type '{0}' en '{1}'</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>Impossible de convertir le type « {0} » pour « {1} »</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>Impossible de convertir la valeur de constante '{0}' en '{1}'</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>L'opérateur '{0}' est ambigu pour des opérandes de type '{1}' et '{2}'</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>L'opérateur '{0}' est ambigu pour un opérande de type '{1}'</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>Impossible de convertir null en '{0}', car il s'agit d'un type valeur qui n'autorise pas les valeurs null</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>Impossible d'accéder à un membre non statique de type externe '{0}' par l'intermédiaire du type imbriqué '{1}'</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>'{0}' ne contient pas de définition pour '{1}'</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>Une référence d'objet est requise pour la propriété, la méthode ou le champ non statique '{0}'</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>L'appel est ambigu entre les méthodes ou propriétés suivantes : '{0}' et '{1}'</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>'{0}' est inaccessible en raison de son niveau de protection</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>Aucune surcharge pour '{0}' ne correspond au délégué '{1}'</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>La partie gauche d'une assignation doit être une variable, une propriété ou un indexeur</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>Aucun constructeur n'est défini pour le type '{0}'</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>Le délégué '{0}' n'a pas de constructeur valide</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>Impossible d'utiliser la propriété ou l'indexeur '{0}' dans ce contexte, car il lui manque l'accesseur get</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>Le membre '{0}' est inaccessible avec une référence d'instance ; qualifiez-le avec un nom de type</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>Un champ readonly ne peut pas être assigné (sauf s'il appartient à un constructeur ou un initialiseur de variable)</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>Un champ readonly ne peut pas être passé en ref ou out (sauf s'il appartient à un constructeur)</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>Un champ readonly statique ne peut pas être assigné (sauf s'il appartient à un constructeur statique ou un initialiseur de variable)</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>Un champ readonly statique ne peut pas être passé en ref ou out (sauf s'il appartient à un constructeur statique)</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>Impossible d'assigner la propriété ou l'indexeur '{0}' -- il est en lecture seule</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>Impossible d'appeler un membre de base abstrait : '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>Une propriété ou un indexeur ne peut pas être passé en tant que paramètre de sortie (out) ni de référence (ref)</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>Impossible de prendre l'adresse, d'obtenir la taille ou de déclarer un pointeur vers un type managé ('{0}')</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>Vous ne pouvez pas utiliser l'instruction fixed pour prendre l'adresse d'une expression qui est déjà fixed</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>Impossible d'utiliser des appels dynamiques avec des pointeurs</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>Pour être applicable en tant qu'opérateur de court-circuit, un opérateur logique défini par l'utilisateur '{0}') doit avoir le même type de retour que le type de ses 2 paramètres</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>Le type ('{0}') doit contenir les déclarations de l'opérateur true et de l'opérateur false</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>L'opération déborde au moment de la compilation en mode activé</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>Impossible de convertir la valeur de constante '{0}' en '{1}' (utilisez la syntaxe 'unchecked)</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>Ambiguïté entre '{0}' et '{1}'</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>'{0}' n'a pas de taille prédéfinie ; c'est pourquoi sizeof ne peut être utilisé que dans un contexte unsafe (utilisez System.Runtime.InteropServices.Marshal.SizeOf)</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>Un initialiseur de champ ne peut pas faire référence au champ, à la méthode ou à la propriété non statique '{0}'</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>Impossible d'appeler directement des destructeurs et object.Finalize. Appelez IDisposable.Dispose s'il est disponible.</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>Ne pas appeler directement votre méthode Finalize de la classe de base. La méthode est automatiquement appelée à partir de votre destructeur.</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>La partie droite d'une assignation d'instruction fixed peut ne pas être une expression de cast</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>Impossible de convertir implicitement le type '{0}' en '{1}'. Une conversion explicite existe (un cast est-il manquant ?)</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>Impossible d'utiliser la propriété ou l'indexeur '{0}' dans ce contexte, car l'accesseur get n'est pas accessible</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>Impossible d'utiliser la propriété ou l'indexeur '{0}' dans ce contexte, car l'accesseur set n'est pas accessible</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>L'utilisation du {1} '{0}' générique requiert les arguments de type '{2}'</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>Le type '{0}' ne peut pas être utilisé comme argument de type</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>Impossible d'utiliser le {1} '{0}' avec des arguments de type</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>Impossible d'utiliser le {1} '{0}' non générique avec des arguments de type</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>'{2}' doit être un type non abstrait avec un constructeur sans paramètre public afin de l'utiliser comme paramètre '{1}' dans le type ou la méthode générique '{0}'</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Il n'y a pas de conversion de référence implicite de '{3}' en '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Le type Nullable '{3}' ne satisfait pas la contrainte de '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Le type Nullable '{3}' ne satisfait pas la contrainte de '{1}'. Les types Nullable ne peuvent pas satisfaire les contraintes d'interface.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Il n'y a pas de conversion boxing ou de conversion de paramètre de type de '{3}' en '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>Impossible d'utiliser le type '{3}' comme paramètre de type '{2}' dans le type ou la méthode générique '{0}'. Il n'y a pas de conversion boxing de '{3}' en '{1}'.</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>Impossible de convertir null en paramètre de type '{0}' car il peut s'agir d'un type valeur qui n'autorise pas les valeurs null. Utilisez 'default({0})' à la place.</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>'{1} {0}' n'a pas le type de retour correct</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>Impossible de déduire les arguments de type pour la méthode '{0}' à partir de l'utilisation. Essayez de spécifier les arguments de type de façon explicite.</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>Impossible de convertir le groupe de méthodes '{0}' en type non-délégué '{1}'. Souhaitiez-vous appeler la méthode ?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>Le type '{2}' doit être un type référence afin d'être utilisé comme paramètre '{1}' dans le type ou la méthode générique '{0}'</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>Le type '{2}' doit être un type valeur non Nullable afin d'être utilisé comme paramètre '{1}' dans le type ou la méthode générique '{0}'</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>Dépendance de contrainte circulaire utilisant '{0}' et '{1}'</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>Le paramètre de type '{0}' hérite des contraintes en conflit '{1}' et '{2}'</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>Le paramètre de type '{1}' a la contrainte 'struct', donc '{1}' ne peut pas être utilisé comme contrainte pour '{0}'</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>Conversions définies par l'utilisateur ambiguës '{0}' et '{1}' lors de la conversion de '{2}' en '{3}'</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>Le type prédéfini '{0}' n'est pas défini ou importé</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>Le type prédéfini '{0}' n'est pas déclaré correctement</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>'{0}' n'est pas pris en charge par le langage</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>'{0}' : impossible d'appeler explicitement un opérateur ou un accesseur</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>'{0}' est un type qui n'est pas pris en charge par le langage</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>Membre requis par le compilateur '{0}.{1}' manquant</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>Impossible de convertir implicitement un littéral de type double en type '{1}' ; utilisez un suffixe '{0}' pour créer un littéral de ce type</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>'{0}' ne peut pas implémenter '{1}' et '{2}', car ils peuvent être réunis pour des substitutions de paramètre de type</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>Impossible de convertir en type static '{0}'</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>'{0}' : impossible d'utiliser les types static en tant qu'arguments de type</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>Impossible de créer un délégué à partir de la méthode '{0}', car il s'agit d'une méthode partielle sans déclaration d'implémentation</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>L'opérande d'un opérateur d'incrémentation ou de décrémentation doit être une variable, une propriété ou un indexeur</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>'{0}' ne contient pas de définition pour '{1}' et aucune méthode d'extension '{1}' acceptant un premier argument de type '{0}' n'a été trouvée (une directive using ou une référence d'assembly est-elle manquante ?)</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>Impossible d'utiliser les méthodes d'extension '{0}' définies dans un type valeur '{1}' pour créer des délégués</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>Aucune surcharge pour la méthode '{0}' ne prend d'arguments '{1}'</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>La méthode surchargée correspondant le mieux à '{0}' a des arguments non valides</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>Argument '{0}' : impossible de convertir de '{1}' en '{2}'</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>Un argument ref ou out doit être une variable qui peut être assignée</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>Impossible d'accéder au membre protégé '{0}' par l'intermédiaire d'un qualificateur de type '{1}' ; le qualificateur doit être de type '{2}' (ou dérivé de celui-ci)</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>La propriété, l'indexeur ou l'événement '{0}' n'est pas pris en charge par le langage ; essayez d'appeler directement les méthodes d'accesseur '{1}' ou '{2}'</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>La propriété, l'indexeur ou l'événement '{0}' n'est pas pris en charge par le langage ; essayez d'appeler directement la méthode d'accesseur '{1}'</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>Le délégué '{0}' ne prend pas les arguments '{1}'</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>Le délégué '{0}' utilise des arguments non valides</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>Impossible d'assigner à '{0}', car il est en lecture seule</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>Impossible de passer '{0}' comme argument ref ou out, car il est en lecture seule</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>Impossible de modifier la valeur de retour de '{0}' car il ne s'agit pas d'une variable</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>L'argument '{0}' ne doit pas être passé avec le mot clé '{1}'</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>L'argument '{0}' doit être passé avec le mot clé '{1}'</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>Impossible de modifier les membres d'un champ readonly '{0}' (sauf s'ils appartiennent à un constructeur ou un initialiseur de variable)</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>Impossible de passer les membres d'un champ readonly '{0}' en ref ou out (sauf s'ils appartiennent à un constructeur)</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>Impossible d'assigner les champs du champ readonly statique '{0}' (sauf s'ils appartiennent à un constructeur statique ou un initialiseur de variable)</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>Impossible de passer les champs d'un champ readonly statique '{0}' en ref ou out (sauf s'ils appartiennent à un constructeur statique)</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>Impossible d'assigner à '{0}', car il s'agit d'un '{1}'</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>Impossible de passer '{0}' en tant qu'argument ref ou out, car il s'agit d'un '{1}'</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>Les méthodes anonymes, les expressions lambda et les expressions de requête dans des structs ne peuvent pas accéder aux membres d'instance de 'this'. Copiez 'this' dans une variable locale en dehors de la méthode anonyme, de l'expression lambda ou de l'expression de requête et utilisez la variable locale à la place.</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>Impossible de lier délégué à « {0} » parce que c'est un membre de « System.Nullable&lt;T&gt;»</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>'{0}' ne contient pas de constructeur qui accepte des arguments '{1}'</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>'{0}' ne contient pas de définition pour '{1}' et la meilleure surcharge de la méthode d'extension '{2}' contient des arguments non valides</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>Argument d'instance : impossible de convertir '{0}' en '{1}'</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>La méthode Add surchargée '{0}' correspondant le mieux à l'initialiseur de collection a des arguments non valides</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>La méthode surchargée '{0}' correspondant le mieux à l'élément de l'initialiseur de collection ne peut pas être utilisée. Les méthodes 'Add' de l'initialiseur de collection ne peuvent pas avoir de paramètres ref ou out.</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>Impossible d'utiliser un membre '{0}' ne pouvant pas être appelé comme une méthode.</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>Les spécifications d'argument nommé doivent s'afficher après la spécification de tous les arguments fixes</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>La meilleure surcharge pour '{0}' n'a pas de paramètre nommé '{1}'</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>Le délégué '{0}' n'a pas de paramètre nommé '{1}'</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>Impossible de spécifier plusieurs fois l'argument nommé '{0}'</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>L'argument nommé '{0}' spécifie un paramètre pour lequel un paramètre positionnel a déjà été donné</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>Eccezione imprevista durante l'associazione di un'operazione dinamica</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>Impossibile associare la chiamata senza oggetto chiamante</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>Risoluzione dell'overload non riuscita</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>Gli operatori binari devono essere richiamati con due argomenti</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>Gli operatori unari devono essere richiamati con un solo argomento</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>Il nome '{0}' è associato a un metodo e non può essere utilizzato come una proprietà</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>L'evento '{0}' può trovarsi soltanto sul lato sinistro di +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>Impossibile richiamare un tipo non delegato</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>Per la conversione implicita viene accettato un solo argomento</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>Per la conversione esplicita viene accettato un solo argomento</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>Impossibile richiamare operatori binari con un solo argomento</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>Impossibile eseguire un'assegnazione membro su un riferimento Null</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>Impossibile eseguire un'associazione di runtime su un riferimento Null</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>Impossibile richiamare in modo dinamico il metodo '{0}' perché contiene un attributo Conditional</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>Impossibile convertire il tipo 'void' in 'object' in modo implicito</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>Impossibile applicare l'operatore '{0}' su operandi di tipo '{1}' e '{2}'</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>Divisione per zero costante</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>Impossibile applicare l'indicizzazione con [] a un'espressione di tipo '{0}'</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>Numero di indici errato in [], previsto '{0}'</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>Impossibile applicare l'operatore '{0}' sull'operando di tipo '{1}'</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>Impossibile convertire in modo implicito il tipo '{0}' in '{1}'</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>Impossibile convertire il tipo '{0}' a '{1}'</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>Impossibile convertire il valore costante '{0}' in '{1}'</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>L'operatore '{0}' è ambiguo su operandi di tipo '{1}' e '{2}'</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>L'operatore '{0}' è ambiguo su un operando di tipo '{1}'</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>Impossibile convertire Null in '{0}' perché è un tipo di valore non nullable</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>Impossibile accedere a un membro non statico di tipo outer '{0}' tramite il tipo annidato '{1}'</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>'{0}' non contiene una definizione per '{1}'</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>È necessario specificare un riferimento a un oggetto per la proprietà, il metodo o il campo non statico '{0}'</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>Chiamata ambigua tra i seguenti metodi o proprietà: '{0}' e '{1}'</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>'{0}' è inaccessibile a causa del livello di protezione.</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>Nessun overload per '{0}' corrisponde al delegato '{1}'</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>La parte sinistra di un'assegnazione deve essere una variabile, una proprietà o un indicizzatore</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>Per il tipo '{0}' non sono definiti costruttori</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>Il delegato '{0}' non presenta un costruttore valido</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>Impossibile utilizzare la proprietà o l'indicizzatore '{0}' in questo contesto perché manca la funzione di accesso get.</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>Impossibile accedere al membro '{0}' con un riferimento a un'istanza. Qualificarlo con un nome di tipo</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>Un campo readonly non può essere assegnato (tranne che in un costruttore o in un inizializzatore di variabile).</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>Un campo readonly non può essere passato a un parametro ref o out (tranne che in un costruttore)</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>Impossibile effettuare un'assegnazione a un campo statico in sola lettura (tranne che in un costruttore statico o in un inizializzatore di variabile).</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>Impossibile passare un parametro ref o out a un campo statico in sola lettura (tranne che in un costruttore statico).</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>Impossibile assegnare un valore alla proprietà o all'indicizzatore '{0}' perché è di sola lettura</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>Impossibile chiamare un membro di base astratto: '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>Una proprietà o un indicizzatore non può essere passato come parametro out o ref</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>Impossibile accettare l'indirizzo di un tipo gestito ('{0}'), recuperarne la dimensione o dichiarare un puntatore a esso</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>Impossibile utilizzare l'istruzione fixed per accettare l'indirizzo di un'espressione già di tipo fixed</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>Impossibile utilizzare le chiamate dinamiche insieme ai puntatori</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>Per essere utilizzato come operatore di corto circuito, un operatore logico definito dall'utente ('{0}') deve avere lo stesso tipo restituito dei 2 parametri</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>Il tipo ('{0}') deve contenere dichiarazioni di operatore true e operatore false.</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>L'operazione di overflow in fase di compilazione in modalità checked</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>Il valore costante '{0}' non può essere convertito in '{1}' (utilizzare la sintassi 'unchecked' per eseguire l'override).</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>Ambiguità tra '{0}' e '{1}'</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>'{0}' non ha una dimensione predefinita, quindi sizeof può essere utilizzato solo in un contesto di tipo unsafe. Si consiglia di utilizzare System.Runtime.InteropServices.Marshal.SizeOf.</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>Un inizializzatore di campo non può fare riferimento alla proprietà, al metodo o al campo non statico '{0}'</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>Impossibile chiamare direttamente i distruttori e object.Finalize. Provare a chiamare IDisposable.Dispose se disponibile.</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>Non chiamare direttamente il metodo Finalize della classe base. Viene chiamato automaticamente dal distruttore.</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>La parte destra dell'assegnazione di un'istruzione fixed non può essere un'espressione cast</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>Impossibile convertire in modo implicito il tipo '{0}' in '{1}'. È presente una conversione esplicita. Probabile cast mancante.</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>Impossibile utilizzare la proprietà o l'indicizzatore '{0}' in questo contesto perché la funzione di accesso get è inaccessibile.</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>Impossibile utilizzare la proprietà o l'indicizzatore '{0}' in questo contesto perché la funzione di accesso set è inaccessibile.</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>L'utilizzo del {1} generico '{0}' richiede argomenti di tipo '{2}'</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>Il tipo '{0}' non può essere utilizzato come argomento di tipo</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>Impossibile utilizzare {1} '{0}' insieme ad argomenti di tipo</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>Impossibile utilizzare {1} non generico '{0}' insieme ad argomenti di tipo</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>'{2}' deve essere un tipo non astratto con un costruttore pubblico senza parametri per essere utilizzato come parametro '{1}' nel tipo o nel metodo generico '{0}'</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Nessuna conversione implicita di riferimenti da '{3}' a '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel tipo o metodo generico '{0}'. Il tipo nullable '{3}' non soddisfa il vincolo di '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel tipo o metodo generico '{0}'. Il tipo nullable '{3}' non soddisfa il vincolo di '{1}'. I tipi nullable non soddisfano i vincoli di interfaccia.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Nessuna conversione boxing o conversione di parametri di tipo da '{3}' a '{1}'.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>Impossibile utilizzare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Nessuna conversione boxing da '{3}' a '{1}'.</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>Impossibile convertire il valore Null nel parametro di tipo '{0}' perché potrebbe essere un tipo di valore non nullable. Si consiglia di utilizzare 'default({0})'.</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>Il tipo restituito di '{1} {0}' è errato</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>Impossibile dedurre gli argomenti di tipo per il metodo '{0}' dall'utilizzo. Provare a specificare gli argomenti di tipo in modo esplicito.</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>Impossibile convertire il gruppo di metodi '{0}' nel tipo non delegato '{1}'. Si desiderava richiamare il metodo?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>È necessario che il tipo '{2}' sia un tipo di riferimento per essere utilizzato come parametro '{1}' nel tipo generico o nel metodo '{0}'</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>Il tipo '{2}' deve essere un tipo di valore non nullable per poter essere utilizzato come parametro '{1}' nel metodo o nel tipo generico '{0}'</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>Dipendenza di vincolo circolare che comprende '{0}' e '{1}'</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>Il parametro di tipo '{0}' eredita i vincoli in conflitto '{1}' e '{2}'</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>Il parametro di tipo '{1}' ha il vincolo 'struct'. Non è pertanto possibile utilizzare '{1}' come vincolo per '{0}'.</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>Conversioni '{0}' e '{1}' ambigue definite dall'utente durante la conversione da '{2}' a '{3}'</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>Il tipo predefinito '{0}' non è definito né importato</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>Il tipo predefinito '{0}' è dichiarato in modo non corretto</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>'{0}' non è supportato dal linguaggio</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>'{0}': impossibile chiamare in modo esplicito l'operatore o la funzione di accesso</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>'{0}' è un tipo non supportato dal linguaggio</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>Manca il membro '{0}.{1}', necessario per il compilatore.</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>Impossibile convertire in modo implicito il valore letterale di tipo double nel tipo '{1}'. Utilizzare un suffisso '{0}' per creare un valore letterale di questo tipo</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>'{0}' non può implementare sia '{1}' che '{2}' perché potrebbero unificarsi per alcune sostituzioni di parametro di tipo.</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>Impossibile convertire nel tipo statico '{0}'</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>'{0}': i tipi statici non possono essere utilizzati come argomenti di tipi</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>Impossibile creare un delegato dal metodo '{0}' perché è un metodo parziale senza una dichiarazione di implementazione</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>L'operando di un operatore di incremento o decremento deve essere una variabile, una proprietà o un indicizzatore</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>'{0}' non contiene una definizione per '{1}' e non è stato trovato alcun metodo di estensione '{1}' che accetta un primo argomento di tipo '{0}'. Probabilmente manca una direttiva using o un riferimento a un assembly.</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>Impossibile utilizzare i metodi di estensione '{0}' definiti nel tipo di valore '{1}' per creare delegati</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>Nessun overload del metodo '{0}' accetta argomenti '{1}'</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>La corrispondenza migliore del metodo di overload per '{0}' presenta alcuni argomenti non validi</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>Argomento '{0}': impossibile eseguire la conversione da '{1}' a '{2}'</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>Un argomento ref o out deve essere una variabile assegnabile.</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>Impossibile accedere al membro protetto '{0}' tramite un qualificatore di tipo '{1}'. Il qualificatore deve essere di tipo '{2}' o derivato da esso.</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>La proprietà, l'indicizzatore o l'evento '{0}' non è supportato dal linguaggio. Provare a chiamare direttamente il metodo '{1}' o '{2}' della funzione di accesso</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>La proprietà, l'indicizzatore o l'evento '{0}' non è supportato dal linguaggio. Provare a chiamare direttamente il metodo '{1}' della funzione di accesso</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>Il delegato '{0}' non accetta argomenti '{1}'</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>Il delegato '{0}' presenta alcuni argomenti non validi</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>Impossibile assegnare a '{0}' perché è di sola lettura</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>Impossibile passare '{0}' come argomento ref o out perché è di sola lettura</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>Impossibile modificare il valore restituito da '{0}' perché non è una variabile</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>L'argomento '{0}' non deve essere passato con la parola chiave '{1}'</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>L'argomento '{0}' deve essere passato con la parola chiave '{1}'</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>Impossibile modificare i membri del campo di sola lettura '{0}' (tranne che in un costruttore o in un inizializzatore di variabile)</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>Impossibile passare i membri del campo di sola lettura '{0}' come argomento ref o out (tranne che in un costruttore)</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>Impossibile effettuare un'assegnazione ai campi di un campo statico di sola lettura '{0}' (tranne che in un costruttore statico o in un inizializzatore di variabile)</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>Impossibile passare un argomento ref o out ai campi di un campo statico di sola lettura '{0}' (tranne che in un costruttore statico)</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>Impossibile assegnare a '{0}' perché è '{1}'</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>Impossibile passare '{0}' come argomento ref o out perché è '{1}'</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>I metodi anonimi, le espressioni lambda e le espressioni di query all'interno delle strutture non possono accedere ai membri di istanza di 'this'. Si consiglia di copiare 'this' in una variabile locale all'esterno del metodo anonimo, dell'espressione lambda o dell'espressione di query e di utilizzare tale variabile locale.</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>Non è possibile associare il delegato a '{0}' perché è un membro di 'System. Nullable&lt;T&gt;'</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>'{0}' non contiene un costruttore che accetta argomenti '{1}'</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>'{0}' non contiene una definizione per '{1}' e l'overload migliore del metodo di estensione '{2}' presenta alcuni argomenti non validi</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>Argomento dell'istanza: impossibile eseguire la conversione da '{0}' a '{1}'</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>Il miglior metodo Add di overload '{0}' per l'inizializzatore di raccolta presenta alcuni argomenti non validi</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>Impossibile utilizzare la corrispondenza migliore del metodo di overload '{0}' per l'elemento inizializzatore della raccolta. I metodi 'Add' dell'inizializzatore di raccolta non possono includere parametri ref o out.</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>Impossibile utilizzare il membro non richiamabile '{0}' come metodo.</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>Le specifiche di argomenti denominati devono trovarsi dopo tutti gli argomenti fissi specificati</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>Il miglior overload per '{0}' non contiene un parametro denominato '{1}'</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>Il delegato '{0}' non dispone di un parametro denominato '{1}'</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>Impossibile specificare l'argomento denominato '{0}' più volte</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>L'argomento denominato '{0}' specifica un parametro per cui è già stato fornito un argomento posizionale</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>動的な操作をバインド中に、予期しない例外が発生しました</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>呼び出し元オブジェクトのない呼び出しはバインドできません</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>オーバーロードの解決に失敗しました</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>二項演算子は 2 つの引数を指定して呼び出す必要があります</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>単項演算子は 1 つの引数を指定して呼び出す必要があります</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>名前 '{0}' はメソッドにバインドされており、プロパティのように使用することはできません</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>イベント '{0}' することができますの左側にのみ表示されます +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>非デリゲート型を呼び出すことはできません</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>暗黙の型変換では 1 つの引数のみ受け取ります</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>明示的な変換では 1 つの引数のみ受け取ります</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>1 つの引数を指定して二項演算子を呼び出すことはできません</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>null 参照に対してメンバー割り当てを実行することはできません</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>null 参照に対して実行時バインディングを実行することはできません</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>条件付き属性があるため、メソッド '{0}' を動的に呼び出すことはできません</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>型 'void' を 'object' に暗黙的に変換することはできません</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>演算子 '{0}' を '{1}' と '{2}' 型のオペランドに適用することはできません</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>定数 0 で除算</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>角かっこ [] 付きインデックスを '{0}' 型の式に適用することはできません</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>角かっこ [] 内のインデックス数が正しくありません。正しい数は '{0}' です</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>演算子 '{0}' は '{1}' 型のオペランドに適用できません</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>型 '{0}' を '{1}' に暗黙的に変換できません</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>型 '{0}' を '{1}' に変換できません。</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>定数値 '{0}' を '{1}' に変換できません</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>型 '{1}' および '{2}' のオペランドの演算子 '{0}' があいまいです</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>演算子 '{0}' は型 '{1}' のオペランドに対してあいまいです</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>Null 非許容の値型であるため、Null を '{0}' に変換できません</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>入れ子にされた型 '{1}' を経由して、外の型 '{0}' の静的でないメンバーにアクセスすることはできません</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>'{0}' に '{1}' の定義がありません</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>静的でないフィールド、メソッド、またはプロパティ '{0}' で、オブジェクト参照が必要です</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>次のメソッドまたはプロパティ間で呼び出しが不適切です: '{0}' と '{1}'</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>'{0}' はアクセスできない保護レベルになっています</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>デリゲート '{1}' に一致する '{0}' のオーバーロードはありません</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>代入式の左辺には変数、プロパティ、またはインデクサーを指定してください。</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>型 '{0}' のコンストラクターが定義されていません</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>デリゲート '{0}' には有効なコンストラクターがありません</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>get アクセサーがないため、プロパティまたはインデクサー '{0}' をこのコンテキストで使用することはできません</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>インスタンス参照でメンバー '{0}' にアクセスできません。代わりに型名を使用してください</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>読み取り専用フィールドに割り当てることはできません (コンストラクター、変数初期化子では可 )。</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>読み取り専用フィールドに ref または out を渡すことはできません (コンストラクターでは可 )。</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>静的読み取り専用フィールドへの割り当てはできません (静的コンストラクターまたは変数初期化子では可)。</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>読み取り専用フィールドに ref または out を渡すことはできません (静的コンストラクターでは可)。</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>プロパティまたはインデクサー '{0}' は読み取り専用であるため、割り当てることはできません</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>抽象基本メンバーを呼び出すことはできません: '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>プロパティまたはインデクサーを out か ref のパラメーターとして渡すことはできません。</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>マネージ型 ('{0}') のアドレスの取得、サイズの取得、またはそのマネージ型へのポインターの宣言が実行できません</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>既に fixed が使用されている式のアドレスを取得するために、fixed ステートメントを使用することはできません。</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>動的な呼び出しはポインターと共に使用できません</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>short circuit 演算子として適用するためには、ユーザー定義の論理演算子 ('{0}') がその 2 つのパラメーターと同じ戻り値の型を持つ必要があります</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>型 ('{0}') に演算子 true および演算子 false の宣言が含まれている必要があります</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>操作はチェック モードでコンパイル時にオーバーフローします。</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>定数値 '{0}' は '{1}' に変換できません (unchecked 構文を使ってオーバーライドしてください)</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>'{0}' と '{1}' 間があいまいです</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>'{0}' には定義済みのサイズが指定されていないため、sizeof は unsafe コンテキストでのみ使用できます (System.Runtime.InteropServices.Marshal.SizeOf の使用をお勧めします)</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>フィールド初期化子は、静的でないフィールド、メソッド、またはプロパティ '{0}' を参照できません</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>デストラクター と object.Finalize を直接呼び出すことはできません。使用可能であれば IDisposable.Dispose を呼び出してください。</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>基本クラスの Finalize メソッドを直接呼び出さないでください。デストラクターから自動的に呼び出されます。</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>固定ステートメントの代入式の右辺はキャスト式ではない可能性があります。</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>型 '{0}' を '{1}' に暗黙的に変換できません。明示的な変換が存在します (cast が不足していないかどうかを確認してください)</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>get アクセサーにアクセスできないため、プロパティまたはインデクサー '{0}' はこのコンテキストでは使用できません。</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>set アクセサーにアクセスできないため、プロパティまたはインデクサー '{0}' はこのコンテキストでは使用できません。</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>ジェネリック {1} '{0}' の使用には、'{2}' 型の引数が必要です</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>型 '{0}' は型引数としては使えません</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1} '{0}' は型引数と一緒には使用できません</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>非ジェネリック {1} '{0}' は型引数と一緒には使用できません。</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>'{2}' は、ジェネリック型またはメソッド '{0}' 内でパラメーター '{1}' として使用するために、パブリック パラメーターなしのコンストラクターを持つ非抽象型でなければなりません</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。'{3}' から '{1}' への暗黙的な参照変換がありません。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。Null 許容型 '{3}' は、'{1}' の制約を満たしていません。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。Null 許容型 '{3}' は、'{1}' の制約を満たしていません。Null 許容型はインターフェイス制約を満たすことはできません。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。'{3}' から '{1}' へのボックス変換または型パラメーター変換がありません。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>型 '{3}' はジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用できません。'{3}' から '{1}' へのボックス変換がありません。</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>Null 非許容の値型である可能性があるため、Null を型パラメーター '{0}' に変換できません。'default({0})' を使用してください。</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>'{1} {0}' には、不適切な戻り値の型が指定されています</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>メソッド '{0}' の型引数を使い方から推論することはできません。型引数を明示的に指定してください。</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>メソッド グループ '{0}' を非デリゲート型 '{1}' に変換することはできません。このメソッドを呼び出しますか?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>型 '{2}' は、ジェネリック型のパラメーター '{1}'、またはメソッド '{0}' として使用するために、参照型でなければなりません</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>型 '{2}' は、ジェネリック型のパラメーター '{1}'、またはメソッド '{0}' として使用するために、Null 非許容の値型でなければなりません</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>'{0}' と '{1}' を含む、循環制約の依存関係です</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>型パラメーター '{0}' は、競合する制約 '{1}' および '{2}' を継承します</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>型パラメーター '{1}' は 'struct' 制約を含むので、'{0}' の制約として '{1}' を使用することはできません</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>'{2}' から '{3}' へ変換するときの、あいまいなユーザー定義の変換 '{0}' および '{1}' です</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>定義済みの型 '{0}' は定義、またはインポートされていません</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>定義済みの型 '{0}' が不適切に宣言されています</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>'{0}' はこの言語でサポートされていません</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>'{0}': 演算子またはアクセサーを明示的に呼び出すことはできません</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>'{0}' はこの言語でサポートされていない型です</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>コンパイラが必要とするメンバー '{0}.{1}' がありません</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>型 double のリテラルを暗黙的に型 '{1}' に変換することはできません。'{0}' サフィックスを使用して、この型のリテラルを作成してください</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>型パラメーターの代用に対して統合している可能性があるため、'{0}' は '{1}' と '{2}' の両方を実装することはできません</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>スタティック型 '{0}' へ変換できません</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>'{0}': スタティック型を型引数として使用することはできません</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>メソッド '{0}' は実装宣言がない部分メソッドであるため、このメソッドからデリゲートを作成できません</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>インクリメント演算子またはデクリメント演算子のオペランドには、変数、プロパティ、またはインデクサーを指定してください。</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>'{0}' に '{1}' の定義が含まれておらず、型 '{0}' の最初の引数を受け付ける拡張メソッド '{1}' が見つかりませんでした。using ディレクティブまたはアセンブリ参照が不足しています</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>値の型 '{1}' で定義された拡張メソッド '{0}' は、デリゲートを作成するために使用できません</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>引数を '{1}' 個指定できる、メソッド '{0}' のオーバーロードはありません</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>'{0}' に最も適しているオーバーロード メソッドには無効な引数がいくつか含まれています</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>引数 '{0}': '{1}' から '{2}' へ変換できません</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>ref または out 引数は、割り当て可能な変数でなければなりません。</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>'{1}' 型の修飾子をとおしてプロテクト メンバー '{0}' にアクセスすることはできません。修飾子は '{2}' 型、またはそれから派生したものでなければなりません</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>プロパティ、インデクサー、またはイベント '{0}' はこの言語でサポートされていません。アクセサー メソッドの '{1}' または '{2}' を直接呼び出してください</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>プロパティ、インデクサー、またはイベント '{0}' はこの言語でサポートされていません。アクセサー メソッドの '{1}' を直接呼び出してください</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>デリゲート '{0}' に '{1}' 個の引数を指定することはできません</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>デリゲート '{0}' に無効な引数があります</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>読み取り専用であるため '{0}' に割り当てできません</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>読み取り専用なので '{0}' は ref または out 引数として渡せません</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>変数ではないため、'{0}' の戻り値を変更できません</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>引数 '{0}' を '{1}' キーワードと共に渡すことはできません</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>引数 '{0}' は '{1}' キーワードと共に渡されなければなりません</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>読み取り専用フィールド '{0}' のメンバーは変更できません (コンストラクターまたは変数初期化子では可)。</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>読み取り専用フィールド '{0}' のメンバーに ref または out を渡すことはできません (コンストラクターでは可)</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>静的読み取り専用フィールド '{0}' のフィールドへの割り当てはできません (静的コンストラクターまたは変数初期化子では可)</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>静的読み取り専用フィールド '{0}' には、静的コンストラクター内を除き、ref または out を渡すことはできません</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>'{0}' は '{1}' であるため、割り当てることはできません</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>'{1}' であるため、'{0}' は ref または out 引数として渡せません</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>構造体内部の匿名メソッド、ラムダ式、またはクエリ式は、'this' のインスタンス メンバーにアクセスできません。'this' を匿名メソッド、ラムダ式、またはクエリ式の外部のローカル変数にコピーして、そのローカルを使用してください。</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>'System.Nullable&lt;T&gt;' のメンバーであるために、'{0}' のデリゲートをバインドできません。</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>'{0}' に、引数を '{1}' 個指定できるコンストラクターがありません</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>'{0}' に '{1}' の定義が含まれておらず、最も適している拡張メソッド オーバーロード '{2}' には無効な引数がいくつか含まれています</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>インスタンス引数: '{0}' から '{1}' へ変換できません</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>コレクション初期化子に最も適しているオーバーロード Add メソッド '{0}' には無効な引数がいくつか含まれています</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>コレクション初期化子要素の '{0}' に最も適しているオーバーロード メソッドは使用できません。コレクション初期化子 'Add' メソッドには、ref パラメーターまたは out パラメーターを使用できません。</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>実行不可能なメンバー '{0}' をメソッドのように使用することはできません。</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>名前付き引数は、すべての固定引数を指定した後で指定する必要があります</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>'{0}' に最も適しているオーバーロードには '{1}' という名前のパラメーターがありません</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>デリゲート '{0}' には '{1}' という名前のパラメーターがありません</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>'{0}' という名前付き引数が複数指定されました</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>名前付き引数 '{0}' は、場所引数が既に指定されているパラメーターを指定します</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>동적 작업을 바인딩하는 동안 예기치 않은 예외가 발생했습니다.</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>호출 개체가 없으면 호출을 바인딩할 수 없습니다.</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>오버로드 확인에 실패했습니다.</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>이항 연산자를 호출하려면 인수 두 개를 사용해야 합니다.</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>단항 연산자를 호출하려면 인수 한 개를 사용해야 합니다.</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>이름 '{0}'은(는) 메서드에 바인딩되어 있으며 속성처럼 사용할 수 없습니다.</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>이벤트 ' (0) '의 왼쪽에만 나타날 수 있습니다 +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>비대리자 형식을 호출할 수 없습니다.</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>암시적 변환에서는 정확히 하나의 인수를 사용합니다.</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>명시적 변환에서는 정확히 하나의 인수를 사용합니다.</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>하나의 인수를 사용하여 이항 연산자를 호출할 수 없습니다.</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>null 참조에 대해 멤버 할당을 수행할 수 없습니다.</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>null 참조에 대해 런타임 바인딩을 수행할 수 없습니다.</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>'{0}' 메서드는 Conditional 특성이 있으므로 동적으로 호출할 수 없습니다.</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>암시적으로 'void' 형식을 'object' 형식으로 변환할 수 없습니다.</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>'{0}' 연산자는 '{1}' 및 '{2}' 형식의 피연산자에 적용할 수 없습니다.</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>상수 0으로 나누기</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>[]을 사용하는 인덱싱을 '{0}' 형식의 식에 적용할 수 없습니다.</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>[] 내부의 인덱스 수가 잘못되었습니다. '{0}'개가 필요합니다.</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>'{0}' 연산자는 '{1}' 형식의 피연산자에 적용할 수 없습니다.</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>암시적으로 '{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다.</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>'{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다.</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>상수 값 '{0}'을(를) '{1}'(으)로 변환할 수 없습니다.</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>'{0}' 연산자가 모호하여 '{1}' 및 '{2}' 형식의 피연산자에 사용할 수 없습니다.</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>'{0}' 연산자가 모호하여 '{1}' 형식의 피연산자에 사용할 수 없습니다.</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>'{0}'은(는) null을 허용하지 않는 값 형식이므로 null을 이 형식으로 변환할 수 없습니다.</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>중첩 형식 '{1}'을(를) 통해 외부 형식 '{0}'의 static이 아닌 멤버에 액세스할 수 없습니다.</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>'{0}'에 '{1}'에 대한 정의가 없습니다.</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>static이 아닌 필드, 메서드 또는 속성 '{0}'에 개체 참조가 필요합니다.</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>다음 메서드 또는 속성 사이의 호출이 모호합니다. '{0}'과(와) '{1}'</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>보호 수준 때문에 '{0}'에 액세스할 수 없습니다.</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>'{1}' 대리자와 일치하는 '{0}'에 대한 오버로드가 없습니다.</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>할당식의 왼쪽은 변수, 속성 또는 인덱서여야 합니다.</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>'{0}' 형식에 정의된 생성자가 없습니다.</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>'{0}' 대리자에 올바른 생성자가 없습니다.</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>'{0}' 속성 또는 인덱서는 get 접근자가 없으므로 이 컨텍스트에서 사용할 수 없습니다.</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>'{0}' 멤버는 인스턴스 참조를 사용하여 액세스할 수 없습니다. 대신 형식 이름을 사용하여 한정하십시오.</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>읽기 전용 필드에는 할당할 수 없습니다. 단 생성자 또는 변수 이니셜라이저에서는 예외입니다.</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>읽기 전용 필드는 ref 또는 out으로 전달할 수 없습니다. 단 생성자에서는 예외입니다.</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>정적 읽기 전용 필드에는 할당할 수 없습니다. 단 정적 생성자 또는 변수 이니셜라이저에서는 예외입니다.</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>정적 읽기 전용 필드는 ref 또는 out으로 전달할 수 없습니다. 단 정적 생성자에서는 예외입니다.</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>'{0}' 속성 또는 인덱서는 읽기 전용이므로 할당할 수 없습니다.</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>추상 기본 멤버를 호출할 수 없습니다. '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>속성 또는 인덱서는 out 또는 ref 매개 변수로 전달할 수 없습니다.</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>관리되는 형식('{0}')의 주소 또는 크기를 가져오거나 해당 형식에 대한 포인터를 선언할 수 없습니다.</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>이미 고정된 식의 주소를 가져오는 데 fixed 문을 사용할 수 없습니다.</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>동적 호출을 포인터와 함께 사용할 수 없습니다.</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>사용자 정의 논리 연산자('{0}')를 단락(short circuit) 연산자로 사용하려면 연산자의 두 매개 변수와 같은 형식을 반환해야 합니다.</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>'{0}' 형식에는 true 및 false 연산자 선언이 있어야 합니다.</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>작업 선택된 모드에서 컴파일 타임에 오버플로</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>상수 값 '{0}'을(를) '{1}'(으)로 변환할 수 없습니다. 재정의하려면 'unchecked' 구문을 사용하십시오.</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>'{0}'과(와) '{1}' 사이에 모호성이 있습니다.</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>'{0}'에 미리 정의된 크기가 없으므로 sizeof는 안전하지 않은 컨텍스트에서만 사용할 수 있습니다. System.Runtime.InteropServices.Marshal.SizeOf를 사용하십시오.</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>필드 이니셜라이저는 static이 아닌 필드, 메서드 또는 속성 '{0}'을(를) 참조할 수 없습니다.</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>소멸자 및 object.Finalize는 직접 호출할 수 없습니다. 가능한 경우 IDisposable.Dispose를 호출하십시오.</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>기본 클래스 Finalize 메서드를 직접 호출하지 마십시오. 이 메서드는 소멸자에서 자동으로 호출됩니다.</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>fixed 문의 오른쪽에는 캐스트 식을 할당할 수 없습니다.</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>암시적으로 '{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다. 명시적 변환이 있습니다. 캐스트가 있는지 확인하십시오.</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>get 접근자에 액세스할 수 없으므로 '{0}' 속성 또는 인덱서는 이 컨텍스트에서 사용할 수 없습니다.</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>set 접근자에 액세스할 수 없으므로 '{0}' 속성 또는 인덱서는 이 컨텍스트에서 사용할 수 없습니다.</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>제네릭 {1} '{0}'을(를) 사용하려면 '{2}' 형식 인수가 필요합니다.</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>'{0}' 형식은 형식 인수로 사용할 수 없습니다.</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1} '{0}'은(는) 형식 인수와 함께 사용할 수 없습니다.</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>제네릭이 아닌 {1} '{0}'은(는) 형식 인수와 함께 사용할 수 없습니다.</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>제네릭 형식 또는 메서드 '{0}'에서 '{1}' 매개 변수로 사용하려면 '{2}'이(가) 매개 변수가 없는 public 생성자를 사용하는 비추상 형식이어야 합니다.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. '{3}'에서 '{1}'(으)로의 암시적 참조 변환이 없습니다.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. nullable 형식 '{3}'이(가) '{1}' 제약 조건을 충족하지 않습니다.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. nullable 형식 '{3}'이(가) '{1}' 제약 조건을 충족하지 않습니다. nullable 형식은 어떠한 인터페이스 제약 조건도 만족할 수 없습니다.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. '{3}'에서 '{1}'(으)로의 boxing 변환 또는 형식 매개 변수 변환이 없습니다.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>'{3}' 형식은 제네릭 형식 또는 메서드 '{0}'에서 형식 매개 변수 '{2}'(으)로 사용할 수 없습니다. '{3}'에서 '{1}'(으)로의 boxing 변환이 없습니다.</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>null을 허용하지 않는 값 형식일 수 있으므로 null을 형식 매개 변수 '{0}'(으)로 변환할 수 없습니다. 대신 'default({0})'를 사용하십시오.</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>'{1} {0}'에 잘못된 반환 형식이 있습니다.</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>'{0}' 메서드의 형식 인수를 유추할 수 없습니다. 형식 인수를 명시적으로 지정하십시오.</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>'{0}' 메서드 그룹을 비대리자 형식 '{1}'(으)로 변환할 수 없습니다. 메서드를 호출하시겠습니까?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>제네릭 형식 또는 메서드 '{0}'에서 '{2}' 형식을 '{1}' 매개 변수로 사용하려면 해당 형식이 참조 형식이어야 합니다.</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>제네릭 형식 또는 메서드 '{0}'에서 '{2}' 형식을 '{1}' 매개 변수로 사용하려면 해당 형식이 null을 허용하지 않는 값 형식이어야 합니다.</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>'{0}' 및 '{1}'과(와) 관련된 순환 제약 조건 종속성입니다.</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>형식 매개 변수 '{0}'이(가) 상속하는 '{1}' 및 '{2}' 제약 조건이 충돌합니다.</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>형식 매개 변수 '{1}'에 'struct' 제약 조건이 있으므로 '{1}'은(는) '{0}'에 대한 제약 조건으로 사용할 수 없습니다.</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>'{2}'에서 '{3}(으)로 변환하는 동안 모호한 사용자 정의 변환 '{0}' 및 '{1}'이(가) 발생했습니다.</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>미리 정의된 형식 '{0}'을(를) 정의하지 않았거나 가져오지 않았습니다.</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>미리 정의된 형식 '{0}'이(가) 잘못 선언되었습니다.</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>'{0}'은(는) 언어에서 지원되지 않습니다.</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>'{0}': 연산자나 접근자를 명시적으로 호출할 수 없습니다.</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>'{0}'은(는) 언어에서 지원하는 형식이 아닙니다.</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>'{0}.{1}' 멤버를 필요로 하는 컴파일러가 없습니다.</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>double 형식의 리터럴을 암시적으로 '{1}' 형식으로 변환할 수 없습니다. 이 형식의 리터럴을 만들려면 '{0}' 접미사를 사용하십시오.</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>'{1}'과(와) '{2}'은(는) 일부 형식 매개 변수를 대체할 때 통합될 수 있으므로 '{0}'에서 둘 다 구현할 수는 없습니다.</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>'{0}' 정적 형식으로 변환할 수 없습니다.</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>'{0}': 정적 형식은 형식 인수로 사용할 수 없습니다.</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>'{0}'은(는) 구현 선언이 없는 부분 메서드(Partial Method)이므로 이 메서드로부터 대리자를 만들 수 없습니다.</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>증가 연산자 또는 감소 연산자의 피연산자는 변수, 속성 또는 인덱서여야 합니다.</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>'{0}'에 '{1}'에 대한 정의가 없고 '{0}' 형식의 첫 번째 인수를 허용하는 확장 메서드 '{1}'을(를) 찾을 수 없습니다. using 지시문 또는 어셈블리 참조가 있는지 확인하십시오.</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>값 형식 '{1}'에 정의된 확장 메서드 '{0}'은(는) 대리자를 만드는 데 사용할 수 없습니다.</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>'{1}'개의 인수를 사용하는 '{0}' 메서드에 대한 오버로드가 없습니다.</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>'{0}'에 가장 일치하는 오버로드된 메서드에 잘못된 인수가 있습니다.</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>'{0}' 인수: '{1}'에서 '{2}'(으)로 변환할 수 없습니다.</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>ref 또는 out 인수는 할당 가능한 변수여야 합니다.</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>'{1}' 형식의 한정자를 통해 보호된 멤버 '{0}'에 액세스할 수 없습니다. 한정자는 '{2}' 형식이거나 여기에서 파생된 형식이어야 합니다.</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>'{0}' 속성, 인덱서 또는 이벤트는 이 언어에서 지원되지 않습니다. '{1}' 또는 '{2}' 접근자 메서드를 직접 호출해 보십시오.</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>'{0}' 속성, 인덱서 또는 이벤트는 이 언어에서 지원되지 않습니다. '{1}' 접근자 메서드를 직접 호출해 보십시오.</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>'{0}' 대리자에는 '{1}'개의 인수를 사용할 수 없습니다.</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>'{0}' 대리자에 잘못된 인수가 있습니다.</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>읽기 전용인 '{0}'에는 할당할 수 없습니다.</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>'{0}'은(는) 읽기 전용이므로 ref 또는 out 인수로 전달할 수 없습니다.</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>'{0}'은(는) 변수가 아니므로 해당 반환 값을 수정할 수 없습니다.</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>'{0}' 인수는 '{1}' 키워드와 함께 전달할 수 없습니다.</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>'{0}' 인수는 '{1}' 키워드와 함께 전달해야 합니다.</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>읽기 전용 필드 '{0}'의 멤버는 수정할 수 없습니다. 단 생성자 또는 변수 이니셜라이저에서는 예외입니다.</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>읽기 전용 필드 '{0}'의 멤버는 ref 또는 out으로 전달할 수 없습니다. 단 생성자에서는 예외입니다.</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>static 읽기 전용 필드 '{0}'의 필드에는 할당할 수 없습니다. 단 static 생성자 또는 변수 이니셜라이저에서는 예외입니다.</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>static 읽기 전용 필드 '{0}'의 필드는 ref 또는 out으로 전달할 수 없습니다. 단 static 생성자에서는 예외입니다.</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>'{1}'인 '{0}'에는 할당할 수 없습니다.</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>'{0}'은(는) '{1}'이므로 ref 또는 out 인수로 전달할 수 없습니다.</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>구조체 안의 무명 메서드, 람다 식 및 쿼리 식은 'this'의 인스턴스 멤버에 액세스할 수 없습니다. 'this'를 무명 메서드, 람다 식 또는 쿼리 식 외부에 있는 지역 변수에 복사한 다음 이 지역 변수를 대신 사용하십시오.</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>그것 'System.Nullable&lt;T&gt;'의 멤버 이므로 ' (0) '에 대리자를 바인딩할 수 없습니다.</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>'{0}'에 '{1}'개의 인수를 사용하는 생성자가 없습니다.</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>'{0}'에 '{1}'에 대한 정의가 없으며 가장 적합한 확장 메서드 오버로드 '{2}'에 잘못된 인수가 있습니다.</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>인스턴스 인수: '{0}'에서 '{1}'(으)로 변환할 수 없습니다.</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>오버로드된 Add 메서드 중 해당 컬렉션 이니셜라이저에 가장 적합한 '{0}'에 잘못된 인수가 있습니다.</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>컬렉션 이니셜라이저에 대해 '{0}'에 가장 일치하는 오버로드된 메서드를 사용할 수 없습니다. 컬렉션 이니셜라이저 'Add' 메서드에는 ref 또는 out 매개 변수를 사용할 수 없습니다.</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>호출할 수 없는 멤버인 '{0}'은(는) 메서드처럼 사용할 수 없습니다.</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>명명된 인수 사양은 모든 고정 인수를 지정한 다음에 와야 합니다.</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>'{0}'에 가장 적합한 오버로드에 '{1}' 매개 변수가 없습니다.</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>'{0}' 대리자에 '{1}' 매개 변수가 없습니다.</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>명명된 인수 '{0}'을(를) 여러 번 지정할 수 없습니다.</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>명명된 인수 '{0}'은(는) 위치 인수가 이미 지정된 매개 변수를 지정합니다.</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>Возникло непредвиденное исключение при выполнении привязки динамической операции</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>Невозможно выполнить привязку вызова к невызывающему объекту</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>Сбой при разрешении перегрузки</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>Бинарные операторы должны вызываться с использованием двух аргументов</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>Унарные операторы должны быть вызваны с использованием одного аргумента</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>Для имени "{0}" выполнена привязка к методу. Невозможно использовать его как свойство</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>Событие «{0}» может появляться только на стороне левой руки +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>Не удалось вызвать тип, не являющийся делегатом</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>Для неявного преобразования нужен строго один аргумент</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>Для явного преобразования нужен строго один аргумент</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>Невозможно вызвать бинарные операторы с использованием одного аргумента</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>Не удается выполнить присваивание члена по нулевой ссылке</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>Не удается выполнить привязки исполняющей среды по нулевой ссылке</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>Не удается динамически вызвать метод "{0}", так как у него есть условный атрибут</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>Нельзя неявно преобразовать тип "void" to "object"</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>Не удается применить оператор "{0}" к операндам типа "{1}" и "{2}"</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>Деление на ноль постоянной</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>Невозможно применить индексирование через [] к выражению типа "{0}"</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>Неверное количество индексов внутри []; ожидалось "{0}"</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>Не удается применить операнд "{0}" типа "{1}"</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>Не удается неявно преобразовать тип "{0}" в "{1}"</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>Невозможно преобразовать тип "{0}" в "{1}"</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>Постоянное значение "{0}" не может быть преобразовано в "{1}"</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>Оператор "{0}" является неоднозначным по отношению к операндам типа "{1}" и "{2}"</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>Оператор "{0}" является неоднозначным по отношению к операнду типа "{1}"</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>Cannot convert null to "{0}" because it is a non-nullable value type</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>Невозможно получить доступ к нестатическому члену внешнего типа "{0}" через вложенный тип "{1}"</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>"{0}" не содержит определения для "{1}"</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>Для нестатического поля, метода или свойства "{0}" требуется ссылка на объект</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>Понятие "вызов" трактуется неоднозначно в следующих методах или свойствах: "{0}" и "{1}"</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>"{0}" недоступен из-за его уровня защиты</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>Нет перегрузки для "{0}", соответствующей делегату "{1}"</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>Левая часть выражения присваивания должна быть переменной, свойством или индексатором</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>Для типа "{0}" нет определенных конструкторов</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>Делегат "{0}" не имеет допустимого конструктора</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>The property or indexer "{0}" cannot be used in this context because it lacks the get accessor</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>Доступ к члену "{0}" через ссылку на экземпляр невозможен; вместо этого уточните его, указав имя типа</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>Присваивание значений доступному только для чтения полю допускается только в конструкторе и в инициализаторе переменных</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>Доступное только для чтения поле может передаваться как параметр с ключевым словом ref или out только в конструкторе</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>Присваивание значений доступному только для чтения статическому полю допускается только в статическом конструкторе и в инициализаторе переменных</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>Доступное только для чтения статическое поле может передаваться как параметр с ключевым словом ref или out только в статическом конструкторе</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>Невозможно присвоить значение свойству или индексатору "{0}" -- доступ только для чтения</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>Не удается вызвать абстрактный член базового класса: "{0}"</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>Свойства и индексаторы не могут передаваться как параметры с ключевыми словами out и ref</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>Невозможно получить адрес, определить размер или объявить указатель на управляемый тип ("{0}")</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>Получить адрес фиксированного выражения с помощью оператора fixed невозможно</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>Динамические вызовы нельзя использовать в сопряжении с указателями</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>Для использования в качестве логического оператора краткой записи тип возвращаемого значения пользовательского логического оператора ("{0}") должен быть аналогичен типам двух его параметров</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>Тип ("{0}") должен содержать объявления оператора true и оператора false</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>Операция вызывает переполнение во время компиляции в проверяемом режиме</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>Постоянное значение "{0}" не может быть преобразовано в "{1}" (для обхода используйте синтаксис "unchecked")</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>Неоднозначность между "{0}" и "{1}"</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>"{0}" does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>Инициализатор поля не может обращаться к нестатическому полю, методу или свойству "{0}"</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>Непосредственный вызов деструкторов и функций object.Finalize запрещен. Рекомендуется вызов IDisposable.Dispose, если она доступна.</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>Не вызывайте метод Finalize базового класса напрямую. Он вызывается автоматически из деструктора.</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>Правая часть присваивания оператора fixed не может быть выражением приведения типа</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>Не удается неявно преобразовать тип "{0}" в "{1}". Существует явное преобразование (требуется приведение типа?)</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>Свойство или индексатор "{0}" невозможно использовать в данном контексте, поскольку метод доступа get недоступен</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>Свойство или индексатор "{0}" невозможно использовать в данном контексте, поскольку метод доступа set недоступен</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>Использование универсального {1} "{0}" требует аргументов типа "{2}"</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>Тип '{0}' не может использоваться в качестве аргумента типа</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1} "{0}" не может использоваться с аргументами типа</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>Неуниверсальный {1} "{0}" не может использоваться с аргументами типа</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>"Для использования в качестве параметра "{1}" в универсальном типе или методе "{0}" тип "{2}" должен быть неабстрактным и иметь открытый конструктор без параметров</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Нет неявного преобразования ссылки из "{3}" в "{1}".</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Для типа "{3}", допускающего значение null, не выполняется ограничение "{1}".</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Для типа "{3}", допускающего значение null, не выполняется ограничение "{1}". Типы, допускающие значение null, не могут удовлетворять ни одному интерфейсному ограничению.</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Нет преобразования-упаковки или преобразования типа параметра из "{3}" в "{1}".</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>Невозможно использовать тип "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Нет преобразования-упаковки из "{3}" в "{1}".</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>Cannot convert null to type parameter "{0}" because it could be a non-nullable value type. Вместо этого рекомендуется использовать "default({0})".</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>"{1} {0}" имеет неправильный возвращаемый тип</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>The type arguments for method "{0}" cannot be inferred from the usage. Попытайтесь явно определить аргументы-типы.</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>Не удается преобразовать группу методов "{0}" в тип, не являющийся делегатом "{1}". Предполагается ли вызывать этот метод?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>Для использования в качестве параметра "{1}" в универсальном типе или методе "{0}" тип "{2}" должен быть ссылочным типом</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>Для использования в качестве параметра "{1}" в универсальном типе или методе "{0}" тип "{2}" должен быть типом значения, не допускающим значения NULL</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>Циклическая зависимость ограничения, включающая "{0}" и "{1}"</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>Параметр типа "{0}" наследует конфликтующие ограничения "{1}" и "{2}"</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>Параметр типа "{1}" имеет ограничение "struct", поэтому "{1}" не может использоваться в качестве ограничения для "{0}"</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>Неоднозначные пользовательские преобразования "{0}" и "{1}" при преобразовании из "{2}" в "{3}"</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>Предопределенный тип "{0}" не определен и не импортирован</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>Предопределенный тип "{0}" объявлен неправильно</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>"{0}" не поддерживается языком</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>"{0}": явный вызов оператора или метода доступа невозможен</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>"{0}" является типом, который не поддерживается в данном языке</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>Отсутствует обязательный для компилятора член "{0}.{1}"</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>Литерал с типом double не может быть неявно преобразован к типу "{1}"; для создания литерала этого типа следует воспользоваться суффиксом "{0}"</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>"{0}" не в состоянии реализовать как "{1}", так и "{2}", поскольку они могут быть идентичными для некоторых подстановок параметров-типов</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>Не удается выполнить преобразование к статическому типу "{0}"</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>"{0}": нельзя использовать статические типы в качестве аргументов-типов</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>Невозможно создать делегат на основе метода "{0}", поскольку он является разделяемым методом без реализующего объявления</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>Операндом оператора инкремента или декремента должна быть переменная, свойство или индексатор</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>"{0}" не содержит определения для "{1}", а найти метод расширения "{1}", принимающий первый аргумент типа "{0}", не удалось (возможно, пропущена директива using или ссылка на сборку)</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>Методы расширения "{0}", определенные для типа значения "{1}", не могут применяться для создания делегатов</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>Отсутствие перегрузки для метода "{0}" принимает"{1}" аргументы</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>Наиболее подходящий перегруженный метод для "{0}" имеет несколько недопустимых аргументов</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>Аргумент "{0}": невозможно преобразовать из "{1}" в "{2}"</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>Аргумент с ключевым словом ref или out должен быть переменной, которой можно присвоить значение</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>Не удается получить доступ к защищенному члену "{0}" через квалификатор типа "{1}"; квалификатор должен иметь тип "{2}" (или производный от него)</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>Свойство, индексатор или событие "{0}" не поддерживается в данном языке; попробуйте вызвать метод доступа "{1}" или "{2}"</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>Свойство, индексатор или событие "{0}" не поддерживается в данном языке; попробуйте вызвать метод доступа "{1}" или "{2}"</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>Делегат "{0}" не принимает аргументы "{1}"</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>Делегат "{0}" имеет недопустимые аргументы</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>Не удается выполнить присвоение параметру "{0}", так как он доступен только для чтения</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>Cannot pass "{0}" as a ref or out argument because it is read-only</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>Cannot modify the return value of "{0}" because it is not a variable</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>Аргумент "{0}" должен быть передан с ключевым словом "{1}"</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>Аргумент "{0}" должен быть передан с ключевым словом "{1}"</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>Члены поля "{0}", предназначенного только для чтения, могут быть изменены только в конструкторе или инициализаторе переменных</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>Members of readonly field "{0}" cannot be passed ref or out (except in a constructor)</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>Присваивание значений полям доступного только для чтения статического поля "{0}" допускается только в статическом конструкторе и в инициализаторе переменных</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>Fields of static readonly field "{0}" cannot be passed ref or out (except in a static constructor)</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>Не удается выполнить присвоение параметру "{0}", так как он является "{1}"</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>Не удалось передать "{0}" как ссылку или аргумент out, так как это "{1}"</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>Анонимные методы, лямбда-выражения и выражения запроса внутри структуры не имеет доступа к членам экземпляра "this". Возможно, следует скопировать "this" в локальную переменную за пределами анонимного метода, лямбда-выражения или выражения запроса и использовать эту локальную переменную.</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>Не удается привязать делегат '{0}', потому что он является членом «System.Nullable&lt;T&gt;»</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>"{0}" не содержит конструктор, принимающий аргументов: {1}</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>"{0}" не содержит определения для "{1}", наилучшая перегрузка метода расширения "{2}" имеет такие же недопустимые аргументы</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>Instance argument: невозможно преобразовать из "{0}" в "{1}"</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>Наиболее подходящий перегруженный метод Add "{0}" для инициализатора коллекции содержит недопустимые аргументы</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>Наиболее подходящий перегруженный метод, соответствующий "{0}" для элемента инициализации коллекции не может быть использован. Методы инициализации коллекции "Add" не имеют ссылочных и выходных параметров.</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>Невызываемый член "{0}" не может использоваться как метод.</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>Спецификации именованного аргумента должны появляться во всех указанных фиксированных аргументах</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>Наиболее подходящий перегруженный метод для "{0}" не имеет параметра "{1}"</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>Делегат "{0}" не имеет параметра "{1}"</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>Не удается задать именованный аргумент "{0}" несколько раз</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>Именованный аргумент "{0}" задает параметр, для которого уже был установлен позиционный аргумент.</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>绑定动态操作时出现异常</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>无法在没有调用对象的情况下绑定调用</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>重载决策失败</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>必须使用两个参数调用二元运算符</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>必须使用一个参数调用一元运算符</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>名称“{0}”已绑定到某个方法，无法像属性一样使用</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>事件 '{0}' 只能出现在左边的 +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>无法调用非委托类型</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>隐式转换采用一个且仅一个参数</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>显式转换采用一个且仅一个参数</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>无法使用一个参数调用二元运算符</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>无法对 null 引用执行成员赋值</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>无法对 null 引用执行运行时绑定</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>无法动态调用方法“{0}”，因为它具有 Conditional 特性</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>无法将类型“void”隐式转换为“object”</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>运算符“{0}”无法应用于“{1}”和“{2}”类型的操作数</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>常数零做除数</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>无法将带 [] 的索引应用于“{0}”类型的表达式</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>[] 内的索引数错误；应为“{0}”</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>运算符“{0}”无法应用于“{1}”类型的操作数</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>无法将类型“{0}”隐式转换为“{1}”</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>不能转换类型 '{0}' 到 '{1}'</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>常量值“{0}”无法转换为“{1}”</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>运算符“{0}”对于“{1}”和“{2}”类型的操作数具有二义性</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>运算符“{0}”对于“{1}”类型的操作数具有二义性</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>无法将 null 转换为“{0}”，因为后者是不可以为 null 的值类型</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>无法通过嵌套类型“{1}”来访问外部类型“{0}”的非静态成员</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>“{0}”未包含“{1}”的定义</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>对象引用对于非静态的字段、方法或属性“{0}”是必需的</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>以下方法或属性之间的调用具有二义性:“{0}”和“{1}”</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>“{0}”不可访问，因为它具有一定的保护级别</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>“{0}”没有与委托“{1}”匹配的重载</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>赋值号左边必须是变量、属性或索引器</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>类型“{0}”未定义构造函数</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>委托“{0}”没有有效的构造函数</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>属性或索引器“{0}”不能用在此上下文中，因为它缺少 get 访问器</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>无法使用实例引用来访问成员“{0}”；请改用类型名来限定它</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>无法对只读的字段赋值(构造函数或变量初始值指定项中除外)</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>对只读字段无法传递 ref 或 out 参数(构造函数中除外)</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>无法对静态只读字段赋值(静态构造函数或变量初始值设定项中除外)</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>无法向静态只读字段传递 ref 或 out 参数(静态构造函数中除外)</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>无法为属性或索引器“{0}”赋值 - 它是只读的</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>无法调用抽象基成员:“{0}”</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>属性或索引器不得作为 out 或 ref 参数传递</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>无法获取托管类型(“{0}”)的地址和大小，或者声明指向它的指针</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>不能使用 fixed 语句来获取已固定的表达式的地址</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>动态调用不能与指针一起使用</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>为了可以像短路运算符一样应用，用户定义的逻辑运算符(“{0}”)的返回类型必须与它的两个参数的类型相同</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>类型(“{0}”)必须包含运算符 True 和运算符 False 的声明</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>操作在检查模式下编译时溢出</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>常量值“{0}”无法转换为“{1}”(使用“unchecked”语法重写)</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>在“{0}”和“{1}”之间具有二义性</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>“{0}”没有预定义的大小，因此 sizeof 只能在不安全的上下文中使用(请考虑使用 System.Runtime.InteropServices.Marshal.SizeOf)</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>字段初始值设定项无法引用非静态字段、方法或属性“{0}”</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>无法直接调用析构函数和 object.Finalize。如果可用，请考虑调用 IDisposable.Dispose。</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>不要直接调用基类 Finalize 方法。它将从析构函数中自动调用。</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>fixed 语句赋值的右边不能是强制转换表达式</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>无法将类型“{0}”隐式转换为“{1}”。存在一个显式转换(是否缺少强制转换?)</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>属性或索引器“{0}”不能用在此上下文中，因为 get 访问器不可访问</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>属性或索引器“{0}”不能用在此上下文中，因为 set 访问器不可访问</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>使用泛型 {1}“{0}”需要“{2}”个类型参数</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>类型"{0}"不可能用作类型参数</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1}“{0}”不能与类型参数一起使用</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>非泛型 {1}“{0}”不能与类型参数一起使用</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>“{2}”必须是具有公共的无参数构造函数的非抽象类型，才能用作泛型类型或方法“{0}”中的参数“{1}”</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。没有从“{3}”到“{1}”的隐式引用转换。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。可以为 null 的类型“{3}”不满足“{1}”的约束。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。可以为 null 的类型“{3}”不满足“{1}”的约束。可以为 null 的类型不能满足任何接口约束。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。没有从“{3}”到“{1}”的装箱转换或类型参数转换。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。没有从“{3}”到“{1}”的装箱转换。</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>无法将 null 转换为类型参数“{0}”，因为它可能是不可以为 null 的值类型。请考虑改用“default({0})”。</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>“{1} {0}”的返回类型错误</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>无法从用法中推断出方法“{0}”的类型参数。请尝试显式指定类型参数。</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>无法将方法组“{0}”转换为非委托类型“{1}”。是否希望调用此方法?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>类型“{2}”必须是引用类型才能用作泛型类型或方法“{0}”中的参数“{1}”</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>类型“{2}”必须是不可以为 null 值的类型，才能用作泛型类型或方法“{0}”中的参数“{1}”</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>涉及“{0}”和“{1}”的循环约束依赖项</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>类型参数“{0}”继承了彼此冲突的“{1}”和“{2}”约束</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>类型参数“{1}”具有“struct”约束，因此“{1}”不能用作“{0}”的约束</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>从“{2}”转换为“{3}”时，用户定义的转换“{0}”和“{1}”具有二义性</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>预定义类型“{0}”未定义或导入</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>预定义类型“{0}”未正确声明</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>现用语言不支持“{0}”</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>“{0}”: 无法显式调用运算符或访问器</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>“{0}”不是现用语言支持的类型</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>缺少编译器要求的成员“{0}.{1}”</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>无法将 Double 类型隐式转换为“{1}”类型；请使用“{0}”后缀创建此类型</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>“{0}”不能同时实现“{1}”和“{2}”，原因是它们可以统一以进行某些类型参数替换</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>无法转换为静态类型“{0}”</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>“{0}”: 静态类型不能用作类型参数</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>无法通过方法“{0}”创建委托，因为该方法是没有实现声明的分部方法</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>递增或递减运算符的操作数必须是变量、属性或索引器</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>“{0}”未包含“{1}”的定义，并且找不到可接受第一个“{0}”类型参数的扩展方法“{1}”(是否缺少 using 指令或程序集引用?)</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>无法使用值类型“{1}”定义的扩展方法“{0}”来创建委托</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>“{0}”方法没有采用“{1}”个参数的重载</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>与“{0}”最匹配的重载方法具有一些无效参数</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>参数“{0}”: 无法从“{1}”转换为“{2}”</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>ref 或 out 参数必须是可以赋值的变量</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>无法通过“{1}”类型的限定符访问受保护的成员“{0}”；限定符必须是“{2}”类型(或者从该类型派生)</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>属性、索引器或事件“{0}”不受现用语言支持；请尝试直接调用访问器方法“{1}”或“{2}”</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>属性、索引器或事件“{0}”不受现用语言支持；请尝试直接调用访问器方法“{1}”</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>委托“{0}”未采用“{1}”个参数</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>委托“{0}”有一些无效参数</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>无法为“{0}”赋值，因为它是只读的</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>无法将“{0}”作为 ref 或 out 参数传递，因为它是只读的</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>无法修改“{0}”的返回值，因为它不是变量</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>参数“{0}”不应使用关键字“{1}”传递</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>参数“{0}”必须使用关键字“{1}”传递</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>无法修改只读字段“{0}”的成员(在构造函数或变量初始值设定项中除外)</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>无法为只读字段“{0}”的成员传递 ref 或 out (在构造函数中除外)</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>无法为静态只读字段“{0}”的字段赋值(在静态构造函数或变量初始值设定项中除外)</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>无法为静态只读字段“{0}”的字段传递 ref 或 out (在静态构造函数中除外)</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>无法为“{0}”赋值，因为它是“{1}”</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>“{0}”是一个“{1}”，无法作为 ref 或 out 参数进行传递</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>结构内部的匿名方法、lambda 表达式和查询表达式无法访问“this”的实例成员。请考虑将“this”复制到匿名方法、lambda 表达式或查询表达式外部的某个局部变量并改用该局部变量。</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>不能将委托绑定到 '{0}'，因为它是 'System.Nullable&lt;T&gt;' 成员</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>“{0}”不包含采用“{1}”个参数的构造函数</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>“{0}”不包含“{1}”的定义，并且最佳扩展方法重载“{2}”具有一些无效参数</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>实例参数: 无法从“{0}”转换为“{1}”</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>集合初始值设定项的最佳重载 Add 方法“{0}”具有一些无效参数</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>无法使用集合初始值设定项元素的最佳重载方法匹配项“{0}”。集合初始值设定项“Add”方法不能具有 ref 或 out 参数。</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>不可调用的成员“{0}”不能像方法一样使用。</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>命名参数规范必须出现在所有指定的固定参数后</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>“{0}”的最佳重载没有名为“{1}”的参数</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>委托“{0}”没有名为“{1}”的参数</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>不能多次指定所命名的参数“{0}”。</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>命名实参“{0}”指定的形参已被赋予位置实参</value>
+  </data>
+</root>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -1,0 +1,396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InternalCompilerError" xml:space="preserve">
+    <value>繫結動態作業時發生意外的例外狀況</value>
+  </data>
+  <data name="BindRequireArguments" xml:space="preserve">
+    <value>無法繫結沒有呼叫物件的呼叫</value>
+  </data>
+  <data name="BindCallFailedOverloadResolution" xml:space="preserve">
+    <value>多載解析失敗</value>
+  </data>
+  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
+    <value>必須以兩個引數叫用二元運算子</value>
+  </data>
+  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
+    <value>必須以一個引數叫用一元運算子</value>
+  </data>
+  <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
+    <value>名稱 '{0}' 已繫結至一個方法，因此不能當成屬性使用</value>
+  </data>
+  <data name="BindPropertyFailedEvent" xml:space="preserve">
+    <value>事件 '{0}' 只能出現在左邊的 +</value>
+  </data>
+  <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
+    <value>無法叫用非委派型別</value>
+  </data>
+  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>隱含轉換只接受一個引數</value>
+  </data>
+  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
+    <value>明確轉換只接受一個引數</value>
+  </data>
+  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
+    <value>無法以一個引數叫用二元運算子</value>
+  </data>
+  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
+    <value>無法對 null 參考進行成員指派</value>
+  </data>
+  <data name="NullReferenceOnMemberException" xml:space="preserve">
+    <value>無法對 null 參考進行執行階段繫結</value>
+  </data>
+  <data name="BindCallToConditionalMethod" xml:space="preserve">
+    <value>無法以動態方式叫用方法 '{0}'，因為它有 Conditional 屬性</value>
+  </data>
+  <data name="BindToVoidMethodButExpectResult" xml:space="preserve">
+    <value>無法將 'void' 型別隱含轉換為 'object' 型別</value>
+  </data>
+  <data name="BadBinaryOps" xml:space="preserve">
+    <value>無法將運算子 '{0}' 套用至型別 '{1}' 和 '{2}' 的運算元</value>
+  </data>
+  <data name="IntDivByZero" xml:space="preserve">
+    <value>常數零做除數</value>
+  </data>
+  <data name="BadIndexLHS" xml:space="preserve">
+    <value>無法套用有 [] 的索引至型別 '{0}' 的運算式</value>
+  </data>
+  <data name="BadIndexCount" xml:space="preserve">
+    <value>[] 內的索引數目錯誤; 必須是 '{0}'</value>
+  </data>
+  <data name="BadUnaryOp" xml:space="preserve">
+    <value>無法將運算子 '{0}' 套用至型別 '{1}' 的運算元</value>
+  </data>
+  <data name="NoImplicitConv" xml:space="preserve">
+    <value>無法將型別 '{0}' 隱含轉換為 '{1}'</value>
+  </data>
+  <data name="NoExplicitConv" xml:space="preserve">
+    <value>不能轉換類型 '{0}' 到 '{1}'</value>
+  </data>
+  <data name="ConstOutOfRange" xml:space="preserve">
+    <value>無法將常數值 '{0}' 轉換為 '{1}'</value>
+  </data>
+  <data name="AmbigBinaryOps" xml:space="preserve">
+    <value>運算子 '{0}' 用在型別 '{1}' 和 '{2}' 的運算元上時其意義會模稜兩可</value>
+  </data>
+  <data name="AmbigUnaryOp" xml:space="preserve">
+    <value>運算子 '{0}' 用在型別 '{1}' 的運算元上時其意義會模稜兩可</value>
+  </data>
+  <data name="ValueCantBeNull" xml:space="preserve">
+    <value>無法將 null 轉換成 '{0}'，因為它是不可為 null 的實值型別</value>
+  </data>
+  <data name="WrongNestedThis" xml:space="preserve">
+    <value>無法透過巢狀型別 '{1}' 存取外部型別 '{0}' 的非靜態成員</value>
+  </data>
+  <data name="NoSuchMember" xml:space="preserve">
+    <value>'{0}' 不包含 '{1}' 的定義</value>
+  </data>
+  <data name="ObjectRequired" xml:space="preserve">
+    <value>需要有物件參考才能使用非靜態欄位、方法或屬性 '{0}'</value>
+  </data>
+  <data name="AmbigCall" xml:space="preserve">
+    <value>在下列方法或屬性之間的呼叫模稜兩可: '{0}' 和 '{1}'</value>
+  </data>
+  <data name="BadAccess" xml:space="preserve">
+    <value>'{0}' 的保護層級導致無法對其進行存取</value>
+  </data>
+  <data name="MethDelegateMismatch" xml:space="preserve">
+    <value>'{0}' 沒有任何多載符合 '{1}' 委派</value>
+  </data>
+  <data name="AssgLvalueExpected" xml:space="preserve">
+    <value>指派的左方必須為變數、屬性或索引子</value>
+  </data>
+  <data name="NoConstructors" xml:space="preserve">
+    <value>型別 '{0}' 沒有已定義的建構函式</value>
+  </data>
+  <data name="BadDelegateConstructor" xml:space="preserve">
+    <value>委派 '{0}' 沒有有效的建構函式</value>
+  </data>
+  <data name="PropertyLacksGet" xml:space="preserve">
+    <value>無法於此內容中使用屬性或索引子 '{0}'，因為其欠缺 get 存取子</value>
+  </data>
+  <data name="ObjectProhibited" xml:space="preserve">
+    <value>成員 '{0}' 無法以執行個體參考存取; 請使用型別名稱代替</value>
+  </data>
+  <data name="AssgReadonly" xml:space="preserve">
+    <value>無法指定唯讀欄位 (除非在建構函式或變數初始設定式)</value>
+  </data>
+  <data name="RefReadonly" xml:space="preserve">
+    <value>ref 或 out 無法傳遞唯讀欄位 (除非在建構函式)</value>
+  </data>
+  <data name="AssgReadonlyStatic" xml:space="preserve">
+    <value>無法指定靜態唯讀欄位 (除非在靜態建構函式或變數初始設定式)</value>
+  </data>
+  <data name="RefReadonlyStatic" xml:space="preserve">
+    <value>ref 或 out 無法傳遞靜態唯讀欄位 (除非在靜態建構函式)</value>
+  </data>
+  <data name="AssgReadonlyProp" xml:space="preserve">
+    <value>無法指派屬性或索引子 '{0}' -- 其為唯讀</value>
+  </data>
+  <data name="AbstractBaseCall" xml:space="preserve">
+    <value>無法呼叫抽象基底成員: '{0}'</value>
+  </data>
+  <data name="RefProperty" xml:space="preserve">
+    <value>無法將屬性或索引子當做 out 或 ref 參數傳遞</value>
+  </data>
+  <data name="ManagedAddr" xml:space="preserve">
+    <value>不能取得 Managed 型別 ('{0}') 的位址、大小，也不能宣告指向它的指標</value>
+  </data>
+  <data name="FixedNotNeeded" xml:space="preserve">
+    <value>您不能使用 fixed 陳述式來取得原本就是 fixed 運算式的位址</value>
+  </data>
+  <data name="UnsafeNeeded" xml:space="preserve">
+    <value>動態呼叫不能與指標一起使用</value>
+  </data>
+  <data name="BadBoolOp" xml:space="preserve">
+    <value>為了可以當成最少運算 (Short Circuit) 運算子使用，使用者定義的邏輯運算子 ('{0}') 其傳回型別必須與其 2 個參數的型別相同</value>
+  </data>
+  <data name="MustHaveOpTF" xml:space="preserve">
+    <value>型別 ('{0}') 必須包含運算子 true 和運算子 false 的宣告</value>
+  </data>
+  <data name="CheckedOverflow" xml:space="preserve">
+    <value>操作在檢查模式下編譯時溢出</value>
+  </data>
+  <data name="ConstOutOfRangeChecked" xml:space="preserve">
+    <value>無法將常數值 '{0}' 轉換為 '{1}' (請使用 'unchecked' 語法覆寫)</value>
+  </data>
+  <data name="AmbigMember" xml:space="preserve">
+    <value>'{0}' 和 '{1}' 之間模稜兩可</value>
+  </data>
+  <data name="SizeofUnsafe" xml:space="preserve">
+    <value>'{0}' 沒有預先定義的大小，因此 sizeof 只能使用於 unsafe 內容 (可考慮使用 System.Runtime.InteropServices.Marshal.SizeOf)</value>
+  </data>
+  <data name="FieldInitRefNonstatic" xml:space="preserve">
+    <value>欄位初始設定式無法參考非靜態欄位、方法或屬性 '{0}'</value>
+  </data>
+  <data name="CallingFinalizeDepracated" xml:space="preserve">
+    <value>不能直接呼叫解構函式和 object.Finalize。請考慮呼叫 IDisposable.Dispose (如果有)。</value>
+  </data>
+  <data name="CallingBaseFinalizeDeprecated" xml:space="preserve">
+    <value>不要直接呼叫您的基底類別 Finalize 方法。會從您的解構函式自動呼叫它。</value>
+  </data>
+  <data name="BadCastInFixed" xml:space="preserve">
+    <value>fixed 陳述式設定運算子的右邊不能是 cast 運算式</value>
+  </data>
+  <data name="NoImplicitConvCast" xml:space="preserve">
+    <value>無法將型別 '{0}' 隱含轉換為 '{1}'。已有明確轉換存在 (您是否漏掉了轉型?)</value>
+  </data>
+  <data name="InaccessibleGetter" xml:space="preserve">
+    <value>這個內容中不能使用屬性或索引子 '{0}'，因為無法存取 get 存取子</value>
+  </data>
+  <data name="InaccessibleSetter" xml:space="preserve">
+    <value>這個內容中不能使用屬性或索引子 '{0}'，因為無法存取 set 存取子</value>
+  </data>
+  <data name="BadArity" xml:space="preserve">
+    <value>使用泛型 {1} '{0}' 需要 '{2}' 個型別引數</value>
+  </data>
+  <data name="BadTypeArgument" xml:space="preserve">
+    <value>類型"{0}"不可能用作類型參數</value>
+  </data>
+  <data name="TypeArgsNotAllowed" xml:space="preserve">
+    <value>{1} '{0}' 不能配合型別引數使用</value>
+  </data>
+  <data name="HasNoTypeVars" xml:space="preserve">
+    <value>非泛型 {1} '{0}' 不能配合型別引數使用</value>
+  </data>
+  <data name="NewConstraintNotSatisfied" xml:space="preserve">
+    <value>'{2}' 必須是具有公用無參數建構函式的非抽象型別，才能在泛型型別或方法 '{0}' 中做為參數 '{1}' 使用</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedRefType" xml:space="preserve">
+    <value>型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。沒有從 '{3}' 到 '{1}' 的隱含參考轉換。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableEnum" xml:space="preserve">
+    <value>型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。可為 Null 的型別 '{3}' 未滿足 '{1}' 的條件約束。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedNullableInterface" xml:space="preserve">
+    <value>型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。可為 Null 的型別 '{3}' 未滿足 '{1}' 的條件約束。可為 Null 的型別無法滿足所有介面條件約束。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedTyVar" xml:space="preserve">
+    <value>型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。沒有從 '{3}' 到 '{1}' 的 Boxing 轉換或型別參數轉換。</value>
+  </data>
+  <data name="GenericConstraintNotSatisfiedValType" xml:space="preserve">
+    <value>型別 '{3}' 不能做為泛型型別或方法 '{0}' 中的型別參數 '{2}'。沒有從 '{3}' 到 '{1}' 的 Boxing 轉換。</value>
+  </data>
+  <data name="TypeVarCantBeNull" xml:space="preserve">
+    <value>無法將 null 轉換成型別參數 '{0}'，因為它是不可為 null 的實值型別。請考慮使用 'default({0})' 代替。</value>
+  </data>
+  <data name="BadRetType" xml:space="preserve">
+    <value>'{1} {0}' 的傳回型別錯誤</value>
+  </data>
+  <data name="CantInferMethTypeArgs" xml:space="preserve">
+    <value>方法 '{0}' 的型別引數不能從使用方式推斷。請嘗試明確指定型別引數。</value>
+  </data>
+  <data name="MethGrpToNonDel" xml:space="preserve">
+    <value>無法將方法群組 '{0}' 轉換為非委派型別 '{1}'。您是否想要叫用這個方法?</value>
+  </data>
+  <data name="RefConstraintNotSatisfied" xml:space="preserve">
+    <value>型別 '{2}' 必須是參考型別，才能在泛型型別或方法 '{0}' 中做為參數 '{1}' 使用</value>
+  </data>
+  <data name="ValConstraintNotSatisfied" xml:space="preserve">
+    <value>型別 '{2}' 必須是不可為 null 的實值型別，才能在泛型型別或方法 '{0}' 中做為參數 '{1}' 使用</value>
+  </data>
+  <data name="CircularConstraint" xml:space="preserve">
+    <value>條件約束 '{0}' 和 '{1}' 循環相依; 必須移除兩者其中之一</value>
+  </data>
+  <data name="BaseConstraintConflict" xml:space="preserve">
+    <value>型別參數 '{0}' 繼承了衝突的條件約束 '{1}' 和 '{2}'</value>
+  </data>
+  <data name="ConWithValCon" xml:space="preserve">
+    <value>型別參數 '{1}' 有 'struct' 條件約束，因此 '{1}' 不能做為 '{0}' 的條件約束</value>
+  </data>
+  <data name="AmbigUDConv" xml:space="preserve">
+    <value>從 '{2}' 轉換為 '{3}' 時，發現模稜兩可的使用者定義轉換 '{0}' 和 '{1}'</value>
+  </data>
+  <data name="PredefinedTypeNotFound" xml:space="preserve">
+    <value>未定義或匯入預先定義的型別 '{0}'</value>
+  </data>
+  <data name="PredefinedTypeBadType" xml:space="preserve">
+    <value>預先定義的型別 '{0}' 宣告不正確</value>
+  </data>
+  <data name="BindToBogus" xml:space="preserve">
+    <value>此語言不支援 '{0}'</value>
+  </data>
+  <data name="CantCallSpecialMethod" xml:space="preserve">
+    <value>'{0}': 無法明確呼叫運算子或存取子</value>
+  </data>
+  <data name="BogusType" xml:space="preserve">
+    <value>此語言不支援型別 '{0}'</value>
+  </data>
+  <data name="MissingPredefinedMember" xml:space="preserve">
+    <value>遺漏編譯器所需的成員 '{0}.{1}'</value>
+  </data>
+  <data name="LiteralDoubleCast" xml:space="preserve">
+    <value>不能隱含將型別 double 的常值轉換為型別 '{1}'; 請使用 '{0}' 後置字元來建立此型別的常值</value>
+  </data>
+  <data name="UnifyingInterfaceInstantiations" xml:space="preserve">
+    <value>'{0}' 不能同時實作 '{1}' 和 '{2}'，因為它們可能對某些型別參數的替代做整合</value>
+  </data>
+  <data name="ConvertToStaticClass" xml:space="preserve">
+    <value>無法轉換為靜態型別 '{0}'</value>
+  </data>
+  <data name="GenericArgIsStaticClass" xml:space="preserve">
+    <value>'{0}': 靜態型別不能當做型別引數使用</value>
+  </data>
+  <data name="PartialMethodToDelegate" xml:space="preserve">
+    <value>無法從方法 '{0}' 建立委派，因為它是沒有實作宣告的部分方法</value>
+  </data>
+  <data name="IncrementLvalueExpected" xml:space="preserve">
+    <value>遞增或遞減運算子的運算元必須是變數、屬性或索引子。</value>
+  </data>
+  <data name="NoSuchMemberOrExtension" xml:space="preserve">
+    <value>'{0}' 不包含 '{1}' 的定義，也找不到擴充方法 '{1}' 來接受型別 '{0}' 的第一個引數 (您是否遺漏 using 指示詞或組件參考?)</value>
+  </data>
+  <data name="ValueTypeExtDelegate" xml:space="preserve">
+    <value>在實值型別 '{1}' 中定義的擴充方法 '{0}' 無法用來建立委派</value>
+  </data>
+  <data name="BadArgCount" xml:space="preserve">
+    <value>方法 '{0}' 沒有任何多載接受 '{1}' 個引數</value>
+  </data>
+  <data name="BadArgTypes" xml:space="preserve">
+    <value>最符合的多載方法 '{0}' 有一些無效的引數</value>
+  </data>
+  <data name="BadArgType" xml:space="preserve">
+    <value>引數 '{0}': 無法從 '{1}' 轉換為 '{2}'</value>
+  </data>
+  <data name="RefLvalueExpected" xml:space="preserve">
+    <value>ref 或 out 引數必須是可指派的變數</value>
+  </data>
+  <data name="BadProtectedAccess" xml:space="preserve">
+    <value>無法經由型別 '{1}' 的限定詞來存取保護的成員 '{0}'; 必須經由型別 '{2}' (或從其衍生的型別) 的限定詞</value>
+  </data>
+  <data name="BindToBogusProp2" xml:space="preserve">
+    <value>此語言不支援屬性、索引子或事件 '{0}'; 請試著直接呼叫存取子方法 '{1}' 或 '{2}'</value>
+  </data>
+  <data name="BindToBogusProp1" xml:space="preserve">
+    <value>此語言不支援屬性、索引子或事件 '{0}'; 請試著直接呼叫存取子方法 '{1}'</value>
+  </data>
+  <data name="BadDelArgCount" xml:space="preserve">
+    <value>委派 '{0}' 不接受 '{1}' 個引數</value>
+  </data>
+  <data name="BadDelArgTypes" xml:space="preserve">
+    <value>委派 '{0}' 有一些無效的引數</value>
+  </data>
+  <data name="AssgReadonlyLocal" xml:space="preserve">
+    <value>無法指派給 '{0}'，因為它是唯讀的</value>
+  </data>
+  <data name="RefReadonlyLocal" xml:space="preserve">
+    <value>無法將 '{0}' 當做 ref 或 out 引數傳遞，因為它是唯讀的</value>
+  </data>
+  <data name="ReturnNotLValue" xml:space="preserve">
+    <value>無法修改 '{0}' 的傳回值，因為它不是變數</value>
+  </data>
+  <data name="BadArgExtraRef" xml:space="preserve">
+    <value>傳遞引數 '{0}' 時不能包含 '{1}' 關鍵字</value>
+  </data>
+  <data name="BadArgRef" xml:space="preserve">
+    <value>傳遞引數 '{0}' 時必須包含 '{1}' 關鍵字</value>
+  </data>
+  <data name="AssgReadonly2" xml:space="preserve">
+    <value>唯讀欄位 '{0}' 的成員無法修改 (除非是在建構函式或變數初始設定式)</value>
+  </data>
+  <data name="RefReadonly2" xml:space="preserve">
+    <value>ref 或 out 無法傳遞唯讀欄位 '{0}' 的成員 (除非是在建構函式中)</value>
+  </data>
+  <data name="AssgReadonlyStatic2" xml:space="preserve">
+    <value>無法指派靜態唯讀欄位 '{0}' 的欄位 (除非是在靜態建構函式或變數初始設定式)</value>
+  </data>
+  <data name="RefReadonlyStatic2" xml:space="preserve">
+    <value>ref 或 out 無法傳遞靜態唯讀欄位 '{0}' 的欄位 (除非是在靜態建構函式)</value>
+  </data>
+  <data name="AssgReadonlyLocalCause" xml:space="preserve">
+    <value>無法指派給 '{0}'，因為它是 '{1}'</value>
+  </data>
+  <data name="RefReadonlyLocalCause" xml:space="preserve">
+    <value>無法將 '{0}' 當做 ref 或 out 引數傳遞，因為它是 '{1}'</value>
+  </data>
+  <data name="ThisStructNotInAnonMeth" xml:space="preserve">
+    <value>結構內部的匿名方法、Lambda 運算式和查詢運算式無法存取 'this' 的執行個體成員。請考慮將 'this' 複製到匿名方法、Lambda 運算式或查詢運算式外部的區域變數，並改用這個區域變數。</value>
+  </data>
+  <data name="DelegateOnNullable" xml:space="preserve">
+    <value>不能將委託綁定到 '{0}'，因為它是 'System.Nullable&lt;T&gt;' 成員</value>
+  </data>
+  <data name="BadCtorArgCount" xml:space="preserve">
+    <value>'{0}' 不包含接受 '{1}' 個引數的建構函式</value>
+  </data>
+  <data name="BadExtensionArgTypes" xml:space="preserve">
+    <value>'{0}' 不包含 '{1}' 的定義，而且最佳的擴充方法多載 '{2}' 有一些無效的引數</value>
+  </data>
+  <data name="BadInstanceArgType" xml:space="preserve">
+    <value>執行個體引數: 無法從 '{0}' 轉換為 '{1}'</value>
+  </data>
+  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
+    <value>集合初始設定式的最佳多載 Add 方法 '{0}' 有一些無效的引數</value>
+  </data>
+  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
+    <value>無法使用集合初始設定式項目之最符合的多載方法 '{0}'。集合初始設定式 'Add' 方法不能具有 ref 或 out 參數。</value>
+  </data>
+  <data name="NonInvocableMemberCalled" xml:space="preserve">
+    <value>非可叫用 (Non-invocable) 成員 '{0}' 不能做為方法使用。</value>
+  </data>
+  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
+    <value>具名引數規格必須出現在所有已指定的固定引數之後</value>
+  </data>
+  <data name="BadNamedArgument" xml:space="preserve">
+    <value>'{0}' 的最佳多載沒有一個名為 '{1}' 的參數</value>
+  </data>
+  <data name="BadNamedArgumentForDelegateInvoke" xml:space="preserve">
+    <value>委派 '{0}' 沒有一個名為 '{1}' 的參數</value>
+  </data>
+  <data name="DuplicateNamedArgument" xml:space="preserve">
+    <value>具名引數 '{0}' 不可以多次指定</value>
+  </data>
+  <data name="NamedArgumentUsedInPositional" xml:space="preserve">
+    <value>具名引數 '{0}' 指定了已給定位置引數的參數</value>
+  </data>
+</root>


### PR DESCRIPTION
This change adds localization to the Microsoft.CSharp project by using
the Multilingual App Toolkit (MAT). It includes machine translations as
generated by MAT. This produces localized satellite assemblies when
building.

When building on a machine without MAT, there will be a warning that MAT
is not installed.  This means that the .xlf files (translation files)
and localized resources files will not be synced with the neutral-
language resource files during that build; they can be synced by
building on a machine with MAT installed.

Localization to the other projects in fxcore will be added in the
future.