### PR TITLE
Deleting System.Runtime test failing after sync primitives change

### DIFF
--- a/src/System.Runtime/tests/System/Threading/WaitHandle.cs
+++ b/src/System.Runtime/tests/System/Threading/WaitHandle.cs
@@ -62,7 +62,7 @@ public static class WaitHandleTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/coreclr/issues/630", PlatformID.AnyUnix)]
+    [PlatformSpecific(PlatformID.Windows)] // names aren't supported on Unix
     public static void WaitAllSameNames()
     {
         Mutex[] wh = new Mutex[2];
@@ -70,19 +70,6 @@ public static class WaitHandleTests
         wh[1] = new Mutex(false, "test");
 
         Assert.Throws<ArgumentException>(() => WaitHandle.WaitAll(wh));
-    }
-
-    [Fact]
-    public static void DisposeTest()
-    {
-        var name = "MyCrazyMutexName" + Guid.NewGuid();
-        var handle = new Mutex(true, name);
-
-        handle.Dispose();
-
-        Assert.False(Mutex.TryOpenExisting(name, out handle));
-        // TODO: Better exceptions on .NET Native
-        //Assert.Throws<ObjectDisposedException>(() => handle.WaitOne(0));
     }
 
     [Fact]


### PR DESCRIPTION
One System.Runtime test is testing the disposal of a Mutex.  Besides that already being covered by multiple System.Threading tests, the test is creating the Mutex with a name, which after recent mscorlib changes fails on Unix, and is preventing successful CI runs.  I'm simply deleting the test.