### PR TITLE
Enable CurrentUser X509Stores on Unix.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
@@ -8,6 +8,12 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
+        // Even though csc will by default use a sequential layout, a CS0649 warning as error
+        // is produced for un-assigned fields when no StructLayout is specified.
+        //
+        // Explicitly saying Sequential disables that warning/error for consumers which only
+        // use Stat in debug builds.
+        [StructLayout(LayoutKind.Sequential)]
         internal struct FileStatus
         {
             internal FileStatusFlags Flags;

--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.IO
+{
+    internal static class PersistedFiles
+    {
+        // If we ever need system persisted data, /etc/dotnet/corefx/
+        private const string TopLevelDirectory = "dotnet";
+        // User persisted data, ~/.dotnet/corefx/
+        private const string TopLevelUserDirectory = "." + TopLevelDirectory;
+        private const string SecondLevelDirectory = "corefx";
+
+        private static string s_userProductDirectory;
+
+        /// <summary>
+        /// Get the location of where to persist information for a particular aspect of the framework,
+        /// such as "cryptography".
+        /// </summary>
+        /// <param name="featureName">The directory name for the feature</param>
+        /// <returns>A path within the user's home directory for persisting data for the feature</returns>
+        internal static string GetUserFeatureDirectory(string featureName)
+        {
+            if (s_userProductDirectory == null)
+            {
+                EnsureUserDirectories();
+            }
+
+            return Path.Combine(s_userProductDirectory, featureName);
+        }
+
+        /// <summary>
+        /// Get the location of where to persist information for a particular aspect of a feature of
+        /// the framework, such as "x509stores" within "cryptography".
+        /// </summary>
+        /// <param name="featureName">The directory name for the feature</param>
+        /// <param name="subFeatureName">The directory name for the sub-feature</param>
+        /// <returns>A path within the user's home directory for persisting data for the sub-feature</returns>
+        internal static string GetUserFeatureDirectory(string featureName, string subFeatureName)
+        {
+            if (s_userProductDirectory == null)
+            {
+                EnsureUserDirectories();
+            }
+
+            return Path.Combine(s_userProductDirectory, featureName, subFeatureName);
+        }
+
+        /// <summary>
+        /// Get the location of where to persist information for a particular aspect of the framework,
+        /// with a lot of hierarchy, such as ["cryptography", "x509stores", "my"]
+        /// </summary>
+        /// <param name="featurePathParts">A non-empty set of directories to use for the storage hierarchy</param>
+        /// <returns>A path within the user's home directory for persisting data for the feature</returns>
+        internal static string GetUserFeatureDirectory(params string[] featurePathParts)
+        {
+            Debug.Assert(featurePathParts != null);
+            Debug.Assert(featurePathParts.Length > 0);
+
+            if (s_userProductDirectory == null)
+            {
+                EnsureUserDirectories();
+            }
+
+            return Path.Combine(s_userProductDirectory, Path.Combine(featurePathParts));
+        }
+
+        private static void EnsureUserDirectories()
+        {
+            // TODO (2820): Use getpwuid_r(geteuid(), ...) instead of the HOME environment variable
+            string userHomeDirectory = Environment.GetEnvironmentVariable("HOME");
+
+            if (string.IsNullOrEmpty(userHomeDirectory))
+            {
+                throw new InvalidOperationException(SR.PersistedFiles_NoHomeDirectory);
+            }
+
+            s_userProductDirectory = Path.Combine(
+                userHomeDirectory,
+                TopLevelUserDirectory,
+                SecondLevelDirectory);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -1,0 +1,447 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Internal.Cryptography.Pal
+{
+    /// <summary>
+    /// Provides an implementation of an X509Store which is backed by files in a directory.
+    /// </summary>
+    internal class DirectoryBasedStoreProvider : IStorePal
+    {
+        // {thumbprint}.1.pfx to {thumbprint}.9.pfx
+        private const int MaxSaveAttempts = 9; 
+        private const string PfxExtension = ".pfx";
+        // *.pfx ({thumbprint}.pfx or {thumbprint}.{ordinal}.pfx)
+        private const string PfxWildcard = "*" + PfxExtension;
+        // .*.pfx ({thumbprint}.{ordinal}.pfx)
+        private const string PfxOrdinalWildcard = "." + PfxWildcard;
+
+        private static string s_userStoreRoot;
+
+        private readonly string _storePath;
+        private readonly object _fileWatcherLock = new object();
+        private List<X509Certificate2> _certificates;
+        private FileSystemWatcher _watcher;
+
+        private readonly bool _readOnly;
+
+#if DEBUG
+        static DirectoryBasedStoreProvider()
+        {
+            Debug.Assert(
+                0 == OpenFlags.ReadOnly,
+                "OpenFlags.ReadOnly is not zero, read-only detection will not work");
+        }
+#endif
+
+        internal DirectoryBasedStoreProvider(string storeName, OpenFlags openFlags)
+        {
+            if (string.IsNullOrEmpty(storeName))
+            {
+                throw new CryptographicException(SR.Arg_EmptyOrNullString);
+            }
+
+            string directoryName = GetDirectoryName(storeName);
+
+            if (s_userStoreRoot == null)
+            {
+                // Do this here instead of a static field initializer so that
+                // the static initializer isn't capable of throwing the "home directory not found"
+                // exception.
+                s_userStoreRoot = PersistedFiles.GetUserFeatureDirectory("cryptography", "x509stores");
+            }
+
+            _storePath = Path.Combine(s_userStoreRoot, directoryName);
+
+            if (0 != (openFlags & OpenFlags.OpenExistingOnly))
+            {
+                if (!Directory.Exists(_storePath))
+                {
+                    throw new CryptographicException(SR.Cryptography_X509_StoreNotFound);
+                }
+            }
+
+            // ReadOnly is 0x00, so it is implicit unless either ReadWrite or MaxAllowed
+            // was requested.
+            OpenFlags writeFlags = openFlags & (OpenFlags.ReadWrite | OpenFlags.MaxAllowed);
+
+            if (writeFlags == OpenFlags.ReadOnly)
+            {
+                _readOnly = true;
+            }
+        }
+        
+        public void Dispose()
+        {
+            if (_watcher != null)
+            {
+                _watcher.Dispose();
+                _watcher = null;
+            }
+        }
+
+        public void FindAndCopyTo(
+            X509FindType findType,
+            object findValue,
+            bool validOnly,
+            X509Certificate2Collection collection)
+        {
+        }
+
+        public byte[] Export(X509ContentType contentType, string password)
+        {
+            // Export is for X509Certificate2Collections in their IStorePal guise,
+            // if someone wanted to export whole stores they'd need to do
+            // store.Certificates.Export(...), which would end up in the
+            // CollectionBackedStoreProvider.
+            Debug.Fail("Export was unexpected on a DirectoryBasedStore");
+            throw new InvalidOperationException();
+        }
+
+        public void CopyTo(X509Certificate2Collection collection)
+        {
+            Debug.Assert(collection != null);
+
+            // Copy the reference locally, any directory change operations
+            // will cause the field to be reset to null.
+            List<X509Certificate2> certificates = _certificates;
+
+            if (certificates == null)
+            {
+                // ReadDirectory will both load _certificates and return the answer, so this call
+                // will have stable results across multiple adds/deletes happening in parallel.
+                certificates = ReadDirectory();
+                Debug.Assert(certificates != null);
+            }
+
+            foreach (X509Certificate2 cert in certificates)
+            {
+                collection.Add(cert);
+            }
+        }
+
+        private List<X509Certificate2> ReadDirectory()
+        {
+            if (!Directory.Exists(_storePath))
+            {
+                // Don't assign the field here, because we don't have a FileSystemWatcher
+                // yet to tell us that something has been added.
+                return new List<X509Certificate2>(0);
+            }
+
+            List<X509Certificate2> certs = new List<X509Certificate2>();
+
+            lock (_fileWatcherLock)
+            {
+                if (_watcher == null)
+                {
+                    _watcher = new FileSystemWatcher(_storePath, PfxWildcard)
+                    {
+                        NotifyFilter = NotifyFilters.LastWrite,
+                    };
+
+                    FileSystemEventHandler handler = FlushCache;
+                    _watcher.Changed += handler;
+                    _watcher.Created += handler;
+                    _watcher.Deleted += handler;
+                    // The Renamed event has a different delegate type
+                    _watcher.Renamed += FlushCache;
+                    _watcher.Error += FlushCache;
+                }
+
+                // Start watching for change events to know that another instance
+                // has messed with the underlying store.  This keeps us aligned
+                // with the Windows implementation, which opens stores with change
+                // notifications.
+                _watcher.EnableRaisingEvents = true;
+
+                foreach (string filePath in Directory.EnumerateFiles(_storePath, PfxWildcard))
+                {
+                    X509Certificate2 cert;
+
+                    try
+                    {
+                        cert = new X509Certificate2(filePath);
+                    }
+                    catch (CryptographicException)
+                    {
+                        // The file wasn't a certificate, move on to the next one.
+                        continue;
+                    }
+
+                    certs.Add(cert);
+                }
+
+                // Don't release _fileWatcherLock until _certificates is assigned, otherwise
+                // we may be setting it to a stale value after the change event said to clear it
+                _certificates = certs;
+            }
+
+            return certs;
+        }
+
+        public void Add(ICertificatePal certPal)
+        {
+            // Save the collection to a local so it's consistent for the whole method
+            List<X509Certificate2> certificates = _certificates;
+            OpenSslX509CertificateReader cert = (OpenSslX509CertificateReader)certPal;
+
+            using (X509Certificate2 copy = new X509Certificate2(cert.DuplicateHandles()))
+            {
+                // certificates will be null if anything has changed since the last call to
+                // get_Certificates; including Add being called without get_Certificates being
+                // called at all.
+                if (certificates != null)
+                {
+                    foreach (X509Certificate2 inCollection in certificates)
+                    {
+                        if (inCollection.Equals(copy))
+                        {
+                            if (!copy.HasPrivateKey || inCollection.HasPrivateKey)
+                            {
+                                // If the existing store only knows about a public key, but we're
+                                // adding a public+private pair, continue with the add.
+                                //
+                                // So, therefore, if we aren't adding a private key, or already have one,
+                                // we don't need to do anything.
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                // This may well be the first time that we've added something to this store.
+                Directory.CreateDirectory(_storePath);
+
+                string thumbprint = copy.Thumbprint;
+                bool findOpenSlot;
+
+                // The odds are low that we'd have a thumbprint colission, but check anyways.
+                string existingFilename = FindExistingFilename(copy, _storePath, out findOpenSlot);
+
+                if (existingFilename != null)
+                {
+                    bool dataExistsAlready = false;
+
+                    // If the file on disk is just a public key, but we're trying to add a private key,
+                    // we'll want to overwrite it.
+                    if (copy.HasPrivateKey)
+                    {
+                        try
+                        {
+                            using (X509Certificate2 fromFile = new X509Certificate2(existingFilename))
+                            {
+                                if (fromFile.HasPrivateKey)
+                                {
+                                    // We have a private key, the file has a private key, we're done here.
+                                    dataExistsAlready = true;
+                                }
+                            }
+                        }
+                        catch (CryptographicException)
+                        {
+                            // We can't read this file anymore, but a moment ago it was this certificate,
+                            // so go ahead and overwrite it.
+                        }
+                    }
+                    else
+                    {
+                        // If we're just a public key then the file has at least as much data as we do.
+                        dataExistsAlready = true;
+                    }
+
+                    if (dataExistsAlready)
+                    {
+                        // The file was added but our collection hasn't resynced yet.
+                        // Set _certificates to null to force a resync.
+                        _certificates = null;
+                        return;
+                    }
+                }
+
+                if (_readOnly)
+                {
+                    // Windows compatibility: Don't throw until it has been established that
+                    // the certificate is not present, and we need to modify the filesystem.
+                    throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
+                }
+
+                string destinationFilename;
+                FileMode mode = FileMode.CreateNew;
+
+                if (existingFilename != null)
+                {
+                    destinationFilename = existingFilename;
+                    mode = FileMode.Create;
+                }
+                else if (findOpenSlot)
+                {
+                    destinationFilename = FindOpenSlot(thumbprint);
+                }
+                else
+                {
+                    destinationFilename = Path.Combine(_storePath, thumbprint + PfxExtension);
+                }
+
+                using (FileStream stream = new FileStream(destinationFilename, mode))
+                {
+                    byte[] pkcs12 = copy.Export(X509ContentType.Pkcs12);
+                    stream.Write(pkcs12, 0, pkcs12.Length);
+                }
+
+#if DEBUG
+                // Verify that we're creating files with u+rw and o-rw, g-rw.
+                const Interop.libc.Permissions requiredPermissions =
+                    Interop.libc.Permissions.S_IRUSR |
+                    Interop.libc.Permissions.S_IWUSR;
+
+                const Interop.libc.Permissions forbiddenPermissions =
+                    Interop.libc.Permissions.S_IROTH |
+                    Interop.libc.Permissions.S_IWOTH |
+                    Interop.libc.Permissions.S_IRGRP |
+                    Interop.libc.Permissions.S_IWGRP;
+
+                Interop.Sys.FileStatus stat;
+
+                Debug.Assert(Interop.Sys.Stat(destinationFilename, out stat) == 0);
+                Debug.Assert((stat.Mode & (int)requiredPermissions) != 0, "Created PFX has insufficient permissions to function");
+                Debug.Assert((stat.Mode & (int)forbiddenPermissions) == 0, "Created PFX has too broad of permissions");
+#endif
+            }
+
+            // Null out _certificates so the next call to get_Certificates causes a re-scan.
+            _certificates = null;
+        }
+
+        public void Remove(ICertificatePal certPal)
+        {
+            OpenSslX509CertificateReader cert = (OpenSslX509CertificateReader)certPal;
+
+            using (X509Certificate2 copy = new X509Certificate2(cert.DuplicateHandles()))
+            {
+                bool hadCandidates;
+                string currentFilename = FindExistingFilename(copy, _storePath, out hadCandidates);
+
+                if (currentFilename != null)
+                {
+                    if (_readOnly)
+                    {
+                        // Windows compatibility, the readonly check isn't done until after a match is found.
+                        throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
+                    }
+
+                    File.Delete(currentFilename);
+                }
+            }
+
+            // Null out _certificates so the next call to get_Certificates causes a re-scan.
+            _certificates = null;
+        }
+
+        private static string FindExistingFilename(X509Certificate2 cert, string storePath, out bool hadCandidates)
+        {
+            hadCandidates = false;
+
+            foreach (string maybeMatch in Directory.EnumerateFiles(storePath, cert.Thumbprint + PfxWildcard))
+            {
+                hadCandidates = true;
+
+                try
+                {
+                    using (X509Certificate2 candidate = new X509Certificate2(maybeMatch))
+                    {
+                        if (candidate.Equals(cert))
+                        {
+                            return maybeMatch;
+                        }
+                    }
+                }
+                catch (CryptographicException)
+                {
+                    // Contents weren't interpretable as a certificate, so it's not a match.
+                }
+            }
+
+            return null;
+        }
+
+        private string FindOpenSlot(string thumbprint)
+        {
+            // We already know that {thumbprint}.pfx is taken, so start with {thumbprint}.1.pfx
+
+            // We need space for {thumbprint} (thumbprint.Length)
+            // And ".0.pfx" (6)
+            // If MaxSaveAttempts is big enough to use more than one digit, we need that space, too (MaxSaveAttempts / 10)
+            StringBuilder pathBuilder = new StringBuilder(thumbprint.Length + PfxOrdinalWildcard.Length + (MaxSaveAttempts / 10));
+
+            pathBuilder.Append(thumbprint);
+            pathBuilder.Append('.');
+            int prefixLength = pathBuilder.Length;
+
+            for (int i = 1; i <= MaxSaveAttempts; i++)
+            {
+                pathBuilder.Length = prefixLength;
+                
+                pathBuilder.Append(i);
+                pathBuilder.Append(PfxExtension);
+
+                string builtPath = Path.Combine(_storePath, pathBuilder.ToString());
+
+                if (!File.Exists(builtPath))
+                {
+                    return builtPath;
+                }
+            }
+
+            throw new CryptographicException(SR.Cryptography_X509_StoreNoFileAvailable);
+        }
+
+        private void FlushCache(object sender, EventArgs e)
+        {
+            lock (_fileWatcherLock)
+            {
+                // Events might end up not firing until after the object was disposed, which could cause
+                // problems consistently reading _watcher; so save it to a local.
+                FileSystemWatcher watcher = _watcher;
+
+                if (watcher != null)
+                {
+                    // Stop processing events until we read again, particularly because
+                    // there's nothing else we'll do until then.
+                    watcher.EnableRaisingEvents = false;
+                }
+
+                _certificates = null;
+            }
+        }
+
+        private static string GetDirectoryName(string storeName)
+        {
+            Debug.Assert(storeName != null);
+
+            try
+            {
+                string fileName = Path.GetFileName(storeName);
+
+                if (!StringComparer.Ordinal.Equals(storeName, fileName))
+                {
+                    throw new CryptographicException(SR.Format(SR.Security_InvalidValue, "storeName"));
+                }
+            }
+            catch (IOException e)
+            {
+                throw new CryptographicException(e.Message, e);
+            }
+
+            return storeName.ToLowerInvariant();
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -68,8 +68,7 @@ namespace Internal.Cryptography.Pal
         {
             if (storeLocation != StoreLocation.LocalMachine)
             {
-                // TODO (#2206): Support CurrentUser persisted stores.
-                throw new NotImplementedException();
+                return new DirectoryBasedStoreProvider(storeName, openFlags);
             }
 
             if (openFlags.HasFlag(OpenFlags.ReadWrite))

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -153,6 +153,9 @@
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
   </data>
+  <data name="Chain_NoPolicyMatch" xml:space="preserve">
+    <value>The certificate has invalid policy.</value>
+  </data>
   <data name="Cryptography_InvalidContextHandle" xml:space="preserve">
     <value>The chain context handle is invalid.</value>
   </data>
@@ -183,8 +186,17 @@
   <data name="Cryptography_X509_KeyMismatch" xml:space="preserve">
     <value>The public key of the certificate does not match the value specified.</value>
   </data>
+  <data name="Cryptography_X509_StoreNoFileAvailable" xml:space="preserve">
+    <value>The X509 certificate could not be added to the store because all candidate file names were in use.</value>
+  </data>
+  <data name="Cryptography_X509_StoreNotFound" xml:space="preserve">
+    <value>The specified X509 certificate store does not exist.</value>
+  </data>
   <data name="Cryptography_X509_StoreNotOpen" xml:space="preserve">
     <value>The X509 certificate store has not been opened.</value>
+  </data>
+  <data name="Cryptography_X509_StoreReadOnly" xml:space="preserve">
+    <value>The X509 certificate store is read-only.</value>
   </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started.  Call MoveNext.</value>
@@ -198,6 +210,9 @@
   <data name="NotSupported_KeyAlgorithm" xml:space="preserve">
     <value>The certificate key algorithm is not supported.</value>
   </data>
+  <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
+    <value>The home directory of the current user could not be determined.</value>
+  </data>
   <data name="Security_InvalidValue" xml:space="preserve">
     <value>The {0} value was invalid.</value>
   </data>
@@ -206,8 +221,5 @@
   </data>
   <data name="WorkInProgress" xml:space="preserve">
     <value>WorkInProgress.</value>
-  </data>
-  <data name="Chain_NoPolicyMatch" xml:space="preserve">
-    <value>The certificate has invalid policy.</value>
   </data>
 </root>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Internal\Cryptography\Pal.Unix\ChainPal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\CollectionBackedStoreProvider.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\DerSequenceReader.cs" />
+    <Compile Include="Internal\Cryptography\Pal.Unix\DirectoryBasedStoreProvider.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslPkcs12Reader.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslX509CertificateReader.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslX509ChainProcessor.cs" />
@@ -139,6 +140,9 @@
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Pal.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
+      <Link>Common\Interop\Unix\libc\Interop.Permissions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ASN1.cs</Link>
@@ -179,6 +183,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.X509Ext.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.Stat.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.NativeCrypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.NativeCrypto.cs</Link>
     </Compile>
@@ -208,6 +215,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.X509Certificates/src/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/project.json
@@ -5,6 +5,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization.Calendars": "4.0.0",
     "System.IO.FileSystem": "4.0.0",
+    "System.IO.FileSystem.Watcher": "4.0.0-beta-*",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime": "4.0.20",
     "System.Runtime.InteropServices": "4.0.20",

--- a/src/System.Security.Cryptography.X509Certificates/src/project.lock.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/project.lock.json
@@ -3,6 +3,18 @@
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "Microsoft.Win32.Primitives/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "System.Collections/4.0.10": {
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -104,6 +116,24 @@
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.IO.FileSystem": "4.0.0-beta-23127",
+          "System.Threading.Overlapped": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Watcher.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.Watcher.dll": {}
         }
       },
       "System.Private.Uri/4.0.0": {
@@ -267,6 +297,37 @@
     }
   },
   "libraries": {
+    "Microsoft.Win32.Primitives/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "RhBDkPQpFEEx6gHmNlge7eG9up6U0lC41Sbgh8ugosNeputVZRzbskXMOPkgNz3I5FMU/E+g0YuJB/T8K0Slhg==",
+      "files": [
+        "Microsoft.Win32.Primitives.4.0.0-beta-23127.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
     "System.Collections/4.0.10": {
       "serviceable": true,
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
@@ -521,6 +582,37 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO.FileSystem.Watcher/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "WSayzShVRSzQCVUJE5Lj+SJopWf7963T25kDU1+47UwjPZ8NVxqtWq51JTt1nzt2t6UVgZB3wo+C95Kh5SzxhA==",
+      "files": [
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23127.nupkg",
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23127.nupkg.sha512",
+        "System.IO.FileSystem.Watcher.nuspec",
+        "lib/DNXCore50/System.IO.FileSystem.Watcher.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Watcher.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.Watcher.dll",
+        "ref/dotnet/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/de/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/it/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Watcher.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Watcher.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._"
       ]
@@ -976,6 +1068,7 @@
       "System.Diagnostics.Debug >= 4.0.10",
       "System.Globalization.Calendars >= 4.0.0",
       "System.IO.FileSystem >= 4.0.0",
+      "System.IO.FileSystem.Watcher >= 4.0.0-beta-*",
       "System.Resources.ResourceManager >= 4.0.0",
       "System.Runtime >= 4.0.20",
       "System.Runtime.InteropServices >= 4.0.20",

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="PropsTests.cs" />
     <Compile Include="PublicKeyTests.cs" />
     <Compile Include="TestData.cs" />
+    <Compile Include="X509StoreTests.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\ByteUtils.cs">
       <Link>CommonTest\Cryptography\ByteUtils.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -1,0 +1,149 @@
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    public class X509StoreTests
+    {
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void OpenMyStore()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadOnly);
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void ReadMyCertificates()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadOnly);
+                int certCount = store.Certificates.Count;
+
+                // This assert is just so certCount appears to be used, the test really
+                // is that store.get_Certificates didn't throw.
+                Assert.True(certCount >= 0);
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void OpenNotExistant()
+        {
+            using (X509Store store = new X509Store(Guid.NewGuid().ToString("N"), StoreLocation.CurrentUser))
+            {
+                Assert.Throws<CryptographicException>(() => store.Open(OpenFlags.OpenExistingOnly));
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void AddReadOnlyThrows()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                // Add only throws when it has to do work.  If, for some reason, this certificate
+                // is already present in the CurrentUser\My store, we can't really test this
+                // functionality.
+                if (!store.Certificates.Contains(cert))
+                {
+                    Assert.Throws<CryptographicException>(() => store.Add(cert));
+                }
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void AddReadOnlyDoesntThrowWhenCertificateExists()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                X509Certificate2 toAdd = null;
+
+                // Look through the certificates to find one with no private key to call add on.
+                // (The private key restriction is so that in the event of an "accidental success"
+                // that no potential permissions would be modified)
+                foreach (X509Certificate2 cert in store.Certificates)
+                {
+                    if (!cert.HasPrivateKey)
+                    {
+                        toAdd = cert;
+                        break;
+                    }
+                }
+
+                if (toAdd != null)
+                {
+                    // This shouldn't throw, the cert is already present.
+                    store.Add(toAdd);
+                }
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void RemoveReadOnlyThrowsWhenFound()
+        {
+            // This test is unfortunate, in that it will mostly never test.
+            // In order to do so it would have to open the store ReadWrite, put in a known value,
+            // and call Remove on a ReadOnly copy.
+            //
+            // Just calling Remove on the first item found could also work (when the store isn't empty),
+            // but if it fails the cost is too high.
+            //
+            // So what's the purpose of this test, you ask? To record why we're not unit testing it.
+            // And someone could test it manually if they wanted.
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                if (store.Certificates.Contains(cert))
+                {
+                    Assert.Throws<CryptographicException>(() => store.Remove(cert));
+                }
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void EnumerateClosedIsEmpty()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                int count = store.Certificates.Count;
+                Assert.Equal(0, count);
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void AddClosedThrows()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                Assert.Throws<CryptographicException>(() => store.Add(cert));
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(2820, PlatformID.AnyUnix)]
+        public static void RemoveClosedThrows()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                Assert.Throws<CryptographicException>(() => store.Remove(cert));
+            }
+        }
+    }
+}


### PR DESCRIPTION
The store is implemented as PFX files in ~/.microsoft/netfx/cryptography/x509stores/{storename}, and utilizes a FileSystemWatcher after first read to synchronize changes across other instances (and processes).

Fixes #2206.