### PR TITLE
More robust RsaCng.Encrypt/Decrypt/SignHash.

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -77,7 +77,7 @@ namespace Internal.Cryptography
                 byte[] propertyValue = new byte[numBytesNeeded];
                 fixed (byte* pPropertyValue = propertyValue)
                 {
-                    errorCode = Interop.NCrypt.NCryptGetProperty(ncryptHandle, propertyName, pPropertyValue, numBytesNeeded, out numBytesNeeded, options);
+                    errorCode = Interop.NCrypt.NCryptGetProperty(ncryptHandle, propertyName, pPropertyValue, propertyValue.Length, out numBytesNeeded, options);
                 }
                 if (errorCode == ErrorCode.NTE_NOT_FOUND)
                     return null;
@@ -130,9 +130,9 @@ namespace Internal.Cryptography
         {
             unsafe
             {
-                int numBytesRequired;
+                int numBytesNeeded;
                 IntPtr value;
-                ErrorCode errorCode = Interop.NCrypt.NCryptGetProperty(ncryptHandle, propertyName, &value, IntPtr.Size, out numBytesRequired, options);
+                ErrorCode errorCode = Interop.NCrypt.NCryptGetProperty(ncryptHandle, propertyName, &value, IntPtr.Size, out numBytesNeeded, options);
                 if (errorCode == ErrorCode.NTE_NOT_FOUND)
                     return IntPtr.Zero;
                 if (errorCode != ErrorCode.ERROR_SUCCESS)

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -84,6 +84,7 @@ namespace Internal.Cryptography
                 if (errorCode != ErrorCode.ERROR_SUCCESS)
                     throw errorCode.ToCryptographicException();
 
+                Array.Resize(ref propertyValue, numBytesNeeded);
                 return propertyValue;
             }
         } 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Export.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Export.cs
@@ -26,17 +26,17 @@ namespace System.Security.Cryptography
             if (format == null)
                 throw new ArgumentNullException("format");
 
-            int numBytesRequired;
-            ErrorCode errorCode = Interop.NCrypt.NCryptExportKey(_keyHandle, IntPtr.Zero, format.Format, IntPtr.Zero, null, 0, out numBytesRequired, 0);
+            int numBytesNeeded;
+            ErrorCode errorCode = Interop.NCrypt.NCryptExportKey(_keyHandle, IntPtr.Zero, format.Format, IntPtr.Zero, null, 0, out numBytesNeeded, 0);
             if (errorCode != ErrorCode.ERROR_SUCCESS)
                 throw errorCode.ToCryptographicException();
 
-            byte[] buffer = new byte[numBytesRequired];
-            errorCode = Interop.NCrypt.NCryptExportKey(_keyHandle, IntPtr.Zero, format.Format, IntPtr.Zero, buffer, buffer.Length, out numBytesRequired, 0);
+            byte[] buffer = new byte[numBytesNeeded];
+            errorCode = Interop.NCrypt.NCryptExportKey(_keyHandle, IntPtr.Zero, format.Format, IntPtr.Zero, buffer, buffer.Length, out numBytesNeeded, 0);
             if (errorCode != ErrorCode.ERROR_SUCCESS)
                 throw errorCode.ToCryptographicException();
 
-            Array.Resize(ref buffer, numBytesRequired);
+            Array.Resize(ref buffer, numBytesNeeded);
             return buffer;
         }
     }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Export.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Export.cs
@@ -32,10 +32,11 @@ namespace System.Security.Cryptography
                 throw errorCode.ToCryptographicException();
 
             byte[] buffer = new byte[numBytesRequired];
-            errorCode = Interop.NCrypt.NCryptExportKey(_keyHandle, IntPtr.Zero, format.Format, IntPtr.Zero, buffer, numBytesRequired, out numBytesRequired, 0);
+            errorCode = Interop.NCrypt.NCryptExportKey(_keyHandle, IntPtr.Zero, format.Format, IntPtr.Zero, buffer, buffer.Length, out numBytesRequired, 0);
             if (errorCode != ErrorCode.ERROR_SUCCESS)
                 throw errorCode.ToCryptographicException();
 
+            Array.Resize(ref buffer, numBytesRequired);
             return buffer;
         }
     }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -243,12 +243,12 @@ namespace System.Security.Cryptography
                 string creationTitle;
                 unsafe
                 {
-                    int numBytesRequired;
-                    ErrorCode errorCode = Interop.NCrypt.NCryptGetProperty(_keyHandle, KeyPropertyName.UIPolicy, null, 0, out numBytesRequired, CngPropertyOptions.None);
+                    int numBytesNeeded;
+                    ErrorCode errorCode = Interop.NCrypt.NCryptGetProperty(_keyHandle, KeyPropertyName.UIPolicy, null, 0, out numBytesNeeded, CngPropertyOptions.None);
                     if (errorCode != ErrorCode.ERROR_SUCCESS && errorCode != ErrorCode.NTE_NOT_FOUND)
                         throw errorCode.ToCryptographicException();
 
-                    if (errorCode != ErrorCode.ERROR_SUCCESS || numBytesRequired == 0)
+                    if (errorCode != ErrorCode.ERROR_SUCCESS || numBytesNeeded == 0)
                     {
                         // No UI policy set. Our defined behavior is to return a non-null CngUIPolicy always, so set the UI policy components to the default values.
                         uiProtectionLevel = CngUIProtectionLevels.None;
@@ -261,14 +261,15 @@ namespace System.Security.Cryptography
                         // The returned property must be at least the size of NCRYPT_UI_POLICY (plus the extra size of the UI policy strings if any.)
                         // If by any chance, a rogue provider passed us something smaller, fail-fast now rather risk dereferencing "pointers" that were actually
                         // constructed from memory garbage.
-                        if (numBytesRequired < sizeof(NCRYPT_UI_POLICY))
+                        if (numBytesNeeded < sizeof(NCRYPT_UI_POLICY))
                             throw ErrorCode.E_FAIL.ToCryptographicException();
 
                         // ! We must keep this byte array pinned until NCryptGetProperty() has returned *and* we've marshaled all of the inner native strings into managed String
                         // ! objects. Otherwise, a badly timed GC will move the native strings in memory and invalidate the pointers to them before we dereference them. 
-                        fixed (byte* pNcryptUiPolicyAndStrings = new byte[numBytesRequired])
+                        byte[] ncryptUiPolicyAndStrings = new byte[numBytesNeeded];
+                        fixed (byte* pNcryptUiPolicyAndStrings = ncryptUiPolicyAndStrings)
                         {
-                            errorCode = Interop.NCrypt.NCryptGetProperty(_keyHandle, KeyPropertyName.UIPolicy, pNcryptUiPolicyAndStrings, numBytesRequired, out numBytesRequired, CngPropertyOptions.None);
+                            errorCode = Interop.NCrypt.NCryptGetProperty(_keyHandle, KeyPropertyName.UIPolicy, pNcryptUiPolicyAndStrings, ncryptUiPolicyAndStrings.Length, out numBytesNeeded, CngPropertyOptions.None);
                             if (errorCode != ErrorCode.ERROR_SUCCESS)
                                 throw errorCode.ToCryptographicException();
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -31,16 +31,24 @@ namespace System.Security.Cryptography
                 SignOrVerify(padding, hashAlgorithm, hash,
                     delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
                     {
+                        int estimatedSize = KeySize / 8;
+#if DEBUG
+                        estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL scenario gets exercised.
+#endif
                         SafeNCryptKeyHandle keyHandle = Key.Handle;
+
+                        signature = new byte[estimatedSize];
                         int numBytesNeeded;
-                        ErrorCode errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, null, 0, out numBytesNeeded, paddingMode);
+                        ErrorCode errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out numBytesNeeded, paddingMode);
+                        if (errorCode == ErrorCode.NTE_BUFFER_TOO_SMALL)
+                        {
+                            signature = new byte[numBytesNeeded];
+                            errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out numBytesNeeded, paddingMode);
+                        }
                         if (errorCode != ErrorCode.ERROR_SUCCESS)
                             throw errorCode.ToCryptographicException();
 
-                        signature = new byte[numBytesNeeded];
-                        errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out numBytesNeeded, paddingMode);
-                        if (errorCode != ErrorCode.ERROR_SUCCESS)
-                            throw errorCode.ToCryptographicException();
+                        Array.Resize(ref signature, numBytesNeeded);
                     }
                 );
                 return signature;


### PR DESCRIPTION
This addresses two pieces of feedback from WinCrypto:

- NCryptDecrypt() can potentially ask for more buffer space than
  he ends up needing (saves him from having to do a extra decrypt
  just to calculate the size.) We need to guard against that
  and shrink the array to fit, in case the api overbudgeted.

  I've added the resize to other places where we do this
  "okay, here's 0 bytes of space. What, you want more? Okay,
  here it is" API pattern. It's cheap insurance.

- Try to avoid the double-call in some cases by estimating
  a buffer size upfront (Encrypt/Decrypt/SignHash).