### PR TITLE
[WIP] Reduce range checks.

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Win32.SafeHandles
             get
             {
                 long h = (long)handle;
-                return h < 0 || h > int.MaxValue;
+                return (ulong)h > (ulong)int.MaxValue;
             }
         }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -2452,15 +2452,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     case FUNDTYPE.FT_I8:
                         return true;
                     case FUNDTYPE.FT_U1:
-                        if (value >= 0 && value <= 0xff)
+                        if ((ulong)value <= (ulong)0xff)
                             return true;
                         break;
                     case FUNDTYPE.FT_U2:
-                        if (value >= 0 && value <= 0xffff)
+                        if ((ulong)value <= (ulong)0xffff)
                             return true;
                         break;
                     case FUNDTYPE.FT_U4:
-                        if (value >= 0 && value <= I64(0xffffffff))
+                        if ((ulong)value <= (ulong)I64(0xffffffff))
                             return true;
                         break;
                     case FUNDTYPE.FT_U8:

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -592,7 +592,7 @@ namespace Microsoft.Win32
             if (machineName == null)
                 throw new ArgumentNullException("machineName");
             int index = (int)hKey & 0x0FFFFFFF;
-            if (index < 0 || index >= hkeyNames.Length || ((int)hKey & 0xFFFFFFF0) != 0x80000000)
+            if ((uint)index >= (uint)hkeyNames.Length || ((int)hKey & 0xFFFFFFF0) != 0x80000000)
             {
                 throw new ArgumentException(SR.Arg_RegKeyOutOfRange);
             }

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1756,7 +1756,7 @@ namespace System.Collections.Concurrent
         private static void ValidateTimeout(TimeSpan timeout)
         {
             long totalMilliseconds = (long)timeout.TotalMilliseconds;
-            if ((totalMilliseconds < 0 || totalMilliseconds > Int32.MaxValue) && (totalMilliseconds != Timeout.Infinite))
+            if (((ulong)totalMilliseconds > (ulong)Int32.MaxValue) && (totalMilliseconds != Timeout.Infinite))
             {
                 throw new ArgumentOutOfRangeException("timeout", timeout,
                     String.Format(CultureInfo.InvariantCulture, SR.BlockingCollection_TimeoutInvalid, Int32.MaxValue));

--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -336,7 +336,7 @@ namespace System.Linq
         [Pure]
         public static T ElementAtOrDefault<T>(this ImmutableArray<T> immutableArray, int index)
         {
-            if (index < 0 || index >= immutableArray.Length)
+            if ((uint)index >= (uint)immutableArray.Length)
             {
                 return default(T);
             }

--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -185,13 +185,13 @@ namespace System.Collections
         {
             get
             {
-                if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
                 return _items[index];
             }
             set
             {
-                if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
                 _items[index] = value;
                 _version++;
@@ -496,7 +496,7 @@ namespace System.Collections
         public virtual void Insert(int index, Object value)
         {
             // Note that insertions at the end are legal.
-            if (index < 0 || index > _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_ArrayListInsert);
+            if ((uint)index > (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_ArrayListInsert);
             //Contract.Ensures(Count == Contract.OldValue(Count) + 1);
             Contract.EndContractBlock();
 
@@ -519,7 +519,7 @@ namespace System.Collections
         {
             if (c == null)
                 throw new ArgumentNullException("c", SR.ArgumentNull_Collection);
-            if (index < 0 || index > _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index > (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             //Contract.Ensures(Count == Contract.OldValue(Count) + c.Count);
             Contract.EndContractBlock();
 
@@ -641,7 +641,7 @@ namespace System.Collections
         // 
         public virtual void RemoveAt(int index)
         {
-            if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.Ensures(Count >= 0);
             //Contract.Ensures(Count == Contract.OldValue(Count) - 1);
             Contract.EndContractBlock();
@@ -1039,7 +1039,7 @@ namespace System.Collections
 
             public override int IndexOf(Object value, int startIndex, int count)
             {
-                if (startIndex < 0 || startIndex > Count) throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                if ((uint)startIndex > (uint)Count) throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
                 if (count < 0 || startIndex > Count - count) throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
                 Contract.EndContractBlock();
 
@@ -1070,7 +1070,7 @@ namespace System.Collections
             {
                 if (c == null)
                     throw new ArgumentNullException("c", SR.ArgumentNull_Collection);
-                if (index < 0 || index > Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index > (uint)Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
 
                 if (c.Count > 0)
@@ -1112,8 +1112,8 @@ namespace System.Collections
                 if (_list.Count == 0)
                     return -1;
 
-                if (startIndex < 0 || startIndex >= _list.Count) throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
-                if (count < 0 || count > startIndex + 1) throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+                if ((uint)startIndex >= (uint)_list.Count) throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                if ((uint)count > (uint)(startIndex + 1)) throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
 
                 int endIndex = startIndex - count + 1;
                 if (value == null)
@@ -2732,7 +2732,7 @@ namespace System.Collections
 
             public override int IndexOf(Object value, int startIndex, int count)
             {
-                if (startIndex < 0 || startIndex > _baseSize)
+                if ((uint)startIndex > (uint)_baseSize)
                     throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
 
                 if (count < 0 || (startIndex > _baseSize - count))
@@ -2747,7 +2747,7 @@ namespace System.Collections
 
             public override void Insert(int index, Object value)
             {
-                if (index < 0 || index > _baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index > (uint)_baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
 
                 InternalUpdateRange();
@@ -2758,7 +2758,7 @@ namespace System.Collections
 
             public override void InsertRange(int index, ICollection c)
             {
-                if (index < 0 || index > _baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index > (uint)_baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 if (c == null)
                 {
                     throw new ArgumentNullException("c");
@@ -2810,7 +2810,7 @@ namespace System.Collections
 
             public override void RemoveAt(int index)
             {
-                if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
 
                 InternalUpdateRange();
@@ -2855,7 +2855,7 @@ namespace System.Collections
             public override void SetRange(int index, ICollection c)
             {
                 InternalUpdateRange();
-                if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 _baseList.SetRange(_baseIndex + index, c);
                 if (c.Count > 0)
                 {
@@ -2881,13 +2881,13 @@ namespace System.Collections
                 get
                 {
                     InternalUpdateRange();
-                    if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                    if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                     return _baseList[_baseIndex + index];
                 }
                 set
                 {
                     InternalUpdateRange();
-                    if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                    if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                     _baseList[_baseIndex + index] = value;
                     InternalUpdateVersion();
                 }

--- a/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
@@ -75,7 +75,7 @@ namespace System.Collections
 
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= Count)
+            if ((uint)index >= (uint)Count)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
             Object temp = InnerList[index];
@@ -122,14 +122,14 @@ namespace System.Collections
         {
             get
             {
-                if (index < 0 || index >= Count)
+                if ((uint)index >= (uint)Count)
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
                 return InnerList[index];
             }
             set
             {
-                if (index < 0 || index >= Count)
+                if ((uint)index >= (uint)Count)
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 Contract.EndContractBlock();
                 OnValidate(value);
@@ -196,7 +196,7 @@ namespace System.Collections
 
         void IList.Insert(int index, Object value)
         {
-            if (index < 0 || index > Count)
+            if ((uint)index > (uint)Count)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
             OnValidate(value);

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -405,7 +405,7 @@ namespace System.Collections
         // 
         public virtual Object GetByIndex(int index)
         {
-            if (index < 0 || index >= Count)
+            if ((uint)index >= (uint)Count)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
             return _values[index];
@@ -435,7 +435,7 @@ namespace System.Collections
         // 
         public virtual Object GetKey(int index)
         {
-            if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
             return _keys[index];
         }
@@ -548,7 +548,7 @@ namespace System.Collections
         // 
         public virtual void RemoveAt(int index)
         {
-            if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
             _size--;
             if (index < _size)
@@ -577,7 +577,7 @@ namespace System.Collections
         // 
         public virtual void SetByIndex(int index, Object value)
         {
-            if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
             _values[index] = value;
             _version++;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -506,7 +506,7 @@ namespace System.Collections.Specialized
             {
                 get
                 {
-                    if (_pos >= 0 && _pos < _coll.Count)
+                    if ((uint)_pos < (uint)_coll.Count)
                     {
                         return _coll.BaseGetKey(_pos);
                     }

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -167,7 +167,7 @@ namespace System.Collections.Specialized
                 {
                     throw new NotSupportedException(SR.OrderedDictionary_ReadOnly);
                 }
-                if (index < 0 || index >= objectsArray.Count)
+                if ((uint)index >= (uint)objectsArray.Count)
                 {
                     throw new ArgumentOutOfRangeException("index");
                 }

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -186,7 +186,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException("array");
             }
 
-            if (index < 0 || index > array.Length)
+            if ((uint)index > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("index", SR.Format(SR.IndexOutOfRange, index));
             }

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -126,7 +126,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException("array");
             }
 
-            if (arrayIndex < 0 || arrayIndex > array.Length)
+            if ((uint)arrayIndex > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_Index);
             }
@@ -167,7 +167,7 @@ namespace System.Collections.Generic
             }
 
             int arrayLen = array.Length;
-            if (index < 0 || index > arrayLen)
+            if ((uint)index > (uint)arrayLen)
             {
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             }

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -450,7 +450,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException("array");
             }
 
-            if (arrayIndex < 0 || arrayIndex > array.Length)
+            if ((uint)arrayIndex > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
@@ -484,7 +484,7 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Arg_NonZeroLowerBound);
             }
 
-            if (arrayIndex < 0 || arrayIndex > array.Length)
+            if ((uint)arrayIndex > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
@@ -544,8 +544,7 @@ namespace System.Collections.Generic
         // 
         private TValue GetByIndex(int index)
         {
-            if (index < 0 || index >= _size)
-                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             return _values[index];
         }
 
@@ -575,7 +574,7 @@ namespace System.Collections.Generic
         // 
         private TKey GetKey(int index)
         {
-            if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             return _keys[index];
         }
 
@@ -711,7 +710,7 @@ namespace System.Collections.Generic
         // 
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             _size--;
             if (index < _size)
             {

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -121,7 +121,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException("array");
             }
 
-            if (arrayIndex < 0 || arrayIndex > array.Length)
+            if ((uint)arrayIndex > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
@@ -163,7 +163,7 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Arg_NonZeroLowerBound);
             }
 
-            if (arrayIndex < 0 || arrayIndex > array.Length)
+            if ((uint)arrayIndex > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
             }

--- a/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarGetWeekOfYear.cs
+++ b/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarGetWeekOfYear.cs
@@ -267,7 +267,7 @@ namespace System.Globalization.CalendarsTests
 
         public virtual int getWeekOfYear(DateTime time, CalendarWeekRule rule, DayOfWeek firstDayOfWeek)
         {
-            if ((int)firstDayOfWeek < 0 || (int)firstDayOfWeek > 6)
+            if ((uint)firstDayOfWeek > 6U)
             {
                 throw new ArgumentOutOfRangeException();
             }

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetWeekOfYear.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetWeekOfYear.cs
@@ -241,7 +241,7 @@ namespace System.Globalization.CalendarsTests
         // integer between 1 and 53.
         private int getWeekOfYear(DateTime time, CalendarWeekRule rule, DayOfWeek firstDayOfWeek)
         {
-            if ((int)firstDayOfWeek < 0 || (int)firstDayOfWeek > 6)
+            if ((uint)firstDayOfWeek > 6U)
             {
                 throw new ArgumentOutOfRangeException();
             }

--- a/src/System.IO.Compression/src/System/IO/Compression/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Inflater.cs
@@ -447,7 +447,7 @@ namespace System.IO.Compression
                             }
                             else
                             {
-                                if (symbol < 0 || symbol >= s_extraLengthBits.Length)
+                                if ((uint)symbol >= (uint)s_extraLengthBits.Length)
                                 {
                                     throw new InvalidDataException(SR.GenericInvalidData);
                                 }
@@ -469,7 +469,7 @@ namespace System.IO.Compression
                                 return false;
                             }
 
-                            if (_length < 0 || _length >= s_lengthBase.Length)
+                            if ((uint)_length >= (uint)s_lengthBase.Length)
                             {
                                 throw new InvalidDataException(SR.GenericInvalidData);
                             }

--- a/src/System.IO.Packaging/src/System/IO/Packaging/XmlCompatibilityReader.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/XmlCompatibilityReader.cs
@@ -443,7 +443,7 @@ namespace System.IO.Packaging
                 // if the current element should not ignored any attributes, call Reader method
                 Reader.MoveToAttribute(i);
             }
-            else if (i < 0 || i >= AttributeCount)
+            else if ((uint)i >= (uint)AttributeCount)
             {
                 throw new ArgumentOutOfRangeException("i");
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -32,7 +32,7 @@ namespace System.Linq.Expressions.Interpreter
             _offset = offset;
 
             var cache = Cache;
-            if (cache != null && offset >= 0 && offset < cache.Length)
+            if (cache != null && (uint)offset < (uint)cache.Length)
             {
                 return cache[offset] ?? (cache[offset] = this);
             }

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3066,7 +3066,7 @@ namespace System.Linq
         {
             get
             {
-                if (index < 0 || index >= count) throw Error.ArgumentOutOfRange("index");
+                if ((uint)index >= (uint)count) throw Error.ArgumentOutOfRange("index");
                 return elements[index];
             }
             set

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -50,7 +50,7 @@ namespace System.Net
         {
             get
             {
-                if (index < 0 || index >= _list.Count)
+                if ((uint)index >= (uint)_list.Count)
                 {
                     throw new ArgumentOutOfRangeException("index");
                 }
@@ -265,7 +265,7 @@ namespace System.Net
             {
                 get
                 {
-                    if (_index < 0 || _index >= _count)
+                    if ((uint)_index >= (uint)_count)
                     {
                         throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
                     }

--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -295,7 +295,7 @@ namespace System.Net
             {
                 get
                 {
-                    if (_index < 0 || _index >= _array.Length)
+                    if ((uint)_index >= (uint)_array.Length)
                     {
                         throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
                     }

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -64,7 +64,7 @@ namespace System.Net
         /// </devdoc>
         public IPAddress(long newAddress)
         {
-            if (newAddress < 0 || newAddress > 0x00000000FFFFFFFF)
+            if ((newAddress & unchecked((long)0xFFFFFFFF00000000)) != 0)
             {
                 throw new ArgumentOutOfRangeException("newAddress");
             }
@@ -97,7 +97,7 @@ namespace System.Net
 
             // Consider: Since scope is only valid for link-local and site-local
             //           addresses we could implement some more robust checking here
-            if (scopeid < 0 || scopeid > 0x00000000FFFFFFFF)
+            if ((scopeid & unchecked((long)0xFFFFFFFF00000000)) != 0)
             {
                 throw new ArgumentOutOfRangeException("scopeid");
             }
@@ -232,7 +232,7 @@ namespace System.Net
 
                 // Consider: Since scope is only valid for link-local and site-local
                 //           addresses we could implement some more robust checking here
-                if (value < 0 || value > 0x00000000FFFFFFFF)
+                if ((value & unchecked((long)0xFFFFFFFF00000000)) != 0)
                 {
                     throw new ArgumentOutOfRangeException("value");
                 }

--- a/src/System.Net.Primitives/src/System/Net/Sockets/SocketAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/Sockets/SocketAddress.cs
@@ -53,7 +53,7 @@ namespace System.Net
         {
             get
             {
-                if (offset < 0 || offset >= Size)
+                if ((uint)offset >= (uint)Size)
                 {
                     throw new IndexOutOfRangeException();
                 }
@@ -61,7 +61,7 @@ namespace System.Net
             }
             set
             {
-                if (offset < 0 || offset >= Size)
+                if ((uint)offset >= (uint)Size)
                 {
                     throw new IndexOutOfRangeException();
                 }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
@@ -776,7 +776,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (startIndex < 0 || startIndex >= destination.Length)
+            if ((uint)startIndex >= (uint)destination.Length)
             {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, startIndex));
             }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -296,7 +296,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (startIndex < 0 || startIndex >= destination.Length)
+            if ((uint)startIndex >= (uint)destination.Length)
             {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, startIndex));
             }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs
@@ -68,7 +68,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
             }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3_Intrinsics.cs
@@ -82,7 +82,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
             }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
@@ -110,7 +110,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
             }

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -276,7 +276,7 @@ namespace System.Collections.ObjectModel
                 throw new ArgumentException(SR.Arg_NonZeroLowerBound);
             }
 
-            if (index < 0 || index > array.Length)
+            if ((uint)index > (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
             }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1886,7 +1886,7 @@ namespace System.Runtime.Serialization
                     else
                     {
                         int paramIndex;
-                        if (!Int32.TryParse(format.Substring(start, i - start), out paramIndex) || paramIndex < 0 || paramIndex >= genericNameProvider.GetParameterCount())
+                        if (!Int32.TryParse(format.Substring(start, i - start), out paramIndex) || (uint)paramIndex >= (uint)genericNameProvider.GetParameterCount())
                             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.GenericParameterNotValid, format.Substring(start, i - start), genericNameProvider.GetGenericTypeName(), genericNameProvider.GetParameterCount() - 1)));
                         typeName.Append(genericNameProvider.GetParameterName(paramIndex));
                     }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
@@ -162,7 +162,7 @@ namespace System.Runtime.Serialization
                 _xmlNodeReader.MoveToAttribute(index);
             else
             {
-                if (index < 0 || index >= _attributeCount)
+                if ((uint)index >= (uint)_attributeCount)
                     throw new XmlException(SR.InvalidXmlDeserializingExtensionData);
 
                 _nodeType = XmlNodeType.Attribute;

--- a/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
@@ -282,7 +282,7 @@ namespace System.Text
         }
         public override int GetMaxCharCount(int byteCount)
         {
-            if (byteCount < 0 || byteCount > int.MaxValue / 4 * 3 - 2)
+            if ((uint)byteCount > (uint)(int.MaxValue / 4 * 3 - 2))
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("byteCount", SR.Format(SR.ValueMustBeInRange, 0, int.MaxValue / 4 * 3 - 2)));
             return ((byteCount + 2) / 3) * 4;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
@@ -106,7 +106,7 @@ namespace System.Text
 #endif
         public override int GetMaxCharCount(int byteCount)
         {
-            if (byteCount < 0 || byteCount > int.MaxValue / 2)
+            if ((uint)byteCount > (uint)(int.MaxValue / 2))
                 throw new ArgumentOutOfRangeException("byteCount", SR.Format(SR.ValueMustBeInRange, 0, int.MaxValue / 2));
             return byteCount * 2;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
@@ -58,7 +58,7 @@ namespace System.Xml
 
         public bool TryLookup(int key, out XmlDictionaryString result)
         {
-            if (_strings != null && key >= 0 && key < _strings.Length)
+            if (_strings != null && (uint)key < (uint)_strings.Length)
             {
                 result = _strings[key];
                 return result != null;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionary.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionary.cs
@@ -77,7 +77,7 @@ namespace System.Xml
 
         public virtual bool TryLookup(int key, out XmlDictionaryString result)
         {
-            if (key < 0 || key >= _nextId)
+            if ((uint)key >= (uint)_nextId)
             {
                 result = null;
                 return false;

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2502,7 +2502,7 @@ namespace System
                 for (int idx = 0; idx < portStr.Length; ++idx)
                 {
                     int val = portStr[idx] - '0';
-                    if (val < 0 || val > 9 || (port = (port * 10 + val)) > 0xFFFF)
+                    if ((uint)val > 9U || (port = (port * 10 + val)) > 0xFFFF)
                         throw new UriFormatException(SR.Format(SR.net_uri_PortOutOfRange, _syntax.GetType().ToString(), portStr));
                 }
                 if (port != _info.Offset.PortValue)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableMemoryStream.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableMemoryStream.cs
@@ -51,7 +51,7 @@ namespace System.Reflection.Internal
             }
             set
             {
-                if (value < 0 || value >= _array.Length)
+                if ((uint)value >= (uint)_array.Length)
                 {
                     throw new ArgumentOutOfRangeException("value");
                 }
@@ -100,7 +100,7 @@ namespace System.Reflection.Internal
                 throw new ArgumentOutOfRangeException("offset");
             }
 
-            if (target < 0 || target >= _array.Length)
+            if ((uint)target >= (uint)_array.Length)
             {
                 throw new ArgumentOutOfRangeException("offset");
             }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ReadOnlyUnmanagedMemoryStream.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ReadOnlyUnmanagedMemoryStream.cs
@@ -113,7 +113,7 @@ namespace System.Reflection.Internal
                 throw new ArgumentOutOfRangeException("offset");
             }
 
-            if (target < 0 || target >= _length)
+            if ((uint)target >= (uint)_length)
             {
                 throw new ArgumentOutOfRangeException("offset");
             }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/HandleCollections.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/HandleCollections.cs
@@ -34,7 +34,7 @@ namespace System.Reflection.Metadata
         {
             get
             {
-                if (index < 0 || index >= _count)
+                if ((uint)index >= (uint)_count)
                 {
                     Throw.IndexOutOfRange();
                 }
@@ -142,7 +142,7 @@ namespace System.Reflection.Metadata
         {
             get
             {
-                if (index < 0 || index >= _count)
+                if ((uint)index >= (uint)_count)
                 {
                     Throw.IndexOutOfRange();
                 }

--- a/src/System.Resources.ReaderWriter/src/System/Resources/ResourceReader.cs
+++ b/src/System.Resources.ReaderWriter/src/System/Resources/ResourceReader.cs
@@ -129,7 +129,7 @@ namespace System.Resources
                     count -= n;
                 }
                 dataOffset = _store.ReadInt32();
-                if (dataOffset < 0 || dataOffset >= _store.BaseStream.Length - _dataSectionOffset)
+                if ((uint)dataOffset >= (uint)(_store.BaseStream.Length - _dataSectionOffset))
                 {
                     throw new FormatException(SR.BadImageFormat_ResourcesDataInvalidOffset + " offset :" + dataOffset);
                 }
@@ -147,7 +147,7 @@ namespace System.Resources
                 SkipString();
 
                 int dataPos = _store.ReadInt32();
-                if (dataPos < 0 || dataPos >= _store.BaseStream.Length - _dataSectionOffset)
+                if ((uint)dataPos >= (uint)(_store.BaseStream.Length - _dataSectionOffset))
                 {
                     throw new FormatException(SR.BadImageFormat_ResourcesDataInvalidOffset + dataPos);
                 }
@@ -344,7 +344,7 @@ namespace System.Resources
        
         private Type FindType(int typeIndex)
         {
-            if (typeIndex < 0 || typeIndex >= _typeTable.Length)
+            if ((uint)typeIndex >= (uint)_typeTable.Length)
             {
                 throw new BadImageFormatException(SR.BadImageFormat_InvalidType);
             }

--- a/src/System.Runtime.Extensions/src/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/src/System/BitConverter.cs
@@ -344,7 +344,7 @@ namespace System
         {
             if (value == null)
                 ThrowValueArgumentNull();
-            if (startIndex < 0 || startIndex >= value.Length && startIndex > 0)
+            if ((uint)startIndex >= (uint)value.Length && startIndex != 0)
                 ThrowStartIndexArgumentOutOfRange();
             if (length < 0)
                 throw new ArgumentOutOfRangeException("length", SR.ArgumentOutOfRange_GenericPositive);

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -635,7 +635,7 @@ namespace System.Net
             {
                 throw new ArgumentNullException("bytes");
             }
-            if (offset < 0 || offset > bytes.Length)
+            if ((uint)offset > (uint)bytes.Length)
             {
                 throw new ArgumentOutOfRangeException("offset");
             }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography
         {
             if (data == null)
                 throw new ArgumentNullException("data");
-            if (offset < 0 || offset > data.Length)
+            if ((uint)offset > (uint)data.Length)
                 throw new ArgumentOutOfRangeException("offset");
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException("count");
@@ -98,7 +98,7 @@ namespace System.Security.Cryptography
         {
             if (data == null)
                 throw new ArgumentNullException("data");
-            if (offset < 0 || offset > data.Length)
+            if ((uint)offset > (uint)data.Length)
                 throw new ArgumentOutOfRangeException("offset");
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException("count");

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/OidCollection.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/OidCollection.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException("array");
             if (array.Rank != 1)
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             if (index + this.Count > array.Length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException("buffer");
             if (offset < 0)
                 throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (count < 0 || (count > buffer.Length))
+            if ((uint)count > (uint)buffer.Length)
                 throw new ArgumentException(SR.Argument_InvalidValue);
             if ((buffer.Length - count) < offset)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -79,7 +79,7 @@ namespace Internal.Cryptography
         private static char NibbleToHex(byte b)
         {
             Debug.Assert(b >= 0 && b <= 15);
-            return (char)(b >= 0 && b <= 9 ? 
+            return (char)(b <= 9 ? 
                 '0' + b : 
                 'A' + (b - 10));
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
@@ -72,14 +72,14 @@ namespace System.Security.Cryptography.X509Certificates
         {
             get
             {
-                if (index < 0 || index >= Count)
+                if ((uint)index >= (uint)Count)
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
 
                 return _list[index];
             }
             set
             {
-                if (index < 0 || index >= Count)
+                if ((uint)index >= (uint)Count)
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
                 if (value == null)
                     throw new ArgumentNullException("value");
@@ -188,7 +188,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= Count)
+            if ((uint)index >= (uint)Count)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             _list.RemoveAt(index);
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentNullException("array");
             if (array.Rank != 1)
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             if (index + Count > array.Length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentNullException("array");
             if (array.Rank != 1)
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
                 throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
             if (index + Count > array.Length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);

--- a/src/System.Security.SecureString/src/System/Security/SecureString.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.cs
@@ -102,7 +102,7 @@ namespace System.Security
         {
             lock (_methodLock)
             {
-                if (index < 0 || index > _decryptedLength)
+                if ((uint)index > (uint)_decryptedLength)
                 {
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
                 }
@@ -142,7 +142,7 @@ namespace System.Security
                 EnsureNotDisposed();
                 EnsureNotReadOnly();
 
-                if (index < 0 || index >= _decryptedLength)
+                if ((uint)index >= (uint)_decryptedLength)
                 {
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
                 }
@@ -156,7 +156,7 @@ namespace System.Security
         {
             lock (_methodLock)
             {
-                if (index < 0 || index >= _decryptedLength)
+                if ((uint)index >= (uint)_decryptedLength)
                 {
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
                 }

--- a/src/System.Text.Encoding.CodePages/src/System/Text/CodePagesEncodingProvider.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/CodePagesEncodingProvider.cs
@@ -22,7 +22,7 @@ namespace System.Text
 
         public override Encoding GetEncoding(int codepage)
         {
-            if (codepage < 0 || codepage > 65535)
+            if ((uint)codepage > 65535U)
                 return null;
 
             if (codepage == 0)

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -147,7 +147,7 @@ namespace System.Text
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException("bytes", SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException("charIndex", SR.ArgumentOutOfRange_Index);
 
             Contract.EndContractBlock();

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
@@ -139,7 +139,7 @@ namespace System.Text
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException("chars", SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException("byteIndex", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
 

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -117,7 +117,7 @@ namespace System.Text
             if (s.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException("s", SR.ArgumentOutOfRange_IndexCount);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException("byteIndex", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
 
@@ -159,7 +159,7 @@ namespace System.Text
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException("chars", SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException("byteIndex", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
 
@@ -259,7 +259,7 @@ namespace System.Text
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException("bytes", SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException("charIndex", SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();
 

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -350,7 +350,7 @@ namespace System.Text.Encodings.Web
 
         private static void ValidateRanges(int startIndex, int characterCount, int actualInputLength)
         {
-            if (startIndex < 0 || startIndex > actualInputLength)
+            if ((uint)startIndex > (uint)actualInputLength)
             {
                 throw new ArgumentOutOfRangeException("startIndex");
             }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnicodeRange.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnicodeRange.cs
@@ -22,7 +22,7 @@ namespace System.Text.Unicode
         {
             // Parameter checking: the first code point and last code point must
             // lie within the BMP. See http://unicode.org/faq/blocks_ranges.html for more info.
-            if (firstCodePoint < 0 || firstCodePoint > 0xFFFF)
+            if ((firstCodePoint & ~0xFFFF) != 0)
             {
                 throw new ArgumentOutOfRangeException("firstCodePoint");
             }

--- a/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Framework.WebEncoders
 
         private static void ValidateInputs(int startIndex, int characterCount, int actualInputLength)
         {
-            if (startIndex < 0 || startIndex > actualInputLength)
+            if ((uint)startIndex > (uint)actualInputLength)
             {
                 throw new ArgumentOutOfRangeException("startIndex");
             }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -353,7 +353,7 @@ namespace System.Text.RegularExpressions
         {
             if (_capslist == null)
             {
-                if (i >= 0 && i < _capsize)
+                if ((uint)i < (uint)_capsize)
                     return i.ToString(CultureInfo.InvariantCulture);
 
                 return String.Empty;
@@ -366,7 +366,7 @@ namespace System.Text.RegularExpressions
                         return String.Empty;
                 }
 
-                if (i >= 0 && i < _capslist.Length)
+                if ((uint)i < (uint)_capslist.Length)
                     return _capslist[i];
 
                 return String.Empty;
@@ -413,7 +413,7 @@ namespace System.Text.RegularExpressions
             }
 
             // return int if it's in range
-            if (result >= 0 && result < _capsize)
+            if ((uint)result < (uint)_capsize)
                 return result;
 
             return -1;
@@ -825,10 +825,10 @@ namespace System.Text.RegularExpressions
             Match match;
             RegexRunner runner = null;
 
-            if (startat < 0 || startat > input.Length)
+            if ((uint)startat > (uint)input.Length)
                 throw new ArgumentOutOfRangeException("start", SR.BeginIndexNotNegative);
 
-            if (length < 0 || length > input.Length)
+            if ((uint)length > (uint)input.Length)
                 throw new ArgumentOutOfRangeException("length", SR.LengthNotNegative);
 
             // There may be a cached runner; grab ownership of it if we can.

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -128,7 +128,7 @@ namespace System.Text.RegularExpressions
             {
                 get
                 {
-                    if (_index < 0 || _index >= _collection.Count)
+                    if ((uint)_index >= (uint)_collection.Count)
                         throw new InvalidOperationException(SR.EnumNotStarted);
 
                     return _collection[_index];

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -150,7 +150,7 @@ namespace System.Text.RegularExpressions
             {
                 get
                 {
-                    if (_index < 0 || _index >= _collection.Count)
+                    if ((uint)_index >= (uint)_collection.Count)
                         throw new InvalidOperationException(SR.EnumNotStarted);
 
                     return _collection[_index];

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -32,7 +32,7 @@ namespace System.Text.RegularExpressions
 
         internal MatchCollection(Regex regex, string input, int beginning, int length, int startat)
         {
-            if (startat < 0 || startat > input.Length)
+            if ((uint)startat > (uint)input.Length)
                 throw new ArgumentOutOfRangeException("startat", SR.BeginIndexNotNegative);
 
             _regex = regex;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1877,7 +1877,7 @@ namespace System.Text.RegularExpressions
             if (_caps != null)
                 return _caps.ContainsKey(i);
 
-            return (i >= 0 && i < _capsize);
+            return ((uint)i < (uint)_capsize);
         }
 
         /*

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -188,7 +188,7 @@ namespace System.Text.RegularExpressions
         {
             if (count < -1)
                 throw new ArgumentOutOfRangeException("count", SR.CountTooSmall);
-            if (startat < 0 || startat > input.Length)
+            if ((uint)startat > (uint)input.Length)
                 throw new ArgumentOutOfRangeException("startat", SR.BeginIndexNotNegative);
 
             if (count == 0)
@@ -270,7 +270,7 @@ namespace System.Text.RegularExpressions
                 throw new ArgumentNullException("evaluator");
             if (count < -1)
                 throw new ArgumentOutOfRangeException("count", SR.CountTooSmall);
-            if (startat < 0 || startat > input.Length)
+            if ((uint)startat > (uint)input.Length)
                 throw new ArgumentOutOfRangeException("startat", SR.BeginIndexNotNegative);
 
             if (count == 0)
@@ -349,7 +349,7 @@ namespace System.Text.RegularExpressions
         {
             if (count < 0)
                 throw new ArgumentOutOfRangeException("count", SR.CountTooSmall);
-            if (startat < 0 || startat > input.Length)
+            if ((uint)startat > (uint)input.Length)
                 throw new ArgumentOutOfRangeException("startat", SR.BeginIndexNotNegative);
 
             String[] result;

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -203,7 +203,7 @@ namespace System.Threading
         public Barrier(int participantCount, Action<Barrier> postPhaseAction)
         {
             // the count must be non negative value
-            if (participantCount < 0 || participantCount > MAX_PARTICIPANTS)
+            if ((uint)participantCount > (uint)MAX_PARTICIPANTS)
             {
                 throw new ArgumentOutOfRangeException("participantCount", participantCount, SR.Barrier_ctor_ArgumentOutOfRange);
             }

--- a/src/System.Threading/src/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/System.Threading/src/System/Threading/ReaderWriterLockSlim.cs
@@ -247,7 +247,7 @@ namespace System.Threading
 
                     int elapsed = Environment.TickCount - _start;
                     // elapsed may be negative if TickCount has overflowed by 2^31 milliseconds.
-                    if (elapsed < 0 || elapsed >= _total)
+                    if ((uint)elapsed >= (uint)_total)
                         return 0;
 
                     return _total - elapsed;

--- a/src/System.Xml.ReaderWriter/src/System/Xml/BufferBuilder.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/BufferBuilder.cs
@@ -118,7 +118,7 @@ namespace System.Xml
                 }
 #endif
 
-                if (value < 0 || value > _length)
+                if ((uint)value > (uint)_length)
                 {
                     throw new ArgumentOutOfRangeException("value");
                 }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -798,7 +798,7 @@ namespace System.Xml
         // Returns value of an attribute at the specified index (position)
         public override string GetAttribute(int i)
         {
-            if (i < 0 || i >= _attrCount)
+            if ((uint)i >= (uint)_attrCount)
             {
                 throw new ArgumentOutOfRangeException("i");
             }
@@ -860,7 +860,7 @@ namespace System.Xml
         // Moves to an attribute at the specified index (position)
         public override void MoveToAttribute(int i)
         {
-            if (i < 0 || i >= _attrCount)
+            if ((uint)i >= (uint)_attrCount)
             {
                 throw new ArgumentOutOfRangeException("i");
             }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Schema/XsdDuration.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Schema/XsdDuration.cs
@@ -52,7 +52,7 @@ namespace System.Xml.Schema
             if (hours < 0) throw new ArgumentOutOfRangeException("hours");
             if (minutes < 0) throw new ArgumentOutOfRangeException("minutes");
             if (seconds < 0) throw new ArgumentOutOfRangeException("seconds");
-            if (nanoseconds < 0 || nanoseconds > 999999999) throw new ArgumentOutOfRangeException("nanoseconds");
+            if ((uint)nanoseconds > 999999999U) throw new ArgumentOutOfRangeException("nanoseconds");
 
             _years = years;
             _months = months;

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
@@ -293,7 +293,7 @@ namespace System.Xml.Linq
                 // Although this means that the first entry will never be used, it avoids the need to initialize all
                 // starting buckets to the EndOfList value.
                 newEntry = Interlocked.Increment(ref _numEntries);
-                if (newEntry < 0 || newEntry >= _buckets.Length)
+                if ((uint)newEntry >= (uint)_buckets.Length)
                     return false;
 
                 _entries[newEntry].Value = value;

--- a/src/System.Xml.XPath/src/System/Xml/Cache/XPathDocumentBuilder.cs
+++ b/src/System.Xml.XPath/src/System/Xml/Cache/XPathDocumentBuilder.cs
@@ -212,7 +212,7 @@ namespace MS.Internal.Xml.Cache
 
                             // If position is not within 256 of parent, don't collapse text
                             int posDiff = _textBldr.LinePosition - _pageParent[_idxParent].LinePosition;
-                            if (posDiff < 0 || posDiff > XPathNode.MaxCollapsedPositionOffset)
+                            if ((uint)posDiff > (uint)XPathNode.MaxCollapsedPositionOffset)
                                 goto case TextBlockType.Whitespace;
 
                             // Set collapsed node line position offset
@@ -651,14 +651,14 @@ namespace MS.Internal.Xml.Cache
             }
 
             lineNumOffset = lineNum - _lineNumBase;
-            if (lineNumOffset < 0 || lineNumOffset > XPathNode.MaxLineNumberOffset)
+            if (lineNumOffset > (uint)XPathNode.MaxLineNumberOffset)
             {
                 _lineNumBase = lineNum;
                 lineNumOffset = 0;
             }
 
             linePosOffset = linePos - _linePosBase;
-            if (linePosOffset < 0 || linePosOffset > XPathNode.MaxLinePositionOffset)
+            if ((uint)linePosOffset > (uint)XPathNode.MaxLinePositionOffset)
             {
                 _linePosBase = linePos;
                 linePosOffset = 0;

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs
@@ -175,7 +175,7 @@ namespace System.Xml
             Debug.Assert(offset != -1); // the if statement above guarantees that the ref node is in the collection
 
             int dupoff = RemoveDuplicateAttribute(newNode);
-            if (dupoff >= 0 && dupoff < offset)
+            if ((uint)dupoff < (uint)offset)
                 offset--;
             InsertNodeAt(offset, newNode);
 
@@ -204,7 +204,7 @@ namespace System.Xml
             Debug.Assert(offset != -1); // the if statement above guarantees that the ref node is in the collection
 
             int dupoff = RemoveDuplicateAttribute(newNode);
-            if (dupoff >= 0 && dupoff < offset)
+            if ((uint)dupoff < (uint)offset)
                 offset--;
             InsertNodeAt(offset + 1, newNode);
 
@@ -229,7 +229,7 @@ namespace System.Xml
         // Removes the attribute node with the specified index from the map.
         public XmlAttribute RemoveAt(int i)
         {
-            if (i < 0 || i >= Count)
+            if ((uint)i >= (uint)Count)
                 return null;
 
             return (XmlAttribute)RemoveNodeAt(i);

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlNamedNodeMap.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlNamedNodeMap.cs
@@ -66,7 +66,7 @@ namespace System.Xml
         // Retrieves the node at the specified index in this XmlNamedNodeMap.
         public virtual XmlNode Item(int index)
         {
-            if (index < 0 || index >= nodes.Count)
+            if ((uint)index >= (uint)nodes.Count)
                 return null;
             try
             {


### PR DESCRIPTION
When a signed value LIMIT is known to be greater than zero, then:

    bool exclusive = value >= 0 && value < LIMIT;
    bool inclusive = value >= 0 && value <= LIMIT;

Is equivalent to:

    bool exclusive = (uint)value < (uint)LIMIT;
    bool inclusive = (uint)value <= (uint)LIMIT;

And so on.

While conceptually in C# replacing the former with the latter would mean
replacing two comparisons with two casts and a comparison, in terms of
the CIL produced there is no cast; rather blt.s is replaced with blt.un.s
clt replaced with clt.un etc.

Changing the former for the latter can therefore not just remove a branch
(in cases where it isn't removed on being jitted) but also increase the odds
of a method being considered "small" by the jitter when it optimises.

Experiment with making such changes.