### PR TITLE
Change timeouts on FSW tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -125,7 +125,7 @@ public class CreatedTests
         {
             using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
             {
-                Utility.ExpectEvent(are, "nested file created", 1000 * 30);
+                Utility.ExpectEvent(are, "nested file created");
             }
         });
     }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
@@ -102,17 +102,17 @@ public class DeletedTests
             using (var firstDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
                 // Wait for the created event
-                Utility.ExpectEvent(createOccured, "create", 1000 * 30);
+                Utility.ExpectEvent(createOccured, "create");
 
                 using (var secondDir = new TemporaryTestDirectory(Path.Combine(firstDir.Path, "dir2")))
                 {
                     // Wait for the created event
-                    Utility.ExpectEvent(createOccured, "create", 1000 * 30);
+                    Utility.ExpectEvent(createOccured, "create");
 
                     using (var nestedDir = new TemporaryTestDirectory(Path.Combine(secondDir.Path, "nested")))
                     {
                         // Wait for the created event
-                        Utility.ExpectEvent(createOccured, "create", 1000 * 30);
+                        Utility.ExpectEvent(createOccured, "create");
                     }
 
                     Utility.ExpectEvent(eventOccured, "deleted");
@@ -142,12 +142,12 @@ public class DeletedTests
             using (var firstDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
                 // Wait for the created event
-                Utility.ExpectEvent(createOccured, "create", 1000 * 30);
+                Utility.ExpectEvent(createOccured, "create");
 
                 using (var secondDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir2")))
                 {
                     // Wait for the created event
-                    Utility.ExpectEvent(createOccured, "create", 1000 * 30);
+                    Utility.ExpectEvent(createOccured, "create");
 
                     using (var nestedDir = new TemporaryTestFile(Path.Combine(secondDir.Path, "nestedFile"))) { }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
@@ -75,7 +75,7 @@ public partial class RenamedTests
         {
             using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile")))
             {
-                Utility.ExpectEvent(are, "file created", Utility.WaitForCreationTimeoutInMs);
+                Utility.ExpectEvent(are, "file created");
                 nestedFile.Move(nestedFile.Path + "_2");
                 Utility.ExpectEvent(are, "renamed");
             }
@@ -103,11 +103,11 @@ public partial class RenamedTests
 
             using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
-                Utility.ExpectEvent(createdOccured, "dir1 created", Utility.WaitForCreationTimeoutInMs);
+                Utility.ExpectEvent(createdOccured, "dir1 created");
 
                 using (var dir2 = new TemporaryTestDirectory(Path.Combine(dir1.Path, "dir2")))
                 {
-                    Utility.ExpectEvent(createdOccured, "dir2 created", Utility.WaitForCreationTimeoutInMs);
+                    Utility.ExpectEvent(createdOccured, "dir2 created");
 
                     using (var file = Utility.CreateTestFile(Path.Combine(dir2.Path, "test file"))) { };
 
@@ -146,7 +146,7 @@ public partial class RenamedTests
 
             using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
-                Utility.ExpectEvent(createdOccured, "dir1 created", Utility.WaitForCreationTimeoutInMs);
+                Utility.ExpectEvent(createdOccured, "dir1 created");
 
                 using (var dir2 = new TemporaryTestDirectory(Path.Combine(dir1.Path, "dir2")))
                 {


### PR DESCRIPTION
When we're waiting for an event that we know will arrive, we can wait for a fairly long time, because if it doesn't arrive we're going to fail the tests anyway.  This changes makes all of the ExpectEvent calls use a long timeout, much longer than most were previously using.  In the process I removed all of the custom values being passed, as they were all the same or shorter than the new default.  This should help to minimize false positive flakiness.

cc: @sokket, @ianhays 

(I'm hoping this is the root cause of #2740 and we'll see that issue go away.)