### PR TITLE
Fix access to user's home directory on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetEGid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetEGid.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static partial class libc
+    internal static partial class Sys
     {
-        [DllImport(Libraries.Libc)]
-        internal static extern int geteuid();
+        [DllImport(Libraries.SystemNative)]
+        internal static extern int GetEGid();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetEUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetEUid.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static partial class libc
+    internal static partial class Sys
     {
-        [DllImport(Libraries.Libc)]
-        internal static extern int getegid();
+        [DllImport(Libraries.SystemNative)]
+        internal static extern int GetEUid();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal unsafe struct Passwd
+        {
+            internal byte* Name;
+            internal byte* Password;
+            internal int   UserId;
+            internal int   GroupId;
+            internal byte* UserInfo;
+            internal byte* HomeDirectory;
+            internal byte* Shell;
+        };
+
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern unsafe int GetPwUid(int uid, out Passwd pwd, byte* buf, long bufLen, out IntPtr result);
+    }
+}

--- a/src/Native/System.Native/CMakeLists.txt
+++ b/src/Native/System.Native/CMakeLists.txt
@@ -4,6 +4,7 @@ set(NATIVE_SOURCES
     pal_errno.cpp
     pal_exec.cpp
     pal_stat.cpp
+    pal_uid.cpp
 )
 
 add_library(System.Native

--- a/src/Native/System.Native/pal_uid.cpp
+++ b/src/Native/System.Native/pal_uid.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "../config.h"
+#include "pal_uid.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+
+/**
+* Gets a password structure for the given uid.
+* Implemented as shim to getpwuid_r(3).
+*
+* Returns 0 for success, -1 for failure. Sets errno on failure.
+*/
+extern "C"
+int32_t GetPwUid(
+	int32_t  uid,
+	Passwd*  pwd,
+	char*    buf,
+	int64_t  buflen,
+	Passwd** result)
+{
+	assert(pwd != nullptr);
+	assert(buf != nullptr);
+	assert(buflen >= 0);
+	assert(result != nullptr);
+
+	struct passwd nativePwd;
+	struct passwd* nativePwdResultPtr;
+	int rv = getpwuid_r(uid, &nativePwd, buf, buflen, &nativePwdResultPtr);
+
+	// If successful, the result will be null if the user couldn't be found,
+	// or it'll contain the address of the provided pwd structure, into
+	// which the results are stored.
+	if (rv == 0 && nativePwdResultPtr != nullptr)
+	{
+		assert(nativePwdResultPtr == &nativePwd);
+		
+		pwd->Name = nativePwd.pw_name;
+		pwd->Password = nativePwd.pw_passwd;
+		pwd->UserId = nativePwd.pw_uid;
+		pwd->GroupId = nativePwd.pw_gid;
+		pwd->UserInfo = nativePwd.pw_gecos;
+		pwd->HomeDirectory = nativePwd.pw_dir;
+		pwd->Shell = nativePwd.pw_shell;
+		*result = pwd;
+	}
+	else
+	{
+		// Make sure we zero out the results fields, as the managed
+		// caller could be using out variables and expect them to be initialized
+		// after the call.
+		*pwd = { };
+		*result = nullptr;
+	}
+
+	return rv;
+}
+
+extern "C"
+int32_t GetEUid()
+{
+	return geteuid();
+}
+
+extern "C"
+int32_t GetEGid()
+{
+	return getegid();
+}

--- a/src/Native/System.Native/pal_uid.h
+++ b/src/Native/System.Native/pal_uid.h
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+* Passwd struct 
+*/
+struct Passwd {
+	char*   Name;
+	char*   Password; 
+	int32_t UserId;
+	int32_t GroupId;
+	char*   UserInfo;
+	char*   HomeDirectory;
+	char*   Shell;
+};
+
+/**
+* Gets a password structure for the given uid. 
+* Implemented as shim to getpwuid_r(3).
+*
+* Returns 0 for success, -1 for failure. Sets errno on failure.
+*/
+extern "C"
+int32_t GetPwUid(
+	int32_t  uid,
+	Passwd*  pwd,
+	char*    buf,
+	int64_t  buflen,
+	Passwd** result);
+
+/**
+* Gets and returns the effective user's identity.
+* Implemented as shim to geteuid(2).
+*
+* Always succeeds.
+*/
+extern "C"
+int32_t GetEUid();
+
+/**
+* Gets and returns the effective group's identity.
+* Implemented as shim to getegid(2).
+*
+* Always succeeds.
+*/
+extern "C"
+int32_t GetEGid();

--- a/src/System.Console/src/Resources/Strings.resx
+++ b/src/System.Console/src/Resources/Strings.resx
@@ -198,4 +198,7 @@
   <data name="PlatformNotSupported_GettingColor" xml:space="preserve">
     <value>This platform does not support getting the current color.</value>
   </data>
+  <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
+    <value>The home directory of the current user could not be determined.</value>
+  </data>
 </root>

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -96,6 +96,12 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
+      <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
@@ -131,6 +137,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.snprintf.cs">
       <Link>Common\Interop\Unix\Interop.snprintf.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPwUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\Interop.Stat.cs</Link>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -490,7 +490,7 @@ namespace System
                     }
 
                     // Then try in the user's home directory.
-                    string home = Environment.GetEnvironmentVariable("HOME");
+                    string home = PersistedFiles.GetHomeDirectory();
                     if (!string.IsNullOrWhiteSpace(home) && (db = ReadDatabase(term, home + "/.terminfo")) != null)
                     {
                         return db;

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -283,12 +283,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.ftruncate.cs">
       <Link>Common\Interop\Unix\Interop.ftruncate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getegid.cs">
-      <Link>Common\Interop\Unix\Interop.getegid.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.geteuid.cs">
-      <Link>Common\Interop\Unix\Interop.geteuid.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
       <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
     </Compile>
@@ -333,6 +327,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.unlink.cs">
       <Link>Common\Interop\Unix\Interop.unlink.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEGid.cs">
+      <Link>Common\Interop\Unix\Interop.GetEGid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\Interop.Stat.cs</Link>

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -107,12 +107,12 @@ namespace System.IO
             get
             {
                 Interop.libc.Permissions readBit, writeBit;
-                if (_fileStatus.Uid == Interop.libc.geteuid())      // does the user effectively own the file?
+                if (_fileStatus.Uid == Interop.Sys.GetEUid())      // does the user effectively own the file?
                 {
                     readBit  = Interop.libc.Permissions.S_IRUSR;
                     writeBit = Interop.libc.Permissions.S_IWUSR;
                 }
-                else if (_fileStatus.Gid == Interop.libc.getegid()) // does the user belong to a group that effectively owns the file?
+                else if (_fileStatus.Gid == Interop.Sys.GetEGid()) // does the user belong to a group that effectively owns the file?
                 {
                     readBit  = Interop.libc.Permissions.S_IRGRP;
                     writeBit = Interop.libc.Permissions.S_IWGRP;

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -180,6 +180,12 @@
   <!-- OSX -->
   <ItemGroup Condition="'$(TargetsOSX)' == 'true'">
     <Compile Include="System\IO\MemoryMappedFiles\MemoryMappedFile.Unix.BackingObject_File.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPwUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.unlink.cs">
       <Link>Common\Interop\Unix\Interop.unlink.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -141,6 +141,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\libc\Interop.Permissions.cs</Link>
     </Compile>
@@ -179,6 +182,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.X509Ext.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPwUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Stat.cs</Link>

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -5,7 +5,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public class X509StoreTests
     {
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void OpenMyStore()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -15,7 +14,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void ReadMyCertificates()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -30,7 +28,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void OpenNotExistant()
         {
             using (X509Store store = new X509Store(Guid.NewGuid().ToString("N"), StoreLocation.CurrentUser))
@@ -40,7 +37,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void AddReadOnlyThrows()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -59,7 +55,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void AddReadOnlyThrowsWhenCertificateExists()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -88,7 +83,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void RemoveReadOnlyThrowsWhenFound()
         {
             // This test is unfortunate, in that it will mostly never test.
@@ -113,7 +107,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void EnumerateClosedIsEmpty()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -124,7 +117,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void AddClosedThrows()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -135,7 +127,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2820, PlatformID.AnyUnix)]
         public static void RemoveClosedThrows()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))

--- a/src/System.Security.SecureString/tests/SecureStringTests.cs
+++ b/src/System.Security.SecureString/tests/SecureStringTests.cs
@@ -13,7 +13,7 @@ public static class SecureStringTest
     // number of pages worth of memory will likely result in OOMs unless in a privileged process.
     private static readonly bool s_isWindowsOrPrivilegedUnix = 
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || 
-        Interop.libc.geteuid() == 0;
+        Interop.Sys.GetEUid() == 0;
 
     private static void VerifyString(SecureString ss, string exString)
     {

--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
@@ -20,8 +20,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.geteuid.cs">
-      <Link>Common\Interop\Unix\libc\Interop.geteuid.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.GetEUid.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Today in several places we get a user's home directory by accessing the HOME environment variable.  This is the right place to check first, but in certain cases it may not be set, such as in initialization scripts.

This commit implements a fallback, such that if HOME doesn't have a path, we consult the pw_dir path from a call to getpwuid_r for the current user.

As long as I was adding getpwuid_r to the native shim, I also moved our existing geteuid and getegid imports to the shims.

Fixes #2820 
cc: @nguerrera, @bartonjs, @sokket, @akoeplinger 