### PR TITLE
Avoid test deadlocks in threading WaitHandle tests

### DIFF
--- a/src/System.Threading/tests/AutoResetEventTests.cs
+++ b/src/System.Threading/tests/AutoResetEventTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 
 public class AutoResetEventTests
 {
+    private const int FailedWaitTimeout = 30000;
+
     [Fact]
     public void Ctor()
     {
@@ -40,7 +42,7 @@ public class AutoResetEventTests
         for (int i = 0; i < handles.Length; i++)
             handles[i] = new AutoResetEvent(false);
 
-        Task<bool> t = Task.Run(() => WaitHandle.WaitAll(handles));
+        Task<bool> t = Task.Run(() => WaitHandle.WaitAll(handles, FailedWaitTimeout));
         for (int i = 0; i < handles.Length; i++)
         {
             Assert.False(t.IsCompleted);
@@ -58,7 +60,7 @@ public class AutoResetEventTests
         for (int i = 0; i < handles.Length; i++)
             handles[i] = new AutoResetEvent(false);
 
-        Task<int> t = Task.Run(() => WaitHandle.WaitAny(handles));
+        Task<int> t = Task.Run(() => WaitHandle.WaitAny(handles, FailedWaitTimeout));
         handles[5].Set();
         Assert.Equal(5, t.Result);
 
@@ -76,7 +78,7 @@ public class AutoResetEventTests
                 {
                     for (int i = 0; i < Iters; i++)
                     {
-                        Assert.True(are1.WaitOne());
+                        Assert.True(are1.WaitOne(FailedWaitTimeout));
                         are2.Set();
                     }
                 }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
@@ -84,7 +86,7 @@ public class AutoResetEventTests
                 {
                     for (int i = 0; i < Iters; i++)
                     {
-                        Assert.True(are2.WaitOne());
+                        Assert.True(are2.WaitOne(FailedWaitTimeout));
                         are1.Set();
                     }
                 }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));

--- a/src/System.Threading/tests/ManualResetEventTests.cs
+++ b/src/System.Threading/tests/ManualResetEventTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 
 public class ManualResetEventTests
 {
+    private const int FailedWaitTimeout = 30000;
+
     [Fact]
     public void Ctor()
     {
@@ -41,7 +43,7 @@ public class ManualResetEventTests
         for (int i = 0; i < handles.Length; i++)
             handles[i] = new ManualResetEvent(false);
 
-        Task<bool> t = Task.Run(() => WaitHandle.WaitAll(handles));
+        Task<bool> t = Task.Run(() => WaitHandle.WaitAll(handles, FailedWaitTimeout));
         for (int i = 0; i < handles.Length; i++)
         {
             Assert.False(t.IsCompleted);
@@ -59,7 +61,7 @@ public class ManualResetEventTests
         for (int i = 0; i < handles.Length; i++)
             handles[i] = new ManualResetEvent(false);
 
-        Task<int> t = Task.Run(() => WaitHandle.WaitAny(handles));
+        Task<int> t = Task.Run(() => WaitHandle.WaitAny(handles, FailedWaitTimeout));
         handles[5].Set();
         Assert.Equal(5, t.Result);
 
@@ -77,7 +79,7 @@ public class ManualResetEventTests
                 {
                     for (int i = 0; i < Iters; i++)
                     {
-                        Assert.True(mre1.WaitOne());
+                        Assert.True(mre1.WaitOne(FailedWaitTimeout));
                         mre1.Reset();
                         mre2.Set();
                     }
@@ -86,7 +88,7 @@ public class ManualResetEventTests
                 {
                     for (int i = 0; i < Iters; i++)
                     {
-                        Assert.True(mre2.WaitOne());
+                        Assert.True(mre2.WaitOne(FailedWaitTimeout));
                         mre2.Reset();
                         mre1.Set();
                     }

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -173,20 +173,23 @@ namespace Test
         {
             string name = Guid.NewGuid().ToString("N");
             const int NumItems = 5;
+            var b = new Barrier(2);
             Task.WaitAll(
                 Task.Factory.StartNew(() =>
                 {
-                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, name))
+                    using (var s = new Semaphore(0, int.MaxValue, name))
                     {
+                        Assert.True(b.SignalAndWait(FailedWaitTimeout));
                         for (int i = 0; i < NumItems; i++)
-                            Assert.True(s.WaitOne(1000));
+                            Assert.True(s.WaitOne(FailedWaitTimeout));
                         Assert.False(s.WaitOne(0));
                     }
                 }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
                 Task.Factory.StartNew(() =>
                 {
-                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, name))
+                    using (var s = new Semaphore(0, int.MaxValue, name))
                     {
+                        Assert.True(b.SignalAndWait(FailedWaitTimeout));
                         for (int i = 0; i < NumItems; i++)
                             s.Release();
                     }

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -10,6 +10,8 @@ namespace Test
 {
     public class SemaphoreTests
     {
+        private const int FailedWaitTimeout = 30000;
+
         [Theory]
         [InlineData(0, 1)]
         [InlineData(1, 1)]
@@ -154,7 +156,7 @@ namespace Test
                     Task.Factory.StartNew(() =>
                     {
                         for (int i = 0; i < NumItems; i++)
-                            s.WaitOne();
+                            Assert.True(s.WaitOne(FailedWaitTimeout));
                         Assert.False(s.WaitOne(0));
                     }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
                     Task.Factory.StartNew(() =>
@@ -169,21 +171,21 @@ namespace Test
         [Fact]
         public void NamedProducerConsumer()
         {
-            const string Name = "NamedProducerConsumerSemaphoreTest";
+            string name = Guid.NewGuid().ToString("N");
             const int NumItems = 5;
             Task.WaitAll(
                 Task.Factory.StartNew(() =>
                 {
-                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, Name))
+                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, name))
                     {
                         for (int i = 0; i < NumItems; i++)
-                            s.WaitOne();
+                            Assert.True(s.WaitOne(1000));
                         Assert.False(s.WaitOne(0));
                     }
                 }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
                 Task.Factory.StartNew(() =>
                 {
-                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, Name))
+                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, name))
                     {
                         for (int i = 0; i < NumItems; i++)
                             s.Release();


### PR DESCRIPTION
A bunch of the Mutex/EventWaitHandle/Semaphore tests are waiting indefinitely for a signal.  If that signal never arrives due to the test failing, CI will end up waiting for several hours and then aborting the whole run.  This change adds timeouts to those waits.  It also changes a name used in one of the semaphore tests to be randomly generated; this should hopefully fix a pervasive failure we're seeing in CI right now.

Edit: updated with an additional commit.  The timeouts added in the first commit identified the failing test in CI, and the second commit should fix the hang.