### PR TITLE
Revert range optimization

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1472,8 +1472,7 @@ namespace System.Linq
 
         private static IEnumerable<int> RangeIterator(int start, int count)
         {
-            for (int end = start + count; start < end; start++)
-                yield return start;
+            for (int i = 0; i < count; i++) yield return start + i;
         }
 
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)

--- a/src/System.Linq/tests/RangeTests.cs
+++ b/src/System.Linq/tests/RangeTests.cs
@@ -92,5 +92,18 @@ namespace System.Linq.Tests
                 Assert.NotSame(enum1, enum2);
             }
         }
+
+        [Fact]
+        public void Range_ToInt32MaxValue()
+        {
+            int from = Int32.MaxValue - 3;
+            int count = 4;
+            var rangeEnumerable = Enumerable.Range(from, count);
+
+            Assert.Equal(count, rangeEnumerable.Count());
+
+            int[] expected = { Int32.MaxValue - 3, Int32.MaxValue - 2, Int32.MaxValue - 1, Int32.MaxValue };
+            Assert.Equal(expected, rangeEnumerable);
+        }
     }
 }


### PR DESCRIPTION
The new implementation does not handle the edge case where Enumerable.Range enumerates up to Int32.MaxValue. If values are given such that the end value will be Int32.MaxValue, no values are enumerated. This simply reverts that change.

I've added a simple case that will catch this regression in the future.

Fixes #2852 .