### PR TITLE
Combine is-operator-then-cast sequences.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2229,17 +2229,19 @@ namespace System.Linq.Expressions.Interpreter
                         _instructions.EmitStoreLocal(memberTemp.Value.Index);
                     }
 
-                    if (member.Member is FieldInfo)
+                    FieldInfo field = member.Member as FieldInfo;
+                    if (field != null)
                     {
-                        _instructions.EmitLoadField((FieldInfo)member.Member);
-                        return new FieldByRefUpdater(memberTemp, (FieldInfo)member.Member, index);
+                        _instructions.EmitLoadField(field);
+                        return new FieldByRefUpdater(memberTemp, field, index);
                     }
-                    else if (member.Member is PropertyInfo)
+                    PropertyInfo property = member.Member as PropertyInfo;
+                    if (property != null)
                     {
-                        _instructions.EmitCall(((PropertyInfo)member.Member).GetGetMethod(true));
-                        if (((PropertyInfo)member.Member).CanWrite)
+                        _instructions.EmitCall(property.GetGetMethod(true));
+                        if (property.CanWrite)
                         {
-                            return new PropertyByRefUpdater(memberTemp, (PropertyInfo)member.Member, index);
+                            return new PropertyByRefUpdater(memberTemp, property, index);
                         }
                         return null;
                     }

--- a/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -14,17 +14,15 @@ namespace System.Linq
         {
             if (source == null)
                 throw Error.ArgumentNull("source");
-            if (source is IQueryable<TElement>)
-                return (IQueryable<TElement>)source;
-            return new EnumerableQuery<TElement>(source);
+            return source as IQueryable<TElement> ?? new EnumerableQuery<TElement>(source);
         }
 
         public static IQueryable AsQueryable(this IEnumerable source)
         {
             if (source == null)
                 throw Error.ArgumentNull("source");
-            if (source is IQueryable)
-                return (IQueryable)source;
+            IQueryable queryable = source as IQueryable;
+            if (queryable != null) return queryable;
             Type enumType = TypeHelper.FindGenericType(typeof(IEnumerable<>), source.GetType());
             if (enumType == null)
                 throw Error.ArgumentNotIEnumerableGeneric("source");

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -14,9 +14,12 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (predicate == null) throw Error.ArgumentNull("predicate");
-            if (source is Iterator<TSource>) return ((Iterator<TSource>)source).Where(predicate);
-            if (source is TSource[]) return new WhereArrayIterator<TSource>((TSource[])source, predicate);
-            if (source is List<TSource>) return new WhereListIterator<TSource>((List<TSource>)source, predicate);
+            Iterator<TSource> iterator = source as Iterator<TSource>;
+            if (iterator != null) return iterator.Where(predicate);
+            TSource[] array = source as TSource[];
+            if (array != null) return new WhereArrayIterator<TSource>(array, predicate);
+            List<TSource> list = source as List<TSource>;
+            if (list != null) return new WhereListIterator<TSource>(list, predicate);
             return new WhereEnumerableIterator<TSource>(source, predicate);
         }
 
@@ -41,9 +44,12 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (selector == null) throw Error.ArgumentNull("selector");
-            if (source is Iterator<TSource>) return ((Iterator<TSource>)source).Select(selector);
-            if (source is TSource[]) return new WhereSelectArrayIterator<TSource, TResult>((TSource[])source, null, selector);
-            if (source is List<TSource>) return new WhereSelectListIterator<TSource, TResult>((List<TSource>)source, null, selector);
+            Iterator<TSource> iterator = source as Iterator<TSource>;
+            if (iterator != null) return iterator.Select(selector);
+            TSource[] array = source as TSource[];
+            if (array != null) return new WhereSelectArrayIterator<TSource, TResult>(array, null, selector);
+            List<TSource> list = source as List<TSource>;
+            if (list != null) return new WhereSelectListIterator<TSource, TResult>(list, null, selector);
             return new WhereSelectEnumerableIterator<TSource, TResult>(source, null, selector);
         }
 
@@ -119,14 +125,14 @@ namespace System.Linq
                 //
                 // This is a workaround implementation that does the "virtual dispatch" manually.
 
-                if (this is WhereEnumerableIterator<TSource>)
-                    return ((WhereEnumerableIterator<TSource>)this).SelectImpl<TResult>(selector);
+                WhereEnumerableIterator<TSource> wei = this as WhereEnumerableIterator<TSource>;
+                if (wei != null) return wei.SelectImpl<TResult>(selector);
 
-                if (this is WhereArrayIterator<TSource>)
-                    return ((WhereArrayIterator<TSource>)this).SelectImpl<TResult>(selector);
+                WhereArrayIterator<TSource> wai = this as WhereArrayIterator<TSource>;
+                if (wai != null) return wai.SelectImpl<TResult>(selector);
 
-                if (this is WhereListIterator<TSource>)
-                    return ((WhereListIterator<TSource>)this).SelectImpl<TResult>(selector);
+                WhereListIterator<TSource> wli = this as WhereListIterator<TSource>;
+                if (wli != null) return wli.SelectImpl<TResult>(selector);
 
                 // If we got here, then "this" is one of these types:
                 //


### PR DESCRIPTION
Convert some cases of the form:

    if (value is T) ((T)value).DoSomething();

Etc. Into:

    T tValue = value as T;
    if (tValue != null) tValue.DoSomething();

Slightly smaller IL output, and removes double-cast in the case that uses it.