### PR TITLE
Bring back range optimisation, fixed for boundary case.

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1472,7 +1472,7 @@ namespace System.Linq
 
         private static IEnumerable<int> RangeIterator(int start, int count)
         {
-            for (int i = 0; i < count; i++) yield return start + i;
+            for (int end = start + count; start != end; start++) yield return start;
         }
 
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)


### PR DESCRIPTION
31599c5 introduced a boundary error, and was hence reverted in b75ffa4.

This reintroduces the idea of 31599c5, but fixed for the boundary case.