### PR TITLE
Reduce running time of Tasks tests

### DIFF
--- a/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
+++ b/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
@@ -101,7 +101,7 @@ namespace System.Threading.Tasks.Tests
             ConcurrentExclusiveSchedulerPair schedPair = null;
             //Need to define the default values since these values are passed to the verification methods
             TaskScheduler scheduler = TaskScheduler.Default;
-            int maxConcurrentLevel = 4;
+            int maxConcurrentLevel = Environment.ProcessorCount;
 
             //Based on input args, use one of the ctor overloads
             switch (ctorType.ToLower())
@@ -283,7 +283,7 @@ namespace System.Threading.Tasks.Tests
             blockMainThreadEvent.WaitOne(); // wait for the blockedTask to start execution
 
             //Now add more reader tasks
-            int maxConcurrentTasks = 8;
+            int maxConcurrentTasks = Environment.ProcessorCount;
             List<Task> taskList = new List<Task>();
             for (int i = 0; i < maxConcurrentTasks; i++)
                 taskList.Add(readers.StartNew(() => { })); //schedule some dummy reader tasks
@@ -339,7 +339,7 @@ namespace System.Threading.Tasks.Tests
         public static void TestIntegration(String apiType, bool useReader)
         {
             Debug.WriteLine(string.Format(" Running apiType:{0} useReader:{1}", apiType, useReader));
-            int taskCount = 8; //To get varying number of tasks as a function of cores
+            int taskCount = Environment.ProcessorCount; //To get varying number of tasks as a function of cores
             ConcurrentExclusiveSchedulerPair schedPair = new ConcurrentExclusiveSchedulerPair();
             CountdownEvent cde = new CountdownEvent(taskCount); //Used to track how many tasks were executed
             Action work = () => { cde.Signal(); }; //Work done by all APIs
@@ -396,7 +396,7 @@ namespace System.Threading.Tasks.Tests
 
             // Can create a bunch of schedulers, do work on them all, complete them all, and they all complete
             {
-                var cesps = new ConcurrentExclusiveSchedulerPair[1000];
+                var cesps = new ConcurrentExclusiveSchedulerPair[100];
                 for (int i = 0; i < cesps.Length; i++)
                 {
                     cesps[i] = new ConcurrentExclusiveSchedulerPair();
@@ -525,7 +525,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(false)]
         public static void TestConcurrentExclusiveChain(bool syncContinuations)
         {
-            var scheduler = new TrackingTaskScheduler(8);
+            var scheduler = new TrackingTaskScheduler(Environment.ProcessorCount);
             var cesp = new ConcurrentExclusiveSchedulerPair(scheduler);
 
             // continuations

--- a/src/System.Threading.Tasks/tests/MethodCoverage.cs
+++ b/src/System.Threading.Tasks/tests/MethodCoverage.cs
@@ -27,7 +27,7 @@ namespace TaskCoverage
         [OuterLoop]
         public static void TaskContinuation()
         {
-            int taskCount = 4;
+            int taskCount = Environment.ProcessorCount;
             int maxDOP = Int32.MaxValue;
             int maxNumberExecutionsPerTask = 1;
             int data = 0;

--- a/src/System.Threading.Tasks/tests/Task/TaskRtTests_Core.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRtTests_Core.cs
@@ -1130,9 +1130,7 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void RunTaskWaitAnyTests()
         {
-            //int numCores = Environment.ProcessorCount;]
-            // We are just selecting a number since Environment exists in a .dll that is not part of the contracts.
-            int numCores = 4;
+            int numCores = Environment.ProcessorCount;
 
             // Basic tests w/ <64 tasks
             CoreWaitAnyTest(0, new bool[] { }, -1);
@@ -1591,10 +1589,7 @@ namespace System.Threading.Tasks.Tests
             // This is computed such that this number of long-running tasks will result in a back-up
             // without some assistance from TaskScheduler.RunBlocking() or TaskCreationOptions.LongRunning.
 
-            // We are selecting some number because Environment exists in a .dll that is not
-            // part of the contracts we are testing.
-            //int ntasks = Environment.ProcessorCount * 2;
-            int ntasks = 8;
+            int ntasks = Environment.ProcessorCount * 2;
 
             Task[] tasks = new Task[ntasks];
             ManualResetEvent mre = new ManualResetEvent(false); // could just use a bool?

--- a/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
@@ -434,6 +434,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
         [Fact]
+        [OuterLoop]
         public static void TaskRunSyncTest3()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Completed, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithInlineExecution);

--- a/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
@@ -809,6 +809,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
         }
 
         [Fact]
+        [OuterLoop]
         public static void TaskWaitAllAny31()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -904,6 +905,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
         }
 
         [Fact]
+        [OuterLoop]
         public static void TaskWaitAllAny34()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -940,6 +942,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
         }
 
         [Fact]
+        [OuterLoop]
         public static void TaskWaitAllAny37()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryHeavy);
@@ -1027,6 +1030,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
         }
 
         [Fact]
+        [OuterLoop]
         public static void TaskWaitAllAny45()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);

--- a/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
@@ -36,9 +36,7 @@ namespace System.Threading.Tasks.Tests
 
             // Create many tasks blocked on the MRE.
 
-            // WE are specifying a fixed number rather than using environment.processorcount because it uses a .dll that is not
-            // in the contracts.
-            int processorCount = 8;
+            int processorCount = Environment.ProcessorCount;
             Task[] tasks = new Task[processorCount];
             for (int i = 0; i < tasks.Length; i++)
             {


### PR DESCRIPTION
@mellinoe, I know you're planning to spend some time fixing up the task tests.  In the meantime, they're taking between 40-80 seconds to run on my machine, and they appear to be taking an equivalent amount of time on the CI servers.  This change makes a few tweaks to bring that time down:
- Marks the worst offending tests as [OuterLoop]
- Changes a few places that used to be Environment.ProcessorCount and were apparently at some point changed to be a hardcoded number back to being Environment.ProcessorCount

The tests now take ~10 seconds on my machine, though still with quite a bit of variability.