### PR TITLE
Support writing colored messages to console in a multi-threaded environment

### DIFF
--- a/src/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.cs
@@ -8,10 +8,12 @@ using System.Threading.Tasks;
 
 namespace System.IO
 {
+    /* SyncTextReader intentionally locks on itself rather than a private lock object.
+     * This is done to synchronize different console readers(Issue#2855).
+     */
     internal sealed class SyncTextReader : TextReader
     {
         private readonly TextReader _in;
-        private readonly object _methodLock = new object();
 
         public static SyncTextReader GetSynchronizedTextReader(TextReader reader)
         {
@@ -29,7 +31,7 @@ namespace System.IO
         {
             if (disposing)
             {
-                lock (_methodLock)
+                lock (this)
                 {
                     _in.Dispose();
                 }
@@ -38,7 +40,7 @@ namespace System.IO
 
         public override int Peek()
         {
-            lock (_methodLock)
+            lock (this)
             {
                 return _in.Peek();
             }
@@ -46,7 +48,7 @@ namespace System.IO
 
         public override int Read()
         {
-            lock (_methodLock)
+            lock (this)
             {
                 return _in.Read();
             }
@@ -54,7 +56,7 @@ namespace System.IO
 
         public override int Read([In, Out] char[] buffer, int index, int count)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 return _in.Read(buffer, index, count);
             }
@@ -62,7 +64,7 @@ namespace System.IO
 
         public override int ReadBlock([In, Out] char[] buffer, int index, int count)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 return _in.ReadBlock(buffer, index, count);
             }
@@ -70,7 +72,7 @@ namespace System.IO
 
         public override String ReadLine()
         {
-            lock (_methodLock)
+            lock (this)
             {
                 return _in.ReadLine();
             }
@@ -78,7 +80,7 @@ namespace System.IO
 
         public override String ReadToEnd()
         {
-            lock (_methodLock)
+            lock (this)
             {
                 return _in.ReadToEnd();
             }

--- a/src/System.Console/src/System/IO/SyncTextWriter.cs
+++ b/src/System.Console/src/System/IO/SyncTextWriter.cs
@@ -7,9 +7,13 @@ using System.Threading.Tasks;
 
 namespace System.IO
 {
+    /* SyncTextWriter intentionally locks on itself rather than a private lock object.
+     * This is done to synchronize different console writers.
+     * For example - colored console writers can be synchronized with non-colored
+     * writers by locking on Console.On (Issue#2855).
+     */
     internal sealed class SyncTextWriter : TextWriter, IDisposable
     {
-        private readonly object _methodLock = new object();
         internal readonly TextWriter _out;
 
         internal static SyncTextWriter GetSynchronizedTextWriter(TextWriter writer)
@@ -37,15 +41,15 @@ namespace System.IO
 
         public override String NewLine
         {
-            get { lock (_methodLock) { return _out.NewLine; } }
-            set { lock (_methodLock) { _out.NewLine = value; } }
+            get { lock (this) { return _out.NewLine; } }
+            set { lock (this) { _out.NewLine = value; } }
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                lock (_methodLock)
+                lock (this)
                 {
                     _out.Dispose();
                 }
@@ -54,7 +58,7 @@ namespace System.IO
 
         public override void Flush()
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Flush();
             }
@@ -62,7 +66,7 @@ namespace System.IO
 
         public override void Write(char value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -70,7 +74,7 @@ namespace System.IO
 
         public override void Write(char[] buffer)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(buffer);
             }
@@ -78,7 +82,7 @@ namespace System.IO
 
         public override void Write(char[] buffer, int index, int count)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(buffer, index, count);
             }
@@ -86,7 +90,7 @@ namespace System.IO
 
         public override void Write(bool value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -94,7 +98,7 @@ namespace System.IO
 
         public override void Write(int value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -102,7 +106,7 @@ namespace System.IO
 
         public override void Write(uint value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -110,7 +114,7 @@ namespace System.IO
 
         public override void Write(long value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -118,7 +122,7 @@ namespace System.IO
 
         public override void Write(ulong value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -126,7 +130,7 @@ namespace System.IO
 
         public override void Write(float value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -134,7 +138,7 @@ namespace System.IO
 
         public override void Write(double value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -142,7 +146,7 @@ namespace System.IO
 
         public override void Write(Decimal value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -150,7 +154,7 @@ namespace System.IO
 
         public override void Write(String value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -158,7 +162,7 @@ namespace System.IO
 
         public override void Write(Object value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(value);
             }
@@ -166,7 +170,7 @@ namespace System.IO
 
         public override void Write(String format, Object[] arg)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.Write(format, arg);
             }
@@ -174,7 +178,7 @@ namespace System.IO
 
         public override void WriteLine()
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine();
             }
@@ -182,7 +186,7 @@ namespace System.IO
 
         public override void WriteLine(char value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -190,7 +194,7 @@ namespace System.IO
 
         public override void WriteLine(decimal value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -198,7 +202,7 @@ namespace System.IO
 
         public override void WriteLine(char[] buffer)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(buffer);
             }
@@ -206,7 +210,7 @@ namespace System.IO
 
         public override void WriteLine(char[] buffer, int index, int count)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(buffer, index, count);
             }
@@ -214,7 +218,7 @@ namespace System.IO
 
         public override void WriteLine(bool value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -222,7 +226,7 @@ namespace System.IO
 
         public override void WriteLine(int value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -230,7 +234,7 @@ namespace System.IO
 
         public override void WriteLine(uint value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -238,7 +242,7 @@ namespace System.IO
 
         public override void WriteLine(long value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -246,7 +250,7 @@ namespace System.IO
 
         public override void WriteLine(ulong value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -254,7 +258,7 @@ namespace System.IO
 
         public override void WriteLine(float value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -262,7 +266,7 @@ namespace System.IO
 
         public override void WriteLine(double value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -270,7 +274,7 @@ namespace System.IO
 
         public override void WriteLine(String value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -278,7 +282,7 @@ namespace System.IO
 
         public override void WriteLine(Object value)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(value);
             }
@@ -286,7 +290,7 @@ namespace System.IO
 
         public override void WriteLine(String format, Object[] arg)
         {
-            lock (_methodLock)
+            lock (this)
             {
                 _out.WriteLine(format, arg);
             }

--- a/src/System.Console/tests/SyncTextWriter.cs
+++ b/src/System.Console/tests/SyncTextWriter.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+
+public class SyncTextWriter
+{
+
+    [Fact]
+    public void SyncTextWriterLockedOnThis()
+    {
+        TextWriter oldWriter = Console.Out;
+        try
+        {
+            var newWriter = new CallbackTextWriter();
+            Console.SetOut(newWriter);
+            TextWriter syncWriter = Console.Out;
+
+            bool called = false;
+            newWriter.Callback = _ =>
+            {
+                Assert.True(Monitor.IsEntered(syncWriter));
+                called = true;
+            };
+            Console.Write("c");
+            Assert.True(called);
+        }
+        finally
+        {
+            Console.SetOut(oldWriter);
+        }
+    }
+
+    private sealed class CallbackTextWriter : TextWriter
+    {
+        internal Action<char> Callback;
+
+        public override Encoding Encoding { get { return Encoding.UTF8; } }
+
+        public override void Write(char value) { Callback(value); }
+    }
+
+}

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -23,6 +23,7 @@
     <Compile Include="SetOut.cs" />
     <Compile Include="NegativeTesting.cs" />
     <Compile Include="SyncTextReader.cs" />
+    <Compile Include="SyncTextWriter.cs" /> 
     <Compile Include="Timeout.cs" />
     <Compile Include="ThreadSafety.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />


### PR DESCRIPTION
Fix #2808  

In the System.Console portable library SyncTextReader/SyncTextWriter (the reader and writer used by the Console) locked on a private lock object which prevented users from writing colored console messages in sync with non-colored writers. Note this behavior was a regression from the Desktop
where this could be achieved by locking against Console.Out which resulted in locking the writer APIs since the SyncTextWriter internally locked on itself.

Although this approach comes from an implementation detail, the scenario is useful and there exists no work-around for it in the portable library.So, moving back to the earlier implementation, where the readers and writers locked against themselves instead of a private object.