### PR TITLE
Enabling cookie container in HTTP xplat

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -38,6 +38,7 @@ internal static partial class Interop
             internal const int CURLOPT_PROXY = CurlOptionObjectPointBase + 4;
             internal const int CURLOPT_PROXYUSERPWD = CurlOptionObjectPointBase + 6;
             internal const int CURLOPT_READDATA = CurlOptionObjectPointBase + 9;
+            internal const int CURLOPT_COOKIE = CurlOptionObjectPointBase + 22;
             internal const int CURLOPT_HTTPHEADER = CurlOptionObjectPointBase + 23;
             internal const int CURLOPT_HEADERDATA = CurlOptionObjectPointBase + 29;
             internal const int CURLOPT_ACCEPTENCODING = CurlOptionObjectPointBase + 102;

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -23,16 +23,7 @@ using CURLProxyType = Interop.libcurl.curl_proxytype;
 using size_t = System.IntPtr;
 
 namespace System.Net.Http
-{
-    #region Enums
-    internal enum CookieUsePolicy
-    {
-        IgnoreCookies = 0,
-        UseSpecifiedCookieContainer = 1
-    }   
-
-    #endregion
-
+{  
     internal partial class CurlHandler : HttpMessageHandler
     {
         #region Constants
@@ -60,7 +51,7 @@ namespace System.Net.Http
         private SafeCurlMultiHandle _multiHandle;
         private GCHandle _multiHandlePtr = new GCHandle();
         private CookieContainer _cookieContainer = null;
-        private CookieUsePolicy _cookieUsePolicy = CookieUsePolicy.IgnoreCookies;
+        private bool _useCookie = false;
 
         #endregion        
 
@@ -189,23 +180,17 @@ namespace System.Net.Http
             }
         }
 
-        internal CookieUsePolicy CookieUsePolicy
+        internal bool UseCookie
         {
             get
             {
-                return _cookieUsePolicy;
+                return _useCookie;
             }
 
             set
-            {
-                if (value != CookieUsePolicy.IgnoreCookies
-                    && value != CookieUsePolicy.UseSpecifiedCookieContainer)
-                {
-                    throw new ArgumentOutOfRangeException("value");
-                }
-
+            {               
                 CheckDisposedOrStarted();
-                _cookieUsePolicy = value;
+                _useCookie = value;
             }
         }
 
@@ -490,7 +475,7 @@ namespace System.Net.Http
 
         private void SetCookieOption(SafeCurlHandle requestHandle, Uri requestUri)
         {
-            if (_cookieUsePolicy != CookieUsePolicy.UseSpecifiedCookieContainer)
+            if (!_useCookie)
             {
                 return;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/HttpClientHandler.Unix.cs
@@ -27,14 +27,21 @@ namespace System.Net.Http
 
         public bool UseCookies
         {
-            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
-            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            get { return (_curlHandler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer); }
+            set { _curlHandler.CookieUsePolicy = value ? CookieUsePolicy.UseSpecifiedCookieContainer : CookieUsePolicy.IgnoreCookies; }
         }
 
         public CookieContainer CookieContainer
         {
-            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
-            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            get
+            {
+                return _curlHandler.CookieContainer;
+            }
+
+            set
+            {
+                _curlHandler.CookieContainer = value;
+            }
         }
 
         public ClientCertificateOption ClientCertificateOptions

--- a/src/System.Net.Http/src/System/Net/Http/Unix/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/HttpClientHandler.Unix.cs
@@ -27,8 +27,15 @@ namespace System.Net.Http
 
         public bool UseCookies
         {
-            get { return (_curlHandler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer); }
-            set { _curlHandler.CookieUsePolicy = value ? CookieUsePolicy.UseSpecifiedCookieContainer : CookieUsePolicy.IgnoreCookies; }
+            get
+            {
+                return _curlHandler.UseCookie;
+            }
+
+            set
+            {
+                _curlHandler.UseCookie = value;
+            }          
         }
 
         public CookieContainer CookieContainer


### PR DESCRIPTION
	modified:   ../../Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
	modified:   System/Net/Http/Unix/CurlHandler.cs
	modified:   System/Net/Http/Unix/HttpClientHandler.Unix.cs

Enabled cookie container & manual cookie support in HTTP.