### PR TITLE
Cleanup and harden X509Certificate collections

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -30,14 +30,11 @@ namespace System.Security.Cryptography.X509Certificates
         {
             get
             {
-                return (X509Certificate2)(List[index]);
+                return (X509Certificate2)(base[index]);
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException("value");
-
-                List[index] = value;
+                base[index] = value;
             }
         }
 
@@ -46,7 +43,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate == null)
                 throw new ArgumentNullException("certificate");
 
-            return List.Add(certificate);
+            return base.Add(certificate);
         }
 
         public void AddRange(X509Certificate2[] certificates)
@@ -100,7 +97,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate == null)
                 throw new ArgumentNullException("certificate");
 
-            return List.Contains(certificate);
+            return base.Contains(certificate);
         }
 
         public byte[] Export(X509ContentType contentType)
@@ -171,7 +168,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate == null)
                 throw new ArgumentNullException("certificate");
 
-            List.Insert(index, certificate);
+            base.Insert(index, certificate);
         }
 
         public void Remove(X509Certificate2 certificate)
@@ -179,7 +176,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate == null)
                 throw new ArgumentNullException("certificate");
 
-            List.Remove(certificate);
+            base.Remove(certificate);
         }
 
         public void RemoveRange(X509Certificate2[] certificates)

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
-using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
 using Internal.Cryptography.Pal;
 
 namespace System.Security.Cryptography.X509Certificates
@@ -44,6 +36,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (value == null)
                     throw new ArgumentNullException("value");
+
                 List[index] = value;
             }
         }
@@ -87,10 +80,9 @@ namespace System.Security.Cryptography.X509Certificates
             int i = 0;
             try
             {
-                foreach (X509Certificate2 certificate in certificates)
+                for (; i < certificates.Count; i++)
                 {
-                    Add(certificate);
-                    i++;
+                    Add(certificates[i]);
                 }
             }
             catch
@@ -116,7 +108,7 @@ namespace System.Security.Cryptography.X509Certificates
             return Export(contentType, password: null);
         }
 
-        public byte[] Export(X509ContentType contentType, String password)
+        public byte[] Export(X509ContentType contentType, string password)
         {
             using (IStorePal storePal = StorePal.LinkFromCertificateCollection(this))
             {
@@ -124,7 +116,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public X509Certificate2Collection Find(X509FindType findType, Object findValue, bool validOnly)
+        public X509Certificate2Collection Find(X509FindType findType, object findValue, bool validOnly)
         {
             if (findValue == null)
                 throw new ArgumentNullException("findValue");
@@ -139,8 +131,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         public new X509Certificate2Enumerator GetEnumerator()
         {
-            X509CertificateEnumerator baseEnumerator = base.GetEnumerator();
-            return new X509Certificate2Enumerator(baseEnumerator);
+            return new X509Certificate2Enumerator(this);
         }
 
         public void Import(byte[] rawData)
@@ -148,7 +139,7 @@ namespace System.Security.Cryptography.X509Certificates
             Import(rawData, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
         }
 
-        public void Import(byte[] rawData, String password, X509KeyStorageFlags keyStorageFlags)
+        public void Import(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
         {
             if (rawData == null)
                 throw new ArgumentNullException("rawData");
@@ -159,12 +150,12 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public void Import(String fileName)
+        public void Import(string fileName)
         {
             Import(fileName, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
         }
 
-        public void Import(String fileName, String password, X509KeyStorageFlags keyStorageFlags)
+        public void Import(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
         {
             if (fileName == null)
                 throw new ArgumentNullException("fileName");
@@ -222,10 +213,9 @@ namespace System.Security.Cryptography.X509Certificates
             int i = 0;
             try
             {
-                foreach (X509Certificate2 certificate in certificates)
+                for (; i < certificates.Count; i++)
                 {
-                    Remove(certificate);
-                    i++;
+                    Remove(certificates[i]);
                 }
             }
             catch
@@ -239,4 +229,3 @@ namespace System.Security.Cryptography.X509Certificates
         }
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -94,8 +94,9 @@ namespace System.Security.Cryptography.X509Certificates
 
         public bool Contains(X509Certificate2 certificate)
         {
-            if (certificate == null)
-                throw new ArgumentNullException("certificate");
+            // This method used to throw ArgumentNullException, but it has been deliberately changed
+            // to no longer throw to match the behavior of X509CertificateCollection.Contains and the
+            // IList.Contains implementation, which do not throw.
 
             return base.Contains(certificate);
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Enumerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Enumerator.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed class X509Certificate2Enumerator : IEnumerator
     {
         // This is a mutable struct enumerator, so don't mark it as readonly.
-        private List<object>.Enumerator _enumerator;
+        private List<X509Certificate>.Enumerator _enumerator;
 
         internal X509Certificate2Enumerator(X509Certificate2Collection collection)
         {

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Enumerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Enumerator.cs
@@ -1,62 +1,56 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
 using System.Diagnostics;
 using System.Collections;
-using System.Globalization;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
+using System.Collections.Generic;
 
 namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class X509Certificate2Enumerator : IEnumerator
     {
-        internal X509Certificate2Enumerator(IEnumerator baseEnumerator)
+        // This is a mutable struct enumerator, so don't mark it as readonly.
+        private List<object>.Enumerator _enumerator;
+
+        internal X509Certificate2Enumerator(X509Certificate2Collection collection)
         {
-            _baseEnumerator = baseEnumerator;
+            Debug.Assert(collection != null);
+
+            collection.GetEnumerator(out _enumerator);
         }
 
         public X509Certificate2 Current
         {
-            get
-            {
-                return (X509Certificate2)(_baseEnumerator.Current);
-            }
+            // Call the struct enumerator's IEnumerator.Current implementation, which has the
+            // behavior we want of throwing InvalidOperationException when the enumerator
+            // hasn't been started or has ended, without boxing.
+            get { return (X509Certificate2)(EnumeratorHelper.GetCurrent(ref _enumerator)); }
         }
 
-        Object IEnumerator.Current
+        object IEnumerator.Current
         {
-            get
-            {
-                return _baseEnumerator.Current;
-            }
+            get { return Current; }
         }
 
         public bool MoveNext()
         {
-            return _baseEnumerator.MoveNext();
+            return _enumerator.MoveNext();
         }
 
         bool IEnumerator.MoveNext()
         {
-            return _baseEnumerator.MoveNext();
+            return MoveNext();
         }
 
         public void Reset()
         {
-            _baseEnumerator.Reset();
+            // Call Reset on the struct enumerator without boxing.
+            EnumeratorHelper.Reset(ref _enumerator);
         }
 
         void IEnumerator.Reset()
         {
-            _baseEnumerator.Reset();
+            Reset();
         }
-
-        private IEnumerator _baseEnumerator;
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
@@ -8,11 +8,11 @@ namespace System.Security.Cryptography.X509Certificates
 {
     public partial class X509CertificateCollection : ICollection, IEnumerable, IList
     {
-        private readonly List<object> _list;
+        private readonly List<X509Certificate> _list;
 
         public X509CertificateCollection()
         {
-            _list = new List<object>();
+            _list = new List<X509Certificate>();
         }
 
         public X509CertificateCollection(X509Certificate[] value)
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         object ICollection.SyncRoot
         {
-            get { return ((ICollection)_list).SyncRoot; }
+            get { return NonGenericList.SyncRoot; }
         }
 
         bool IList.IsFixedSize
@@ -56,6 +56,21 @@ namespace System.Security.Cryptography.X509Certificates
         {
             get
             {
+                return NonGenericList[index];
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+
+                NonGenericList[index] = value;
+            }
+        }
+
+        public X509Certificate this[int index]
+        {
+            get
+            {
                 return _list[index];
             }
             set
@@ -67,22 +82,14 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public X509Certificate this[int index]
-        {
-            get
-            {
-                // Note: If a non-X509Certificate was inserted at this position, the result InvalidCastException is the defined behavior.
-                return (X509Certificate)(List[index]);
-            }
-            set
-            {
-                List[index] = value;
-            }
-        }
-
         public int Add(X509Certificate value)
         {
-            return List.Add(value);
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            int index = _list.Count;
+            _list.Add(value);
+            return index;
         }
 
         public void AddRange(X509Certificate[] value)
@@ -119,7 +126,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         public void CopyTo(X509Certificate[] array, int index)
         {
-            List.CopyTo(array, index);
+            _list.CopyTo(array, index);
         }
 
         public X509CertificateEnumerator GetEnumerator()
@@ -144,17 +151,23 @@ namespace System.Security.Cryptography.X509Certificates
 
         public int IndexOf(X509Certificate value)
         {
-            return List.IndexOf(value);
+            return _list.IndexOf(value);
         }
 
         public void Insert(int index, X509Certificate value)
         {
-            List.Insert(index, value);
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            _list.Insert(index, value);
         }
 
         public void Remove(X509Certificate value)
         {
-            List.Remove(value);
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            _list.Remove(value);
         }
 
         public void RemoveAt(int index)
@@ -164,7 +177,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         void ICollection.CopyTo(Array array, int index)
         {
-            ((ICollection)_list).CopyTo(array, index);
+            NonGenericList.CopyTo(array, index);
         }
 
         int IList.Add(object value)
@@ -172,19 +185,17 @@ namespace System.Security.Cryptography.X509Certificates
             if (value == null)
                 throw new ArgumentNullException("value");
 
-            int index = _list.Count;
-            _list.Add(value);
-            return index;
+            return NonGenericList.Add(value);
         }
 
         bool IList.Contains(object value)
         {
-            return _list.Contains(value);
+            return NonGenericList.Contains(value);
         }
 
         int IList.IndexOf(object value)
         {
-            return _list.IndexOf(value);
+            return NonGenericList.IndexOf(value);
         }
 
         void IList.Insert(int index, object value)
@@ -192,7 +203,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (value == null)
                 throw new ArgumentNullException("value");
 
-            _list.Insert(index, value);
+            NonGenericList.Insert(index, value);
         }
 
         void IList.Remove(object value)
@@ -200,15 +211,15 @@ namespace System.Security.Cryptography.X509Certificates
             if (value == null)
                 throw new ArgumentNullException("value");
 
-            _list.Remove(value);
+            NonGenericList.Remove(value);
         }
 
-        internal IList List
+        private IList NonGenericList
         {
-            get { return this; }
+            get { return _list; }
         }
 
-        internal void GetEnumerator(out List<object>.Enumerator enumerator)
+        internal void GetEnumerator(out List<X509Certificate>.Enumerator enumerator)
         {
             enumerator = _list.GetEnumerator();
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateEnumerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateEnumerator.cs
@@ -11,10 +11,13 @@ namespace System.Security.Cryptography.X509Certificates
         public class X509CertificateEnumerator : IEnumerator
         {
             // This is a mutable struct enumerator, so don't mark it as readonly.
-            private List<object>.Enumerator _enumerator;
+            private List<X509Certificate>.Enumerator _enumerator;
 
             public X509CertificateEnumerator(X509CertificateCollection mappings)
             {
+                if (mappings == null)
+                    throw new ArgumentNullException("mappings");
+
                 mappings.GetEnumerator(out _enumerator);
             }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateEnumerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateEnumerator.cs
@@ -1,15 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Text;
 using System.Collections;
-using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
+using System.Collections.Generic;
 
 namespace System.Security.Cryptography.X509Certificates
 {
@@ -17,48 +10,68 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public class X509CertificateEnumerator : IEnumerator
         {
+            // This is a mutable struct enumerator, so don't mark it as readonly.
+            private List<object>.Enumerator _enumerator;
+
             public X509CertificateEnumerator(X509CertificateCollection mappings)
             {
-                _baseEnumerator = mappings.GetEnumerator();
+                mappings.GetEnumerator(out _enumerator);
             }
 
             public X509Certificate Current
             {
-                get { return (X509Certificate)(_baseEnumerator.Current); }
+                // Call the struct enumerator's IEnumerator.Current implementation, which has the
+                // behavior we want of throwing InvalidOperationException when the enumerator
+                // hasn't been started or has ended, without boxing.
+                get { return (X509Certificate)(EnumeratorHelper.GetCurrent(ref _enumerator)); }
             }
 
-            Object System.Collections.IEnumerator.Current
+            object IEnumerator.Current
             {
-                get { return _baseEnumerator.Current; }
+                get { return Current; }
             }
 
             public bool MoveNext()
             {
-                return _baseEnumerator.MoveNext();
+                return _enumerator.MoveNext();
             }
 
             bool IEnumerator.MoveNext()
             {
-                return _baseEnumerator.MoveNext();
+                return MoveNext();
             }
 
             public void Reset()
             {
-                _baseEnumerator.Reset();
+                // Call Reset on the struct enumerator without boxing.
+                EnumeratorHelper.Reset(ref _enumerator);
             }
 
             void IEnumerator.Reset()
             {
-                _baseEnumerator.Reset();
+                Reset();
             }
+        }
+    }
 
-            internal X509CertificateEnumerator(IEnumerator baseEnumerator)
-            {
-                _baseEnumerator = baseEnumerator;
-            }
+    internal static class EnumeratorHelper
+    {
+        /// <summary>
+        /// Allows calling List<T>.Enumerator's explicit implementation of IEnumerator.Current without boxing.
+        /// We call the non-generic IEnumerator.Current implementation because it handles throwing InvalidOperationException
+        /// when the enumerator hasn't been started or has ended, which is the behavior we want.
+        /// </summary>
+        internal static object GetCurrent<TEnumerator>(ref TEnumerator enumerator) where TEnumerator : IEnumerator
+        {
+            return enumerator.Current;
+        }
 
-            private IEnumerator _baseEnumerator;
+        /// <summary>
+        /// Allows calling List<T>.Enumerator's explicit implementation of IEnumerator.Reset without boxing.
+        /// </summary>
+        internal static void Reset<TEnumerator>(ref TEnumerator enumerator) where TEnumerator : IEnumerator
+        {
+            enumerator.Reset();
         }
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -22,26 +22,31 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 X509Certificate2Enumerator e = cc.GetEnumerator();
                 object ignored;
 
-                // Not started
-                Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+                for (int i = 0; i < 2; i++)
+                {
+                    // Not started
+                    Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
 
-                Assert.True(e.MoveNext());
-                Assert.Same(c1, e.Current);
+                    Assert.True(e.MoveNext());
+                    Assert.Same(c1, e.Current);
 
-                Assert.True(e.MoveNext());
-                Assert.Same(c2, e.Current);
+                    Assert.True(e.MoveNext());
+                    Assert.Same(c2, e.Current);
 
-                Assert.True(e.MoveNext());
-                Assert.Same(c3, e.Current);
+                    Assert.True(e.MoveNext());
+                    Assert.Same(c3, e.Current);
 
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
 
-                // ended.
-                Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+                    // ended.
+                    Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+
+                    e.Reset();
+                }
             }
         }
 
@@ -56,26 +61,167 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 X509CertificateCollection.X509CertificateEnumerator e = cc.GetEnumerator();
                 object ignored;
 
-                // Not started
-                Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+                for (int i = 0; i < 2; i++)
+                {
+                    // Not started
+                    Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
 
-                Assert.True(e.MoveNext());
-                Assert.Same(c1, e.Current);
+                    Assert.True(e.MoveNext());
+                    Assert.Same(c1, e.Current);
 
-                Assert.True(e.MoveNext());
-                Assert.Same(c2, e.Current);
+                    Assert.True(e.MoveNext());
+                    Assert.Same(c2, e.Current);
 
-                Assert.True(e.MoveNext());
-                Assert.Same(c3, e.Current);
+                    Assert.True(e.MoveNext());
+                    Assert.Same(c3, e.Current);
 
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
-                Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
+                    Assert.False(e.MoveNext());
 
-                // ended.
-                Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+                    // ended.
+                    Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+
+                    e.Reset();
+                }
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionThrowsArgumentNullException()
+        {
+            using (X509Certificate certificate = new X509Certificate())
+            {
+                X509CertificateCollection collection = new X509CertificateCollection { certificate };
+
+                Assert.Throws<ArgumentNullException>(() => collection[0] = null);
+                Assert.Throws<ArgumentNullException>(() => collection.Add(null));
+                Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509Certificate[])null));
+                Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509CertificateCollection)null));
+                Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
+                Assert.Throws<ArgumentNullException>(() => collection.Insert(0, null));
+                Assert.Throws<ArgumentNullException>(() => collection.Remove(null));
+
+                IList ilist = (IList)collection;
+                Assert.Throws<ArgumentNullException>(() => ilist[0] = null);
+                Assert.Throws<ArgumentNullException>(() => ilist.Add(null));
+                Assert.Throws<ArgumentNullException>(() => ilist.CopyTo(null, 0));
+                Assert.Throws<ArgumentNullException>(() => ilist.Insert(0, null));
+                Assert.Throws<ArgumentNullException>(() => ilist.Remove(null));
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionThrowsArgumentNullException()
+        {
+            using (X509Certificate2 certificate = new X509Certificate2())
+            {
+                X509Certificate2Collection collection = new X509Certificate2Collection { certificate };
+
+                Assert.Throws<ArgumentNullException>(() => collection[0] = null);
+                Assert.Throws<ArgumentNullException>(() => collection.Add((X509Certificate)null));
+                Assert.Throws<ArgumentNullException>(() => collection.Add((X509Certificate2)null));
+                Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509Certificate[])null));
+                Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509CertificateCollection)null));
+                Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509Certificate2[])null));
+                Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509Certificate2Collection)null));
+
+                // Note: X509CertificateCollection.Contains does not throw, but X509Certificate2Collection.Contains does throw.
+                Assert.Throws<ArgumentNullException>(() => collection.Contains((X509Certificate2)null));
+
+                Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
+                Assert.Throws<ArgumentNullException>(() => collection.Insert(0, (X509Certificate)null));
+                Assert.Throws<ArgumentNullException>(() => collection.Insert(0, (X509Certificate2)null));
+                Assert.Throws<ArgumentNullException>(() => collection.Remove((X509Certificate)null));
+                Assert.Throws<ArgumentNullException>(() => collection.Remove((X509Certificate2)null));
+                Assert.Throws<ArgumentNullException>(() => collection.RemoveRange((X509Certificate2[])null));
+                Assert.Throws<ArgumentNullException>(() => collection.RemoveRange((X509Certificate2Collection)null));
+
+                Assert.Throws<ArgumentNullException>(() => collection.Import((byte[])null));
+                Assert.Throws<ArgumentNullException>(() => collection.Import((string)null));
+
+                IList ilist = (IList)collection;
+                Assert.Throws<ArgumentNullException>(() => ilist[0] = null);
+                Assert.Throws<ArgumentNullException>(() => ilist.Add(null));
+                Assert.Throws<ArgumentNullException>(() => ilist.CopyTo(null, 0));
+                Assert.Throws<ArgumentNullException>(() => ilist.Insert(0, null));
+                Assert.Throws<ArgumentNullException>(() => ilist.Remove(null));
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionThrowsArgumentOutOfRangeException()
+        {
+            using (X509Certificate certificate = new X509Certificate())
+            {
+                X509CertificateCollection collection = new X509CertificateCollection { certificate };
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[-1]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[collection.Count]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[-1] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[collection.Count] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.Insert(-1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.Insert(collection.Count + 1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveAt(-1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveAt(collection.Count));
+
+                IList ilist = (IList)collection;
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[-1]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[collection.Count]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[-1] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[collection.Count] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.Insert(-1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.Insert(collection.Count + 1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.RemoveAt(-1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.RemoveAt(collection.Count));
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionThrowsArgumentOutOfRangeException()
+        {
+            using (X509Certificate2 certificate = new X509Certificate2())
+            {
+                X509Certificate2Collection collection = new X509Certificate2Collection { certificate };
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[-1]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[collection.Count]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[-1] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection[collection.Count] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.Insert(-1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.Insert(collection.Count + 1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveAt(-1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveAt(collection.Count));
+
+                IList ilist = (IList)collection;
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[-1]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[collection.Count]);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[-1] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist[collection.Count] = certificate);
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.Insert(-1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.Insert(collection.Count + 1, certificate));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.RemoveAt(-1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ilist.RemoveAt(collection.Count));
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionEnumeratorModification()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+                X509CertificateCollection.X509CertificateEnumerator e = cc.GetEnumerator();
+
+                cc.Add(c1);
+
+                // Collection changed.
+                Assert.Throws<InvalidOperationException>(() => e.MoveNext());
+                Assert.Throws<InvalidOperationException>(() => e.Reset());
             }
         }
 
@@ -86,13 +232,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c2 = new X509Certificate2())
             using (X509Certificate2 c3 = new X509Certificate2())
             {
-                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
-                X509Certificate2Collection.X509CertificateEnumerator e = cc.GetEnumerator();
+                X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
+                X509Certificate2Enumerator e = cc.GetEnumerator();
 
                 cc.Add(c1);
 
                 // Collection changed.
                 Assert.Throws<InvalidOperationException>(() => e.MoveNext());
+                Assert.Throws<InvalidOperationException>(() => e.Reset());
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -12,6 +12,74 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class CollectionTests
     {
         [Fact]
+        public static void X509CertificateCollectionsProperties()
+        {
+            IList ilist = new X509CertificateCollection();
+            Assert.False(ilist.IsSynchronized);
+            Assert.False(ilist.IsFixedSize);
+            Assert.False(ilist.IsReadOnly);
+
+            ilist = new X509Certificate2Collection();
+            Assert.False(ilist.IsSynchronized);
+            Assert.False(ilist.IsFixedSize);
+            Assert.False(ilist.IsReadOnly);
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionConstructors()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+                Assert.Equal(3, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c3, cc[2]);
+
+                X509CertificateCollection cc2 = new X509CertificateCollection(cc);
+                Assert.Equal(3, cc2.Count);
+                Assert.Same(c1, cc2[0]);
+                Assert.Same(c2, cc2[1]);
+                Assert.Same(c3, cc2[2]);
+
+                Assert.Throws<ArgumentNullException>(() => new X509CertificateCollection(new X509Certificate[] { c1, c2, null, c3 }));
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionConstructors()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
+                Assert.Equal(3, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c3, cc[2]);
+
+                X509Certificate2Collection cc2 = new X509Certificate2Collection(cc);
+                Assert.Equal(3, cc2.Count);
+                Assert.Same(c1, cc2[0]);
+                Assert.Same(c2, cc2[1]);
+                Assert.Same(c3, cc2[2]);
+
+                Assert.Throws<ArgumentNullException>(() => new X509Certificate2Collection(new X509Certificate2[] { c1, c2, null, c3 }));
+
+                using (X509Certificate c4 = new X509Certificate())
+                {
+                    X509Certificate2Collection collection = new X509Certificate2Collection { c1, c2, c3 };
+                    ((IList)collection).Add(c4); // Add non-X509Certificate2 object
+
+                    Assert.Throws<InvalidCastException>(() => new X509Certificate2Collection(collection));
+                }
+            }
+        }
+
+        [Fact]
         public static void X509Certificate2CollectionEnumerator()
         {
             using (X509Certificate2 c1 = new X509Certificate2())
@@ -19,9 +87,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c3 = new X509Certificate2())
             {
                 X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
-                X509Certificate2Enumerator e = cc.GetEnumerator();
                 object ignored;
 
+                X509Certificate2Enumerator e = cc.GetEnumerator();
                 for (int i = 0; i < 2; i++)
                 {
                     // Not started
@@ -42,11 +110,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.False(e.MoveNext());
                     Assert.False(e.MoveNext());
 
-                    // ended.
+                    // Ended
                     Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
 
                     e.Reset();
                 }
+
+                IEnumerator e2 = cc.GetEnumerator();
+                TestNonGenericEnumerator(e2, c1, c2, c3);
+
+                IEnumerator e3 = ((IEnumerable)cc).GetEnumerator();
+                TestNonGenericEnumerator(e3, c1, c2, c3);
             }
         }
 
@@ -58,9 +132,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c3 = new X509Certificate2())
             {
                 X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
-                X509CertificateCollection.X509CertificateEnumerator e = cc.GetEnumerator();
                 object ignored;
 
+                X509CertificateCollection.X509CertificateEnumerator e = cc.GetEnumerator();
                 for (int i = 0; i < 2; i++)
                 {
                     // Not started
@@ -81,11 +155,48 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.False(e.MoveNext());
                     Assert.False(e.MoveNext());
 
-                    // ended.
+                    // Ended
                     Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
 
                     e.Reset();
                 }
+
+                IEnumerator e2 = cc.GetEnumerator();
+                TestNonGenericEnumerator(e2, c1, c2, c3);
+
+                IEnumerator e3 = ((IEnumerable)cc).GetEnumerator();
+                TestNonGenericEnumerator(e3, c1, c2, c3);
+            }
+        }
+
+        private static void TestNonGenericEnumerator(IEnumerator e, object c1, object c2, object c3)
+        {
+            object ignored;
+
+            for (int i = 0; i < 2; i++)
+            {
+                // Not started
+                Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+
+                Assert.True(e.MoveNext());
+                Assert.Same(c1, e.Current);
+
+                Assert.True(e.MoveNext());
+                Assert.Same(c2, e.Current);
+
+                Assert.True(e.MoveNext());
+                Assert.Same(c3, e.Current);
+
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+
+                // Ended
+                Assert.Throws<InvalidOperationException>(() => ignored = e.Current);
+
+                e.Reset();
             }
         }
 
@@ -94,6 +205,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (X509Certificate certificate = new X509Certificate())
             {
+                Assert.Throws<ArgumentNullException>(() => new X509CertificateCollection((X509Certificate[])null));
+                Assert.Throws<ArgumentNullException>(() => new X509CertificateCollection((X509CertificateCollection)null));
+
                 X509CertificateCollection collection = new X509CertificateCollection { certificate };
 
                 Assert.Throws<ArgumentNullException>(() => collection[0] = null);
@@ -120,6 +234,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (X509Certificate2 certificate = new X509Certificate2())
             {
+                Assert.Throws<ArgumentNullException>(() => new X509Certificate2Collection((X509Certificate2[])null));
+                Assert.Throws<ArgumentNullException>(() => new X509Certificate2Collection((X509Certificate2Collection)null));
+
                 X509Certificate2Collection collection = new X509Certificate2Collection { certificate };
 
                 Assert.Throws<ArgumentNullException>(() => collection[0] = null);
@@ -301,11 +418,25 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 X509CertificateCollection cc = new X509CertificateCollection();
                 int idx = cc.Add(c1);
                 Assert.Equal(0, idx);
+                Assert.Same(c1, cc[0]);
 
                 idx = cc.Add(c2);
                 Assert.Equal(1, idx);
+                Assert.Same(c2, cc[1]);
 
                 Assert.Throws<ArgumentNullException>(() => cc.Add(null));
+
+
+                IList il = new X509CertificateCollection();
+                idx = il.Add(c1);
+                Assert.Equal(0, idx);
+                Assert.Same(c1, il[0]);
+
+                idx = il.Add(c2);
+                Assert.Equal(1, idx);
+                Assert.Same(c2, il[1]);
+
+                Assert.Throws<ArgumentNullException>(() => il.Add(null));
             }
         }
 
@@ -315,11 +446,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c1 = new X509Certificate2())
             using (X509Certificate2 c2 = new X509Certificate2())
             {
-                X509CertificateCollection cc = new X509CertificateCollection();
-                cc.Add(c1);
-                cc.Add(c2);
+                IList il = new X509CertificateCollection();
+                il.Add(c1);
+                il.Add(c2);
 
-                IList il = cc;
                 Assert.Throws<ArgumentNullException>(() => il[0] = null);
 
                 string bogus = "Bogus";
@@ -708,9 +838,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void X509CertificateCollectionCopyTo()
         {
-            using (X509Certificate2 c1 = new X509Certificate2())
-            using (X509Certificate2 c2 = new X509Certificate2())
-            using (X509Certificate2 c3 = new X509Certificate2())
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
             {
                 X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
 
@@ -727,6 +857,298 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Same(c1, array2[0]);
                 Assert.Same(c2, array2[1]);
                 Assert.Same(c3, array2[2]);
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionIndexOf()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2 });
+                Assert.Equal(0, cc.IndexOf(c1));
+                Assert.Equal(1, cc.IndexOf(c2));
+
+                IList il = cc;
+                Assert.Equal(0, il.IndexOf(c1));
+                Assert.Equal(1, il.IndexOf(c2));
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionRemove()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2 });
+
+                cc.Remove(c1);
+                Assert.Equal(1, cc.Count);
+                Assert.Same(c2, cc[0]);
+
+                cc.Remove(c2);
+                Assert.Equal(0, cc.Count);
+
+
+                IList il = new X509CertificateCollection(new X509Certificate[] { c1, c2 });
+
+                il.Remove(c1);
+                Assert.Equal(1, il.Count);
+                Assert.Same(c2, il[0]);
+
+                il.Remove(c2);
+                Assert.Equal(0, il.Count);
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionRemoveAt()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+
+                cc.RemoveAt(0);
+                Assert.Equal(2, cc.Count);
+                Assert.Same(c2, cc[0]);
+                Assert.Same(c3, cc[1]);
+
+                cc.RemoveAt(1);
+                Assert.Equal(1, cc.Count);
+                Assert.Same(c2, cc[0]);
+
+                cc.RemoveAt(0);
+                Assert.Equal(0, cc.Count);
+
+
+                IList il = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+
+                il.RemoveAt(0);
+                Assert.Equal(2, il.Count);
+                Assert.Same(c2, il[0]);
+                Assert.Same(c3, il[1]);
+
+                il.RemoveAt(1);
+                Assert.Equal(1, il.Count);
+                Assert.Same(c2, il[0]);
+
+                il.RemoveAt(0);
+                Assert.Equal(0, il.Count);
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionRemoveRangeArray()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            {
+                X509Certificate2[] array = new X509Certificate2[] { c1, c2 };
+
+                X509Certificate2Collection cc = new X509Certificate2Collection(array);
+                cc.RemoveRange(array);
+                Assert.Equal(0, cc.Count);
+
+                cc = new X509Certificate2Collection(array);
+                cc.RemoveRange(new X509Certificate2[] { c2, c1 });
+                Assert.Equal(0, cc.Count);
+
+                cc = new X509Certificate2Collection(array);
+                cc.RemoveRange(new X509Certificate2[] { c1 });
+                Assert.Equal(1, cc.Count);
+                Assert.Same(c2, cc[0]);
+
+                cc = new X509Certificate2Collection(array);
+                Assert.Throws<ArgumentNullException>(() => cc.RemoveRange(new X509Certificate2[] { c1, c2, null }));
+                Assert.Equal(2, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+
+                cc = new X509Certificate2Collection(array);
+                Assert.Throws<ArgumentNullException>(() => cc.RemoveRange(new X509Certificate2[] { c1, null, c2 }));
+                Assert.Equal(2, cc.Count);
+                Assert.Same(c2, cc[0]);
+                Assert.Same(c1, cc[1]);
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionRemoveRangeCollection()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509Certificate2[] array = new X509Certificate2[] { c1, c2 };
+
+                X509Certificate2Collection cc = new X509Certificate2Collection(array);
+                cc.RemoveRange(new X509Certificate2Collection { c1, c2 });
+                Assert.Equal(0, cc.Count);
+
+                cc = new X509Certificate2Collection(array);
+                cc.RemoveRange(new X509Certificate2Collection { c2, c1 });
+                Assert.Equal(0, cc.Count);
+
+                cc = new X509Certificate2Collection(array);
+                cc.RemoveRange(new X509Certificate2Collection { c1 });
+                Assert.Equal(1, cc.Count);
+                Assert.Same(c2, cc[0]);
+
+                cc = new X509Certificate2Collection(array);
+                X509Certificate2Collection collection = new X509Certificate2Collection();
+                collection.Add(c1);
+                collection.Add(c2);
+                ((IList)collection).Add(c3); // Add non-X509Certificate2 object
+                Assert.Throws<InvalidCastException>(() => cc.RemoveRange(collection));
+                Assert.Equal(2, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+
+                cc = new X509Certificate2Collection(array);
+                collection = new X509Certificate2Collection();
+                collection.Add(c1);
+                ((IList)collection).Add(c3); // Add non-X509Certificate2 object
+                collection.Add(c2);
+                Assert.Throws<InvalidCastException>(() => cc.RemoveRange(collection));
+                Assert.Equal(2, cc.Count);
+                Assert.Same(c2, cc[0]);
+                Assert.Same(c1, cc[1]);
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionIndexer()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+                cc[0] = c3;
+                cc[1] = c2;
+                cc[2] = c1;
+                Assert.Same(c3, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c1, cc[2]);
+
+                IList il = cc;
+                il[0] = c1;
+                il[1] = c2;
+                il[2] = c3;
+                Assert.Same(c1, il[0]);
+                Assert.Same(c2, il[1]);
+                Assert.Same(c3, il[2]);
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionIndexer()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
+                cc[0] = c3;
+                cc[1] = c2;
+                cc[2] = c1;
+                Assert.Same(c3, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c1, cc[2]);
+
+                IList il = cc;
+                il[0] = c1;
+                il[1] = c2;
+                il[2] = c3;
+                Assert.Same(c1, il[0]);
+                Assert.Same(c2, il[1]);
+                Assert.Same(c3, il[2]);
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionInsertAndClear()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection();
+                cc.Insert(0, c1);
+                cc.Insert(1, c2);
+                cc.Insert(2, c3);
+                Assert.Equal(3, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c3, cc[2]);
+
+                cc.Clear();
+                Assert.Equal(0, cc.Count);
+
+                cc.Add(c1);
+                cc.Add(c3);
+                Assert.Equal(2, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c3, cc[1]);
+
+                cc.Insert(1, c2);
+                Assert.Equal(3, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c3, cc[2]);
+
+                cc.Clear();
+                Assert.Equal(0, cc.Count);
+
+                IList il = cc;
+                il.Insert(0, c1);
+                il.Insert(1, c2);
+                il.Insert(2, c3);
+                Assert.Equal(3, il.Count);
+                Assert.Same(c1, il[0]);
+                Assert.Same(c2, il[1]);
+                Assert.Same(c3, il[2]);
+
+                il.Clear();
+                Assert.Equal(0, il.Count);
+
+                il.Add(c1);
+                il.Add(c3);
+                Assert.Equal(2, il.Count);
+                Assert.Same(c1, il[0]);
+                Assert.Same(c3, il[1]);
+
+                il.Insert(1, c2);
+                Assert.Equal(3, il.Count);
+                Assert.Same(c1, il[0]);
+                Assert.Same(c2, il[1]);
+                Assert.Same(c3, il[2]);
+
+                il.Clear();
+                Assert.Equal(0, il.Count);
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionInsert()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection();
+                cc.Insert(0, c3);
+                cc.Insert(0, c2);
+                cc.Insert(0, c1);
+
+                Assert.Equal(3, cc.Count);
+                Assert.Same(c1, cc[0]);
+                Assert.Same(c2, cc[1]);
+                Assert.Same(c3, cc[2]);
             }
         }
 
@@ -752,6 +1174,34 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Same(c1, array2[0]);
                 Assert.Same(c2, array2[1]);
                 Assert.Same(c3, array2[2]);
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionGetHashCode()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection cc = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+
+                int expected = c1.GetHashCode() + c2.GetHashCode() + c3.GetHashCode();
+                Assert.Equal(expected, cc.GetHashCode());
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionGetHashCode()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
+
+                int expected = c1.GetHashCode() + c2.GetHashCode() + c3.GetHashCode();
+                Assert.Equal(expected, cc.GetHashCode());
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -129,10 +129,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509CertificateCollection)null));
                 Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509Certificate2[])null));
                 Assert.Throws<ArgumentNullException>(() => collection.AddRange((X509Certificate2Collection)null));
-
-                // Note: X509CertificateCollection.Contains does not throw, but X509Certificate2Collection.Contains does throw.
-                Assert.Throws<ArgumentNullException>(() => collection.Contains((X509Certificate2)null));
-
                 Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
                 Assert.Throws<ArgumentNullException>(() => collection.Insert(0, (X509Certificate)null));
                 Assert.Throws<ArgumentNullException>(() => collection.Insert(0, (X509Certificate2)null));
@@ -206,6 +202,57 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<ArgumentOutOfRangeException>(() => ilist.Insert(collection.Count + 1, certificate));
                 Assert.Throws<ArgumentOutOfRangeException>(() => ilist.RemoveAt(-1));
                 Assert.Throws<ArgumentOutOfRangeException>(() => ilist.RemoveAt(collection.Count));
+            }
+        }
+
+        [Fact]
+        public static void X509CertificateCollectionContains()
+        {
+            using (X509Certificate c1 = new X509Certificate())
+            using (X509Certificate c2 = new X509Certificate())
+            using (X509Certificate c3 = new X509Certificate())
+            {
+                X509CertificateCollection collection = new X509CertificateCollection(new X509Certificate[] { c1, c2, c3 });
+
+                Assert.True(collection.Contains(c1));
+                Assert.True(collection.Contains(c2));
+                Assert.True(collection.Contains(c3));
+                Assert.False(collection.Contains(null));
+
+                IList ilist = (IList)collection;
+                Assert.True(ilist.Contains(c1));
+                Assert.True(ilist.Contains(c2));
+                Assert.True(ilist.Contains(c3));
+                Assert.False(ilist.Contains(null));
+                Assert.False(ilist.Contains("Bogus"));
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2CollectionContains()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2())
+            using (X509Certificate2 c2 = new X509Certificate2())
+            using (X509Certificate2 c3 = new X509Certificate2())
+            {
+                X509Certificate2Collection collection = new X509Certificate2Collection(new X509Certificate2[] { c1, c2, c3 });
+
+                Assert.True(collection.Contains(c1));
+                Assert.True(collection.Contains(c2));
+                Assert.True(collection.Contains(c3));
+
+                // Note: X509Certificate2Collection.Contains used to throw ArgumentNullException, but it
+                // has been deliberately changed to no longer throw to match the behavior of
+                // X509CertificateCollection.Contains and the IList.Contains implementation, which do not
+                // throw.
+                Assert.False(collection.Contains(null));
+
+                IList ilist = (IList)collection;
+                Assert.True(ilist.Contains(c1));
+                Assert.True(ilist.Contains(c2));
+                Assert.True(ilist.Contains(c3));
+                Assert.False(ilist.Contains(null));
+                Assert.False(ilist.Contains("Bogus"));
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -111,6 +111,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<ArgumentNullException>(() => ilist.Insert(0, null));
                 Assert.Throws<ArgumentNullException>(() => ilist.Remove(null));
             }
+
+            Assert.Throws<ArgumentNullException>(() => new X509CertificateCollection.X509CertificateEnumerator(null));
         }
 
         [Fact]
@@ -273,11 +275,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 IList il = cc;
                 Assert.Throws<ArgumentNullException>(() => il[0] = null);
 
-                il[0] = "Bogus";
-                Assert.Equal("Bogus", il[0]);
-
-                object ignored;
-                Assert.Throws<InvalidCastException>(() => ignored = cc[0]);
+                string bogus = "Bogus";
+                Assert.Throws<ArgumentException>(() => il[0] = bogus);
+                Assert.Throws<ArgumentException>(() => il.Add(bogus));
+                Assert.Throws<ArgumentException>(() => il.Insert(0, bogus));
             }
         }
 


### PR DESCRIPTION
This PR is broken up into three separate commits (details below). The latter two commits have minor behavior changes that I think are worth doing for .NET Core.

cc: @bartonjs, @weshaggard 

@weshaggard, are the behavior changes in commits 2 and 3 acceptable for .NET Core? If not, I can remove or modify these commits.

#### 1. Cleanup X509Certificate collections

- Avoid enumerator allocations when enumerating the collections.
 - Either enumerate the underlying list directly, or use a for loop and and the indexer, to avoid the enumerator allocation.
- Reduce the allocations associated with creating an enumerator.
 - Unfortunately these already use public reference type enumerators. Internally we can have the enumerators use `List<T>`'s struct enumerator instead of a boxed `IEnumerator`, reducing the allocations associated with the `X509CertificateEnumerator` from 2 allocations to 1. `X509Certificate2Enumerator` was allocating and using the `X509CertificateEnumerator`, and we can just have it use the list's struct enumerator directly, so its allocations are down from 3 allocations to 1.
- Throw `ArgumentNullException` from `Insert` and `Remove` to match the full .NET Framework (desktop) behavior. Add tests to verify.
- Remove some `ArgumentOutOfRangeException` checks as the underlying `List<T>` already handles the same checks. Add tests to verify.
- Use `List<T>`'s `ICollection.SyncObject`, allowing the field to be removed.
- Remove unused usings.
- Move fields to the top of class definitions.
- `Object` -> `object`; `String` -> `string`.
- Minor whitespace cleanup.

#### 2. Harden X509Certificate collections

This commit introduces minor behavior changes in order to harden the `X509Certificate` collections in .NET Core:

- Using `X509CertificateCollection` or `X509Certificate2Collection` as an `IList` allows adding/inserting non-`X509Certificate` objects into the collection. Subsequent calls to enumerate or access these items results in `InvalidCastException` being thrown. This matches the full .NET Framework (desktop) behavior. Clearly this is not the intended behavior of these collections, which are meant to hold `X509Certificate` and `X509Certificate2` objects. This commit changes `X509CertificateCollection` and `X509Certificate2Collection` to throw `ArgumentException` when non-`X509Certificate` objects are attempted to be added/inserted (this behavior comes "for-free" by switching the underlying list from `List<object>` to `List<X509Certificate>`).

- `X509CertificateEnumerator` has a public constructor with a collection parameter that it uses without first verifying the parameter is non-null, which could result in a `NullReferenceException`. This commit adds a null check, throwing `ArgumentNullException` if the parameter is null.

#### 3. X509Certificate2Collection.Contains: Allow null certificates

`X509Certificate2Collection.Contains` throws `ArgumentNullException` when a null value is passed in, but its `IList.Contains` implementation and `X509CertificateCollection.Contains` do not throw. This commit changes `X509Certificate2Collection.Contains` to not throw for a null value to be consistent with its `IList.Contains` implementation and `X509CertificateCollection.Contains`.