### PR TITLE
The result of the arithmetic + operation in Write method could end up…

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -100,7 +100,7 @@ namespace System.Net.Http
                 throw new ArgumentOutOfRangeException("count");
             }
 
-            if (offset + count > buffer.Length)
+            if (count > buffer.Length - offset)
             {
                 throw new ArgumentException("buffer");
             }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -102,7 +102,7 @@ namespace System.Net.Http
                 throw new ArgumentOutOfRangeException("count");
             }
 
-            if ((long)offset + (long)count > (long)buffer.Length)
+            if (count > buffer.Length - offset)
             {
                 throw new ArgumentException("buffer");
             }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -196,6 +196,14 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
+        public void Write_OffsetPlusCountMaxValueExceedsBufferLength_ThrowsArgumentException()
+        {
+            Stream stream = MakeRequestStream();
+
+            Assert.Throws<ArgumentException>(() => { stream.Write(new byte[1], int.MaxValue, int.MaxValue); });
+        }
+
+        [Fact]
         public void Write_WhenDisposed_ThrowsObjectDisposedException()
         {
             Stream stream = MakeRequestStream();


### PR DESCRIPTION
… being less than zero if the sum of the operands combined is greater than int.MaxValue.
As a consequence of this integer overflow the intended check might be bypassed
leading to unexpected consequences. This change adds and aditional cast to long to avoid this overflow.