### PR TITLE
Add HashSet<T> ctors with capacity

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -92,6 +92,10 @@ namespace System.Collections.Generic
             _version = 0;
         }
 
+        public HashSet(int capacity)
+            : this(capacity, EqualityComparer<T>.Default)
+        { }
+
         public HashSet(IEnumerable<T> collection)
             : this(collection, EqualityComparer<T>.Default)
         { }
@@ -128,6 +132,21 @@ namespace System.Collections.Generic
                 (_count > 0 && _slots.Length / _count > ShrinkThreshold))
             {
                 TrimExcess();
+            }
+        }
+
+        public HashSet(int capacity, IEqualityComparer<T> comparer)
+            : this(comparer)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException("capacity");
+            }
+            Contract.EndContractBlock();
+
+            if (capacity > 0)
+            {
+                Initialize(capacity);
             }
         }
 


### PR DESCRIPTION
Replaces PR #2122.  I squashed and fixed up @MarkusSintonen's commits from that PR.
Fixes #382.

New tests are not included due to System.Collections.dll being a partial facade, and the repo not currently having the infrastructure to enable adding tests for new surface area in partial facades.

cc: @terrajobst, @KrzysztofCwalina