### PR TITLE
Fixed interpreter support for properties on Nullable<T>

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -960,7 +960,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitNullableCall(MethodInfo method, ParameterInfo[] parameters)
         {
-            Emit(NullableMethodCallInstruction.Create(method.Name, parameters.Length));
+            Emit(NullableMethodCallInstruction.Create(method.Name, parameters.Length, method));
         }
 
         public void EmitNullCheck(int stackOffset)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -1925,14 +1925,10 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var obj = frame.Pop();
-                if (obj == null)
+                if (frame.Peek() == null)
                 {
+                    frame.Pop();
                     throw new InvalidOperationException();
-                }
-                else
-                {
-                    frame.Push(obj);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -1899,7 +1899,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class NullableMethodCallInstruction : Instruction
     {
-        private static NullableMethodCallInstruction s_hasValue,s_value,s_equals,s_getHashCode,s_getValueOrDefault1,s_toString;
+        private static NullableMethodCallInstruction s_hasValue, s_value, s_equals, s_getHashCode, s_getValueOrDefault1, s_toString;
 
         public override int ConsumedStack { get { return 1; } }
         public override int ProducedStack { get { return 1; } }
@@ -1940,7 +1940,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private class GetValueOrDefault : NullableMethodCallInstruction
         {
-            private Type defaultValueType;
+            private readonly Type defaultValueType;
 
             public GetValueOrDefault(MethodInfo mi)
             {
@@ -1951,8 +1951,8 @@ namespace System.Linq.Expressions.Interpreter
             {
                 if (frame.Peek() == null)
                 {
-                        frame.Pop();
-                        frame.Push(Activator.CreateInstance(defaultValueType));
+                    frame.Pop();
+                    frame.Push(Activator.CreateInstance(defaultValueType));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -1899,7 +1899,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class NullableMethodCallInstruction : Instruction
     {
-        private static NullableMethodCallInstruction s_hasValue,s_value,s_equals,s_getHashCode,s_getValueOrDefault,s_getValueOrDefault1,s_toString;
+        private static NullableMethodCallInstruction s_hasValue,s_value,s_equals,s_getHashCode,s_getValueOrDefault1,s_toString;
 
         public override int ConsumedStack { get { return 1; } }
         public override int ProducedStack { get { return 1; } }
@@ -1940,9 +1940,20 @@ namespace System.Linq.Expressions.Interpreter
 
         private class GetValueOrDefault : NullableMethodCallInstruction
         {
+            private Type defaultValueType;
+
+            public GetValueOrDefault(MethodInfo mi)
+            {
+                defaultValueType = mi.ReturnType;
+            }
+
             public override int Run(InterpretedFrame frame)
             {
-                // we're already unboxed in the interpreter, so this is a nop.
+                if (frame.Peek() == null)
+                {
+                        frame.Pop();
+                        frame.Push(Activator.CreateInstance(defaultValueType));
+                }
                 return +1;
             }
         }
@@ -2025,8 +2036,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-
-        public static Instruction Create(string method, int argCount)
+        public static Instruction Create(string method, int argCount, MethodInfo mi)
         {
             switch (method)
             {
@@ -2037,7 +2047,7 @@ namespace System.Linq.Expressions.Interpreter
                 case "GetValueOrDefault":
                     if (argCount == 0)
                     {
-                        return s_getValueOrDefault ?? (s_getValueOrDefault = new GetValueOrDefault());
+                        return new GetValueOrDefault(mi);
                     }
                     else
                     {
@@ -2048,6 +2058,11 @@ namespace System.Linq.Expressions.Interpreter
                     // System.Nullable doesn't have other instance methods 
                     throw Assert.Unreachable;
             }
+        }
+
+        public static Instruction CreateGetValue()
+        {
+            return s_value ?? (s_value = new GetValue());
         }
     }
 

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -4266,6 +4266,31 @@ namespace Tests
             Assert.Equal(2, d(2));
         }
 
+        [Fact]
+        public static void TestNullableMethods()
+        {
+            TestNullableCall(new ArraySegment<int>(), (v) => v.HasValue, (v) => v.HasValue);
+            TestNullableCall(5.1, (v) => v.GetHashCode(), (v) => v.GetHashCode());
+            TestNullableCall(5L, (v) => v.ToString(), (v) => v.ToString());
+            TestNullableCall(5, (v) => v.GetValueOrDefault(7), (v) => v.GetValueOrDefault(7));
+            TestNullableCall(42, (v) => v.Equals(42), (v) => v.Equals(42));
+            TestNullableCall(42, (v) => v.Equals(0), (v) => v.Equals(0));
+            TestNullableCall(5, (v) => v.GetValueOrDefault(), (v) => v.GetValueOrDefault());
+
+            Expression<Func<int?, int>> f = x => x.Value;
+            Func<int?, int> d = f.Compile();
+            Assert.Equal(2, d(2));
+            Assert.Throws(typeof(InvalidOperationException), () => d(null));
+        }
+
+        private static void TestNullableCall<T, U>(T arg, Func<T?, U> f, Expression<Func<T?, U>> e)
+            where T : struct
+        {
+            Func<T?, U> d = e.Compile();
+            Assert.Equal(f(arg), d(arg));
+            Assert.Equal(f(null), d(null));
+        }
+
         public static int BadJuju(int v)
         {
             throw new Exception("Bad Juju");

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -2980,7 +2980,7 @@ namespace Tests
         }
 
         [Fact]
-        public static void InvokeLambda()      
+        public static void InvokeLambda()
         {
             Expression<Func<int, int>> f = x => x + 1;
             InvocationExpression ie = Expression.Invoke(f, Expression.Constant(5));
@@ -3002,7 +3002,7 @@ namespace Tests
         [Fact]
         public static void CallCompiledLambdaWithTypeMissing()
         {
-            Expression<Func<object, bool>> f = x => x == Type.Missing;  
+            Expression<Func<object, bool>> f = x => x == Type.Missing;
             var compiled = f.Compile();
             Expression<Func<object, bool>> lambda = x => compiled(x);
             Func<object, bool> d = lambda.Compile();
@@ -3427,7 +3427,8 @@ namespace Tests
 
 
         [Fact]
-        public void NewStructWithMemberListIntializer() {
+        public void NewStructWithMemberListIntializer()
+        {
             Expression<Func<int, StructX>> f =
                 v => new StructX { A = v, B = v + 1, Ys = { new ClassY { B = v + 2 } } };
             var d = f.Compile();
@@ -3439,7 +3440,8 @@ namespace Tests
         }
 
         [Fact]
-        public void NewStructWithStructMemberMemberIntializer() {
+        public void NewStructWithStructMemberMemberIntializer()
+        {
             Expression<Func<int, StructX>> f =
                 v => new StructX { A = v, B = v + 1, SY = new StructY { B = v + 2 } };
             var d = f.Compile();
@@ -3847,7 +3849,7 @@ namespace Tests
             Assert.Equal("default", f(null));
         }
 
-        [Fact]  
+        [Fact]
         public static void ObjectSwitch1()
         {
             var p = Expression.Parameter(typeof(object));
@@ -4280,7 +4282,7 @@ namespace Tests
             Expression<Func<int?, int>> f = x => x.Value;
             Func<int?, int> d = f.Compile();
             Assert.Equal(2, d(2));
-            Assert.Throws(typeof(InvalidOperationException), () => d(null));
+            Assert.Throws<InvalidOperationException>(() => d(null));
         }
 
         private static void TestNullableCall<T, U>(T arg, Func<T?, U> f, Expression<Func<T?, U>> e)


### PR DESCRIPTION
such as HasValue / Value

Also fixed a problem with invoking of GetValueOrDefault on null receiver discovered while testing.
We should return a default  value in such case, not the boxed receiver which is null and would cause NRE.