### PR TITLE
Add a gitattribute rule for .sh files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,9 @@ indent_size = 2
 # Xml config files
 [*.{props,targets,config,nuspec}]
 indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,7 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# Force bash scripts to always use lf line endings so that if a repro is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf


### PR DESCRIPTION
This forces bash scripts to always use lf line endings so that if a
repro is accessed in Unix via a file share from Windows, the scripts
will work.