### PR TITLE
Add tests for System.Runtime based on mscorlib code coverage data

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="System\MulticastDelegate.cs" />
     <Compile Include="System\Nullable.cs" />
     <Compile Include="System\Object.cs" />
+    <Compile Include="System\Runtime\CompilerServices\ConditionalWeakTable.cs" />
     <Compile Include="System\Runtime\CompilerServices\StrongBox.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="System\SByte.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="System\UInt32.cs" />
     <Compile Include="System\UInt64.cs" />
     <Compile Include="System\UIntPtr.cs" />
+    <Compile Include="System\Uri.cs" />
     <Compile Include="System\ValueType.cs" />
     <Compile Include="System\Version.cs" />
     <Compile Include="System\WeakReference.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -100,6 +100,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.CoreCLR.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/tests/System/Array.cs
+++ b/src/System.Runtime/tests/System/Array.cs
@@ -223,145 +223,85 @@ public static unsafe class ArrayTests
         Assert.Throws<RankException>(() => il4.IndexOf(0));
     }
 
-    [Fact]
-    public static void TestBinarySearch()
+    public static IEnumerable<object[]> BinarySearchTestData
     {
-        //@todo: Must pass in a non-null comparer for now (due to incomplete support in underlying Compare class)
-        //
-        IComparer comparer = new IntegerComparer();
-        IComparer<int> icomparer = new IntegerComparer();
-        int idx;
-        int[] ia = { 1, 3, 6, 6, 8, 10, 12, 16 };
-        idx = Array.BinarySearch((Array)ia, 8, comparer);
-        Assert.Equal(idx, 4);
+        get
+        {
+            int[] intArray = { 1, 3, 6, 6, 8, 10, 12, 16 };
+            IComparer intComparer = new IntegerComparer();
+            IComparer<int> intGenericComparer = new IntegerComparer();
 
-        //Return value semantics: Quoted from MSDN without comment.
-        //
-        //The index of the specified value in the specified array, 
-        //if value is found. If value is not found and value is 
-        //less than one or more elements in array, a negative 
-        //number which is the bitwise complement of the index of 
-        //the first element that is larger than value. 
-        //If value is not found and value is greater than any 
-        //of the elements in array, a negative number which is the bitwise complement of (the index of the last element plus 1).
-        idx = Array.BinarySearch((Array)ia, 99, comparer);
-        Assert.Equal(idx, ~(ia.Length));
+            string[] strArray = { null, "aa", "bb", "bb", "cc", "dd", "ee" };
+            IComparer strComparer = new StringComparer();
+            IComparer<string> strGenericComparer = new StringComparer();
 
-        idx = Array.BinarySearch<int>(ia, 0, 8, 99, icomparer);
-        Assert.Equal(idx, ~(ia.Length));
-
-        idx = Array.BinarySearch((Array)ia, 6, comparer);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
-
-        idx = Array.BinarySearch((Array)ia, 0, 8, 6, comparer);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
-
-        idx = Array.BinarySearch<int>(ia, 6, icomparer);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
-
-        idx = Array.BinarySearch<int>(ia, 0, 8, 6, icomparer);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one
-
-        comparer = new StringComparer();
-        IComparer<String> scomparer = new StringComparer();
-
-        String[] sa = { null, "aa", "bb", "bb", "cc", "dd", "ee" };
-        idx = Array.BinarySearch((Array)sa, "bb", comparer);
-        Assert.Equal(idx, 3);
-
-        idx = Array.BinarySearch<String>(sa, 0, sa.Length, "bb", scomparer);
-        Assert.Equal(idx, 3);
-
-        idx = Array.BinarySearch((Array)sa, 3, 4, "bb", comparer);
-        Assert.Equal(idx, 3);
-
-        idx = Array.BinarySearch<String>(sa, 3, 4, "bb", scomparer);
-        Assert.Equal(idx, 3);
-
-        idx = Array.BinarySearch((Array)sa, 4, 3, "bb", comparer);
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch<String>(sa, 4, 3, "bb", scomparer);
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch((Array)sa, 4, 0, "bb", comparer);
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch<String>(sa, 4, 0, "bb", scomparer);
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch((Array)sa, 0, 7, null, comparer);
-        Assert.Equal(idx, 0);
-
-        idx = Array.BinarySearch<String>(sa, 0, 7, null, scomparer);
-        Assert.Equal(idx, 0);
+            return new[]
+            {
+               new object[] { intArray, 8, intComparer, intGenericComparer, new Func<int, bool>(i => i == 4) },
+               new object[] { intArray, 99, intComparer, intGenericComparer, new Func<int, bool>(i => i == ~(intArray.Length))  },
+               new object[] { intArray, 6, intComparer, intGenericComparer, new Func<int, bool>(i => i == 2 || i == 3)  },
+               new object[] { strArray, "bb", strComparer, strGenericComparer, new Func<int, bool>(i => i == 2 || i == 3)  },
+               new object[] { strArray, null, strComparer, null, new Func<int, bool>(i => i == 0)  },
+           };
+        }
     }
 
-    [Fact]
-    public static void TestBinarySearch_NoIComparer()
+    [Theory, MemberData("BinarySearchTestData")]
+    public static void TestBinarySearch<T>(T[] array, T value, IComparer comparer, IComparer<T> genericComparer, Func<int, bool> verifier)
     {
-        int idx;
-        int[] ia = { 1, 3, 6, 6, 8, 10, 12, 16 };
-        idx = Array.BinarySearch((Array)ia, 8);
-        Assert.Equal(idx, 4);
+        int idx = Array.BinarySearch((Array)array, value, comparer);
+        Assert.True(verifier(idx));
 
-        //Return value semantics: Quoted from MSDN without comment.
-        //
-        //The index of the specified value in the specified array, 
-        //if value is found. If value is not found and value is 
-        //less than one or more elements in array, a negative 
-        //number which is the bitwise complement of the index of 
-        //the first element that is larger than value. 
-        //If value is not found and value is greater than any 
-        //of the elements in array, a negative number which is the bitwise complement of (the index of the last element plus 1).
-        idx = Array.BinarySearch((Array)ia, 99);
-        Assert.Equal(idx, ~(ia.Length));
+        idx = Array.BinarySearch<T>(array, value, genericComparer);
+        Assert.True(verifier(idx));
 
-        idx = Array.BinarySearch<int>(ia, 0, 8, 99);
-        Assert.Equal(idx, ~(ia.Length));
+        idx = Array.BinarySearch((Array)array, value);
+        Assert.True(verifier(idx));
 
-        idx = Array.BinarySearch((Array)ia, 6);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
+        idx = Array.BinarySearch<T>(array, value);
+        Assert.True(verifier(idx));
+    }
 
-        idx = Array.BinarySearch((Array)ia, 0, 8, 6);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
+    public static IEnumerable<object[]> BinarySearchTestDataInRange
+    {
+        get
+        {
+            int[] intArray = { 1, 3, 6, 6, 8, 10, 12, 16 };
+            IComparer intComparer = new IntegerComparer();
+            IComparer<int> intGenericComparer = new IntegerComparer();
 
-        idx = Array.BinarySearch<int>(ia, 6);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
+            string[] strArray = { null, "aa", "bb", "bb", "cc", "dd", "ee" };
+            IComparer strComparer = new StringComparer();
+            IComparer<string> strGenericComparer = new StringComparer();
 
-        idx = Array.BinarySearch<int>(ia, 0, 8, 6);
-        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one
+            return new[]
+            {
+               new object[] { intArray, 0, 8, 99, intComparer, intGenericComparer, new Func<int, bool>(i => i == ~(intArray.Length))  },
+               new object[] { intArray, 0, 8, 6, intComparer, intGenericComparer, new Func<int, bool>(i => i == 2 || i == 3)  },
+               new object[] { intArray, 1, 5, 16, intComparer, intGenericComparer, new Func<int, bool>(i => i == -7)  },
+               new object[] { strArray, 0, strArray.Length, "bb", strComparer, strGenericComparer, new Func<int, bool>(i => i == 2 || i == 3)  },
+               new object[] { strArray, 3, 4, "bb", strComparer, strGenericComparer, new Func<int, bool>(i => i == 3)  },
+               new object[] { strArray, 4, 3, "bb", strComparer, strGenericComparer, new Func<int, bool>(i => i == -5)  },
+               new object[] { strArray, 4, 0, "bb", strComparer, strGenericComparer, new Func<int, bool>(i => i == -5)  },
+               new object[] { strArray, 0, 7, null, strComparer, null, new Func<int, bool>(i => i == 0)  },
+           };
+        }
+    }
 
-        String[] sa = { null, "aa", "bb", "bb", "cc", "dd", "ee" };
-        idx = Array.BinarySearch((Array)sa, "bb");
-        Assert.Equal(idx, 3);
+    [Theory, MemberData("BinarySearchTestDataInRange")]
+    public static void TestBinarySearchInRange<T>(T[] array, int index, int length, T value, IComparer comparer, IComparer<T> genericComparer, Func<int, bool> verifier)
+    {
+        int idx = Array.BinarySearch((Array)array, index, length, value, comparer);
+        Assert.True(verifier(idx));
 
-        idx = Array.BinarySearch<String>(sa, 0, sa.Length, "bb");
-        Assert.Equal(idx, 3);
+        idx = Array.BinarySearch<T>(array, index, length, value, genericComparer);
+        Assert.True(verifier(idx));
 
-        idx = Array.BinarySearch((Array)sa, 3, 4, "bb");
-        Assert.Equal(idx, 3);
+        idx = Array.BinarySearch((Array)array, index, length, value);
+        Assert.True(verifier(idx));
 
-        idx = Array.BinarySearch<String>(sa, 3, 4, "bb");
-        Assert.Equal(idx, 3);
-
-        idx = Array.BinarySearch((Array)sa, 4, 3, "bb");
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch<String>(sa, 4, 3, "bb");
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch((Array)sa, 4, 0, "bb");
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch<String>(sa, 4, 0, "bb");
-        Assert.Equal(idx, -5);
-
-        idx = Array.BinarySearch((Array)sa, 0, 7, null);
-        Assert.Equal(idx, 0);
-
-        idx = Array.BinarySearch<String>(sa, 0, 7, null);
-        Assert.Equal(idx, 0);
+        idx = Array.BinarySearch<T>(array, index, length, value);
+        Assert.True(verifier(idx));
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/Array.cs
+++ b/src/System.Runtime/tests/System/Array.cs
@@ -94,6 +94,7 @@ public static unsafe class ArrayTests
         Assert.Equal(a.Rank, 1);
         IList il = (IList)a;
         Assert.Equal(il.Count, 3);
+        Assert.Equal(il.SyncRoot, a);
         Assert.False(il.IsSynchronized);
         Assert.True(il.IsFixedSize);
         Assert.False(il.IsReadOnly);
@@ -252,10 +253,10 @@ public static unsafe class ArrayTests
         idx = Array.BinarySearch((Array)ia, 6, comparer);
         Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
 
-        idx = Array.BinarySearch<int>(ia, 0, 8, 6, icomparer);
+        idx = Array.BinarySearch((Array)ia, 0, 8, 6, comparer);
         Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
 
-        idx = Array.BinarySearch((Array)ia, 6, comparer);
+        idx = Array.BinarySearch<int>(ia, 6, icomparer);
         Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
 
         idx = Array.BinarySearch<int>(ia, 0, 8, 6, icomparer);
@@ -293,6 +294,73 @@ public static unsafe class ArrayTests
         Assert.Equal(idx, 0);
 
         idx = Array.BinarySearch<String>(sa, 0, 7, null, scomparer);
+        Assert.Equal(idx, 0);
+    }
+
+    [Fact]
+    public static void TestBinarySearch_NoIComparer()
+    {
+        int idx;
+        int[] ia = { 1, 3, 6, 6, 8, 10, 12, 16 };
+        idx = Array.BinarySearch((Array)ia, 8);
+        Assert.Equal(idx, 4);
+
+        //Return value semantics: Quoted from MSDN without comment.
+        //
+        //The index of the specified value in the specified array, 
+        //if value is found. If value is not found and value is 
+        //less than one or more elements in array, a negative 
+        //number which is the bitwise complement of the index of 
+        //the first element that is larger than value. 
+        //If value is not found and value is greater than any 
+        //of the elements in array, a negative number which is the bitwise complement of (the index of the last element plus 1).
+        idx = Array.BinarySearch((Array)ia, 99);
+        Assert.Equal(idx, ~(ia.Length));
+
+        idx = Array.BinarySearch<int>(ia, 0, 8, 99);
+        Assert.Equal(idx, ~(ia.Length));
+
+        idx = Array.BinarySearch((Array)ia, 6);
+        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
+
+        idx = Array.BinarySearch((Array)ia, 0, 8, 6);
+        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
+
+        idx = Array.BinarySearch<int>(ia, 6);
+        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one 
+
+        idx = Array.BinarySearch<int>(ia, 0, 8, 6);
+        Assert.True(idx == 2 || idx == 3); // Duplicates are allowed but no promises on which one
+
+        String[] sa = { null, "aa", "bb", "bb", "cc", "dd", "ee" };
+        idx = Array.BinarySearch((Array)sa, "bb");
+        Assert.Equal(idx, 3);
+
+        idx = Array.BinarySearch<String>(sa, 0, sa.Length, "bb");
+        Assert.Equal(idx, 3);
+
+        idx = Array.BinarySearch((Array)sa, 3, 4, "bb");
+        Assert.Equal(idx, 3);
+
+        idx = Array.BinarySearch<String>(sa, 3, 4, "bb");
+        Assert.Equal(idx, 3);
+
+        idx = Array.BinarySearch((Array)sa, 4, 3, "bb");
+        Assert.Equal(idx, -5);
+
+        idx = Array.BinarySearch<String>(sa, 4, 3, "bb");
+        Assert.Equal(idx, -5);
+
+        idx = Array.BinarySearch((Array)sa, 4, 0, "bb");
+        Assert.Equal(idx, -5);
+
+        idx = Array.BinarySearch<String>(sa, 4, 0, "bb");
+        Assert.Equal(idx, -5);
+
+        idx = Array.BinarySearch((Array)sa, 0, 7, null);
+        Assert.Equal(idx, 0);
+
+        idx = Array.BinarySearch<String>(sa, 0, 7, null);
         Assert.Equal(idx, 0);
     }
 

--- a/src/System.Runtime/tests/System/Buffer.cs
+++ b/src/System.Runtime/tests/System/Buffer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Xunit;
 
 public static unsafe class BufferTests
@@ -69,18 +71,46 @@ public static unsafe class BufferTests
         }
     }
 
-    [Fact]
-    public static void TestByteLength()
+    public static IEnumerable<object[]> ByteLengthTestData
     {
-        int i;
+        get
+        {
+           return new[]
+           {
+               new object[] {typeof(byte), sizeof(byte) },
+               new object[] {typeof(sbyte), sizeof(sbyte) },
+               new object[] {typeof(short), sizeof(short) },
+               new object[] {typeof(ushort), sizeof(ushort) },
+               new object[] {typeof(int), sizeof(int) },
+               new object[] {typeof(uint), sizeof(uint) },
+               new object[] {typeof(long), sizeof(long) },
+               new object[] {typeof(ulong), sizeof(ulong) },
+               new object[] {typeof(IntPtr), sizeof(IntPtr) },
+               new object[] {typeof(UIntPtr), sizeof(UIntPtr) },
+               new object[] {typeof(double), sizeof(double) },
+               new object[] {typeof(float), sizeof(float) },
+               new object[] {typeof(bool), sizeof(bool) },
+               new object[] {typeof(char), sizeof(char) },
+               new object[] {typeof(decimal), sizeof(decimal) },
+               new object[] {typeof(DateTime), sizeof(DateTime) },
+               new object[] {typeof(string), -1 },
+           };
+        }
+    }
 
-        i = Buffer.ByteLength(new int[7]);
-        Assert.Equal(i, 7 * sizeof(int));
-
-        i = Buffer.ByteLength(new double[33]);
-        Assert.Equal(i, 33 * sizeof(double));
-
-        Assert.Throws<ArgumentException>(() => Buffer.ByteLength(new DateTime[10]));
+    [Theory, MemberData("ByteLengthTestData")]
+    public static void TestByteLength(Type type, int size)
+    {
+        const int length = 25;
+        Array array = Array.CreateInstance(type, length);
+        if (type.GetTypeInfo().IsPrimitive)
+        {
+            Assert.Equal(length * size, Buffer.ByteLength(array));
+        }
+        else
+        {
+            Assert.Throws<ArgumentException>(() => Buffer.ByteLength(array));
+        }
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/Buffer.cs
+++ b/src/System.Runtime/tests/System/Buffer.cs
@@ -79,6 +79,8 @@ public static unsafe class BufferTests
 
         i = Buffer.ByteLength(new double[33]);
         Assert.Equal(i, 33 * sizeof(double));
+
+        Assert.Throws<ArgumentException>(() => Buffer.ByteLength(new DateTime[10]));
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/DateTime.cs
+++ b/src/System.Runtime/tests/System/DateTime.cs
@@ -298,8 +298,9 @@ public static unsafe class DateTimeTests
     [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void TestGetDateTimeFormats()
     {
-        // Running in the new thread so that we do not interfere with the Main thread's culture
-        Task.Run(() =>
+        var savedCulture = CultureInfo.CurrentCulture;
+
+        try
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
             DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
@@ -307,15 +308,20 @@ public static unsafe class DateTimeTests
             List<string> actualJuly28Formats = july28.GetDateTimeFormats().ToList();
 
             Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
-        }).Wait();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
     }
 
     [Fact]
     [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void TestGetDateTimeFormats_FormatSpecifier()
     {
-        // Running in the new thread so that we do not interfere with the Main thread's culture
-        Task.Run(() =>
+        var savedCulture = CultureInfo.CurrentCulture;
+
+        try
         {
             char[] allStandardFormats =
             {
@@ -334,7 +340,11 @@ public static unsafe class DateTimeTests
             }
 
             Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
-        }).Wait();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/DateTime.cs
+++ b/src/System.Runtime/tests/System/DateTime.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 public static unsafe class DateTimeTests
@@ -291,6 +294,68 @@ public static unsafe class DateTimeTests
         Assert.Equal(s, actual);
     }
 
+    [Fact]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void TestGetDateTimeFormats()
+    {
+        // Running in the new thread so that we do not interfere with the Main thread's culture
+        Task.Run(() =>
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
+
+            List<string> actualJuly28Formats = july28.GetDateTimeFormats().ToList();
+
+            Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
+        }).Wait();
+    }
+
+    [Fact]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void TestGetDateTimeFormats_FormatSpecifier()
+    {
+        // Running in the new thread so that we do not interfere with the Main thread's culture
+        Task.Run(() =>
+        {
+            char[] allStandardFormats =
+            {
+                'd', 'D', 'f', 'F', 'g', 'G',
+                'm', 'M', 'o', 'O', 'r', 'R',
+                's', 't', 'T', 'u', 'U', 'y', 'Y',
+            };
+
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
+
+            List<string> actualJuly28Formats = new List<string>();
+            foreach (char format in allStandardFormats)
+            {
+                actualJuly28Formats.AddRange(july28.GetDateTimeFormats(format));
+            }
+
+            Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
+        }).Wait();
+    }
+
+    [Fact]
+    public static void TestGetDateTimeFormats_FormatSpecifier_InvalidFormat()
+    {
+        DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
+
+        Assert.Throws<FormatException>(() => july28.GetDateTimeFormats('x'));
+    }
+
+    [Fact]
+    [ActiveIssue(846, PlatformID.AnyUnix)]
+    public static void TestGetDateTimeFormats_FormatProvider()
+    {
+        DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
+
+        List<string> actualJuly28Formats = july28.GetDateTimeFormats(new CultureInfo("en-US")).ToList();
+
+        Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
+    }
+
     internal static void ValidateYearMonthDay(DateTime dt, int year, int month, int day)
     {
         Assert.Equal(dt.Year, year);
@@ -311,5 +376,143 @@ public static unsafe class DateTimeTests
         ValidateYearMonthDay(dt, year, month, day, hour, minute, second);
         Assert.Equal(dt.Millisecond, millisecond);
     }
+
+
+    private static List<string> expectedJuly28Formats = new List<string>
+    {
+        "7/28/2009",
+        "7/28/09",
+        "07/28/09",
+        "07/28/2009",
+        "09/07/28",
+        "2009-07-28",
+        "28-Jul-09",
+        "Tuesday, July 28, 2009",
+        "July 28, 2009",
+        "Tuesday, 28 July, 2009",
+        "28 July, 2009",
+        "Tuesday, July 28, 2009 5:23 AM",
+        "Tuesday, July 28, 2009 05:23 AM",
+        "Tuesday, July 28, 2009 5:23",
+        "Tuesday, July 28, 2009 05:23",
+        "July 28, 2009 5:23 AM",
+        "July 28, 2009 05:23 AM",
+        "July 28, 2009 5:23",
+        "July 28, 2009 05:23",
+        "Tuesday, 28 July, 2009 5:23 AM",
+        "Tuesday, 28 July, 2009 05:23 AM",
+        "Tuesday, 28 July, 2009 5:23",
+        "Tuesday, 28 July, 2009 05:23",
+        "28 July, 2009 5:23 AM",
+        "28 July, 2009 05:23 AM",
+        "28 July, 2009 5:23",
+        "28 July, 2009 05:23",
+        "Tuesday, July 28, 2009 5:23:15 AM",
+        "Tuesday, July 28, 2009 05:23:15 AM",
+        "Tuesday, July 28, 2009 5:23:15",
+        "Tuesday, July 28, 2009 05:23:15",
+        "July 28, 2009 5:23:15 AM",
+        "July 28, 2009 05:23:15 AM",
+        "July 28, 2009 5:23:15",
+        "July 28, 2009 05:23:15",
+        "Tuesday, 28 July, 2009 5:23:15 AM",
+        "Tuesday, 28 July, 2009 05:23:15 AM",
+        "Tuesday, 28 July, 2009 5:23:15",
+        "Tuesday, 28 July, 2009 05:23:15",
+        "28 July, 2009 5:23:15 AM",
+        "28 July, 2009 05:23:15 AM",
+        "28 July, 2009 5:23:15",
+        "28 July, 2009 05:23:15",
+        "7/28/2009 5:23 AM",
+        "7/28/2009 05:23 AM",
+        "7/28/2009 5:23",
+        "7/28/2009 05:23",
+        "7/28/09 5:23 AM",
+        "7/28/09 05:23 AM",
+        "7/28/09 5:23",
+        "7/28/09 05:23",
+        "07/28/09 5:23 AM",
+        "07/28/09 05:23 AM",
+        "07/28/09 5:23",
+        "07/28/09 05:23",
+        "07/28/2009 5:23 AM",
+        "07/28/2009 05:23 AM",
+        "07/28/2009 5:23",
+        "07/28/2009 05:23",
+        "09/07/28 5:23 AM",
+        "09/07/28 05:23 AM",
+        "09/07/28 5:23",
+        "09/07/28 05:23",
+        "2009-07-28 5:23 AM",
+        "2009-07-28 05:23 AM",
+        "2009-07-28 5:23",
+        "2009-07-28 05:23",
+        "28-Jul-09 5:23 AM",
+        "28-Jul-09 05:23 AM",
+        "28-Jul-09 5:23",
+        "28-Jul-09 05:23",
+        "7/28/2009 5:23:15 AM",
+        "7/28/2009 05:23:15 AM",
+        "7/28/2009 5:23:15",
+        "7/28/2009 05:23:15",
+        "7/28/09 5:23:15 AM",
+        "7/28/09 05:23:15 AM",
+        "7/28/09 5:23:15",
+        "7/28/09 05:23:15",
+        "07/28/09 5:23:15 AM",
+        "07/28/09 05:23:15 AM",
+        "07/28/09 5:23:15",
+        "07/28/09 05:23:15",
+        "07/28/2009 5:23:15 AM",
+        "07/28/2009 05:23:15 AM",
+        "07/28/2009 5:23:15",
+        "07/28/2009 05:23:15",
+        "09/07/28 5:23:15 AM",
+        "09/07/28 05:23:15 AM",
+        "09/07/28 5:23:15",
+        "09/07/28 05:23:15",
+        "2009-07-28 5:23:15 AM",
+        "2009-07-28 05:23:15 AM",
+        "2009-07-28 5:23:15",
+        "2009-07-28 05:23:15",
+        "28-Jul-09 5:23:15 AM",
+        "28-Jul-09 05:23:15 AM",
+        "28-Jul-09 5:23:15",
+        "28-Jul-09 05:23:15",
+        "July 28",
+        "July 28",
+        "2009-07-28T05:23:15.0000000",
+        "2009-07-28T05:23:15.0000000",
+        "Tue, 28 Jul 2009 05:23:15 GMT",
+        "Tue, 28 Jul 2009 05:23:15 GMT",
+        "2009-07-28T05:23:15",
+        "5:23 AM",
+        "05:23 AM",
+        "5:23",
+        "05:23",
+        "5:23:15 AM",
+        "05:23:15 AM",
+        "5:23:15",
+        "05:23:15",
+        "2009-07-28 05:23:15Z",
+        "Tuesday, July 28, 2009 12:23:15 PM",
+        "Tuesday, July 28, 2009 12:23:15 PM",
+        "Tuesday, July 28, 2009 12:23:15",
+        "Tuesday, July 28, 2009 12:23:15",
+        "July 28, 2009 12:23:15 PM",
+        "July 28, 2009 12:23:15 PM",
+        "July 28, 2009 12:23:15",
+        "July 28, 2009 12:23:15",
+        "Tuesday, 28 July, 2009 12:23:15 PM",
+        "Tuesday, 28 July, 2009 12:23:15 PM",
+        "Tuesday, 28 July, 2009 12:23:15",
+        "Tuesday, 28 July, 2009 12:23:15",
+        "28 July, 2009 12:23:15 PM",
+        "28 July, 2009 12:23:15 PM",
+        "28 July, 2009 12:23:15",
+        "28 July, 2009 12:23:15",
+        "July 2009",
+        "July 2009",
+    };
 }
 

--- a/src/System.Runtime/tests/System/DateTime.cs
+++ b/src/System.Runtime/tests/System/DateTime.cs
@@ -295,56 +295,35 @@ public static unsafe class DateTimeTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void TestGetDateTimeFormats()
-    {
-        var savedCulture = CultureInfo.CurrentCulture;
-
-        try
+    {        
+        char[] allStandardFormats =
         {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-            DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
+            'd', 'D', 'f', 'F', 'g', 'G',
+            'm', 'M', 'o', 'O', 'r', 'R',
+            's', 't', 'T', 'u', 'U', 'y', 'Y',
+        };
 
-            List<string> actualJuly28Formats = july28.GetDateTimeFormats().ToList();
+        DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
+        List<string> july28Formats = new List<string>();
 
-            Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
-        }
-        finally
+        foreach (char format in allStandardFormats)
         {
-            CultureInfo.CurrentCulture = savedCulture;
+            string[] dates = july28.GetDateTimeFormats(format);
+
+            Assert.True(dates.Length > 0);
+
+            DateTime parsedDate;
+            Assert.True(DateTime.TryParseExact(dates[0], format.ToString(), CultureInfo.CurrentCulture, DateTimeStyles.None, out parsedDate));
+
+            july28Formats.AddRange(dates);
         }
-    }
 
-    [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
-    public static void TestGetDateTimeFormats_FormatSpecifier()
-    {
-        var savedCulture = CultureInfo.CurrentCulture;
+        List<string> actualJuly28Formats = july28.GetDateTimeFormats().ToList();
+        Assert.Equal(july28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
 
-        try
-        {
-            char[] allStandardFormats =
-            {
-                'd', 'D', 'f', 'F', 'g', 'G',
-                'm', 'M', 'o', 'O', 'r', 'R',
-                's', 't', 'T', 'u', 'U', 'y', 'Y',
-            };
-
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-            DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
-
-            List<string> actualJuly28Formats = new List<string>();
-            foreach (char format in allStandardFormats)
-            {
-                actualJuly28Formats.AddRange(july28.GetDateTimeFormats(format));
-            }
-
-            Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = savedCulture;
-        }
+        actualJuly28Formats = july28.GetDateTimeFormats(CultureInfo.CurrentCulture).ToList();
+        Assert.Equal(july28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
     }
 
     [Fact]
@@ -353,17 +332,6 @@ public static unsafe class DateTimeTests
         DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
 
         Assert.Throws<FormatException>(() => july28.GetDateTimeFormats('x'));
-    }
-
-    [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
-    public static void TestGetDateTimeFormats_FormatProvider()
-    {
-        DateTime july28 = new DateTime(2009, 7, 28, 5, 23, 15);
-
-        List<string> actualJuly28Formats = july28.GetDateTimeFormats(new CultureInfo("en-US")).ToList();
-
-        Assert.Equal(expectedJuly28Formats.OrderBy(t => t), actualJuly28Formats.OrderBy(t => t));
     }
 
     internal static void ValidateYearMonthDay(DateTime dt, int year, int month, int day)
@@ -386,143 +354,5 @@ public static unsafe class DateTimeTests
         ValidateYearMonthDay(dt, year, month, day, hour, minute, second);
         Assert.Equal(dt.Millisecond, millisecond);
     }
-
-
-    private static List<string> expectedJuly28Formats = new List<string>
-    {
-        "7/28/2009",
-        "7/28/09",
-        "07/28/09",
-        "07/28/2009",
-        "09/07/28",
-        "2009-07-28",
-        "28-Jul-09",
-        "Tuesday, July 28, 2009",
-        "July 28, 2009",
-        "Tuesday, 28 July, 2009",
-        "28 July, 2009",
-        "Tuesday, July 28, 2009 5:23 AM",
-        "Tuesday, July 28, 2009 05:23 AM",
-        "Tuesday, July 28, 2009 5:23",
-        "Tuesday, July 28, 2009 05:23",
-        "July 28, 2009 5:23 AM",
-        "July 28, 2009 05:23 AM",
-        "July 28, 2009 5:23",
-        "July 28, 2009 05:23",
-        "Tuesday, 28 July, 2009 5:23 AM",
-        "Tuesday, 28 July, 2009 05:23 AM",
-        "Tuesday, 28 July, 2009 5:23",
-        "Tuesday, 28 July, 2009 05:23",
-        "28 July, 2009 5:23 AM",
-        "28 July, 2009 05:23 AM",
-        "28 July, 2009 5:23",
-        "28 July, 2009 05:23",
-        "Tuesday, July 28, 2009 5:23:15 AM",
-        "Tuesday, July 28, 2009 05:23:15 AM",
-        "Tuesday, July 28, 2009 5:23:15",
-        "Tuesday, July 28, 2009 05:23:15",
-        "July 28, 2009 5:23:15 AM",
-        "July 28, 2009 05:23:15 AM",
-        "July 28, 2009 5:23:15",
-        "July 28, 2009 05:23:15",
-        "Tuesday, 28 July, 2009 5:23:15 AM",
-        "Tuesday, 28 July, 2009 05:23:15 AM",
-        "Tuesday, 28 July, 2009 5:23:15",
-        "Tuesday, 28 July, 2009 05:23:15",
-        "28 July, 2009 5:23:15 AM",
-        "28 July, 2009 05:23:15 AM",
-        "28 July, 2009 5:23:15",
-        "28 July, 2009 05:23:15",
-        "7/28/2009 5:23 AM",
-        "7/28/2009 05:23 AM",
-        "7/28/2009 5:23",
-        "7/28/2009 05:23",
-        "7/28/09 5:23 AM",
-        "7/28/09 05:23 AM",
-        "7/28/09 5:23",
-        "7/28/09 05:23",
-        "07/28/09 5:23 AM",
-        "07/28/09 05:23 AM",
-        "07/28/09 5:23",
-        "07/28/09 05:23",
-        "07/28/2009 5:23 AM",
-        "07/28/2009 05:23 AM",
-        "07/28/2009 5:23",
-        "07/28/2009 05:23",
-        "09/07/28 5:23 AM",
-        "09/07/28 05:23 AM",
-        "09/07/28 5:23",
-        "09/07/28 05:23",
-        "2009-07-28 5:23 AM",
-        "2009-07-28 05:23 AM",
-        "2009-07-28 5:23",
-        "2009-07-28 05:23",
-        "28-Jul-09 5:23 AM",
-        "28-Jul-09 05:23 AM",
-        "28-Jul-09 5:23",
-        "28-Jul-09 05:23",
-        "7/28/2009 5:23:15 AM",
-        "7/28/2009 05:23:15 AM",
-        "7/28/2009 5:23:15",
-        "7/28/2009 05:23:15",
-        "7/28/09 5:23:15 AM",
-        "7/28/09 05:23:15 AM",
-        "7/28/09 5:23:15",
-        "7/28/09 05:23:15",
-        "07/28/09 5:23:15 AM",
-        "07/28/09 05:23:15 AM",
-        "07/28/09 5:23:15",
-        "07/28/09 05:23:15",
-        "07/28/2009 5:23:15 AM",
-        "07/28/2009 05:23:15 AM",
-        "07/28/2009 5:23:15",
-        "07/28/2009 05:23:15",
-        "09/07/28 5:23:15 AM",
-        "09/07/28 05:23:15 AM",
-        "09/07/28 5:23:15",
-        "09/07/28 05:23:15",
-        "2009-07-28 5:23:15 AM",
-        "2009-07-28 05:23:15 AM",
-        "2009-07-28 5:23:15",
-        "2009-07-28 05:23:15",
-        "28-Jul-09 5:23:15 AM",
-        "28-Jul-09 05:23:15 AM",
-        "28-Jul-09 5:23:15",
-        "28-Jul-09 05:23:15",
-        "July 28",
-        "July 28",
-        "2009-07-28T05:23:15.0000000",
-        "2009-07-28T05:23:15.0000000",
-        "Tue, 28 Jul 2009 05:23:15 GMT",
-        "Tue, 28 Jul 2009 05:23:15 GMT",
-        "2009-07-28T05:23:15",
-        "5:23 AM",
-        "05:23 AM",
-        "5:23",
-        "05:23",
-        "5:23:15 AM",
-        "05:23:15 AM",
-        "5:23:15",
-        "05:23:15",
-        "2009-07-28 05:23:15Z",
-        "Tuesday, July 28, 2009 12:23:15 PM",
-        "Tuesday, July 28, 2009 12:23:15 PM",
-        "Tuesday, July 28, 2009 12:23:15",
-        "Tuesday, July 28, 2009 12:23:15",
-        "July 28, 2009 12:23:15 PM",
-        "July 28, 2009 12:23:15 PM",
-        "July 28, 2009 12:23:15",
-        "July 28, 2009 12:23:15",
-        "Tuesday, 28 July, 2009 12:23:15 PM",
-        "Tuesday, 28 July, 2009 12:23:15 PM",
-        "Tuesday, 28 July, 2009 12:23:15",
-        "Tuesday, 28 July, 2009 12:23:15",
-        "28 July, 2009 12:23:15 PM",
-        "28 July, 2009 12:23:15 PM",
-        "28 July, 2009 12:23:15",
-        "28 July, 2009 12:23:15",
-        "July 2009",
-        "July 2009",
-    };
 }
 

--- a/src/System.Runtime/tests/System/GC.cs
+++ b/src/System.Runtime/tests/System/GC.cs
@@ -271,21 +271,27 @@ public class GCTests
     }
 
     [Fact]
-    public static void GetTotalMemoryTest_ForceCollection()
+    public static void GetTotalMemoryTest_NoForceCollection()
     {
-        long garbageSize = MakeSomeGarbage(1024 * 1024);
-        long garbageCollected = GC.GetTotalMemory(false) - GC.GetTotalMemory(true);
-        Assert.True(garbageCollected >= garbageSize - 10000); // 10000 bytes threshold to stabilize the test
+        GC.Collect();
+
+        byte[] bytes = new byte[50000];
+        int genBefore = GC.GetGeneration(bytes);
+
+        Assert.True(GC.GetTotalMemory(false) >= bytes.Length);
+        Assert.True(GC.GetGeneration(bytes) == genBefore);
     }
 
     [Fact]
-    public static void GetTotalMemoryTest_NoForceCollection()
+    public static void GetTotalMemoryTest_ForceCollection()
     {
-        long garbageSize = MakeSomeGarbage(1024 * 1024);
-        long before = GC.GetTotalMemory(false);
         GC.Collect();
-        long garbageCollected = before - GC.GetTotalMemory(false);
-        Assert.True(garbageCollected >= garbageSize - 10000); // 10000 bytes threshold to stabilize the test
+
+        byte[] bytes = new byte[50000];
+        int genBeforeGC = GC.GetGeneration(bytes);
+
+        Assert.True(GC.GetTotalMemory(true) >= bytes.Length);
+        Assert.True(GC.GetGeneration(bytes) > genBeforeGC);
     }
 
     [Fact]
@@ -299,12 +305,5 @@ public class GCTests
             Assert.Equal(i, GC.GetGeneration(obj));
             GC.Collect();
         }
-    }
-
-    private static long MakeSomeGarbage(int size)
-    {
-        byte[] bytes = new byte[size];
-        GC.Collect();
-        return bytes.Length;
     }
 }

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+
+public class ConditionalWeakTableTests
+{
+    [Fact]
+    public static void AddTest()
+    {
+        ConditionalWeakTable<object, object> cwt = new ConditionalWeakTable<object, object>();
+        object key = new object();
+        object value = new object();
+        object obj = null;
+
+        cwt.Add(key, value);
+
+        Assert.True(cwt.TryGetValue(key, out value));
+        Assert.Equal(value, cwt.GetOrCreateValue(key));
+        Assert.Equal(value, cwt.GetValue(key , k => new object()));
+
+        WeakReference<object> wrValue = new WeakReference<object>(value, false);
+        WeakReference<object> wrkey = new WeakReference<object>(key, false);
+        key = null;
+        value = null;
+
+        GC.Collect();
+
+        // key and value must be collected
+        Assert.False(wrValue.TryGetTarget(out obj));
+        Assert.False(wrkey.TryGetTarget(out obj));
+    }
+
+    [Fact]
+    public static void GetOrCreateValueTest()
+    {
+        ConditionalWeakTable<object, object> cwt = new ConditionalWeakTable<object, object>();
+        object key = new object();
+        object obj = null;
+
+        object value = cwt.GetOrCreateValue(key);
+
+        Assert.True(cwt.TryGetValue(key, out value));
+        Assert.Equal(value, cwt.GetValue(key, k => new object()));
+
+        WeakReference<object> wrValue = new WeakReference<object>(value, false);
+        WeakReference<object> wrkey = new WeakReference<object>(key, false);
+        key = null;
+        value = null;
+
+        GC.Collect();
+
+        // key and value must be collected
+        Assert.False(wrValue.TryGetTarget(out obj));
+        Assert.False(wrkey.TryGetTarget(out obj));
+    }
+
+    [Fact]
+    public static void GetValueTest()
+    {
+        ConditionalWeakTable<object, object> cwt = new ConditionalWeakTable<object, object>();
+        object key = new object();
+        object obj = null;
+
+        object value = cwt.GetValue(key, k => new object());
+
+        Assert.True(cwt.TryGetValue(key, out value));
+        Assert.Equal(value, cwt.GetOrCreateValue(key));
+
+        WeakReference<object> wrValue = new WeakReference<object>(value, false);
+        WeakReference<object> wrkey = new WeakReference<object>(key, false);
+        key = null;
+        value = null;
+
+        GC.Collect();
+
+        // key and value must be collected
+        Assert.False(wrValue.TryGetTarget(out obj));
+        Assert.False(wrkey.TryGetTarget(out obj));
+    }
+}
+

--- a/src/System.Runtime/tests/System/TimeSpan.cs
+++ b/src/System.Runtime/tests/System/TimeSpan.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 
 public static unsafe class TimeSpanTests
@@ -59,5 +61,86 @@ public static unsafe class TimeSpanTests
 
         spanRes = TimeSpan.FromMilliseconds(ts.Milliseconds);
         Assert.Equal(new TimeSpan(0, 0, 0, 0, ts.Milliseconds), spanRes);
+    }
+
+    [Theory, MemberData("TimeSpanTestData")]
+    public static void ParseExactTest(string inputTimeSpan, string format, TimeSpan expectedTimeSpan)
+    {
+        TimeSpan actualTimeSpan = TimeSpan.ParseExact(inputTimeSpan, format, new CultureInfo("en-US"));
+        Assert.Equal(expectedTimeSpan, actualTimeSpan);
+
+        bool parsed = TimeSpan.TryParseExact(inputTimeSpan, format, new CultureInfo("en-US"), out actualTimeSpan);
+        Assert.True(parsed);
+        Assert.Equal(expectedTimeSpan, actualTimeSpan);
+
+        // TimeSpanStyles is interpreted only for custom formats
+        if (format != "c" && format != "g" && format != "G")
+        {
+            actualTimeSpan = TimeSpan.ParseExact(inputTimeSpan, format, new CultureInfo("en-US"), TimeSpanStyles.AssumeNegative);
+            Assert.Equal(expectedTimeSpan.Negate(), actualTimeSpan);
+
+            parsed = TimeSpan.TryParseExact(inputTimeSpan, format, new CultureInfo("en-US"), TimeSpanStyles.AssumeNegative, out actualTimeSpan);
+            Assert.True(parsed);
+            Assert.Equal(expectedTimeSpan.Negate(), actualTimeSpan);
+        }
+    }
+
+    [Theory, MemberData("TimeSpanTestData_IncorrectFormat")]
+    public static void ParseExactTest_Exception(string inputTimeSpan, string format, Type expectedException)
+    {
+        Assert.Throws(expectedException, () => TimeSpan.ParseExact(inputTimeSpan, format, new CultureInfo("en-US")));
+
+        TimeSpan actualTimeSpan;
+        bool parsed = TimeSpan.TryParseExact(inputTimeSpan, format, new CultureInfo("en-US"), out actualTimeSpan);
+
+        Assert.False(parsed);
+        Assert.Equal(TimeSpan.Zero, actualTimeSpan);
+    }
+
+    public static IEnumerable<object[]> TimeSpanTestData
+    {
+        get
+        {
+            return new[]
+            {
+                //standard timespan formats 'c', 'g', 'G'
+                new object[] { "12:24:02", "c", new TimeSpan(0, 12, 24, 2) },
+                new object[] { "1.12:24:02", "c", new TimeSpan(1, 12, 24, 2) },
+                new object[] { "-01.07:45:16.999", "c", new TimeSpan(1, 7, 45, 16, 999).Negate() },
+                new object[] { "12:24:02", "g", new TimeSpan(0, 12, 24, 2) },
+                new object[] { "1:12:24:02", "g", new TimeSpan(1, 12, 24, 2) },
+                new object[] { "-01:07:45:16.999", "g", new TimeSpan(1, 7, 45, 16, 999).Negate() },
+                new object[] { "1:12:24:02.243", "G", new TimeSpan(1, 12, 24, 2, 243) },
+                new object[] { "-01:07:45:16.999", "G", new TimeSpan(1, 7, 45, 16, 999).Negate() },
+
+                //custom timespan formats
+                new object[] { "12.23:32:43", @"dd\.h\:m\:s", new TimeSpan(12, 23, 32, 43) },
+                new object[] { "012.23:32:43.893", @"ddd\.h\:m\:s\.fff", new TimeSpan(12, 23, 32, 43, 893) },
+                new object[] { "12.05:02:03", @"d\.hh\:mm\:ss", new TimeSpan(12, 5, 2, 3) },
+                new object[] { "12:34 minutes", @"mm\:ss\ \m\i\n\u\t\e\s", new TimeSpan(0, 12, 34) }
+            };
+        }
+    }
+
+    public static IEnumerable<object[]> TimeSpanTestData_IncorrectFormat
+    {
+        get
+        {
+            return new[]
+            {
+                //standard timespan formats 'c', 'g', 'G'
+                new object[] { "24:24:02", "c", typeof(OverflowException) },
+                new object[] { "1:12:24:02", "c",  typeof(FormatException) },
+                new object[] { "12:61:02", "g", typeof(OverflowException)  },
+                new object[] { "1.12:24:02", "g", typeof(FormatException) },
+                new object[] { "1:07:45:16.99999999", "G", typeof(OverflowException) },
+                new object[] { "1:12:24:02", "G", typeof(FormatException) },
+
+                //custom timespan formats
+                new object[] { "12.35:32:43", @"dd\.h\:m\:s", typeof(OverflowException) },
+                new object[] { "12.5:2:3", @"d\.hh\:mm\:ss", typeof(FormatException) },
+                new object[] { "12.5:2", @"d\.hh\:mm\:ss", typeof(FormatException) }
+            };
+        }
     }
 }

--- a/src/System.Runtime/tests/System/Uri.cs
+++ b/src/System.Runtime/tests/System/Uri.cs
@@ -1,33 +1,11 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Xunit;
 
 public static unsafe class UriTests
 {
-    // Bug 740420
-    [Fact]
-    public static void TestAppxName()
-    {
-        if (TestRunner.TestRunner.OnCoreCLR)
-            return;
-
-        bool ret = true;
-        try
-        {
-            Uri _uri = new Uri("ms-app://s-1-15-2-3682223341-1746277572-4098775175-2728279147-2871887747-149063373-1758401009/");
-        }
-        catch (Exception)
-        {
-            ret = false;
-        }
-        Assert.True(ret);
-    }
-
     [Fact]
     public static void TestCtor_String()
     {


### PR DESCRIPTION
System.Array - add 'BinarySearch' overload tests
System.DateTime - add 'GetDateTimeFormats' tests
System.Decimal - add 'GetBits' tests
System.GC - add 'ReRegisterForFinalize', 'GetTotalMemory' and 'GetGeneration' tests
System.Runtime.CompilerServices.ConditionalWeakTable - add new tests
System.TimeSpan - add 'ParseExact' tests
System.Type - add 'GetType' by name tests
System.Uri - fix the C# project to include Uri tests.