### PR TITLE
Disable parallelization of FSW tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="FileSystemEventArgs.unit.cs" />
     <Compile Include="FileSystemWatcher.unit.cs" />
     <Compile Include="RenamedEventArgs.unit.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.FileSystem.Watcher/tests/XunitAssemblyAttributes.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+// Disable parallelization of FileSystemWatcher tests
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
My previous change to rename FSW test classes led to FSW tests getting parallelized.  It turns out that some of the tests are not robust against this due to using file names that can end up conflicting with other tests.  Additionally, it appears that the waiting / timeouts used by the tests is very susceptible to failure when run in parallel due to reliance on the shared thread pool, causing more failures in CI.