### PR TITLE
Fix process enumeration bug on Linux

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -96,7 +96,7 @@ namespace System.Diagnostics
                     // arbitrary other processes.
                 };
             }
-            catch (FileNotFoundException)
+            catch (IOException)
             {
                 // Between the time that we get an ID and the time that we try to read the associated stat
                 // file(s), the process could be gone.
@@ -128,8 +128,7 @@ namespace System.Diagnostics
                     }
                 }
             }
-            catch (FileNotFoundException) { } // process and/or threads may go away by the time we try to read from them
-            catch (DirectoryNotFoundException) { }
+            catch (IOException) { } // process and/or threads may go away by the time we try to read from them
 
             // Finally return what we've built up
             return pi;


### PR DESCRIPTION
To find all of the processes on the system, we enumerate procfs looking for all of the pids, and then try to parse the data for each pid.  Between the time that we find a pid and try to open the relevant file for it, the process might go away, resulting in an exception.  We're currently catching FileNotFoundException, but other IOExceptions are possible for the same condition.  Same goes for subsequently enumerating the threads associated with a process. The fix is simply to be a bit more lenient in what we catch.

Fixes #2731.
cc: @Priya91 