### PR TITLE
Allow a SwitchExpression that has no SwitchCase

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -781,12 +781,14 @@ namespace System.Linq.Expressions
 
             switch (expressions.Length)
             {
+                case 0:
+                    expressions = new []{ Empty() };
+                    goto default;
                 case 2: return Block(expressions[0], expressions[1]);
                 case 3: return Block(expressions[0], expressions[1], expressions[2]);
                 case 4: return Block(expressions[0], expressions[1], expressions[2], expressions[3]);
                 case 5: return Block(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
                 default:
-                    ContractUtils.RequiresNotEmpty(expressions, "expressions");
                     RequiresCanRead(expressions, "expressions");
                     return new BlockN(expressions.Copy());
             }
@@ -857,8 +859,12 @@ namespace System.Linq.Expressions
         public static BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions)
         {
             ContractUtils.RequiresNotNull(expressions, "expressions");
+            var variableList = variables.ToReadOnly();
             var expressionList = expressions.ToReadOnly();
-            ContractUtils.RequiresNotEmpty(expressionList, "expressions");
+            if (variableList.Count != 0)
+                ContractUtils.RequiresNotEmpty(expressionList, "expressions");
+            else if (expressionList.Count == 0)
+                expressionList = new ReadOnlyCollection<Expression>(new []{ Empty() });
             RequiresCanRead(expressionList, "expressions");
 
             return Block(expressionList.Last().Type, variables, expressionList);
@@ -879,7 +885,10 @@ namespace System.Linq.Expressions
             var expressionList = expressions.ToReadOnly();
             var variableList = variables.ToReadOnly();
 
-            ContractUtils.RequiresNotEmpty(expressionList, "expressions");
+            if (variableList.Count != 0)
+                ContractUtils.RequiresNotEmpty(expressionList, "expressions");
+            else if (expressionList.Count == 0)
+                expressionList = new ReadOnlyCollection<Expression>(new []{ Empty() });
             RequiresCanRead(expressionList, "expressions");
             ValidateVariables(variableList, "variables");
 

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -3871,6 +3871,57 @@ namespace Tests
             Assert.Equal("default", f("HI"));
             Assert.Equal("null", f(null));
         }
+        
+        [Fact]
+        public static void DefaultOnlySwitch()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var s = Expression.Switch(p, Expression.Constant(42));
+            
+            var fInt32Int32 = Expression.Lambda<Func<int, int>>(s, p).Compile();
+            
+            Assert.Equal(42, fInt32Int32(0));
+            Assert.Equal(42, fInt32Int32(1));
+            Assert.Equal(42, fInt32Int32(-1));
+            
+            s = Expression.Switch(typeof(object), p, Expression.Constant("A test string"), null);
+            
+            var fInt32Object = Expression.Lambda<Func<int, object>>(s, p).Compile();
+
+            Assert.Equal("A test string", fInt32Object(0));
+            Assert.Equal("A test string", fInt32Object(1));
+            Assert.Equal("A test string", fInt32Object(-1));
+            
+            p = Expression.Parameter(typeof(string));
+            s = Expression.Switch(p, Expression.Constant("foo"));
+            
+            var fStringString = Expression.Lambda<Func<string, string>>(s, p).Compile();
+            
+            Assert.Equal("foo", fStringString("bar"));
+            Assert.Equal("foo", fStringString(null));
+            Assert.Equal("foo", fStringString("foo"));
+        }
+        
+        [Fact]
+        public static void NoDefaultOrCasesSwitch()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var s = Expression.Switch(p, (Expression)null);
+            
+            var f = Expression.Lambda<Action<int>>(s, p).Compile();
+            
+            f(0);
+            
+            Assert.Equal(s.Type, typeof(void));
+        }
+
+        [Fact]
+        public static void TypedNoDefaultOrCasesSwitch()
+        {
+            var p = Expression.Parameter(typeof(int));
+            // A SwitchExpression with neither a defaultBody nor any cases can not be any type except void.
+            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), p, (Expression)null, null));
+        }
 
         static class System_Linq_Expressions_Expression_TDelegate__1
         {


### PR DESCRIPTION
Fixes #1877

Currently, we do not allow for a switch expression with no SwitchCases. This
though can be useful if the SwitchCases are determined dynamically, in not
having to special-case the case where there are zero such SwitchCases.

However, merely changing this method to allow the zero-cases condition may have
compatibility issues with code acting on the expression tree assuming that this
condition cannot occur. Therefore we produce a switch with a case for the
default value of the expression matching that of the the default case.

By analogy to C#, we turn the equivalent to the (valid) C#:

    switch(expr)
    {
        default:
            doSomething();
            break;
    }

into:

    switch(expr)
    {
        case 0:
            doSomething();
            break;
        default:
            doSomething();
            break;
    }

but where the `0` is typed according to the type of `expr` as `default(T)` for whatever that type is.

If there is no `defaultBody` either we create a noop body. This will mean the
type of the expression is `void`.

If there is no `defaultBody` and the type is explicitly set to something other
than void, an `ArgumentException` is thrown.