### PR TITLE
HttpClient xplat: Optimize number of socket callbacks

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.poll.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.poll.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         internal enum PollFlags : short
         {
             POLLIN      = 0x0001,       /* any readable data available */
+            POLLOUT     = 0x0004,       /* data can be written without blocking */
             POLLERR     = 0x0008,       /* some poll error occurred */
             POLLHUP     = 0x0010,       /* file descriptor was "hung up" */
             POLLNVAL    = 0x0020,       /* requested events "invalid" */
@@ -36,7 +37,7 @@ internal static partial class Interop
         /// descriptors were ready, or -1 on error.
         /// </returns>
         [DllImport(Libraries.Libc, SetLastError = true)]
-        private static unsafe extern int poll(pollfd* fds, uint count, int timeout);
+        internal static unsafe extern int poll(pollfd* fds, uint count, int timeout);
 
         /// <summary>
         /// Polls a File Descriptor for the passed in flags.

--- a/src/Common/src/Interop/Unix/libcurl/Interop.SafeCurlHandle.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.SafeCurlHandle.cs
@@ -2,7 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
+
+using size_t = System.IntPtr;
+using libc = Interop.libc;
+using libcurl = Interop.libcurl;
+using PollFlags = Interop.libc.PollFlags;
 
 internal static partial class Interop
 {
@@ -30,16 +38,48 @@ internal static partial class Interop
 
             protected override bool ReleaseHandle()
             {
-                Interop.libcurl.curl_easy_cleanup(this.handle);
+                libcurl.curl_easy_cleanup(this.handle);
                 return true;
             }
         }
 
         internal sealed class SafeCurlMultiHandle : SafeHandle
         {
+            private bool _pollCancelled = true;
+            private readonly int[] _specialFds = new int[2];
+            private readonly HashSet<int> _fdSet = new HashSet<int>();
+            private int _requestCount = 0;
+            private Timer _timer;
+
+            internal bool PollCancelled
+            {
+                get { return _pollCancelled; }
+                set { _pollCancelled = value; }
+            }
+
+            internal int RequestCount
+            {
+                get { return _requestCount; }
+                set { _requestCount = value; }
+            }
+
+            internal Timer Timer
+            {
+                get { return _timer; }
+                set { _timer = value; }
+            }
+
+
             public SafeCurlMultiHandle()
                 : base(IntPtr.Zero, true)
             {
+                unsafe
+                {
+                    fixed(int* fds = _specialFds)
+                    {
+                        while (Interop.CheckIo(libc.pipe(fds)));
+                    }
+                }
             }
 
             public override bool IsInvalid
@@ -56,10 +96,168 @@ internal static partial class Interop
                 }
             }
 
+            internal void PollFds(List<libc.pollfd> readyFds)
+            {
+                int count;
+                libc.pollfd[] pollFds;
+
+                readyFds.Clear();
+
+                lock (this)
+                {
+                    // TODO: Avoid the allocation when count is in 100s
+                    count = _fdSet.Count + 1;
+                    pollFds = new libc.pollfd[count];
+
+                    // Always include special fd in the poll set. This is used to
+                    // return from the poll in case any fds have been added or
+                    // removed to the set of fds being polled. This prevents starvation
+                    // in case current set of fds have no activity but the new fd
+                    // is ready for a read/write. The special fd is the read end of a pipe
+                    // Whenever an fd is added/removed in _fdSet, a write happens to the
+                    // write end of the pipe thus causing the poll to return.
+                    pollFds[0].fd = _specialFds[libc.ReadEndOfPipe];
+                    pollFds[0].events = PollFlags.POLLIN | PollFlags.POLLOUT;
+                    int i = 1;
+                    foreach (int fd in _fdSet)
+                    {
+                        pollFds[i].fd = fd;
+                        pollFds[i].events = PollFlags.POLLIN | PollFlags.POLLOUT;
+                        i++;
+                    }
+                }
+
+                unsafe
+                {
+                    fixed (libc.pollfd* fds = pollFds)
+                    {
+                        int numFds = libc.poll(fds, (uint)count, -1);
+                        if (numFds <= 0)
+                        {
+                            Debug.Assert(numFds != 0); // Since timeout is infinite
+
+                            // TODO: How to handle errors?
+                            throw new InvalidOperationException("Poll failure: " + Marshal.GetLastWin32Error());
+                        }
+
+                        lock (this)
+                        {
+                            if (0 == _requestCount)
+                            {
+                                return;
+                            }
+                        }
+
+                        // Check for any fdset changes
+                        if (fds[0].revents != 0)
+                        {
+                            if (ReadSpecialFd(fds[0].revents) < 0)
+                            {
+                                // TODO: How to handle errors?
+                                throw new InvalidOperationException("Cannot read data: " + Marshal.GetLastWin32Error());
+                            }
+                            numFds--;
+                        }
+
+                        // Now check for events on the remaining fds
+                        for (int i = 1; i < count && numFds > 0; i++)
+                        {
+                            if (fds[i].revents == 0)
+                            {
+                                continue;
+                            }
+                            readyFds.Add(fds[i]);
+                            numFds--;
+                        }
+                    }
+                }
+            }
+
+            internal void SignalFdSetChange(int fd, bool isRemove)
+            {
+                Debug.Assert(Monitor.IsEntered(this));
+
+                bool changed = isRemove ? _fdSet.Remove(fd) : _fdSet.Add(fd);
+                if (!changed)
+                {
+                    return;
+                }
+
+                unsafe
+                {
+                    // Write to special fd
+                    byte* dummyBytes = stackalloc byte[1];
+                    if ((int)libc.write(_specialFds[libc.WriteEndOfPipe], dummyBytes, (size_t)1) <= 0)
+                    {
+                        // TODO: How to handle errors?
+                        throw new InvalidOperationException("Cannot write data: " + Marshal.GetLastWin32Error());
+                    }
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    if (null != _timer)
+                    {
+                        _timer.Dispose();
+                    }
+                }
+                base.Dispose(disposing);
+            }
+
             protected override bool ReleaseHandle()
             {
-                Interop.libcurl.curl_multi_cleanup(this.handle);
+                Debug.Assert(0 == _fdSet.Count);
+                Debug.Assert(0 == _requestCount);
+                Debug.Assert(_pollCancelled);
+
+                libc.close(_specialFds[libc.ReadEndOfPipe]);
+                libc.close(_specialFds[libc.WriteEndOfPipe]);
+                libcurl.curl_multi_cleanup(this.handle);
+
                 return true;
+            }
+
+            private int ReadSpecialFd(PollFlags revents)
+            {
+                PollFlags badEvents = PollFlags.POLLERR | PollFlags.POLLHUP | PollFlags.POLLNVAL;
+                if ((revents & badEvents) != 0)
+                {
+                    return -1;
+                }
+                int pipeReadFd = _specialFds[libc.ReadEndOfPipe];
+                int bytesRead = 0;
+                unsafe
+                {
+                    do
+                    {
+                        // Read available data from the pipe
+                        int bufferLength = 1024;
+                        byte* dummyBytes = stackalloc byte[bufferLength];
+                        int numBytes = (int)libc.read(pipeReadFd, dummyBytes, (size_t)bufferLength);
+                        if (numBytes <= 0)
+                        {
+                            return -1;
+                        }
+                        bytesRead += numBytes;
+
+                        // Check if more data is available
+                        PollFlags outFlags;
+                        int retVal = libc.poll(pipeReadFd, PollFlags.POLLIN, 0, out outFlags);
+                        if (retVal < 0)
+                        {
+                            return -1;
+                        }
+                        else if (0 == retVal)
+                        {
+                            break;
+                        }
+                    }
+                    while (true);
+                }
+                return bytesRead;
             }
         }
 
@@ -91,7 +289,7 @@ internal static partial class Interop
 
             protected override bool ReleaseHandle()
             {
-                Interop.libcurl.curl_slist_free_all(this.handle);
+                libcurl.curl_slist_free_all(this.handle);
                 return true;
             }
         }

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -294,4 +294,37 @@
   <data name="net_http_unix_https_support_unavailable_libcurl" xml:space="preserve">
     <value>libcurl library available on the system does not support https</value>
   </data>
+  <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
+    <value>Specified file length was too large for the file system.</value>
+  </data>
+  <data name="IO_FileExists_Name" xml:space="preserve">
+    <value>The file '{0}' already exists.</value>
+  </data>
+  <data name="IO_FileNotFound" xml:space="preserve">
+    <value>Unable to find the specified file.</value>
+  </data>
+  <data name="IO_FileNotFound_FileName" xml:space="preserve">
+    <value>Could not find file '{0}'.</value>
+  </data>
+  <data name="IO_PathNotFound_NoPathName" xml:space="preserve">
+    <value>Could not find a part of the path.</value>
+  </data>
+  <data name="IO_PathNotFound_Path" xml:space="preserve">
+    <value>Could not find a part of the path '{0}'.</value>
+  </data>
+  <data name="IO_PathTooLong" xml:space="preserve">
+    <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
+  </data>
+  <data name="IO_SharingViolation_File" xml:space="preserve">
+    <value>The process cannot access the file '{0}' because it is being used by another process.</value>
+  </data>
+  <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
+    <value>The process cannot access the file because it is being used by another process.</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
+    <value>Access to the path is denied.</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
+    <value>Access to the path '{0}' is denied.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -140,8 +140,32 @@
     <Compile Include="System\Net\Http\Unix\CurlHandler.cs" />
     <Compile Include="System\Net\Http\Unix\CurlResponseMessage.cs" />
     <Compile Include="System\Net\Http\Unix\HttpClientHandler.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
+      <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.close.cs">
+      <Link>Common\Interop\Unix\libc\Interop.close.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
+      <Link>Common\Interop\Unix\libc\Interop.open.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.pipe.cs">
+      <Link>Common\Interop\Unix\libc\Interop.pipe.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.poll.cs">
+      <Link>Common\Interop\Unix\libc\Interop.poll.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.read.cs">
+      <Link>Common\Interop\Unix\libc\Interop.read.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.write.cs">
+      <Link>Common\Interop\Unix\libc\Interop.write.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcurl\Interop.libcurl.cs">
       <Link>Common\Interop\Unix\libcurl\Interop.libcurl.cs</Link>
@@ -155,6 +179,21 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>    
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Linux\libc\Interop.OpenFlags.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\OSX\libc\Interop.OpenFlags.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\FreeBSD\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\FreeBSD\libc\Interop.OpenFlags.cs</Link>
+    </Compile>
   </ItemGroup>
   
   <ItemGroup>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseMessage.cs
@@ -158,6 +158,9 @@ namespace System.Net.Http
                         continue;
                     }
 
+                    // Since this is under lock, make sure the Read is non-blocking
+                    Debug.Assert((_innerStream is MemoryStream) || (_innerStream is UnmanagedMemoryStream));
+
                     int bytesRead = _innerStream.Read(buffer, offset, (int)Math.Min((long)count, _innerStream.Length));
                     if (_innerStream.Position == _innerStream.Length)
                     {

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -16,7 +16,8 @@
     "System.Security.Principal": "4.0.0",
     "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.0",
-    "System.Threading.Tasks": "4.0.10"
+    "System.Threading.Tasks": "4.0.10",
+    "System.Threading.Timer": "4.0.0",
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Net.Http/src/project.lock.json
+++ b/src/System.Net.Http/src/project.lock.json
@@ -513,6 +513,17 @@
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
+      },
+      "System.Threading.Timer/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
       }
     }
   },
@@ -1707,6 +1718,36 @@
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
+    },
+    "System.Threading.Timer/4.0.0": {
+      "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
+      "files": [
+        "System.Threading.Timer.4.0.0.nupkg",
+        "System.Threading.Timer.4.0.0.nupkg.sha512",
+        "System.Threading.Timer.nuspec",
+        "lib/DNXCore50/System.Threading.Timer.dll",
+        "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
+        "lib/win81/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
+        "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
+        "ref/dotnet/fr/System.Threading.Timer.xml",
+        "ref/dotnet/it/System.Threading.Timer.xml",
+        "ref/dotnet/ja/System.Threading.Timer.xml",
+        "ref/dotnet/ko/System.Threading.Timer.xml",
+        "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hans/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "ref/net451/_._",
+        "ref/netcore50/System.Threading.Timer.dll",
+        "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+      ]
     }
   },
   "projectFileDependencyGroups": {
@@ -1727,7 +1768,8 @@
       "System.Security.Principal >= 4.0.0",
       "System.Text.Encoding >= 4.0.10",
       "System.Threading >= 4.0.0",
-      "System.Threading.Tasks >= 4.0.10"
+      "System.Threading.Tasks >= 4.0.10",
+      "System.Threading.Timer >= 4.0.0"
     ],
     "DNXCore,Version=v5.0": []
   }


### PR DESCRIPTION
In earlier version, a curl_multi_socket_action was performed everytime
the callback was invoked irrespective of whether there was activity on
the socket. This in turn causes more callbacks when libcurl tries to read
the socket but finds no data. This can be made more efficient by waiting
for activity on the socket and informing libcurl accordingly
- Also fixed a bug in the timer callback for <=0 timeout values
- Fixed a bug in CheckForCompletedTransfers where a mismatch could occur
  between the easy handle specified in the DONE msg
- Fixing a SEGV that can happen due to stack overflow caused by callback getting invoked recursively because curl_multi_socket_action was being called in the callback code

cc: @stephentoub @davidsh @CIPop @SidharthNabar @pgavlin 