### PR TITLE
Fix failing TaskWaitAllAny* tests

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
@@ -294,7 +294,8 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
                 if (taskInfo.Task.Status == TaskStatus.Running)
                 {
                     taskInfo.CancellationTokenSource.Cancel();
-                    taskInfo.Task.Wait();
+                    try { taskInfo.Task.GetAwaiter().GetResult(); }
+                    catch (OperationCanceledException) { }
                 }
             }
         }


### PR DESCRIPTION
Some of these tests have been failing in CI.  While unwieldy in general, the specific issue is that when the tests are shutting down, they cancel any tasks that haven't yet completed, but then simply wait on the tasks to complete.  If the task hadn't yet started, the cancellation request would cause the task to end as Canceled, which would cause the Wait to throw.  The fix is simply to catch and ignore the resulting OperationCanceledException.

cc: @mellinoe 