### PR TITLE
Avoid intermediate collection/enumerator allocations in X509 IStorePal

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IStorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IStorePal.cs
@@ -9,9 +9,9 @@ namespace Internal.Cryptography.Pal
 {
     internal interface IStorePal : IDisposable
     {
-        IEnumerable<X509Certificate2> Find(X509FindType findType, Object findValue, bool validOnly);
+        void FindAndCopyTo(X509FindType findType, object findValue, bool validOnly, X509Certificate2Collection collection);
         byte[] Export(X509ContentType contentType, String password);
-        IEnumerable<X509Certificate2> Certificates { get; }
+        void CopyTo(X509Certificate2Collection collection);
         void Add(ICertificatePal cert);
         void Remove(ICertificatePal cert);
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509StoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509StoreProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Internal.Cryptography.Pal
@@ -20,9 +21,8 @@ namespace Internal.Cryptography.Pal
         {
         }
 
-        public IEnumerable<X509Certificate2> Find(X509FindType findType, object findValue, bool validOnly)
+        public void FindAndCopyTo(X509FindType findType, object findValue, bool validOnly, X509Certificate2Collection collection)
         {
-            return Array.Empty<X509Certificate2>();
         }
 
         public byte[] Export(X509ContentType contentType, string password)
@@ -30,15 +30,11 @@ namespace Internal.Cryptography.Pal
             throw new NotImplementedException();
         }
 
-        public IEnumerable<X509Certificate2> Certificates
+        public void CopyTo(X509Certificate2Collection collection)
         {
-            get
-            {
-                foreach (X509Certificate2 cert in _certs)
-                {
-                    yield return cert;
-                }
-            }
+            Debug.Assert(collection != null);
+
+            collection.AddRange(_certs);
         }
 
         public void Add(ICertificatePal cert)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Find.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Find.cs
@@ -23,10 +23,12 @@ namespace Internal.Cryptography.Pal
 {
     internal sealed partial class StorePal : IDisposable, IStorePal
     {
-        public IEnumerable<X509Certificate2> Find(X509FindType findType, Object findValue, bool validOnly)
+        public void FindAndCopyTo(X509FindType findType, object findValue, bool validOnly, X509Certificate2Collection collection)
         {
+            Debug.Assert(collection != null);
+
             StorePal findResults = CreatedLinkedStoreWithFindResults(findType, findValue, validOnly);
-            return findResults.Certificates;
+            findResults.CopyTo(collection);
         }
 
         private StorePal CreatedLinkedStoreWithFindResults(X509FindType findType, Object findValue, bool validOnly)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.cs
@@ -21,19 +21,15 @@ namespace Internal.Cryptography.Pal
 {
     internal sealed partial class StorePal : IDisposable, IStorePal
     {
-        public IEnumerable<X509Certificate2> Certificates
+        public void CopyTo(X509Certificate2Collection collection)
         {
-            get
-            {
-                LowLevelListWithIList<X509Certificate2> certificates = new LowLevelListWithIList<X509Certificate2>();
+            Debug.Assert(collection != null);
 
-                SafeCertContextHandle pCertContext = null;
-                while (Interop.crypt32.CertEnumCertificatesInStore(_certStore, ref pCertContext))
-                {
-                    X509Certificate2 cert = new X509Certificate2(pCertContext.DangerousGetHandle());
-                    certificates.Add(cert);
-                }
-                return certificates;
+            SafeCertContextHandle pCertContext = null;
+            while (Interop.crypt32.CertEnumCertificatesInStore(_certStore, ref pCertContext))
+            {
+                X509Certificate2 cert = new X509Certificate2(pCertContext.DangerousGetHandle());
+                collection.Add(cert);
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -132,10 +132,7 @@ namespace System.Security.Cryptography.X509Certificates
             X509Certificate2Collection collection = new X509Certificate2Collection();
             using (IStorePal storePal = StorePal.LinkFromCertificateCollection(this))
             {
-                foreach (X509Certificate2 certificate in storePal.Find(findType, findValue, validOnly))
-                {
-                    collection.Add(certificate);
-                }
+                storePal.FindAndCopyTo(findType, findValue, validOnly, collection);
             }
             return collection;
         }
@@ -158,12 +155,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             using (IStorePal storePal = StorePal.FromBlob(rawData, password, keyStorageFlags))
             {
-                foreach (X509Certificate2 cert in storePal.Certificates)
-                {
-                    Add(cert);
-                }
+                storePal.CopyTo(this);
             }
-            return;
         }
 
         public void Import(String fileName)
@@ -178,12 +171,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             using (IStorePal storePal = StorePal.FromFile(fileName, password, keyStorageFlags))
             {
-                foreach (X509Certificate2 cert in storePal.Certificates)
-                {
-                    Add(cert);
-                }
+                storePal.CopyTo(this);
             }
-            return;
         }
 
         public void Insert(int index, X509Certificate2 certificate)

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public X509CertificateCollection()
         {
-            _list = new LowLevelListWithIList<Object>();
+            _list = new List<Object>();
         }
 
         public X509CertificateCollection(X509Certificate[] value)
@@ -195,7 +195,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         void ICollection.CopyTo(Array array, int index)
         {
-            List.CopyTo(array, index);
+            ((ICollection)_list).CopyTo(array, index);
         }
 
         int IList.Add(Object value)
@@ -233,7 +233,7 @@ namespace System.Security.Cryptography.X509Certificates
             get { return this; }
         }
 
-        private LowLevelListWithIList<Object> _list;
+        private List<Object> _list;
         private Object _syncRoot;
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -88,10 +88,7 @@ namespace System.Security.Cryptography.X509Certificates
                 X509Certificate2Collection certificates = new X509Certificate2Collection();
                 if (_storePal != null)
                 {
-                    foreach (X509Certificate2 certificate in _storePal.Certificates)
-                    {
-                        certificates.Add(certificate);
-                    }
+                    _storePal.CopyTo(certificates);
                 }
                 return certificates;
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization.Calendars": "4.0.0",

--- a/src/System.Security.Cryptography.X509Certificates/src/project.lock.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/project.lock.json
@@ -971,6 +971,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "System.Collections >= 4.0.10",
       "System.Diagnostics.Contracts >= 4.0.0",
       "System.Diagnostics.Debug >= 4.0.10",
       "System.Globalization.Calendars >= 4.0.0",

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -510,6 +510,56 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(originalPrivateKeyCount, importedPrivateKeyCount);
         }
 
+        [Fact]
+        public static void X509CertificateCollectionCopyTo()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+
+                X509Certificate[] array1 = new X509Certificate[cc.Count];
+                cc.CopyTo(array1, 0);
+
+                Assert.Same(c1, array1[0]);
+                Assert.Same(c2, array1[1]);
+                Assert.Same(c3, array1[2]);
+
+                X509Certificate[] array2 = new X509Certificate[cc.Count];
+                ((ICollection)cc).CopyTo(array2, 0);
+
+                Assert.Same(c1, array2[0]);
+                Assert.Same(c2, array2[1]);
+                Assert.Same(c3, array2[2]);
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionCopyTo()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
+
+                X509Certificate2[] array1 = new X509Certificate2[cc.Count];
+                cc.CopyTo(array1, 0);
+
+                Assert.Same(c1, array1[0]);
+                Assert.Same(c2, array1[1]);
+                Assert.Same(c3, array1[2]);
+
+                X509Certificate2[] array2 = new X509Certificate2[cc.Count];
+                ((ICollection)cc).CopyTo(array2, 0);
+
+                Assert.Same(c1, array2[0]);
+                Assert.Same(c2, array2[1]);
+                Assert.Same(c3, array2[2]);
+            }
+        }
+
         private static void TestExportSingleCert(X509ContentType ct)
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))


### PR DESCRIPTION
All callers of `IStorePal.Certificates` and `IStorePal.Find` enumerate the resulting `IEnumerable<X509Certificate2>` and add each item to a `X509Certificate2Collection`. This PR changes `IStorePal` to instead accept a `X509Certificate2Collection` to add items to, avoiding any intermediate collection and enumerator allocations.