### PR TITLE
Fixed test that was leaving temp directories in root folder

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -238,7 +238,6 @@ namespace System.IO.FileSystem.Tests
             Assert.All(paths, (path) =>
             {
                 Assert.Throws<PathTooLongException>(() => Create(path));
-                Directory.Delete(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), path.Split(Path.DirectorySeparatorChar)[1]), true);
             });
         }
 

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -95,7 +95,7 @@ internal class IOServices
 
     public static PathInfo GetPath(int characterCount, bool extended = false)
     {
-        string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+        string root = Path.GetTempPath();
         if (extended)
             root = IOInputs.ExtendedPrefix + root;
         return GetPath(root, characterCount);


### PR DESCRIPTION
One of the Extended Path FileSystem tests was leaving temporary test directories in the root folder of the running directory. This small change modified the tests to instead treat the user's temp directory as the root.