### PR TITLE
Enabling MaxRedirection support in HTTP xplat

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -31,6 +31,7 @@ internal static partial class Interop
             internal const int CURLOPT_UPLOAD = CurlOptionLongBase + 46;
             internal const int CURLOPT_FOLLOWLOCATION = CurlOptionLongBase + 52;
             internal const int CURLOPT_PROXYPORT = CurlOptionLongBase + 59;
+            internal const int CURLOPT_MAXREDIRS = CurlOptionLongBase + 68;
             internal const int CURLOPT_PROXYTYPE = CurlOptionLongBase + 101;
 
             internal const int CURLOPT_WRITEDATA = CurlOptionObjectPointBase + 1;

--- a/src/System.Net.Http/src/System/Net/Http/Unix/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/HttpClientHandler.Unix.cs
@@ -99,8 +99,14 @@ namespace System.Net.Http
 
         public int MaxAutomaticRedirections
         {
-            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
-            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            get
+            {
+                return _curlHandler.MaxAutomaticRedirections;
+            }
+            set
+            {
+                _curlHandler.MaxAutomaticRedirections = value;
+            }
         }
 
         public long MaxRequestContentBufferSize


### PR DESCRIPTION
modified:   ../../Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
modified:   System/Net/Http/Unix/CurlHandler.cs
modified:   System/Net/Http/Unix/HttpClientHandler.Unix.cs

Enabled max redirection support in HTTP xplat.