### PR TITLE
Fix System.IO.Pipes test on 64-bit

### DIFF
--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -89,7 +90,7 @@ namespace System.IO.Pipes.Tests
 
             using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message))
             {
-                using (NamedPipeClientStream client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None, Security.Principal.TokenImpersonationLevel.Identification))
+                using (NamedPipeClientStream client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Impersonation))
                 {
                     server.ReadMode = PipeTransmissionMode.Message;
                     Assert.Equal(PipeTransmissionMode.Message, server.ReadMode);

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -11,8 +11,6 @@
     <ProjectGuid>{142469EC-D665-4FE2-845A-FDA69F9CC557}</ProjectGuid>
     <NuGetPackageImportStamp>d2615b94</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Temporary workaround until tests are fixed on x64 -->
-    <TestArchitecture>x86</TestArchitecture>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
A test is trying to use NamedPipeServerStream.GetImpersonationUserName and is failing when run in a 64-bit process.  The client stream is being created with TokenImpersonalLevel.Identification, but MSDN states that the underlying GetNamedPipeHandleState being used to get the name will only allow retrieval of the name if SECURITY_IMPERSONATION is used, e.g. TokenImpersonationLevel.Impersonation.  Changing the TokenImpersonationLevel allows the test to pass, on both 32-bit and 64-bit.  This commit does that.

Fixes #2818 
cc: @pallavit, @ericstj

What's strange is that the test passes as-is on 32-bit with Identification rather than Impersonation.  This is true on desktop as well, e.g. this program runs fine in a 32-bit process but fails with an exception in a 64-bit process:
```C#
using System;
using System.IO.Pipes;
using System.Security.Principal;
using System.Threading.Tasks;

class Program
{
    static void Main()
    {
        string pipeName = Guid.NewGuid().ToString("N");
        using (var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut))
        using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Identification))
        {
            Task t = server.WaitForConnectionAsync();
            client.Connect();
            t.Wait();

            Console.WriteLine(server.GetImpersonationUserName()); // succeeds 32-bit, fails 64-bit
        }
    }
}
```
Something to follow-up on separately.