### PR TITLE
Fix System.Native shim on FreeBSD

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/Common/src/Interop/Unix/Interop.Errors.cs
@@ -61,7 +61,6 @@ internal static partial class Interop
         ENETUNREACH      = 0x10028,           // Network unreachable.
         ENFILE           = 0x10029,           // Too many files open in system.
         ENOBUFS          = 0x1002A,           // No buffer space available.
-        ENODATA          = 0x1002B,           // No message is available on the STREAM head read queue.
         ENODEV           = 0x1002C,           // No such device.
         ENOENT           = 0x1002D,           // No such file or directory.
         ENOEXEC          = 0x1002E,           // Executable file format error.
@@ -71,8 +70,6 @@ internal static partial class Interop
         ENOMSG           = 0x10032,           // No message of the desired type.
         ENOPROTOOPT      = 0x10033,           // Protocol not available.
         ENOSPC           = 0x10034,           // No space left on device.
-        ENOSR            = 0x10035,           // No STREAM resources.
-        ENOSTR           = 0x10036,           // Not a STREAM.
         ENOSYS           = 0x10037,           // Function not supported.
         ENOTCONN         = 0x10038,           // The socket is not connected.
         ENOTDIR          = 0x10039,           // Not a directory or a symbolic link to a directory.
@@ -94,7 +91,6 @@ internal static partial class Interop
         ESPIPE           = 0x10049,           // Invalid seek.
         ESRCH            = 0x1004A,           // No such process.
         ESTALE           = 0x1004B,           // Reserved.
-        ETIME            = 0x1004C,           // Stream ioctl() timeout.
         ETIMEDOUT        = 0x1004D,           // Connection timed out.
         ETXTBSY          = 0x1004E,           // Text file busy.
         EXDEV            = 0x1004F,           // Cross-device link.

--- a/src/Native/System.Native/pal_errno.cpp
+++ b/src/Native/System.Native/pal_errno.cpp
@@ -56,7 +56,6 @@ Error ConvertErrorPlatformToPal(int32_t platformErrno)
         case ENETUNREACH:      return Error::PAL_ENETUNREACH;
         case ENFILE:           return Error::PAL_ENFILE;
         case ENOBUFS:          return Error::PAL_ENOBUFS;
-        case ENODATA:          return Error::PAL_ENODATA;
         case ENODEV:           return Error::PAL_ENODEV;
         case ENOENT:           return Error::PAL_ENOENT;
         case ENOEXEC:          return Error::PAL_ENOEXEC;
@@ -66,8 +65,6 @@ Error ConvertErrorPlatformToPal(int32_t platformErrno)
         case ENOMSG:           return Error::PAL_ENOMSG;
         case ENOPROTOOPT:      return Error::PAL_ENOPROTOOPT;
         case ENOSPC:           return Error::PAL_ENOSPC;
-        case ENOSR:            return Error::PAL_ENOSR;
-        case ENOSTR:           return Error::PAL_ENOSTR;
         case ENOSYS:           return Error::PAL_ENOSYS;
         case ENOTCONN:         return Error::PAL_ENOTCONN;
         case ENOTDIR:          return Error::PAL_ENOTDIR;
@@ -89,7 +86,6 @@ Error ConvertErrorPlatformToPal(int32_t platformErrno)
         case ESPIPE:           return Error::PAL_ESPIPE;
         case ESRCH:            return Error::PAL_ESRCH;
         case ESTALE:           return Error::PAL_ESTALE;
-        case ETIME:            return Error::PAL_ETIME;
         case ETIMEDOUT:        return Error::PAL_ETIMEDOUT;
         case ETXTBSY:          return Error::PAL_ETXTBSY;
         case EXDEV:            return Error::PAL_EXDEV;
@@ -155,7 +151,6 @@ int32_t ConvertErrorPalToPlatform(Error error)
         case Error::PAL_ENETUNREACH:      return ENETUNREACH;
         case Error::PAL_ENFILE:           return ENFILE;
         case Error::PAL_ENOBUFS:          return ENOBUFS;
-        case Error::PAL_ENODATA:          return ENODATA;
         case Error::PAL_ENODEV:           return ENODEV;
         case Error::PAL_ENOENT:           return ENOENT;
         case Error::PAL_ENOEXEC:          return ENOEXEC;
@@ -165,8 +160,6 @@ int32_t ConvertErrorPalToPlatform(Error error)
         case Error::PAL_ENOMSG:           return ENOMSG;
         case Error::PAL_ENOPROTOOPT:      return ENOPROTOOPT;
         case Error::PAL_ENOSPC:           return ENOSPC;
-        case Error::PAL_ENOSR:            return ENOSR;
-        case Error::PAL_ENOSTR:           return ENOSTR;
         case Error::PAL_ENOSYS:           return ENOSYS;
         case Error::PAL_ENOTCONN:         return ENOTCONN;
         case Error::PAL_ENOTDIR:          return ENOTDIR;
@@ -188,7 +181,6 @@ int32_t ConvertErrorPalToPlatform(Error error)
         case Error::PAL_ESPIPE:           return ESPIPE;
         case Error::PAL_ESRCH:            return ESRCH;
         case Error::PAL_ESTALE:           return ESTALE;
-        case Error::PAL_ETIME:            return ETIME;
         case Error::PAL_ETIMEDOUT:        return ETIMEDOUT;
         case Error::PAL_ETXTBSY:          return ETXTBSY;
         case Error::PAL_EXDEV:            return EXDEV;

--- a/src/Native/System.Native/pal_errno.h
+++ b/src/Native/System.Native/pal_errno.h
@@ -70,7 +70,6 @@ enum class Error : int32_t
     PAL_ENETUNREACH      = 0x10028,           // Network unreachable.
     PAL_ENFILE           = 0x10029,           // Too many files open in system.
     PAL_ENOBUFS          = 0x1002A,           // No buffer space available.
-    PAL_ENODATA          = 0x1002B,           // No message is available on the STREAM head read queue.
     PAL_ENODEV           = 0x1002C,           // No such device.
     PAL_ENOENT           = 0x1002D,           // No such file or directory.
     PAL_ENOEXEC          = 0x1002E,           // Executable file format error.
@@ -80,8 +79,6 @@ enum class Error : int32_t
     PAL_ENOMSG           = 0x10032,           // No message of the desired type.
     PAL_ENOPROTOOPT      = 0x10033,           // Protocol not available.
     PAL_ENOSPC           = 0x10034,           // No space left on device.
-    PAL_ENOSR            = 0x10035,           // No STREAM resources.
-    PAL_ENOSTR           = 0x10036,           // Not a STREAM.
     PAL_ENOSYS           = 0x10037,           // Function not supported.
     PAL_ENOTCONN         = 0x10038,           // The socket is not connected.
     PAL_ENOTDIR          = 0x10039,           // Not a directory or a symbolic link to a directory.
@@ -103,7 +100,6 @@ enum class Error : int32_t
     PAL_ESPIPE           = 0x10049,           // Invalid seek.
     PAL_ESRCH            = 0x1004A,           // No such process.
     PAL_ESTALE           = 0x1004B,           // Reserved.
-    PAL_ETIME            = 0x1004C,           // Stream ioctl() timeout.
     PAL_ETIMEDOUT        = 0x1004D,           // Connection timed out.
     PAL_ETXTBSY          = 0x1004E,           // Text file busy.
     PAL_EXDEV            = 0x1004F,           // Cross-device link.


### PR DESCRIPTION
The error codes ENODATA, ENOSR, ENOSTR and ETIME are not defined on
FreeBSD. Guard these codes with conditional compilation and return
EINVAL.