### PR TITLE
Removed the Unix restriction on MaxNumberOfServerInstances

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -31,7 +31,7 @@ namespace System.IO.Pipes
             Debug.Assert(direction >= PipeDirection.In && direction <= PipeDirection.InOut, "invalid pipe direction");
             Debug.Assert(inBufferSize >= 0, "inBufferSize is negative");
             Debug.Assert(outBufferSize >= 0, "outBufferSize is negative");
-            Debug.Assert((maxNumberOfServerInstances >= 1 && maxNumberOfServerInstances <= 254) || (maxNumberOfServerInstances == MaxAllowedServerInstances), "maxNumberOfServerInstances is invalid");
+            Debug.Assert((maxNumberOfServerInstances >= 1) || (maxNumberOfServerInstances == MaxAllowedServerInstances), "maxNumberOfServerInstances is invalid");
             Debug.Assert(transmissionMode >= PipeTransmissionMode.Byte && transmissionMode <= PipeTransmissionMode.Message, "transmissionMode is out of range");
 
             if (transmissionMode == PipeTransmissionMode.Message)
@@ -130,6 +130,16 @@ namespace System.IO.Pipes
         {
             CheckWriteOperations();
             throw new PlatformNotSupportedException();
+        }
+
+        private void ValidateMaxNumberOfServerInstances(int maxNumberOfServerInstances)
+        {
+            // Since Unix has no notion of Max allowed Server Instances per named pipe, we don't enforce an
+            // upper bound on maxNumberOfServerInstances.
+            if ((maxNumberOfServerInstances < 1) && (maxNumberOfServerInstances != MaxAllowedServerInstances))
+            {
+                throw new ArgumentOutOfRangeException("maxNumberOfServerInstances", SR.ArgumentOutOfRange_MaxNumServerInstances);
+            }
         }
 
         // -----------------------------

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -298,5 +298,15 @@ namespace System.IO.Pipes
             }
             CheckConnectOperationsServer();
         }
+
+        private void ValidateMaxNumberOfServerInstances(int maxNumberOfServerInstances)
+        {
+            // win32 allows fixed values of 1-254 or 255 to mean max allowed by system. We expose 255 as -1 (unlimited)
+            // through the MaxAllowedServerInstances constant. This is consistent e.g. with -1 as infinite timeout, etc
+            if ((maxNumberOfServerInstances < 1 || maxNumberOfServerInstances > 254) && (maxNumberOfServerInstances != MaxAllowedServerInstances))
+            {
+                throw new ArgumentOutOfRangeException("maxNumberOfServerInstances", SR.ArgumentOutOfRange_MaxNumServerInstances);
+            }
+        }
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -61,8 +61,8 @@ namespace System.IO.Pipes
         /// Win32 note: this gets OR'd into dwOpenMode to CreateNamedPipe
         /// </param>
         /// <param name="maxNumberOfServerInstances">Maximum number of server instances. Specify a fixed value between 
-        /// 1 and 254, or use NamedPipeServerStream.MaxAllowedServerInstances to use the maximum amount allowed by 
-        /// system resources.</param>
+        /// 1 and 254 (Windows)/greater than 1 (Unix), or use NamedPipeServerStream.MaxAllowedServerInstances to use the 
+        /// maximum amount allowed by system resources.</param>
         /// <param name="transmissionMode">Byte mode or message mode.
         /// Win32 note: this gets used for dwPipeMode. CreateNamedPipe allows you to specify PIPE_TYPE_BYTE/MESSAGE
         /// and PIPE_READMODE_BYTE/MESSAGE independently, but this sets type and readmode to match.
@@ -102,12 +102,7 @@ namespace System.IO.Pipes
             {
                 throw new ArgumentOutOfRangeException("inBufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
-            // win32 allows fixed values of 1-254 or 255 to mean max allowed by system. We expose 255 as -1 (unlimited)
-            // through the MaxAllowedServerInstances constant. This is consistent e.g. with -1 as infinite timeout, etc
-            if ((maxNumberOfServerInstances < 1 || maxNumberOfServerInstances > 254) && (maxNumberOfServerInstances != MaxAllowedServerInstances))
-            {
-                throw new ArgumentOutOfRangeException("maxNumberOfServerInstances", SR.ArgumentOutOfRange_MaxNumServerInstances);
-            }
+            ValidateMaxNumberOfServerInstances(maxNumberOfServerInstances);
             // inheritability will always be None since this private constructor is only called from other constructors from which
             // inheritability is always set to None. Desktop has a public constructor to allow setting it to something else, but Core
             // doesnt.

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
@@ -90,15 +90,41 @@ namespace System.IO.Pipes.Tests
         }
 
         [Theory]
+        [InlineData(0)]
+        [InlineData(-2)]
+        public static void InvalidServerInstances_Throws_ArgumentOutOfRangeException(int numberOfServerInstances)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, numberOfServerInstances));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, numberOfServerInstances, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, numberOfServerInstances, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", PipeDirection.In, numberOfServerInstances, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+        }
+
+        [Theory]
         [InlineData(PipeDirection.In)]
         [InlineData(PipeDirection.InOut)]
         [InlineData(PipeDirection.Out)]
-        public static void InvalidServerInstances_Throws_ArgumentOutOfRangeException(PipeDirection direction)
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void Unix_ServerInstancesOver254_Allowed(PipeDirection direction)
         {
-            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 0, PipeTransmissionMode.Byte));
-            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 0, PipeTransmissionMode.Byte, PipeOptions.None));
-            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 0, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            // MaxNumberOfServerInstances has functionality on Unix and as such is not upper bound.
+            new NamedPipeServerStream(GetUniquePipeName(), direction, 255).Dispose();
+            new NamedPipeServerStream(GetUniquePipeName(), direction, 255, PipeTransmissionMode.Byte).Dispose();
+            new NamedPipeServerStream(GetUniquePipeName(), direction, 255, PipeTransmissionMode.Byte, PipeOptions.None).Dispose();
+            new NamedPipeServerStream(GetUniquePipeName(), direction, 255, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0).Dispose();
+        }
+
+        [Theory]
+        [InlineData(PipeDirection.In)]
+        [InlineData(PipeDirection.InOut)]
+        [InlineData(PipeDirection.Out)]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void Windows_ServerInstancesOver254_Throws_ArgumentOutOfRangeException(PipeDirection direction)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 255));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 255, PipeTransmissionMode.Byte));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 255, PipeTransmissionMode.Byte, PipeOptions.None));
+            Assert.Throws<ArgumentOutOfRangeException>("maxNumberOfServerInstances", () => new NamedPipeServerStream("temp3", direction, 255, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Theory]


### PR DESCRIPTION
There were previously checks to ensure that MaxNumberOfServerInstances was within the same boundaries as it was on Windows despite never actually being used in the Unix implementation. This commit removes those checks and adds platform specific tests for the new behavior.

- Resolves #2764