### PR TITLE
Don't do null check on every loop when filling buffer.

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3442,18 +3442,21 @@ namespace System.Linq
 
             if (items == null)
             {
-                foreach (TElement item in source)
+                using (IEnumerator<TElement> e = source.GetEnumerator())
                 {
-                    if (items == null)
+                    if (e.MoveNext())
                     {
                         items = new TElement[4];
+                        items[0] = e.Current;
+                        count = 1;
+                        
+                        while (e.MoveNext())
+                        {
+                            if (items.Length == count) Array.Resize(ref items, checked(count * 2));
+                            items[count] = e.Current;
+                            ++count;
+                        }
                     }
-                    else if (items.Length == count)
-                    {
-                        Array.Resize(ref items, checked(count * 2));
-                    }
-                    items[count] = item;
-                    count++;
                 }
             }
 


### PR DESCRIPTION
Buffer has an optimisation of using a null array to represent an empty state, that
also plays well with it being a value type.

When the buffer is filled from an enumerable, this possible null state is checked
for on every loop.

Restructure to avoid this redundancy.