### PR TITLE
Removed USE_OVERLAPPED from FileSystem

### DIFF
--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -39,9 +39,7 @@ namespace Microsoft.Win32.SafeHandles
             }
         }
 
-#if USE_OVERLAPPED
         internal ThreadPoolBoundHandle ThreadPoolBinding { get; set; }
-#endif
 
         [System.Security.SecurityCritical]
         override protected bool ReleaseHandle()

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -13,10 +13,6 @@
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
     <NoWarn>$(NoWarn);414</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
-    <!-- The System.Threading.Overlapped contract currently only works on Windows -->
-    <DefineConstants>$(DefineConstants);USE_OVERLAPPED</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup>
     <TargetsBSD Condition="'$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true'">true</TargetsBSD>
   </PropertyGroup>

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -41,18 +41,12 @@ namespace System.IO
     internal sealed partial class Win32FileStream : FileStreamBase
     {
         internal const int DefaultBufferSize = 4096;
-#if USE_OVERLAPPED
         internal const bool DefaultUseAsync = true;
-#else
-        internal const bool DefaultUseAsync = false;
-#endif
         internal const bool DefaultIsAsync = false;
 
         private byte[] _buffer;   // Shared read/write buffer.  Alloc on first use.
         private String _fileName; // Fully qualified file name.
-#if USE_OVERLAPPED
         private bool _isAsync;    // Whether we opened the handle for overlapped IO
-#endif
         private bool _canRead;
         private bool _canWrite;
         private bool _canSeek;
@@ -95,13 +89,8 @@ namespace System.IO
             if (mode == FileMode.Append)
                 mode = FileMode.OpenOrCreate;
 
-#if USE_OVERLAPPED
             if ((options & FileOptions.Asynchronous) != 0)
                 _isAsync = true;
-#else
-            // Disallow overlapped IO.
-            options &= ~FileOptions.Asynchronous;
-#endif
 
             int flagsAndAttributes = (int)options;
 
@@ -115,9 +104,7 @@ namespace System.IO
             try
             {
                 _handle = Interop.mincore.SafeCreateFile(path, fAccess, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
-#if USE_OVERLAPPED
                 _handle.IsAsync = _isAsync;
-#endif
 
                 if (_handle.IsInvalid)
                 {
@@ -150,7 +137,6 @@ namespace System.IO
                 throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
             }
 
-#if USE_OVERLAPPED
             // This is necessary for async IO using IO Completion ports via our 
             // managed Threadpool API's.  This (theoretically) calls the OS's 
             // BindIoCompletionCallback method, and passes in a stub for the 
@@ -179,7 +165,6 @@ namespace System.IO
                     }
                 }
             }
-#endif
 
             _canRead = (access & FileAccess.Read) != 0;
             _canWrite = (access & FileAccess.Write) != 0;
@@ -240,9 +225,7 @@ namespace System.IO
             int handleType = Interop.mincore.GetFileType(_handle);
             Debug.Assert(handleType == Interop.mincore.FileTypes.FILE_TYPE_DISK || handleType == Interop.mincore.FileTypes.FILE_TYPE_PIPE || handleType == Interop.mincore.FileTypes.FILE_TYPE_CHAR, "FileStream was passed an unknown file type!");
 
-#if USE_OVERLAPPED
             _isAsync = isAsync;
-#endif
             _canRead = 0 != (access & FileAccess.Read);
             _canWrite = 0 != (access & FileAccess.Write);
             _canSeek = handleType == Interop.mincore.FileTypes.FILE_TYPE_DISK;
@@ -253,7 +236,6 @@ namespace System.IO
             _fileName = null;
             _isPipe = handleType == Interop.mincore.FileTypes.FILE_TYPE_PIPE;
 
-#if USE_OVERLAPPED
             // This is necessary for async IO using IO Completion ports via our 
             // managed Threadpool API's.  This calls the OS's 
             // BindIoCompletionCallback method, and passes in a stub for the 
@@ -280,22 +262,10 @@ namespace System.IO
                 }
             }
             else if (!_isAsync)
-#endif
             {
                 if (handleType != Interop.mincore.FileTypes.FILE_TYPE_PIPE)
                     VerifyHandleIsSync();
             }
-
-#if !USE_OVERLAPPED
-            // When USE_OVERLAPPED is not supported we ignore the isAsync property and always call
-            // VerifyHandleIsSync above.  We'll then throw here if we were told it was Async.
-
-            if (isAsync)
-            {
-                // Passed in a synchronous handle and told us isAsync
-                throw new ArgumentException(SR.Arg_HandleNotAsync, "handle");
-            }
-#endif
 
             if (_canSeek)
                 SeekCore(0, SeekOrigin.Current);
@@ -385,11 +355,7 @@ namespace System.IO
 
         public override bool IsAsync
         {
-#if USE_OVERLAPPED
             get { return _isAsync; }
-#else
-            get { return false; }
-#endif
         }
 
         public override long Length
@@ -483,10 +449,8 @@ namespace System.IO
                 if (_handle != null && !_handle.IsClosed)
                     _handle.Dispose();
 
-#if USE_OVERLAPPED
                 if (_handle.ThreadPoolBinding != null)
                     _handle.ThreadPoolBinding.Dispose();
-#endif
 
                 _canRead = false;
                 _canWrite = false;
@@ -563,7 +527,6 @@ namespace System.IO
         {
             Debug.Assert(_readPos == 0 && _readLen == 0, "FileStream: Read buffer must be empty in FlushWrite!");
 
-#if USE_OVERLAPPED
             if (_isAsync)
             {
                 Task writeTask = WriteInternalCoreAsync(_buffer, 0, _writePos, CancellationToken.None);
@@ -586,7 +549,6 @@ namespace System.IO
                 }
             }
             else
-#endif
             {
                 WriteCore(_buffer, 0, _writePos);
             }
@@ -755,23 +717,18 @@ namespace System.IO
             Debug.Assert(_writePos == 0, "_writePos == 0");
             Debug.Assert(offset >= 0, "offset is negative");
             Debug.Assert(count >= 0, "count is negative");
-#if USE_OVERLAPPED
             if (_isAsync)
             {
                 return ReadInternalCoreAsync(buffer, offset, count, 0, CancellationToken.None).GetAwaiter().GetResult();
             }
-#endif
 
             // Make sure we are reading from the right spot
             if (_exposedHandle)
                 VerifyOSHandlePosition();
 
             int errorCode = 0;
-#if USE_OVERLAPPED
             int r = ReadFileNative(_handle, buffer, offset, count, null, out errorCode);
-#else       
-            int r = ReadFileNative(_handle, buffer, offset, count, out errorCode);
-#endif
+
             if (r == -1)
             {
                 // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
@@ -977,13 +934,11 @@ namespace System.IO
                 // Reset our buffer.  We essentially want to call FlushWrite
                 // without calling Flush on the underlying Stream.
 
-#if USE_OVERLAPPED
                 if (_isAsync)
                 {
                     WriteInternalCoreAsync(_buffer, 0, _writePos, CancellationToken.None).GetAwaiter().GetResult();
                 }
                 else
-#endif
                 {
                     WriteCore(_buffer, 0, _writePos);
                 }
@@ -1015,24 +970,18 @@ namespace System.IO
             Debug.Assert(_readPos == _readLen, "_readPos == _readLen");
             Debug.Assert(offset >= 0, "offset is negative");
             Debug.Assert(count >= 0, "count is negative");
-#if USE_OVERLAPPED
             if (_isAsync)
             {
                 WriteInternalCoreAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
                 return;
             }
-#endif
 
             // Make sure we are writing to the position that we think we are
             if (_exposedHandle)
                 VerifyOSHandlePosition();
 
             int errorCode = 0;
-#if USE_OVERLAPPED
             int r = WriteFileNative(_handle, buffer, offset, count, null, out errorCode);
-#else
-            int r = WriteFileNative(_handle, buffer, offset, count, out errorCode);
-#endif
 
             if (r == -1)
             {
@@ -1057,7 +1006,6 @@ namespace System.IO
             return;
         }
 
-#if USE_OVERLAPPED
         [System.Security.SecuritySafeCritical]  // auto-generated
         private Task<int> ReadInternalAsync(byte[] array, int offset, int numBytes, CancellationToken cancellationToken)
         {
@@ -1278,7 +1226,6 @@ namespace System.IO
 
             return completionSource.Task;
         }       
-#endif
 
         // Reads a byte from the file stream.  Returns the byte cast to an int
         // or -1 if reading from the end of the stream.
@@ -1304,7 +1251,6 @@ namespace System.IO
             return result;
         }
 
-#if USE_OVERLAPPED
         [System.Security.SecuritySafeCritical]  // auto-generated
         private Task WriteInternalAsync(byte[] array, int offset, int numBytes, CancellationToken cancellationToken)
         {
@@ -1469,7 +1415,6 @@ namespace System.IO
 
             return completionSource.Task;
         }
-#endif
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override void WriteByte(byte value)
@@ -1513,11 +1458,7 @@ namespace System.IO
 
         // __ConsoleStream also uses this code. 
         [System.Security.SecurityCritical]  // auto-generated
-#if USE_OVERLAPPED
         private unsafe int ReadFileNative(SafeFileHandle handle, byte[] bytes, int offset, int count, NativeOverlapped* overlapped, out int errorCode)
-#else
-        private unsafe int ReadFileNative(SafeFileHandle handle, byte[] bytes, int offset, int count, out int errorCode)
-#endif
         {
             Contract.Requires(handle != null, "handle != null");
             Contract.Requires(offset >= 0, "offset >= 0");
@@ -1529,9 +1470,7 @@ namespace System.IO
                 throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
             Contract.EndContractBlock();
 
-#if USE_OVERLAPPED
             Debug.Assert((_isAsync && overlapped != null) || (!_isAsync && overlapped == null), "Async IO and overlapped parameters inconsistent in call to ReadFileNative.");
-#endif
 
             // You can't use the fixed statement on an array of length 0.
             if (bytes.Length == 0)
@@ -1545,12 +1484,10 @@ namespace System.IO
 
             fixed (byte* p = bytes)
             {
-#if USE_OVERLAPPED
                 if (_isAsync)
                     r = Interop.mincore.ReadFile(handle, p + offset, count, IntPtr.Zero, overlapped);
                 else
-#endif
-                r = Interop.mincore.ReadFile(handle, p + offset, count, out numBytesRead, IntPtr.Zero);
+                    r = Interop.mincore.ReadFile(handle, p + offset, count, out numBytesRead, IntPtr.Zero);
             }
 
             if (r == 0)
@@ -1566,13 +1503,8 @@ namespace System.IO
         }
 
         [System.Security.SecurityCritical]  // auto-generated
-#if USE_OVERLAPPED
         private unsafe int WriteFileNative(SafeFileHandle handle, byte[] bytes, int offset, int count, NativeOverlapped* overlapped, out int errorCode)
         {
-#else
-        private unsafe int WriteFileNative(SafeFileHandle handle, byte[] bytes, int offset, int count, out int errorCode)
-        {
-#endif
             Contract.Requires(handle != null, "handle != null");
             Contract.Requires(offset >= 0, "offset >= 0");
             Contract.Requires(count >= 0, "count >= 0");
@@ -1585,9 +1517,7 @@ namespace System.IO
                 throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
             Contract.EndContractBlock();
 
-#if USE_OVERLAPPED
             Debug.Assert((_isAsync && overlapped != null) || (!_isAsync && overlapped == null), "Async IO and overlapped parameters inconsistent in call to WriteFileNative.");
-#endif
 
             // You can't use the fixed statement on an array of length 0.
             if (bytes.Length == 0)
@@ -1601,12 +1531,10 @@ namespace System.IO
 
             fixed (byte* p = bytes)
             {
-#if USE_OVERLAPPED
                 if (_isAsync)
                     r = Interop.mincore.WriteFile(handle, p + offset, count, IntPtr.Zero, overlapped);
                 else
-#endif
-                r = Interop.mincore.WriteFile(handle, p + offset, count, out numBytesWritten, IntPtr.Zero);
+                    r = Interop.mincore.WriteFile(handle, p + offset, count, out numBytesWritten, IntPtr.Zero);
             }
 
             if (r == 0)
@@ -1663,20 +1591,16 @@ namespace System.IO
             if (_handle.IsClosed)
                 throw __Error.GetFileNotOpen();
 
-#if USE_OVERLAPPED
             // If async IO is not supported on this platform or 
             // if this Win32FileStream was not opened with FileOptions.Asynchronous.
             if (!_isAsync)
-#endif
             {
                 return base.ReadAsync(buffer, offset, count, cancellationToken);
             }
-#if USE_OVERLAPPED
             else
             {
                 return ReadInternalAsync(buffer, offset, count, cancellationToken);
             }
-#endif
         }
 
         [System.Security.SecuritySafeCritical]
@@ -1688,20 +1612,16 @@ namespace System.IO
             if (_handle.IsClosed)
                 throw __Error.GetFileNotOpen();
 
-#if USE_OVERLAPPED
             // If async IO is not supported on this platform or 
             // if this Win32FileStream was not opened with FileOptions.Asynchronous.
             if (!_isAsync)
-#endif
             {
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
             }
-#if USE_OVERLAPPED
             else
             {
                 return WriteInternalAsync(buffer, offset, count, cancellationToken);
             } 
-#endif
         }
         
         // Unlike Flush(), FlushAsync() always flushes to disk. This is intentional.

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStreamCompletionSource.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStreamCompletionSource.cs
@@ -11,7 +11,6 @@ namespace System.IO
 {
     internal partial class Win32FileStream
     {
-#if USE_OVERLAPPED
         // This is an internal object extending TaskCompletionSource with fields
         // for all of the relevant data necessary to complete the IO operation.
         // This is used by AsyncFSCallback and all of the async methods.
@@ -208,6 +207,5 @@ namespace System.IO
                 }
             }
         } 
-#endif
     }
 }


### PR DESCRIPTION
All ifdefs around USE_OVERLAPPED have been removed such that the new behavior mimics the old behavior when USE_OVERLAPPED = true. Resolves #2722