### PR TITLE
Improve tasks tests

### DIFF
--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -13,212 +13,206 @@ namespace System.Threading.Tasks.Tests
 {
     public class AsyncTaskMethodBuilderTests
     {
-        // building tasks
+        // Test captured sync context with successful completion (SetResult)
         [Fact]
-        public static void RunAsyncMethodBuilderTests()
+        public static void VoidMethodBuilder_TrackedContext()
         {
-            // AsyncVoidMethodBuilder
+            SynchronizationContext previousContext = SynchronizationContext.Current;
+            var trackedContext = new TrackOperationsSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(trackedContext);
+
+            // TrackedCount should increase as Create() is called, and decrease as SetResult() is called.
+
+            // Completing in opposite order as created.
+            var avmb1 = AsyncVoidMethodBuilder.Create();
+            Assert.Equal(1, trackedContext.TrackedCount);
+            var avmb2 = AsyncVoidMethodBuilder.Create();
+            Assert.Equal(2, trackedContext.TrackedCount);
+            avmb2.SetResult();
+            Assert.Equal(1, trackedContext.TrackedCount);
+            avmb1.SetResult();
+            Assert.Equal(0, trackedContext.TrackedCount);
+
+            // Completing in same order as created
+            avmb1 = AsyncVoidMethodBuilder.Create();
+            Assert.Equal(1, trackedContext.TrackedCount);
+            avmb2 = AsyncVoidMethodBuilder.Create();
+            Assert.Equal(2, trackedContext.TrackedCount);
+            avmb1.SetResult();
+            Assert.Equal(1, trackedContext.TrackedCount);
+            avmb2.SetResult();
+            Assert.Equal(0, trackedContext.TrackedCount);
+
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+
+        // Test not having a sync context with successful completion (SetResult)
+        [Fact]
+        public static void VoidMethodBuilder_NoContext()
+        {
+            SynchronizationContext previousContext = SynchronizationContext.Current;
+            try
             {
-                // Test captured sync context with successful completion (SetResult)
-                {
-                    SynchronizationContext previousContext = SynchronizationContext.Current;
-                    var trackedContext = new TrackOperationsSynchronizationContext();
-                    SynchronizationContext.SetSynchronizationContext(trackedContext);
-
-                    // Completing in opposite order as created
-                    var avmb1 = AsyncVoidMethodBuilder.Create();
-                    Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Should have been one active builder (SetResult, opposite order).");
-                    var avmb2 = AsyncVoidMethodBuilder.Create();
-                    Assert.True(trackedContext.TrackedCount == 2, "RunAsyncMethodBuilderTests > FAILED: Should have been two active builders (SetResult, opposite order).");
-                    avmb2.SetResult();
-                    Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have decremented count (SetResult, opposite order).");
-                    avmb1.SetResult();
-                    Assert.True(trackedContext.TrackedCount == 0, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have returned count to 0 (SetResult, opposite order).");
-
-                    // Completing in same order as created
-                    avmb1 = AsyncVoidMethodBuilder.Create();
-                    Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Should have been one active builder (SetResult, same order).");
-                    avmb2 = AsyncVoidMethodBuilder.Create();
-                    Assert.True(trackedContext.TrackedCount == 2, "RunAsyncMethodBuilderTests > FAILED: Should have been two active builders (SetResult, same order).");
-                    avmb1.SetResult();
-                    Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have decremented count (SetResult, same order).");
-                    avmb2.SetResult();
-                    Assert.True(trackedContext.TrackedCount == 0, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have returned count to 0 (SetResult, same order).");
-
-                    SynchronizationContext.SetSynchronizationContext(previousContext);
-                }
-
-                // Test not having a sync context with successful completion (SetResult)
-                {
-                    SynchronizationContext previousContext = SynchronizationContext.Current;
-                    try
-                    {
-                        // Make sure not having a sync context doesn't cause us to blow up
-                        SynchronizationContext.SetSynchronizationContext(null);
-                        var avmb = AsyncVoidMethodBuilder.Create();
-                        avmb.SetResult();
-                    }
-                    catch (Exception)
-                    {
-                        Assert.True(false, string.Format("RunAsyncMethodBuilderTests > FAILURE.  Sync context caused us to blow up with Create/SetResult"));
-                    }
-                    finally
-                    {
-                        SynchronizationContext.SetSynchronizationContext(previousContext);
-                    }
-                }
+                // Make sure not having a sync context doesn't cause us to blow up
+                SynchronizationContext.SetSynchronizationContext(null);
+                var avmb = AsyncVoidMethodBuilder.Create();
+                avmb.SetResult();
             }
-
-            // AsyncTaskMethodBuilder
+            finally
             {
-                // Creating a task builder, building it, completing it successfully
-                {
-                    var atmb = AsyncTaskMethodBuilder.Create();
-                    var t = atmb.Task;
-                    Assert.True(t.Status == TaskStatus.WaitingForActivation, "    > FAILURE. Builder should still be active (ATMB, build then set");
-                    atmb.SetResult();
-                    Assert.True(t.Status == TaskStatus.RanToCompletion, "Task status should equal RanToCompletion");
-                }
-
-                // Verify that AsyncTaskMethodBuilder is not touching sync context
-                {
-                    SynchronizationContext previousContext = SynchronizationContext.Current;
-                    var trackedContext = new TrackOperationsSynchronizationContext();
-                    SynchronizationContext.SetSynchronizationContext(trackedContext);
-
-                    var atmb = AsyncTaskMethodBuilder.Create();
-                    Assert.True(trackedContext.TrackedCount == 0, "    > FAILURE. Builder should not interact with the sync context (before ATMB set)");
-                    atmb.SetResult();
-                    Assert.True(trackedContext.TrackedCount == 0, "    > FAILURE. Builder should not interact with the sync context (after ATMB set)");
-                    SynchronizationContext.SetSynchronizationContext(previousContext);
-                }
-            }
-
-            // AsyncTaskMethodBuilder<T>
-            {
-                // Creating a task builder, building it, completing it successfully
-                {
-                    var atmb = AsyncTaskMethodBuilder<int>.Create();
-                    var t = atmb.Task;
-                    Assert.True(t.Status == TaskStatus.WaitingForActivation, "    > FAILURE. Builder should still be active (ATMBT, build then set)");
-                    atmb.SetResult(43);
-                    Assert.True(t.Status == TaskStatus.RanToCompletion, "    > FAILURE. Builder should have successfully completed (ATMBT, build then set)");
-                    Assert.True(t.Result == 43, "    > FAILURE. Builder should completed with the set result (ATMBT, build then set)");
-                }
-
-                // Verify that AsyncTaskMethodBuilder<T> is not touching sync context
-                {
-                    SynchronizationContext previousContext = SynchronizationContext.Current;
-                    var trackedContext = new TrackOperationsSynchronizationContext();
-                    SynchronizationContext.SetSynchronizationContext(trackedContext);
-
-                    var atmb = AsyncTaskMethodBuilder<string>.Create();
-                    Assert.True(trackedContext.TrackedCount == 0, "    > FAILURE. Builder should not interact with the sync context (before ATMBT set)");
-                    atmb.SetResult("async");
-                    Assert.True(trackedContext.TrackedCount == 0, "    > FAILURE. Builder should not interact with the sync context (after ATMBT set)");
-
-                    SynchronizationContext.SetSynchronizationContext(previousContext);
-                }
+                SynchronizationContext.SetSynchronizationContext(previousContext);
             }
         }
 
+        // AsyncTaskMethodBuilder
+        [Fact]
+        public static void TaskMethodBuilder_Basic()
+        {
+            // Creating a task builder, building it, completing it successfully
+            {
+                var atmb = AsyncTaskMethodBuilder.Create();
+                var t = atmb.Task;
+                Assert.Equal(TaskStatus.WaitingForActivation, t.Status);
+                atmb.SetResult();
+                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+            }
+        }
+
+        [Fact]
+        public static void TaskMethodBuilder_DoesNotTouchSyncContext()
+        {
+            // Verify that AsyncTaskMethodBuilder is not touching sync context
+            SynchronizationContext previousContext = SynchronizationContext.Current;
+            var trackedContext = new TrackOperationsSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(trackedContext);
+
+            var atmb = AsyncTaskMethodBuilder.Create();
+            Assert.Equal(0, trackedContext.TrackedCount);
+            atmb.SetResult();
+            Assert.Equal(0, trackedContext.TrackedCount);
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+
+        // AsyncTaskMethodBuilder<T>
+
+        [Fact]
+        public static void TaskMethodBuilderT_Basic()
+        {
+            // Creating a task builder, building it, completing it successfully
+            var atmb = AsyncTaskMethodBuilder<int>.Create();
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.WaitingForActivation, t.Status);
+            atmb.SetResult(43);
+            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+            Assert.Equal(43, t.Result);
+        }
+
+        [Fact]
+        public static void TaskMethodBuilderT_DoesNotTouchSyncContext()
+        {
+            // Verify that AsyncTaskMethodBuilder<T> is not touching sync context
+            SynchronizationContext previousContext = SynchronizationContext.Current;
+            var trackedContext = new TrackOperationsSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(trackedContext);
+
+            var atmb = AsyncTaskMethodBuilder<string>.Create();
+            Assert.Equal(0, trackedContext.TrackedCount);
+            atmb.SetResult("async");
+            Assert.Equal(0, trackedContext.TrackedCount);
+
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+
+        // Incorrect usage for AsyncTaskMethodBuilder
         [Fact]
         [ActiveIssue("Hangs")]
-        public static void RunAsyncMethodBuilderTests_NegativeTests()
+        public static void TaskMethodBuilder_IncorrectUsage()
         {
-            // Incorrect usage for AsyncVoidMethodBuilder
-            {
-                var atmb = new AsyncTaskMethodBuilder();
-                Assert.Throws<ArgumentNullException>(
-                   () => { atmb.SetException(null); });
-            }
-
-            // Incorrect usage for AsyncTaskMethodBuilder
-            {
-                var avmb = AsyncVoidMethodBuilder.Create();
-                Assert.Throws<ArgumentNullException>(
-                 () => { avmb.SetException(null); });
-            }
-
-            // Creating a task builder, building it, completing it successfully, and making sure it can't be reset
-            {
-                var atmb = AsyncTaskMethodBuilder.Create();
-                atmb.SetResult();
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
-
-            // Incorrect usage for AsyncTaskMethodBuilder<T>
-            {
-                var atmb = new AsyncTaskMethodBuilder<int>();
-                Assert.Throws<ArgumentNullException>(
-                   () => { atmb.SetException(null); });
-            }
-
-            // Creating a task builder <T>, building it, completing it successfully, and making sure it can't be reset
-            {
-                var atmb = AsyncTaskMethodBuilder<int>.Create();
-                atmb.SetResult(43);
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(44); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
+            var atmb = new AsyncTaskMethodBuilder();
+            Assert.Throws<ArgumentNullException>(() => { atmb.SetException(null); });
         }
 
+        // Incorrect usage for AsyncVoidMethodBuilder
         [Fact]
-        public static void AsyncMethodBuilderCreate_SetExceptionTest()
+        [ActiveIssue("Hangs")]
+        public static void VoidMethodBuilder_IncorrectUsage()
         {
-            // Creating a task builder, building it, completing it faulted, and making sure it can't be reset
-            {
-                var atmb = AsyncTaskMethodBuilder.Create();
-                var t = atmb.Task;
-                Assert.True(t.Status == TaskStatus.WaitingForActivation, "    > FAILURE. Builder should still be active (ATMB, build then fault)");
-                atmb.SetException(new InvalidCastException());
-                Assert.True(t.Status == TaskStatus.Faulted, "    > FAILURE. Builder should be faulted after an exception occurs (ATMB, build then fault)");
-                Assert.True(t.Exception.InnerException is InvalidCastException, "    > FAILURE. Wrong exception found in builder (ATMB, build then fault)");
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
+            var avmb = AsyncVoidMethodBuilder.Create();
+            Assert.Throws<ArgumentNullException>(() => { avmb.SetException(null); });
+        }
 
-            // Creating a task builder, completing it faulted, building it, and making sure it can't be reset
-            {
-                var atmb = AsyncTaskMethodBuilder.Create();
-                atmb.SetException(new InvalidCastException());
-                var t = atmb.Task;
-                Assert.True(t.Status == TaskStatus.Faulted, "    > FAILURE. Builder should be faulted after an exception occurs (ATMB, fault then build)");
-                Assert.True(t.Exception.InnerException is InvalidCastException, "    > FAILURE. Wrong exception found in builder (ATMB, fault then build)");
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
+        // Creating a task builder, building it, completing it successfully, and making sure it can't be reset
+        [Fact]
+        public static void TaskMethodBuilder_CantBeReset()
+        {
+            var atmb = AsyncTaskMethodBuilder.Create();
+            atmb.SetResult();
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
+        }
 
-            // Test cancellation
+        // Incorrect usage for AsyncTaskMethodBuilder<T>
+        [Fact]
+        public static void TaskMethodBuilderT_IncorrectUsage()
+        {
+            var atmb = new AsyncTaskMethodBuilder<int>();
+            Assert.Throws<ArgumentNullException>(() => { atmb.SetException(null); });
+        }
+
+        // Creating a task builder <T>, building it, completing it successfully, and making sure it can't be reset
+        [Fact]
+        public static void TaskMethodBuilderT_CantBeReset()
+        {
+            var atmb = AsyncTaskMethodBuilder<int>.Create();
+            atmb.SetResult(43);
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(44); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
+        }
+
+        // Creating a task builder, building it, completing it faulted, and making sure it can't be reset
+        [Fact]
+        public static void TaskMethodBuilder_SetException_CantBeReset0()
+        {
+            var atmb = AsyncTaskMethodBuilder.Create();
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.WaitingForActivation, t.Status);
+            atmb.SetException(new InvalidCastException());
+            Assert.Equal(TaskStatus.Faulted, t.Status);
+            Assert.True(t.Exception.InnerException is InvalidCastException, "Wrong exception found in builder (ATMB, build then fault)");
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
+        }
+
+        // Creating a task builder, completing it faulted, building it, and making sure it can't be reset
+        [Fact]
+        public static void TaskMethodBuilder_SetException_CantBeReset1()
+        {
+            var atmb = AsyncTaskMethodBuilder.Create();
+            atmb.SetException(new InvalidCastException());
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.Faulted, t.Status);
+            Assert.True(t.Exception.InnerException is InvalidCastException, "Wrong exception found in builder (ATMB, fault then build)");
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
+        }
+
+        // Test cancellation
+        [Fact]
+        public static void TaskMethodBuilder_Cancellation()
+        {
+            var atmb = AsyncTaskMethodBuilder.Create();
+            var oce = new OperationCanceledException();
+            atmb.SetException(oce);
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.Canceled, t.Status);
+
+            OperationCanceledException caught = Assert.Throws<OperationCanceledException>(() =>
             {
-                var atmb = AsyncTaskMethodBuilder.Create();
-                var oce = new OperationCanceledException();
-                atmb.SetException(oce);
-                var t = atmb.Task;
-                Assert.True(t.Status == TaskStatus.Canceled, "    > FAILURE. Builder should be canceled from an unhandled OCE (ATMB cancellation)");
-                try
-                {
-                    t.GetAwaiter().GetResult();
-                    Assert.True(false, "    > FAILURE. Excepted GetResult to throw. (ATMB cancellation)");
-                }
-                catch (Exception exc)
-                {
-                    Assert.True(Object.ReferenceEquals(oce, exc), "    > FAILURE. Excepted original OCE to be thrown. (ATMB cancellation)");
-                }
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
+                t.GetAwaiter().GetResult();
+            });
+            Assert.Same(oce, caught);
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
         }
 
         [Fact]
@@ -233,244 +227,232 @@ namespace System.Threading.Tasks.Tests
 
             // Completing in opposite order as created
             var avmb1 = AsyncVoidMethodBuilder.Create();
-            Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Should have been one active builder (SetException, opposite order).");
+            Assert.Equal(1, trackedContext.TrackedCount);
             var avmb2 = AsyncVoidMethodBuilder.Create();
-            Assert.True(trackedContext.TrackedCount == 2, "RunAsyncMethodBuilderTests > FAILED: Should have been two active builders (SetException, opposite order).");
+            Assert.Equal(2, trackedContext.TrackedCount);
             avmb2.SetException(new InvalidOperationException("uh oh 1"));
-            Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have decremented count (SetException, opposite order).");
+            Assert.Equal(1, trackedContext.TrackedCount);
             avmb1.SetException(new InvalidCastException("uh oh 2"));
-            Assert.True(trackedContext.TrackedCount == 0, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have returned count to 0 (SetException, opposite order).");
+            Assert.Equal(0, trackedContext.TrackedCount);
 
-            Assert.True(
-            trackedContext.PostExceptions.Count == 2 &&
-            trackedContext.PostExceptions[0] is InvalidOperationException &&
-            trackedContext.PostExceptions[1] is InvalidCastException,
-            "    > FAILED: Expected two exceptions of the right types.");
+            Assert.Equal(2, trackedContext.PostExceptions.Count);
+            Assert.IsType<InvalidOperationException>(trackedContext.PostExceptions[0]);
+            Assert.IsType<InvalidCastException>(trackedContext.PostExceptions[1]);
 
             // Completing in same order as created
             var avmb3 = AsyncVoidMethodBuilder.Create();
-            Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Should have been one active builder (SetException, same order).");
+            Assert.Equal(1, trackedContext.TrackedCount);
             var avmb4 = AsyncVoidMethodBuilder.Create();
-            Assert.True(trackedContext.TrackedCount == 2, "RunAsyncMethodBuilderTests > FAILED: Should have been two active builders (SetException, same order).");
+            Assert.Equal(2, trackedContext.TrackedCount);
             avmb3.SetException(new InvalidOperationException("uh oh 3"));
-            Assert.True(trackedContext.TrackedCount == 1, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have decremented count (SetException, same order).");
+            Assert.Equal(1, trackedContext.TrackedCount);
             avmb4.SetException(new InvalidCastException("uh oh 4"));
-            Assert.True(trackedContext.TrackedCount == 0, "RunAsyncMethodBuilderTests > FAILED: Completed builder should have returned count to 0 (SetException, same order).");
+            Assert.Equal(0, trackedContext.TrackedCount);
 
-            Assert.True(
-            trackedContext.PostExceptions.Count == 4 &&
-            trackedContext.PostExceptions[2] is InvalidOperationException &&
-            trackedContext.PostExceptions[3] is InvalidCastException,
-            "RunAsyncMethodBuilderTests > FAILED: Expected two more exceptions of the right types.");
+            Assert.Equal(4, trackedContext.PostExceptions.Count);
+            Assert.IsType<InvalidOperationException>(trackedContext.PostExceptions[2]);
+            Assert.IsType<InvalidCastException>(trackedContext.PostExceptions[3]);
 
             SynchronizationContext.SetSynchronizationContext(previousContext);
         }
 
+        // Creating a task builder, building it, completing it faulted, and making sure it can't be reset
         [Fact]
-        public static void AsyncMethodBuilderTCreate_SetExceptionTest()
+        public static void TaskMethodBuilderT_SetExceptionTest0()
         {
-            // Creating a task builder, building it, completing it faulted, and making sure it can't be reset
-            {
-                var atmb = AsyncTaskMethodBuilder<int>.Create();
-                var t = atmb.Task;
-                Assert.True(t.Status == TaskStatus.WaitingForActivation, "    > FAILURE. Builder should still be active (ATMBT, build then fault)");
-                atmb.SetException(new InvalidCastException());
-                Assert.True(t.Status == TaskStatus.Faulted, "    > FAILURE. Builder should be faulted after an exception occurs (ATMBT, build then fault)");
-                Assert.True(t.Exception.InnerException is InvalidCastException, "    > FAILURE. Wrong exception found in builder (ATMBT, build then fault)");
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(44); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
-
-            // Creating a task builder, completing it faulted, building it, and making sure it can't be reset
-            {
-                var atmb = AsyncTaskMethodBuilder<int>.Create();
-                atmb.SetException(new InvalidCastException());
-                var t = atmb.Task;
-                Assert.True(t.Status == TaskStatus.Faulted, "    > FAILURE. Builder should be faulted after an exception occurs (ATMBT, fault then build)");
-                Assert.True(t.Exception.InnerException is InvalidCastException, "    > FAILURE. Wrong exception found in builder (ATMBT, fault then build)");
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(44); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
-
-            // Test cancellation
-            {
-                var atmb = AsyncTaskMethodBuilder<int>.Create();
-                var oce = new OperationCanceledException();
-                atmb.SetException(oce);
-                var t = atmb.Task;
-                Assert.True(t.Status == TaskStatus.Canceled, "    > FAILURE. Builder should be canceled from an unhandled OCE (ATMBT cancellation)");
-                try
-                {
-                    t.GetAwaiter().GetResult();
-                    Assert.True(false, "    > FAILURE. Excepted GetResult to throw. (ATMBT cancellation)");
-                }
-                catch (Exception exc)
-                {
-                    Assert.True(Object.ReferenceEquals(oce, exc), "    > FAILURE. Excepted original OCE to be thrown. (ATMBT cancellation)");
-                }
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetResult(44); });
-                Assert.Throws<InvalidOperationException>(
-                   () => { atmb.SetException(new Exception()); });
-            }
+            var atmb = AsyncTaskMethodBuilder<int>.Create();
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.WaitingForActivation, t.Status);
+            atmb.SetException(new InvalidCastException());
+            Assert.Equal(TaskStatus.Faulted, t.Status);
+            Assert.IsType<InvalidCastException>(t.Exception.InnerException);
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(44); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
         }
 
-        // random other stuff, e.g. exception dispatch info
+        // Creating a task builder, completing it faulted, building it, and making sure it can't be reset
         [Fact]
-        public static void RunAsyncAdditionalBehaviorsTests()
+        public static void TaskMethodBuilderT_SetExceptionTest1()
         {
+            var atmb = AsyncTaskMethodBuilder<int>.Create();
+            atmb.SetException(new InvalidCastException());
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.Faulted, t.Status);
+            Assert.IsType<InvalidCastException>(t.Exception.InnerException);
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(44); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
+        }
+
+        // Test cancellation
+        [Fact]
+        public static void TaskMethodBuilderT_Cancellation()
+        {
+            var atmb = AsyncTaskMethodBuilder<int>.Create();
+            var oce = new OperationCanceledException();
+            atmb.SetException(oce);
+            var t = atmb.Task;
+            Assert.Equal(TaskStatus.Canceled, t.Status);
+
+            OperationCanceledException e = Assert.Throws<OperationCanceledException>(() =>
             {
-                var atmb = new AsyncTaskMethodBuilder();
-                var t1 = atmb.Task;
-                var t2 = atmb.Task;
-                Assert.True(t1 != null, "     > FAILURE. Task should have been initialized.");
-                Assert.True(t2 != null, "     > FAILURE. Task should have been initialized.");
-                Assert.True(t1 == t2, "     > FAILURE. Task should be cached once initialized.");
-            }
-            {
-                var atmb = new AsyncTaskMethodBuilder<int>();
-                var t1 = atmb.Task;
-                var t2 = atmb.Task;
-                Assert.True(t1 != null, "     > FAILURE. Task should have been initialized.");
-                Assert.True(t2 != null, "     > FAILURE. Task should have been initialized.");
-                Assert.True(t1 == t2, "     > FAILURE. Task should be cached once initialized.");
-            }
+                t.GetAwaiter().GetResult();
+            });
+            Assert.Same(oce, e);
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetResult(44); });
+            Assert.Throws<InvalidOperationException>(() => { atmb.SetException(new Exception()); });
         }
 
         [Fact]
-        public static void RunAsyncAdditionalBehaviorsTests_NegativeCases()
+        public static void TaskMethodBuilder_TaskIsCached()
         {
-            // Test ExceptionDispatchInfo usage
-            //if (Thread.CurrentThread.CurrentCulture.ThreeLetterWindowsLanguageName == "ENU") // only on ENU because of string comparisons
-            //{
-            {
-                var tcs = new TaskCompletionSource<int>();
-                try { throw new InvalidOperationException(); }
-                catch (Exception e) { tcs.SetException(e); }
-                Assert.True(ValidateFaultedTask(tcs.Task), "     > FAILURE. Task's stack trace is incorrect");
-            }
-
-            {
-                var atmb = AsyncTaskMethodBuilder.Create();
-                try { throw new InvalidOperationException(); }
-                catch (Exception e) { atmb.SetException(e); }
-                Assert.True(ValidateFaultedTask(atmb.Task), "     > FAILURE. Task's stack trace is incorrect");
-            }
-
-            {
-                var atmbtr = AsyncTaskMethodBuilder<object>.Create();
-                try { throw new InvalidOperationException(); }
-                catch (Exception e) { atmbtr.SetException(e); }
-                Assert.True(ValidateFaultedTask(atmbtr.Task), "     > FAILURE. Task's stack trace is incorrect");
-            }
-
-            {
-                SynchronizationContext previousContext = SynchronizationContext.Current;
-                var tosc = new TrackOperationsSynchronizationContext();
-                SynchronizationContext.SetSynchronizationContext(tosc);
-                var avmb = AsyncVoidMethodBuilder.Create();
-                try { throw new InvalidOperationException(); }
-                catch (Exception exc) { avmb.SetException(exc); }
-                Assert.True(
-                   tosc.PostExceptions.Count > 0 && ValidateException(tosc.PostExceptions[0]),
-                   "     > FAILURE. AVMB task should have posted exceptions to the sync context");
-                SynchronizationContext.SetSynchronizationContext(previousContext);
-            }
+            var atmb = new AsyncTaskMethodBuilder();
+            var t1 = atmb.Task;
+            var t2 = atmb.Task;
+            Assert.NotNull(t1);
+            Assert.NotNull(t2);
+            Assert.Same(t1, t2);
         }
 
         [Fact]
-        public static void RunAsyncAdditionalBehaviorsTests_NegativeCases2()
+        public static void TaskMethodBuilderT_TaskIsCached()
         {
-            // Running tasks with exceptions.
+            var atmb = new AsyncTaskMethodBuilder<int>();
+            var t1 = atmb.Task;
+            var t2 = atmb.Task;
+            Assert.NotNull(t1);
+            Assert.NotNull(t2);
+            Assert.Same(t1, t2);
+        }
+
+        [Fact]
+        public static void Tcs_ValidateFaultedTask()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            try { throw new InvalidOperationException(); }
+            catch (Exception e) { tcs.SetException(e); }
+            ValidateFaultedTask(tcs.Task);
+        }
+
+        [Fact]
+        public static void TaskMethodBuilder_ValidateFaultedTask()
+        {
+            var atmb = AsyncTaskMethodBuilder.Create();
+            try { throw new InvalidOperationException(); }
+            catch (Exception e) { atmb.SetException(e); }
+            ValidateFaultedTask(atmb.Task);
+        }
+
+        [Fact]
+        public static void TaskMethodBuilderT_ValidateFaultedTask()
+        {
+            var atmbtr = AsyncTaskMethodBuilder<object>.Create();
+            try { throw new InvalidOperationException(); }
+            catch (Exception e) { atmbtr.SetException(e); }
+            ValidateFaultedTask(atmbtr.Task);
+        }
+
+        [Fact]
+        public static void TrackedSyncContext_ValidateException()
+        {
+            SynchronizationContext previousContext = SynchronizationContext.Current;
+            var tosc = new TrackOperationsSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(tosc);
+            var avmb = AsyncVoidMethodBuilder.Create();
+            try { throw new InvalidOperationException(); }
+            catch (Exception exc) { avmb.SetException(exc); }
+            Assert.NotEmpty(tosc.PostExceptions);
+            ValidateException(tosc.PostExceptions[0]);
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+
+        // Running tasks with exceptions.
+        [Fact]
+        public static void FaultedTaskExceptions()
+        {
+            var twa1 = Task.Run(() => { throw new Exception("uh oh"); });
+            var twa2 = Task.Factory.StartNew(() => { throw new Exception("uh oh"); });
+            var tasks = new Task[]
             {
-                var twa1 = Task.Run(() => { throw new Exception("uh oh"); });
-                var twa2 = Task.Factory.StartNew(() => { throw new Exception("uh oh"); });
-                var tasks = new Task[]
-                    {
-                        Task.Run(() => { throw new Exception("uh oh"); }),
-                        Task.Factory.StartNew<int>(() => { throw new Exception("uh oh"); }),
-                        Task.WhenAll(Task.Run(() => { throw new Exception("uh oh"); }), Task.Run(() => { throw new Exception("uh oh"); })),
-                        Task.WhenAll<int>(Task.Run(new Func<int>(() => { throw new Exception("uh oh"); })), Task.Run(new Func<int>(() => { throw new Exception("uh oh"); }))),
-                        Task.WhenAny(twa1, twa2).Unwrap(),
-                        Task.WhenAny<int>(Task.Run(new Func<Task<int>>(() => { throw new Exception("uh oh"); }))).Unwrap(),
-                        Task.Factory.StartNew(() => Task.Factory.StartNew(() => { throw new Exception("uh oh"); })).Unwrap(),
-                        Task.Factory.StartNew<Task<int>>(() => Task.Factory.StartNew<int>(() => { throw new Exception("uh oh"); })).Unwrap(),
-                        Task.Run(() => Task.Run(() => { throw new Exception("uh oh"); })),
-                        Task.Run(() => Task.Run(new Func<int>(() => { throw new Exception("uh oh"); }))),
-                        Task.Run(new Func<Task>(() => { throw new Exception("uh oh"); })),
-                        Task.Run(new Func<Task<int>>(() => { throw new Exception("uh oh"); }))
-                    };
+                Task.Run(() => { throw new Exception("uh oh"); }),
+                Task.Factory.StartNew<int>(() => { throw new Exception("uh oh"); }),
+                Task.WhenAll(Task.Run(() => { throw new Exception("uh oh"); }), Task.Run(() => { throw new Exception("uh oh"); })),
+                Task.WhenAll<int>(Task.Run(new Func<int>(() => { throw new Exception("uh oh"); })), Task.Run(new Func<int>(() => { throw new Exception("uh oh"); }))),
+                Task.WhenAny(twa1, twa2).Unwrap(),
+                Task.WhenAny<int>(Task.Run(new Func<Task<int>>(() => { throw new Exception("uh oh"); }))).Unwrap(),
+                Task.Factory.StartNew(() => Task.Factory.StartNew(() => { throw new Exception("uh oh"); })).Unwrap(),
+                Task.Factory.StartNew<Task<int>>(() => Task.Factory.StartNew<int>(() => { throw new Exception("uh oh"); })).Unwrap(),
+                Task.Run(() => Task.Run(() => { throw new Exception("uh oh"); })),
+                Task.Run(() => Task.Run(new Func<int>(() => { throw new Exception("uh oh"); }))),
+                Task.Run(new Func<Task>(() => { throw new Exception("uh oh"); })),
+                Task.Run(new Func<Task<int>>(() => { throw new Exception("uh oh"); }))
+            };
 
-                for (int i = 0; i < tasks.Length; i++)
-                {
-                    var task = tasks[i];
-                    Assert.True(ValidateFaultedTask(task), "     > FAILURE. Task " + i + " didn't fault with the right stack trace.");
-                }
-
-                ((IAsyncResult)twa1).AsyncWaitHandle.WaitOne();
-                ((IAsyncResult)twa2).AsyncWaitHandle.WaitOne();
-                Exception ignored = twa1.Exception;
-                ignored = twa2.Exception;
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                ValidateFaultedTask(tasks[i]);
             }
 
-            // Test that OCEs don't result in the unobserved event firing
+            ((IAsyncResult)twa1).AsyncWaitHandle.WaitOne();
+            ((IAsyncResult)twa2).AsyncWaitHandle.WaitOne();
+            Exception ignored = twa1.Exception;
+            ignored = twa2.Exception;
+        }
+
+        // Test that OCEs don't result in the unobserved event firing
+        [Fact]
+        public static void CancellationDoesntResultInEventFiring()
+        {
+            var cts = new CancellationTokenSource();
+            var oce = new OperationCanceledException(cts.Token);
+
+            // A Task that throws an exception to cancel
+            var b = new Barrier(2);
+            Task t1 = Task.Factory.StartNew(() =>
             {
-                var cts = new CancellationTokenSource();
-                var oce = new OperationCanceledException(cts.Token);
+                b.SignalAndWait();
+                b.SignalAndWait();
+                throw oce;
+            }, cts.Token);
+            b.SignalAndWait(); // make sure task is started before we cancel
+            cts.Cancel();
+            b.SignalAndWait(); // release task to complete
 
-                // A Task that throws an exception to cancel
-                var b = new Barrier(2);
-                Task t1 = Task.Factory.StartNew(() =>
-                {
-                    b.SignalAndWait();
-                    b.SignalAndWait();
-                    throw oce;
-                }, cts.Token);
-                b.SignalAndWait(); // make sure task is started before we cancel
-                cts.Cancel();
-                b.SignalAndWait(); // release task to complete
-
-                // This test may be run concurrently with other tests in the suite, 
-                // which can be problematic as TaskScheduler.UnobservedTaskException
-                // is global state.  The handler is carefully written to be non-problematic
-                // if it happens to be set during the execution of another test that has 
-                // an unobserved exception.
-                EventHandler<UnobservedTaskExceptionEventArgs> handler = 
-                    (s, e) => Assert.DoesNotContain(oce, e.Exception.InnerExceptions);
-                TaskScheduler.UnobservedTaskException += handler;
-                ((IAsyncResult)t1).AsyncWaitHandle.WaitOne();
-                t1 = null;
-                for (int i = 0; i < 10; i++)
-                {
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                }
-                TaskScheduler.UnobservedTaskException -= handler;
+            // This test may be run concurrently with other tests in the suite, 
+            // which can be problematic as TaskScheduler.UnobservedTaskException
+            // is global state.  The handler is carefully written to be non-problematic
+            // if it happens to be set during the execution of another test that has 
+            // an unobserved exception.
+            EventHandler<UnobservedTaskExceptionEventArgs> handler =
+                (s, e) => Assert.DoesNotContain(oce, e.Exception.InnerExceptions);
+            TaskScheduler.UnobservedTaskException += handler;
+            ((IAsyncResult)t1).AsyncWaitHandle.WaitOne();
+            t1 = null;
+            for (int i = 0; i < 10; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
             }
+            TaskScheduler.UnobservedTaskException -= handler;
         }
 
         #region Helper Methods / Classes
 
-        private static bool ValidateFaultedTask(Task t)
+        private static void ValidateFaultedTask(Task t)
         {
             ((IAsyncResult)t).AsyncWaitHandle.WaitOne();
-            bool localPassed = t.IsFaulted;
-            try
+            Assert.True(t.IsFaulted);
+            Exception e = Assert.ThrowsAny<Exception>(() =>
             {
                 t.GetAwaiter().GetResult();
-                Debug.WriteLine("     > FAILURE. Faulted task's GetResult should have thrown.");
-            }
-            catch (Exception e) { localPassed &= ValidateException(e); }
-            return localPassed;
+            });
+            ValidateException(e);
         }
 
-        private static bool ValidateException(Exception e)
+        private static void ValidateException(Exception e)
         {
-            return e != null && e.StackTrace != null && e.StackTrace.Contains("End of stack trace");
+            Assert.NotNull(e);
+            Assert.NotNull(e.StackTrace);
+            Assert.Contains("End of stack trace", e.StackTrace);
         }
 
         private class TrackOperationsSynchronizationContext : SynchronizationContext

--- a/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
@@ -4,6 +4,7 @@
 // =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
 //
 // Test class that verifies the integration with APM (Task => APM) section 2.5.11 in the TPL spec
+// "Asynchronous Programming Model", or the "Begin/End" pattern
 // 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -18,101 +19,120 @@ namespace System.Threading.Tasks.Tests
     /// <summary>
     /// A class that implements the APM pattern to ensure that TPL can support APM patttern
     /// </summary>
-    public sealed class TaskAPMTest
+    public sealed class TaskAPMTests : IDisposable
     {
         /// <summary>
         /// Used to indicate whether to test TPL's Task or Future functionality for the APM pattern
         /// </summary>
-        private readonly bool _hasReturnType;
+        private bool _hasReturnType;
 
         /// <summary>
         /// Used to synchornize between Main thread and async thread, by blocking the main thread until
         /// the thread that invokes the TaskCompleted method via AsyncCallback finishes
         /// </summary>
-        private ManualResetEvent _mre;
+        private ManualResetEvent _mre = new ManualResetEvent(false);
 
-        private const int INTINPUT = 1000;     // the input to the LongTask<int>.DoTask/BeginDoTask
+        /// <summary>
+        /// The input value to LongTask<int>.DoTask/BeginDoTask
+        /// </summary>
+        private const int IntInput = 1000;
+
         /// <summary>
         /// The constant that defines the amount time to spinwait (to simulate work) in the LongTask class
         /// </summary>
-        private const int LongTaskSeconds = 5;
+        private const int LongTaskMilliseconds = 1000;
 
-        /// <summary>
-        /// Ctor that reads the XML testcase and sets the boolean to indicate whether to test Task or Future
-        /// functionality
-        /// </summary>
-        /// <param name="hasReturnType"></param>
-        public TaskAPMTest(bool hasReturnType)
+        [Theory]
+        [OuterLoop]
+        [InlineData(true)]
+        [InlineData(false)]        
+        public void WaitUntilCompleteTechnique(bool hasReturnType)
         {
             _hasReturnType = hasReturnType;
-            _mre = new ManualResetEvent(false);
+
+            LongTask longTask;
+            if (_hasReturnType)
+                longTask = new LongTask<int>(LongTaskMilliseconds);
+            else
+                longTask = new LongTask(LongTaskMilliseconds);
+
+            // Prove that the Wait-until-done technique works
+            IAsyncResult asyncResult = longTask.BeginDoTask(null, null);
+            longTask.EndDoTask(asyncResult);
+
+            AssertTaskCompleted(asyncResult);
+            Assert.False(asyncResult.CompletedSynchronously, "Should not have completed synchronously.");
         }
 
-        /// <summary>
-        /// Method that tests that the four APM patterns works
-        /// </summary>
-        /// <returns></returns>
-        internal void RealRun()
+        [Theory]
+        [OuterLoop]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PollUntilCompleteTechnique(bool hasReturnType)
         {
-            IAsyncResult ar;
+            _hasReturnType = hasReturnType;
 
-            LongTask lt = null;
+            LongTask longTask;
             if (_hasReturnType)
-                lt = new LongTask<int>(LongTaskSeconds);
+                longTask = new LongTask<int>(LongTaskMilliseconds);
             else
-                lt = new LongTask(LongTaskSeconds);
+                longTask = new LongTask(LongTaskMilliseconds);
 
-            //1. Prove that the Wait-until-done technique works
-            ar = lt.BeginDoTask(null, null);
-            lt.EndDoTask(ar);
-            // verify task completed
-            if (!VerifyTaskCompleted(ar))
-                Assert.True(false, string.Format("Wait-until-done: Task is not completed"));
-
-            Debug.WriteLine("Wait-until-Done -- Task completed");
-
-            //2. Prove that the Polling technique works
-            ar = lt.BeginDoTask(null, null);
-            while (!ar.IsCompleted)
+            IAsyncResult asyncResult = longTask.BeginDoTask(null, null);
+            while (!asyncResult.IsCompleted)
             {
-                Task delay = Task.Delay(1000);
-                delay.Wait();
-                //Thread.Sleep(1000);
+                Task.Delay(300).Wait();
             }
-            // verify task completed
-            if (!VerifyTaskCompleted(ar))
-                Assert.True(false, string.Format("Polling: Task is not completed"));
 
-            Debug.WriteLine("Polling -- Task completed");
+            AssertTaskCompleted(asyncResult);
+            Assert.False(asyncResult.CompletedSynchronously, "Should not have completed synchronously.");
+        }
 
-            //3. Prove the AsyncWaitHandle works
-            ar = lt.BeginDoTask(null, null);
-            ar.AsyncWaitHandle.WaitOne();
-            // verify task completed
-            if (!VerifyTaskCompleted(ar))
-                Assert.True(false, string.Format("wait via AsyncWaitHandle: Task is not completed"));
+        [Theory]
+        [OuterLoop]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WaitOnAsyncWaitHandleTechnique(bool hasReturnType)
+        {
+            _hasReturnType = hasReturnType;
 
-            Debug.WriteLine("Wait on AsyncWaitHandle -- Task completed");
-
-            //4. Prove that the Callback technique works
+            LongTask longTask;
             if (_hasReturnType)
-                ar = ((LongTask<int>)lt).BeginDoTask(INTINPUT, TaskCompleted, lt);
+                longTask = new LongTask<int>(LongTaskMilliseconds);
             else
-                ar = lt.BeginDoTask(TaskCompleted, lt);
+                longTask = new LongTask(LongTaskMilliseconds);
+
+            IAsyncResult asyncResult = longTask.BeginDoTask(null, null);
+            asyncResult.AsyncWaitHandle.WaitOne();
+
+            AssertTaskCompleted(asyncResult);
+            Assert.False(asyncResult.CompletedSynchronously, "Should not have completed synchronously.");
+        }
+
+        [Theory]
+        [OuterLoop]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CallbackTechnique(bool hasReturnType)
+        {
+            _hasReturnType = hasReturnType;
+
+            LongTask longTask;
+            if (_hasReturnType)
+                longTask = new LongTask<int>(LongTaskMilliseconds);
+            else
+                longTask = new LongTask(LongTaskMilliseconds);
+
+            IAsyncResult asyncResult;
+            if (_hasReturnType)
+                asyncResult = ((LongTask<int>)longTask).BeginDoTask(IntInput, TaskCompleted, longTask);
+            else
+                asyncResult = longTask.BeginDoTask(TaskCompleted, longTask);
 
             _mre.WaitOne(); //Block the main thread until async thread finishes executing the call back
-            // verify task completed
-            if (!VerifyTaskCompleted(ar))
-                Assert.True(false, string.Format("Callback: Task is not completed"));
 
-            Debug.WriteLine("Callback -- Task completed");
-            //reaching this point means that the test didnt encounter any crashes or hangs.
-            //So set the test as passed by returning true
-            Assert.False(ar.CompletedSynchronously, "Should not have completed synchronously.");
-
-
-            // Cleanup
-            _mre.Dispose();
+            AssertTaskCompleted(asyncResult);
+            Assert.False(asyncResult.CompletedSynchronously, "Should not have completed synchronously.");
         }
 
         /// <summary>
@@ -125,8 +145,8 @@ namespace System.Threading.Tasks.Tests
             {
                 LongTask<int> lt = (LongTask<int>)ar.AsyncState;
                 int retValue = lt.EndDoTask(ar);
-                if (retValue != INTINPUT)
-                    Assert.True(false, string.Format("Mismatch: Return = {0} vs Expect = {1}", retValue, INTINPUT));
+                if (retValue != IntInput)
+                    Assert.True(false, string.Format("Mismatch: Return = {0} vs Expect = {1}", retValue, IntInput));
             }
             else
             {
@@ -138,33 +158,17 @@ namespace System.Threading.Tasks.Tests
         }
 
         /// <summary>
-        /// Verify the IAsyncResult represent a completed Task
+        /// Assert that the IAsyncResult represent a completed Task
         /// </summary>
-        /// <param name="ar"></param>
-        /// <returns></returns>
-        private bool VerifyTaskCompleted(IAsyncResult ar)
+        private void AssertTaskCompleted(IAsyncResult ar)
         {
-            return ar.IsCompleted &&
-                ((Task)ar).Status == TaskStatus.RanToCompletion; // assume no exception thrown           
-        }
-    }
-
-    public static class TaskAPMTestCases
-    {
-        [Fact]
-        [OuterLoop]
-        public static void TaskAPMTest0()
-        {
-            TaskAPMTest test = new TaskAPMTest(false);
-            test.RealRun();
+            Assert.True(ar.IsCompleted);
+            Assert.Equal(TaskStatus.RanToCompletion, ((Task)ar).Status);
         }
 
-        [Fact]
-        [OuterLoop]
-        public static void TaskAPMTest1()
+        public void Dispose()
         {
-            TaskAPMTest test = new TaskAPMTest(true);
-            test.RealRun();
+            _mre.Dispose();
         }
     }
 
@@ -173,20 +177,19 @@ namespace System.Threading.Tasks.Tests
     /// </summary>
     public class LongTask
     {
-        //Used to store the amount time to perform spinWait
-        protected readonly Int32 _ms;  // Milliseconds;
+        // Amount of time to SpinWait, in milliseconds.
+        protected readonly Int32 _msWaitDuration;
 
-        public LongTask(Int32 seconds)
+        public LongTask(Int32 milliseconds)
         {
-            _ms = seconds * 1000;
+            _msWaitDuration = milliseconds;
         }
 
         // Synchronous version of time-consuming method
         public void DoTask()
         {
             // Simulate time-consuming task
-            SpinWait.SpinUntil(() => false, _ms);
-            //Thread.SpinWait(_ms); 
+            SpinWait.SpinUntil(() => false, _msWaitDuration);
         }
 
         // Asynchronous version of time-consuming method (Begin part)
@@ -208,7 +211,7 @@ namespace System.Threading.Tasks.Tests
                 });
             }
 
-            return task;  // Return the IAsyncResult to the caller
+            return task; // Return the IAsyncResult to the caller
         }
 
         // Asynchronous version of time-consuming method (End part)
@@ -226,16 +229,16 @@ namespace System.Threading.Tasks.Tests
     /// </summary>
     public sealed class LongTask<T> : LongTask
     {
-        public LongTask(Int32 seconds)
-            : base(seconds)
+        public LongTask(Int32 milliseconds)
+            : base(milliseconds)
         {
         }
 
         // Synchronous version of time-consuming method
         public T DoTask(T input)
         {
-            SpinWait.SpinUntil(() => false, _ms); // Simulate time-consuming task
-            return input;           // Return some result, for now, just return the input
+            SpinWait.SpinUntil(() => false, _msWaitDuration); // Simulate time-consuming task
+            return input; // Return some result, for now, just return the input
         }
 
         public IAsyncResult BeginDoTask(T input, AsyncCallback callback, Object state)
@@ -253,7 +256,7 @@ namespace System.Threading.Tasks.Tests
                 callback(task);
             });
 
-            return task;  // Return the IAsyncResult to the caller
+            return task; // Return the IAsyncResult to the caller
         }
 
         // Asynchronous version of time-consuming method (End part)

--- a/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
@@ -38,9 +38,9 @@ namespace System.Threading.Tasks.Tests
         private const int IntInput = 1000;
 
         /// <summary>
-        /// The constant that defines the amount time to spinwait (to simulate work) in the LongTask class
+        /// The constant that defines the number of milliseconds to spinwait (to simulate work) in the LongTask class
         /// </summary>
-        private const int LongTaskMilliseconds = 1000;
+        private const int LongTaskMilliseconds = 100;
 
         [Theory]
         [OuterLoop]

--- a/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
@@ -39,7 +39,7 @@ namespace System.Threading.Tasks.Tests
             t = Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, stateObject);
             t.Wait();
             Assert.Equal(0, check.Length);
-            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Exercise 1-arg void option
             Task.Factory.FromAsync(
@@ -48,7 +48,7 @@ namespace System.Threading.Tasks.Tests
                 "1234", stateObject).Wait();
             check = fac.ToString();
             Assert.Equal("1234", check);
-            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Exercise 2-arg void option
             Task.Factory.FromAsync(
@@ -58,7 +58,7 @@ namespace System.Threading.Tasks.Tests
                 4, stateObject).Wait();
             check = fac.ToString();
             Assert.Equal("1234aaaa", check);
-            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Exercise 3-arg void option
             Task.Factory.FromAsync(
@@ -70,7 +70,7 @@ namespace System.Threading.Tasks.Tests
                 stateObject).Wait();
             check = fac.ToString();
             Assert.Equal("1234aaaazzzz", check);
-            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Read side, exercises getting return values from EndMethod
             char[] carray = new char[100];
@@ -86,7 +86,7 @@ namespace System.Threading.Tasks.Tests
             string s = f.Result;
             Assert.Equal("1234", s);
             Assert.Equal('1', carray[0]);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 2-arg value option
             f = Task<string>.Factory.FromAsync(
@@ -98,7 +98,7 @@ namespace System.Threading.Tasks.Tests
             s = f.Result;
             Assert.Equal("aaaa", s);
             Assert.Equal('a', carray[0]);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 1-arg value option
             f = Task<string>.Factory.FromAsync(
@@ -108,7 +108,7 @@ namespace System.Threading.Tasks.Tests
                 stateObject);
             s = f.Result;
             Assert.Equal("z", s);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 0-arg value option
             f = Task<string>.Factory.FromAsync(
@@ -117,7 +117,7 @@ namespace System.Threading.Tasks.Tests
                 stateObject);
             s = f.Result;
             Assert.Equal("zzz", s);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             //
             // Do all of the read tests again, except with Task.Factory.FromAsync<string>(), instead of Task<string>.Factory.FromAsync().
@@ -137,7 +137,7 @@ namespace System.Threading.Tasks.Tests
             s = f.Result;
             Assert.Equal("1234", s);
             Assert.Equal('1', carray[0]);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // one more with the creationOptions overload
             f = Task.Factory.FromAsync<int, char[], int, string>(
@@ -153,7 +153,7 @@ namespace System.Threading.Tasks.Tests
             s = f.Result;
             Assert.Equal("5678", s);
             Assert.Equal('5', carray[0]);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 2-arg value option
             f = Task.Factory.FromAsync<int, char[], string>(
@@ -165,7 +165,7 @@ namespace System.Threading.Tasks.Tests
             s = f.Result;
             Assert.Equal("aaaa", s);
             Assert.Equal('a', carray[0]);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             //one more with the creation option overload
             f = Task.Factory.FromAsync<int, char[], string>(
@@ -178,7 +178,7 @@ namespace System.Threading.Tasks.Tests
             s = f.Result;
             Assert.Equal("AAAA", s);
             Assert.Equal('A', carray[0]);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 1-arg value option
             f = Task.Factory.FromAsync<int, string>(
@@ -188,7 +188,7 @@ namespace System.Threading.Tasks.Tests
                 stateObject);
             s = f.Result;
             Assert.Equal("z", s);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // one more with creation option overload
             f = Task.Factory.FromAsync<int, string>(
@@ -199,7 +199,7 @@ namespace System.Threading.Tasks.Tests
              TaskCreationOptions.None);
             s = f.Result;
             Assert.Equal("z", s);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 0-arg value option
             f = Task.Factory.FromAsync<string>(
@@ -208,7 +208,7 @@ namespace System.Threading.Tasks.Tests
                 stateObject);
             s = f.Result;
             Assert.Equal("zz", s);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             //one more with Creation options overload
             f = Task.Factory.FromAsync<string>(
@@ -218,7 +218,7 @@ namespace System.Threading.Tasks.Tests
                TaskCreationOptions.None);
             s = f.Result;
             Assert.Equal(string.Empty, s);
-            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
+            Assert.Same(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Inject a few more characters into the buffer
             fac.EndWrite(fac.StartWrite("0123456789", null, null));

--- a/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
@@ -23,36 +23,23 @@ namespace System.Threading.Tasks.Tests
             string check;
             object stateObject = new object();
 
-
             // Exercise void overload that takes IAsyncResult instead of StartMethod
             t = Task.Factory.FromAsync(fac.StartWrite("", 0, 0, null, null), delegate (IAsyncResult iar) { });
             t.Wait();
             check = fac.ToString();
-            if (check.Length != 0)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write1 -- expected empty fac."));
-            }
+            Assert.Equal(0, check.Length);
 
             //CreationOption overload
             t = Task.Factory.FromAsync(fac.StartWrite("", 0, 0, null, null), delegate (IAsyncResult iar) { }, TaskCreationOptions.None);
             t.Wait();
             check = fac.ToString();
-            if (check.Length != 0)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write2 -- expected empty fac."));
-            }
+            Assert.Equal(0, check.Length);
 
             // Exercise 0-arg void option
             t = Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, stateObject);
             t.Wait();
-            if (check.Length != 0)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write3 -- expected empty fac."));
-            }
-            else if (((IAsyncResult)t).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write3 -- state object not stored correctly."));
-            }
+            Assert.Equal(0, check.Length);
+            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Exercise 1-arg void option
             Task.Factory.FromAsync(
@@ -60,14 +47,8 @@ namespace System.Threading.Tasks.Tests
                 fac.EndWrite,
                 "1234", stateObject).Wait();
             check = fac.ToString();
-            if (!check.Equals("1234"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Write4.  Expected fac \"1234\" after wait, got {0}.", check));
-            }
-            else if (((IAsyncResult)t).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write4 -- state object not stored correctly."));
-            }
+            Assert.Equal("1234", check);
+            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Exercise 2-arg void option
             Task.Factory.FromAsync(
@@ -76,14 +57,8 @@ namespace System.Threading.Tasks.Tests
                 "aaaabcdef",
                 4, stateObject).Wait();
             check = fac.ToString();
-            if (!check.Equals("1234aaaa"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Write5.  Expected fac \"1234aaaa\" after wait, got {0}.", check));
-            }
-            else if (((IAsyncResult)t).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write5 -- state object not stored correctly."));
-            }
+            Assert.Equal("1234aaaa", check);
+            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Exercise 3-arg void option
             Task.Factory.FromAsync(
@@ -94,14 +69,8 @@ namespace System.Threading.Tasks.Tests
                 4,
                 stateObject).Wait();
             check = fac.ToString();
-            if (!check.Equals("1234aaaazzzz"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Write6.  Expected fac \"1234aaaazzzz\" after wait, got {0}.", check));
-            }
-            else if (((IAsyncResult)t).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Write6 -- state object not stored correctly."));
-            }
+            Assert.Equal("1234aaaazzzz", check);
+            Assert.Equal(stateObject, ((IAsyncResult)t).AsyncState);
 
             // Read side, exercises getting return values from EndMethod
             char[] carray = new char[100];
@@ -115,18 +84,9 @@ namespace System.Threading.Tasks.Tests
                 0,
                 stateObject);
             string s = f.Result;
-            if (!s.Equals("1234"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read1.  Expected Result = \"1234\", got {0}.", s));
-            }
-            else if (carray[0] != '1')
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read1.  Expected carray[0] = '1', got {0}.", carray[0]));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read1 -- state object not stored correctly."));
-            }
+            Assert.Equal("1234", s);
+            Assert.Equal('1', carray[0]);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 2-arg value option
             f = Task<string>.Factory.FromAsync(
@@ -136,18 +96,9 @@ namespace System.Threading.Tasks.Tests
                 carray,
                 stateObject);
             s = f.Result;
-            if (!s.Equals("aaaa"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read2.  Expected Result = \"aaaa\", got {0}.", s));
-            }
-            else if (carray[0] != 'a')
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read2.  Expected carray[0] = 'a', got {0}.", carray[0]));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read2 -- state object not stored correctly."));
-            }
+            Assert.Equal("aaaa", s);
+            Assert.Equal('a', carray[0]);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 1-arg value option
             f = Task<string>.Factory.FromAsync(
@@ -156,14 +107,8 @@ namespace System.Threading.Tasks.Tests
                 1,
                 stateObject);
             s = f.Result;
-            if (!s.Equals("z"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read3.  Expected Result = \"z\", got {0}.", s));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read3 -- state object not stored correctly."));
-            }
+            Assert.Equal("z", s);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 0-arg value option
             f = Task<string>.Factory.FromAsync(
@@ -171,14 +116,8 @@ namespace System.Threading.Tasks.Tests
                 fac.EndRead,
                 stateObject);
             s = f.Result;
-            if (!s.Equals("zzz"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read4.  Expected Result = \"zzz\", got {0}.", s));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read4 -- state object not stored correctly."));
-            }
+            Assert.Equal("zzz", s);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             //
             // Do all of the read tests again, except with Task.Factory.FromAsync<string>(), instead of Task<string>.Factory.FromAsync().
@@ -196,18 +135,9 @@ namespace System.Threading.Tasks.Tests
                 stateObject);
 
             s = f.Result;
-            if (!s.Equals("1234"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read1a.  Expected Result = \"1234\", got {0}.", s));
-            }
-            else if (carray[0] != '1')
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read1a.  Expected carray[0] = '1', got {0}.", carray[0]));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read1a -- state object not stored correctly."));
-            }
+            Assert.Equal("1234", s);
+            Assert.Equal('1', carray[0]);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // one more with the creationOptions overload
             f = Task.Factory.FromAsync<int, char[], int, string>(
@@ -221,19 +151,9 @@ namespace System.Threading.Tasks.Tests
               TaskCreationOptions.None);
 
             s = f.Result;
-            if (!s.Equals("5678"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read1b.  Expected Result = \"1234\", got {0}.", s));
-            }
-            else if (carray[0] != '5')
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read1b.  Expected carray[0] = '1', got {0}.", carray[0]));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read1b -- state object not stored correctly."));
-            }
-
+            Assert.Equal("5678", s);
+            Assert.Equal('5', carray[0]);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 2-arg value option
             f = Task.Factory.FromAsync<int, char[], string>(
@@ -243,18 +163,9 @@ namespace System.Threading.Tasks.Tests
                 carray,
                 stateObject);
             s = f.Result;
-            if (!s.Equals("aaaa"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read2a.  Expected Result = \"aaaa\", got {0}.", s));
-            }
-            else if (carray[0] != 'a')
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read2a.  Expected carray[0] = 'a', got {0}.", carray[0]));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read2a -- state object not stored correctly."));
-            }
+            Assert.Equal("aaaa", s);
+            Assert.Equal('a', carray[0]);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             //one more with the creation option overload
             f = Task.Factory.FromAsync<int, char[], string>(
@@ -265,18 +176,9 @@ namespace System.Threading.Tasks.Tests
                stateObject,
                TaskCreationOptions.None);
             s = f.Result;
-            if (!s.Equals("AAAA"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read2b.  Expected Result = \"aaaa\", got {0}.", s));
-            }
-            else if (carray[0] != 'A')
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read2b.  Expected carray[0] = 'a', got {0}.", carray[0]));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read2b -- state object not stored correctly."));
-            }
+            Assert.Equal("AAAA", s);
+            Assert.Equal('A', carray[0]);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 1-arg value option
             f = Task.Factory.FromAsync<int, string>(
@@ -285,14 +187,8 @@ namespace System.Threading.Tasks.Tests
                 1,
                 stateObject);
             s = f.Result;
-            if (!s.Equals("z"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read3a.  Expected Result = \"z\", got {0}.", s));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read3a -- state object not stored correctly."));
-            }
+            Assert.Equal("z", s);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // one more with creation option overload
             f = Task.Factory.FromAsync<int, string>(
@@ -302,14 +198,8 @@ namespace System.Threading.Tasks.Tests
              stateObject,
              TaskCreationOptions.None);
             s = f.Result;
-            if (!s.Equals("z"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read3b.  Expected Result = \"z\", got {0}.", s));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read3b -- state object not stored correctly."));
-            }
+            Assert.Equal("z", s);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Exercise 0-arg value option
             f = Task.Factory.FromAsync<string>(
@@ -317,14 +207,8 @@ namespace System.Threading.Tasks.Tests
                 fac.EndRead,
                 stateObject);
             s = f.Result;
-            if (!s.Equals("zz"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read4a.  Expected Result = \"zz\", got {0}.", s));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read4a -- state object not stored correctly."));
-            }
+            Assert.Equal("zz", s);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             //one more with Creation options overload
             f = Task.Factory.FromAsync<string>(
@@ -333,14 +217,8 @@ namespace System.Threading.Tasks.Tests
                stateObject,
                TaskCreationOptions.None);
             s = f.Result;
-            if (!s.Equals(""))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read4b.  Expected Result = \"\", got {0}.", s));
-            }
-            else if (((IAsyncResult)f).AsyncState != stateObject)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED on Read4b -- state object not stored correctly."));
-            }
+            Assert.Equal(string.Empty, s);
+            Assert.Equal(stateObject, ((IAsyncResult)f).AsyncState);
 
             // Inject a few more characters into the buffer
             fac.EndWrite(fac.StartWrite("0123456789", null, null));
@@ -351,19 +229,13 @@ namespace System.Threading.Tasks.Tests
                 fac.StartRead(4, null, null),
                 fac.EndRead);
             s = f.Result;
-            if (!s.Equals("0123"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read5.  Expected Result = \"0123\", got {0}.", s));
-            }
+            Assert.Equal("0123", s);
 
             f = Task.Factory.FromAsync<string>(
                 fac.StartRead(4, null, null),
                 fac.EndRead);
             s = f.Result;
-            if (!s.Equals("4567"))
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED @ Read5a.  Expected Result = \"4567\", got {0}.", s));
-            }
+            Assert.Equal("4567", s);
 
             // Test Exception handling from beginMethod
             Assert.ThrowsAsync<NullReferenceException>(() =>
@@ -392,84 +264,53 @@ namespace System.Threading.Tasks.Tests
             Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
               Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, null, TaskCreationOptions.PreferFairness));
 
-            // 
-            // Test that parent cancellation flows correctly through FromAsync()
-            //
-
-            // Allow some time for whatever happened above to sort itself out.
-            //Thread.Sleep(200);
-
             // Empty the buffer, then inject a few more characters into the buffer
             fac.ResetStateTo("0123456789");
 
             Task asyncTask = null;
-
-            // Now check to see that the cancellation behaved like we thought it would -- even though the tasks were canceled,
-            // the operations still took place.
-            //
-            // I'm commenting this one out because it has some timing problems -- if some things above get delayed,
-            // then the final chars in the buffer might not read like this.
-            //
-            //s = Task<string>.Factory.FromAsync(fac.StartRead(200, null, null), fac.EndRead).Result;
-            //if (!s.Equals("89abcdef"))
-            //{
-            //    Assert.True(false, string.Format("    > FAILED.  Unexpected result after cancellations: Expected \"89abcdef\", got \"{0}\"", s));
-            //    passed = false;
-            //}
 
             //
             // Now check that the endMethod throwing an OCE correctly results in a canceled task.
             //
 
             // Test IAsyncResult overload that returns Task
-            asyncTask = null;
             asyncTask = Task.Factory.FromAsync(
                 fac.StartWrite("abc", null, null),
                 delegate (IAsyncResult iar) { throw new OperationCanceledException("FromAsync"); });
-            try
+
+            AggregateException ae = Assert.Throws<AggregateException>(() =>
             {
                 asyncTask.Wait();
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected exception on FAS(iar,endMethod) throwing OCE"));
-            }
-            catch (Exception) { }
-            if (asyncTask.Status != TaskStatus.Canceled)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected Canceled status on FAS(iar,endMethod) OCE, got {0}", asyncTask.Status));
-            }
+            });
+            Assert.Equal(typeof(TaskCanceledException), ae.InnerException.GetType());
+            Assert.Equal(TaskStatus.Canceled, asyncTask.Status);
 
             // Test beginMethod overload that returns Task
-            asyncTask = null;
             asyncTask = Task.Factory.FromAsync(
                 fac.StartWrite,
                 delegate (IAsyncResult iar) { throw new OperationCanceledException("FromAsync"); },
                 "abc",
                 null);
-            try
+
+            ae = Assert.Throws<AggregateException>(() =>
             {
                 asyncTask.Wait();
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected exception on FAS(beginMethod,endMethod) throwing OCE"));
-            }
-            catch (Exception) { }
-            if (asyncTask.Status != TaskStatus.Canceled)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected Canceled status on FAS(beginMethod,endMethod) OCE, got {0}", asyncTask.Status));
-            }
+            });
+            Assert.Equal(typeof(TaskCanceledException), ae.InnerException.GetType());
+            Assert.Equal(TaskStatus.Canceled, asyncTask.Status);
 
             // Test IAsyncResult overload that returns Task<string>
             Task<string> asyncFuture = null;
             asyncFuture = Task<string>.Factory.FromAsync(
                 fac.StartRead(3, null, null),
                 delegate (IAsyncResult iar) { throw new OperationCanceledException("FromAsync"); });
-            try
+
+            ae = Assert.Throws<AggregateException>(() =>
             {
-                asyncFuture.Wait();
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected exception on FAS<string>(iar,endMethod) throwing OCE"));
-            }
-            catch (Exception) { }
-            if (asyncFuture.Status != TaskStatus.Canceled)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected Canceled status on FAS<string>(iar,endMethod) OCE, got {0}", asyncFuture.Status));
-            }
+                asyncTask.Wait();
+            });
+            Assert.Equal(typeof(TaskCanceledException), ae.InnerException.GetType());
+            Assert.Equal(TaskStatus.Canceled, asyncTask.Status);
 
             // Test beginMethod overload that returns Task<string>
             asyncFuture = null;
@@ -477,17 +318,13 @@ namespace System.Threading.Tasks.Tests
                 fac.StartRead,
                 delegate (IAsyncResult iar) { throw new OperationCanceledException("FromAsync"); },
                 3, null);
-            try
+
+            ae = Assert.Throws<AggregateException>(() =>
             {
                 asyncFuture.Wait();
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected exception on FAS<string>(beginMethod,endMethod) throwing OCE"));
-            }
-            catch (Exception) { }
-            if (asyncFuture.Status != TaskStatus.Canceled)
-            {
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED! Expected Canceled status on FAS<string>(beginMethod,endMethod) OCE, got {0}", asyncFuture.Status));
-            }
-
+            });
+            Assert.Equal(typeof(TaskCanceledException), ae.InnerException.GetType());
+            Assert.Equal(TaskStatus.Canceled, asyncFuture.Status);
 
             //
             // Make sure that tasks aren't left hanging if StartXYZ() throws an exception
@@ -506,12 +343,11 @@ namespace System.Threading.Tasks.Tests
             });
 
             Debug.WriteLine("RunAPMFactoryTests: Waiting on task w/ faulted FromAsync() calls.  If we hang, there is a problem");
-            try
+
+            Assert.Throws<AggregateException>(() =>
             {
                 foo.Wait();
-                Assert.True(false, string.Format("RunAPMFactoryTests:    > FAILED!  Expected an exception."));
-            }
-            catch (Exception) { }
+            });
         }
 
         // This class is used in testing APM Factory tests.


### PR DESCRIPTION
Here are some small, incremental improvements to some of the Tasks tests. I cleaned up four files that had some particularly ugly assertions and assertion messages, and which were all crammed into a single "test method" in each class. In general I did the following:

* Split things into individual test methods where it was simple
* Replace old assertion calls with regular, standard ones
* Remove old, unnecessary comments, debug statements, dead code, etc
* Formatting, etc.

This is just my incremental progress from the past day, I'm still planning on doing more cleanup in time, as this only covers 4 of the 30 files in the project (some of which I cleaned up enough previously). We could merge the fixes in incrementally or keep this PR open for more commits.

@stephentoub 