### PR TITLE
Consolidate temp files in Unix implementations

### DIFF
--- a/src/Common/src/System/IO/PersistedFiles.Names.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Names.Unix.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    internal static partial class PersistedFiles
+    {
+        // Temporary data, /tmp/.dotnet/corefx
+        // User-persisted data, ~/.dotnet/corefx/
+        // System-persisted data, /etc/dotnet/corefx/
+
+        internal const string TopLevelDirectory = "dotnet";
+        internal const string TopLevelHiddenDirectory = "." + TopLevelDirectory;
+        internal const string SecondLevelDirectory = "corefx";
+    }
+}

--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -7,7 +7,25 @@ namespace System.IO
 {
     internal static partial class PersistedFiles
     {
+        private static string s_tempProductDirectory;
         private static string s_userProductDirectory;
+
+        /// <summary>
+        /// Get the location of where to store temporary files for a particular aspect of the framework,
+        /// such as "maps".
+        /// </summary>
+        /// <param name="featureName">The directory name for the feature</param>
+        /// <returns>A path within the temp directory for storing temporary files related to the feature.</returns>
+        internal static string GetTempFeatureDirectory(string featureName)
+        {
+            string path = s_tempProductDirectory;
+            if (path == null)
+            {
+                s_tempProductDirectory = path = Path.Combine(Path.GetTempPath(), TopLevelHiddenDirectory, SecondLevelDirectory);
+            }
+
+            return Path.Combine(path, featureName);
+        }
 
         /// <summary>
         /// Get the location of where to persist information for a particular aspect of the framework,

--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -5,14 +5,8 @@ using System.Diagnostics;
 
 namespace System.IO
 {
-    internal static class PersistedFiles
+    internal static partial class PersistedFiles
     {
-        // If we ever need system persisted data, /etc/dotnet/corefx/
-        private const string TopLevelDirectory = "dotnet";
-        // User persisted data, ~/.dotnet/corefx/
-        private const string TopLevelUserDirectory = "." + TopLevelDirectory;
-        private const string SecondLevelDirectory = "corefx";
-
         private static string s_userProductDirectory;
 
         /// <summary>
@@ -79,7 +73,7 @@ namespace System.IO
 
             s_userProductDirectory = Path.Combine(
                 userHomeDirectory,
-                TopLevelUserDirectory,
+                TopLevelHiddenDirectory,
                 SecondLevelDirectory);
         }
     }

--- a/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
+++ b/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
@@ -216,4 +216,7 @@
   <data name="PlatformNotSupported_NamedMaps" xml:space="preserve">
     <value>Named maps are not supported.</value>
   </data>
+  <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
+    <value>The home directory of the current user could not be determined.</value>
+  </data>
 </root>

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -198,6 +198,9 @@
     <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.SysConfNames.cs">
       <Link>Common\Interop\OSX\Interop.SysConfNames.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Resource files -->
   <ItemGroup>

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -201,6 +201,9 @@
     <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
       <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Resource files -->
   <ItemGroup>

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_File.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_File.cs
@@ -9,8 +9,9 @@ namespace System.IO.MemoryMappedFiles
     {
         private static FileStream CreateSharedBackingObject(Interop.libc.MemoryMappedProtections protections, long capacity)
         {
-            string path = TmpPathPrefix + Guid.NewGuid().ToString("N") + ".tmp";
-
+            Directory.CreateDirectory(s_tempMapsDirectory);
+            string path = Path.Combine(s_tempMapsDirectory, Guid.NewGuid().ToString("N"));
+            
             FileAccess access =
                 (protections & (Interop.libc.MemoryMappedProtections.PROT_READ | Interop.libc.MemoryMappedProtections.PROT_WRITE)) != 0 ? FileAccess.ReadWrite :
                 (protections & (Interop.libc.MemoryMappedProtections.PROT_WRITE)) != 0 ? FileAccess.Write :
@@ -37,6 +38,10 @@ namespace System.IO.MemoryMappedFiles
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        private static readonly string TmpPathPrefix = Path.Combine(Path.GetTempPath(), MemoryMapObjectFilePrefix);
+        private static readonly string s_tempMapsDirectory = Path.Combine(
+            Path.GetTempPath(),
+            PersistedFiles.TopLevelHiddenDirectory,
+            PersistedFiles.SecondLevelDirectory,
+            "maps");
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_File.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_File.cs
@@ -38,10 +38,6 @@ namespace System.IO.MemoryMappedFiles
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        private static readonly string s_tempMapsDirectory = Path.Combine(
-            Path.GetTempPath(),
-            PersistedFiles.TopLevelHiddenDirectory,
-            PersistedFiles.SecondLevelDirectory,
-            "maps");
+        private static readonly string s_tempMapsDirectory = PersistedFiles.GetTempFeatureDirectory("maps");
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_Memory.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_Memory.cs
@@ -11,7 +11,7 @@ namespace System.IO.MemoryMappedFiles
             Interop.libc.MemoryMappedProtections protections, long capacity)
         {
             // The POSIX shared memory object name must begin with '/'.  After that we just want something short and unique.
-            string mapName = "/" + MemoryMapObjectFilePrefix + Guid.NewGuid().ToString("N");
+            string mapName = "/corefx_map_" + Guid.NewGuid().ToString("N");
 
             // Determine the flags to use when creating the shared memory object
             Interop.libc.OpenFlags flags = (protections & Interop.libc.MemoryMappedProtections.PROT_WRITE) != 0 ?

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -122,9 +122,7 @@ namespace System.IO.MemoryMappedFiles
         {
             return new PlatformNotSupportedException(SR.PlatformNotSupported_NamedMaps);
         }
-
-        private const string MemoryMapObjectFilePrefix = "corefx_mmf_";
-
+        
         private static FileAccess TranslateProtectionsToFileAccess(Interop.libc.MemoryMappedProtections protections)
         {
             return

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -139,10 +139,6 @@
     <Compile Include="System\IO\Pipes\PipeStreamAsyncResult.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
-      <!-- TODO: Remove once implemented -->
-      <Link>Common\System\NotImplemented.cs</Link>
-    </Compile>
     <Compile Include="Microsoft\Win32\SafeHandles\SafePipeHandle.Unix.cs" />
     <Compile Include="System\IO\Pipes\AnonymousPipeServerStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\NamedPipeClientStream.Unix.cs" />
@@ -198,6 +194,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Linux -->

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -37,7 +37,7 @@ namespace System.IO.Pipes
             }
 
             // Return the pipe path
-            return Path.Combine(GetPipeDirectoryPath(), pipeName);
+            return Path.Combine(EnsurePipeDirectoryPath(), pipeName);
         }
 
         /// <summary>Throws an exception if the supplied handle does not represent a valid pipe.</summary>
@@ -228,31 +228,57 @@ namespace System.IO.Pipes
 
         private static string s_pipeDirectoryPath;
 
-        private static string GetPipeDirectoryPath()
+        private static string EnsurePipeDirectoryPath()
         {
-            string path = s_pipeDirectoryPath;
-            if (path == null)
+            const string PipesFeatureName = "pipes";
+
+            // Ideally this would simply use PersistedFiles.GetTempFeatureDirectory(PipesFeatureName) and then
+            // Directory.CreateDirectory to ensure it exists.  But this assembly doesn't reference System.IO.FileSystem.
+            // As such, we'd be calling GetTempFeatureDirectory, only to then need to parse it in order
+            // to create each of the individual directories as part of the path.  We instead access the named portions 
+            // of the path directly and do the building of the path and directory structure manually.
+
+            // First ensure we know what the full path should be, e.g. /tmp/.dotnet/corefx/pipes/
+            string fullPath = s_pipeDirectoryPath;
+            string tempPath = null;
+            if (fullPath == null)
             {
-                // Create the pipes temporary directory, e.g. "/tmp/.dotnet/corefx/pipes".
-                // We don't have access to Directory.CreateDirectory (which handles creating
-                // all levels of the directory full path specified), so we create each nested
-                // level individually (though we assume that the temp path already exists).
-
-                path = Path.GetTempPath();
-
-                path = Path.Combine(path, PersistedFiles.TopLevelHiddenDirectory);
-                CreateDirectory(path);
-
-                path = Path.Combine(path, PersistedFiles.SecondLevelDirectory);
-                CreateDirectory(path);
-
-                const string PipesFeatureName = "pipes";
-                path = Path.Combine(path, PipesFeatureName);
-                CreateDirectory(path);
-
-                s_pipeDirectoryPath = path;
+                tempPath = Path.GetTempPath();
+                fullPath = Path.Combine(tempPath, PersistedFiles.TopLevelHiddenDirectory, PersistedFiles.SecondLevelDirectory, PipesFeatureName);
+                s_pipeDirectoryPath = fullPath;
             }
-            return path;
+
+            // Then create the directory if it doesn't already exist.  If we get any error back from stat,
+            // just proceed to build up the directory, failing in the CreateDirectory calls if there's some
+            // problem.  Similarly, it's possible stat succeeds but the path is a file rather than directory; we'll
+            // call that success for now and let this fail later when the code tries to create a file in this "directory"
+            // (we don't want to overwrite/delete whatever that unknown file may be, and this is similar to other cases
+            // we can't control where the file system is manipulated concurrently with and separately from this code).
+            Interop.Sys.FileStatus ignored;
+            bool pathExists = Interop.Sys.Stat(fullPath, out ignored) == 0;
+            if (!pathExists)
+            {
+                // We need to build up the directory manually.  Ensure we have the temp directory in which
+                // we'll create the structure, e.g. /tmp/
+                if (tempPath == null)
+                {
+                    tempPath = Path.GetTempPath();
+                }
+                Debug.Assert(Interop.Sys.Stat(tempPath, out ignored) == 0, "Path.GetTempPath() directory could not be accessed");
+
+                // Create /tmp/.dotnet/ if it doesn't exist.
+                string partialPath = Path.Combine(tempPath, PersistedFiles.TopLevelHiddenDirectory);
+                CreateDirectory(partialPath);
+
+                // Create /tmp/.dotnet/corefx/ if it doesn't exist
+                partialPath = Path.Combine(partialPath, PersistedFiles.SecondLevelDirectory);
+                CreateDirectory(partialPath);
+
+                // Create /tmp/.dotnet/corefx/pipes/ if it doesn't exist
+                CreateDirectory(fullPath);
+            }
+
+            return fullPath;
         }
 
         private static void CreateDirectory(string directoryPath)

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -219,6 +219,9 @@
     <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Unix.cs">
       <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
System.IO.Pipes and System.IO.MemoryMappedFiles both create temporary files, and end up doing so in inconsistent locations.  This commit changes them to use a consistently named location under the temporary path, e.g. /tmp/.dotnet/corefx/pipes/* and /tmp/.dotnet/corefx/maps/*

cc: @bartonjs, @ianhays 