### PR TITLE
Re-enable several System.Threading tests

### DIFF
--- a/src/Scenarios/tests/InterProcessCommunication/EventWaitHandleTests.cs
+++ b/src/Scenarios/tests/InterProcessCommunication/EventWaitHandleTests.cs
@@ -10,7 +10,7 @@ namespace InterProcessCommunication.Tests
 {
     public class EventWaitHandleTests : RemoteExecutorTestBase
     {
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/1237", PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)] // names aren't supported on Unix
         [Theory]
         [InlineData(EventResetMode.ManualReset)]
         [InlineData(EventResetMode.AutoReset)]

--- a/src/Scenarios/tests/InterProcessCommunication/SemaphoreTests.cs
+++ b/src/Scenarios/tests/InterProcessCommunication/SemaphoreTests.cs
@@ -10,7 +10,7 @@ namespace InterProcessCommunication.Tests
 {
     public class SemaphoreTests : RemoteExecutorTestBase
     {
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/1237", PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)] // names aren't supported on Unix
         [Fact]
         public void PingPong()
         {

--- a/src/System.Threading/tests/EventWaitHandleTests.cs
+++ b/src/System.Threading/tests/EventWaitHandleTests.cs
@@ -31,7 +31,6 @@ public class EventWaitHandleTests
         Assert.Throws<ArgumentException>(() => new EventWaitHandle(true, EventResetMode.AutoReset, new string('a', 1000)));
     }
 
-    [ActiveIssue("https://github.com/dotnet/coreclr/issues/1237")]
     [PlatformSpecific(PlatformID.AnyUnix)]
     [Fact]
     public void Ctor_NamesArentSupported_Unix()
@@ -130,7 +129,6 @@ public class EventWaitHandleTests
         }
     }
 
-    [ActiveIssue("https://github.com/dotnet/coreclr/issues/1237")]
     [PlatformSpecific(PlatformID.AnyUnix)]
     [Fact]
     public void OpenExisting_NotSupported_Unix()

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -31,7 +31,6 @@ public class MutexTests
         }
     }
 
-    [ActiveIssue("https://github.com/dotnet/coreclr/issues/1237")]
     [PlatformSpecific(PlatformID.AnyUnix)]
     [Fact]
     public void Ctor_NamesNotSupported_Unix()


### PR DESCRIPTION
With https://github.com/dotnet/coreclr/pull/1387 merged, these can now be enabled.