### PR TITLE
Added ZLib decompression support to DeflateStream

### DIFF
--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -41,8 +41,10 @@
     <Compile Include="System\IO\Compression\GZipUtils.cs" />
     <Compile Include="System\IO\Compression\HuffmanTree.cs" />
     <Compile Include="System\IO\Compression\IDeflater.cs" />
-    <Compile Include="System\IO\Compression\Inflater.cs" />
+    <Compile Include="System\IO\Compression\IInflater.cs" />
+    <Compile Include="System\IO\Compression\InflaterManaged.cs" />
     <Compile Include="System\IO\Compression\InflaterState.cs" />
+    <Compile Include="System\IO\Compression\InflaterZlib.cs" />
     <Compile Include="System\IO\Compression\InputBuffer.cs" />
     <Compile Include="System\IO\Compression\Match.cs" />
     <Compile Include="System\IO\Compression\MatchState.cs" />

--- a/src/System.IO.Compression/src/System/IO/Compression/FileFormats.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/FileFormats.cs
@@ -16,6 +16,30 @@ namespace System.IO.Compression
         bool ReadFooter(InputBuffer input);
         void UpdateWithBytesRead(byte[] buffer, int offset, int bytesToCopy);
         void Validate();
+
+        /// <summary>
+        /// A reader corresponds to an expected file format and contains methods
+        /// to read header/footer data from a file of that format. If the Zlib library
+        /// is instead being used and the file format is supported, we can simply pass
+        /// a supported WindowSize and let Zlib do the header/footer parsing for us.
+        /// 
+        /// This Property allows getting of a ZLibWindowSize that can be used in place
+        /// of manually parsing the raw data stream.
+        /// </summary>
+        /// <return>
+        /// For raw data, return -8..-15
+        /// For GZip header detection and decoding, return 16..31
+        /// For GZip and Zlib header detection and decoding, return 32..47
+        /// </return>
+        /// <remarks>
+        /// The windowBits parameter for inflation must be greater than or equal to the
+        /// windowBits parameter used in deflation. 
+        /// </remarks>
+        /// <remarks>
+        /// If the incorrect header information is used, zlib inflation will likely throw a 
+        /// Z_DATA_ERROR exception.
+        ///</remarks>
+        int ZLibWindowSize { get; }
     }
 }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipDecoder.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipDecoder.cs
@@ -21,6 +21,17 @@ namespace System.IO.Compression
         private uint _actualCrc32;
         private long _actualStreamSizeModulo;
 
+        public int ZLibWindowSize
+        {
+            get
+            {
+                // Since we don't necessarily know what WindowSize the stream was compressed with,
+                // we use the upper bound of (32..47) as the WindowSize for decompression. This enables
+                // detection for Zlib and GZip headers
+                return 47;
+            }
+        }
+
         public GZipDecoder()
         {
             Reset();

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -21,8 +21,15 @@ namespace System.IO.Compression
 
         public GZipStream(Stream stream, CompressionMode mode, bool leaveOpen)
         {
-            _deflateStream = new DeflateStream(stream, mode, leaveOpen);
-            SetDeflateStreamFileFormatter(mode);
+            if (mode == CompressionMode.Decompress)
+            {
+                _deflateStream = new DeflateStream(stream, leaveOpen, new GZipDecoder());
+            }
+            else
+            {
+                _deflateStream = new DeflateStream(stream, mode, leaveOpen);
+                _deflateStream.SetFileFormatWriter(new GZipFormatter());
+            }
         }
 
 
@@ -38,24 +45,8 @@ namespace System.IO.Compression
         public GZipStream(Stream stream, CompressionLevel compressionLevel, bool leaveOpen)
         {
             _deflateStream = new DeflateStream(stream, compressionLevel, leaveOpen);
-            SetDeflateStreamFileFormatter(CompressionMode.Compress);
+            _deflateStream.SetFileFormatWriter(new GZipFormatter());
         }
-
-
-        private void SetDeflateStreamFileFormatter(CompressionMode mode)
-        {
-            if (mode == CompressionMode.Compress)
-            {
-                IFileFormatWriter writeCommand = new GZipFormatter();
-                _deflateStream.SetFileFormatWriter(writeCommand);
-            }
-            else
-            {
-                IFileFormatReader readCommand = new GZipDecoder();
-                _deflateStream.SetFileFormatReader(readCommand);
-            }
-        }
-
 
         public override bool CanRead
         {

--- a/src/System.IO.Compression/src/System/IO/Compression/IInflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/IInflater.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO.Compression
+{
+    internal interface IInflater : IDisposable
+    {
+        /// <summary>
+        /// The remaining free space at next_out i.e. number of bytes available
+        /// in output
+        /// </summary>
+        int AvailableOutput { get;}
+
+        /// <summary>
+        /// Performs the actual inflation of data currently in the input buffer of the Inflater
+        /// and stores it into the given array with the given information
+        /// </summary>
+        /// <param name="bytes">Buffer for the output of the inflation</param>
+        /// <param name="offset">The starting point at which to store output data</param>
+        /// <param name="length">The maximum number of bytes to write to "bytes"</param>
+        /// <returns>The number of bytes written to "bytes"</returns>
+        int Inflate(byte[] bytes, int offset, int length);
+
+        /// <summary>
+        /// Whether the end of the stream has been reached and no more data is available
+        /// </summary>
+        bool Finished();
+
+        /// <summary>
+        /// Returns true if the number of available bytes to be inflated is equal to
+        /// zero.
+        /// </summary>
+        /// <remarks>Before running Inflate(), this should return false.</remarks>
+        bool NeedsInput();
+
+        /// <summary>
+        /// Sets the input of the underlying stream to be equal to the byte array
+        /// provided.
+        /// </summary>
+        /// <param name="inputBytes">Bytes to put into next_in</param>
+        /// <param name="offset">Offset into inputBytes</param>
+        /// <param name="length">Number of bytes to write to the input stream</param>
+        /// <remarks>requires that NeedsInput() == true</remarks>
+        void SetInput(byte[] inputBytes, int offset, int length);
+    }
+}

--- a/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //
-
-//
 //  zlib.h -- interface of the 'zlib' general purpose compression library
 //  version 1.2.1, November 17th, 2003
 //
@@ -27,12 +25,11 @@
 //
 //
 
-using System;
 using System.Diagnostics;
 
 namespace System.IO.Compression
 {
-    internal class Inflater
+    internal class InflaterManaged : IInflater
     {
         // const tables used in decoding:
 
@@ -91,7 +88,7 @@ namespace System.IO.Compression
 
         private IFileFormatReader _formatReader;  // class to decode header and footer (e.g. gzip)
 
-        public Inflater()
+        public InflaterManaged()
         {
             _output = new OutputWindow();
             _input = new InputBuffer();
@@ -101,7 +98,22 @@ namespace System.IO.Compression
             Reset();
         }
 
-        internal void SetFileFormatReader(IFileFormatReader reader)
+        internal InflaterManaged(IFileFormatReader reader)
+        {
+            _output = new OutputWindow();
+            _input = new InputBuffer();
+
+            _codeList = new byte[HuffmanTree.MaxLiteralTreeElements + HuffmanTree.MaxDistTreeElements];
+            _codeLengthTreeCodeLength = new byte[HuffmanTree.NumberOfCodeLengthTreeElements];
+            if (reader != null)
+            {
+                _formatReader = reader;
+                _hasFormatReader = true;
+            }
+            Reset();
+        }
+
+        public void SetFileFormatReader(IFileFormatReader reader)
         {
             _formatReader = reader;
             _hasFormatReader = true;
@@ -125,7 +137,6 @@ namespace System.IO.Compression
             _input.SetInput(inputBytes, offset, length);    // append the bytes
         }
 
-
         public bool Finished()
         {
             return (_state == InflaterState.Done || _state == InflaterState.VerifyingFooter);
@@ -146,7 +157,7 @@ namespace System.IO.Compression
 
         public int Inflate(byte[] bytes, int offset, int length)
         {
-            // copy bytes from output to outputbytes if we have aviable bytes 
+            // copy bytes from output to outputbytes if we have available bytes 
             // if buffer is not filled up. keep decoding until no input are available
             // if decodeBlock returns false. Throw an exception.
             int count = 0;
@@ -731,6 +742,8 @@ namespace System.IO.Compression
             _state = InflaterState.DecodeTop;
             return true;
         }
+
+        public void Dispose() { }
     }
 }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/InflaterZlib.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/InflaterZlib.cs
@@ -1,0 +1,242 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace System.IO.Compression
+{
+    /// <summary>
+    /// Provides a wrapper around the ZLib decompression API that implements the
+    /// IInflater interface such that this implementation functions may be used interchangeably
+    /// with the Managed implementation found in InflaterManaged.cs
+    /// </summary>
+    internal class InflaterZlib : IInflater
+    {
+        private bool _finished;                             // Whether the end of the stream has been reached
+        private bool _isDisposed;                           // Prevents multiple disposals
+        private ZLibNative.ZLibStreamHandle _zlibStream;    // The handle to the primary underlying zlib stream
+        private GCHandle _inputBufferHandle;               // The handle to the buffer that provides input to _zlibStream
+        private readonly object _syncLock = new object();   // Used to make writing to unmanaged structures atomic 
+
+        #region Exposed Members
+
+        /// <summary>
+        /// Initialized the Inflater with the given windowBits size
+        /// </summary>
+        internal InflaterZlib(int windowBits)
+        {
+            _finished = false;
+            _isDisposed = false;
+            InflateInit(windowBits);
+        }
+
+        public int AvailableOutput
+        {
+            get
+            {
+                return (int)_zlibStream.AvailOut;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the end of the stream has been reached.
+        /// </summary>
+        public bool Finished()
+        {
+            return _finished && _zlibStream.AvailIn == 0 && _zlibStream.AvailOut == 0;
+        }
+
+        public int Inflate(byte[] bytes, int offset, int length)
+        {
+            Debug.Assert(null != bytes, "Can't pass in a null output buffer!");
+
+            // If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes
+            // have been read
+            if (NeedsInput() || _inputBufferHandle == null || !_inputBufferHandle.IsAllocated || length == 0)
+                return 0;
+
+            // State is valid; attempt inflation
+            try
+            {
+                int bytesRead;
+                ZLibNative.ErrorCode errc = ReadInflateOutput(bytes, offset, length, ZLibNative.FlushCode.NoFlush, out bytesRead);
+                if (errc == ZLibNative.ErrorCode.StreamEnd)
+                    _finished = true;
+                return bytesRead;
+            }
+            finally
+            {
+                // Before returning, make sure to release input buffer if necesary:
+                if (0 == _zlibStream.AvailIn && _inputBufferHandle.IsAllocated)
+                    DeallocateInputBufferHandle();
+            }
+        }
+
+        public bool NeedsInput()
+        {
+            return _zlibStream.AvailIn == 0;
+        }
+
+        public void SetInput(byte[] inputBuffer, int startIndex, int count)
+        {
+            Debug.Assert(NeedsInput(), "We have something left in previous input!");
+            Debug.Assert(inputBuffer != null);
+            Debug.Assert(startIndex >= 0 && count >= 0 && count + startIndex <= inputBuffer.Length);
+            Debug.Assert(!_inputBufferHandle.IsAllocated);
+
+            if (0 == count)
+                return;
+
+            lock (_syncLock)
+            {
+                _inputBufferHandle = GCHandle.Alloc(inputBuffer, GCHandleType.Pinned);
+                _zlibStream.NextIn = _inputBufferHandle.AddrOfPinnedObject() + startIndex;
+                _zlibStream.AvailIn = (uint)count;
+                _finished = false;
+            }
+        }
+
+        [SecuritySafeCritical]
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                    _zlibStream.Dispose();
+
+                if (_inputBufferHandle.IsAllocated)
+                    DeallocateInputBufferHandle();
+
+                _isDisposed = true;
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~InflaterZlib()
+        {
+            Dispose(false);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates the ZStream that will handle inflation
+        /// </summary>
+        [SecuritySafeCritical]
+        private void InflateInit(int windowBits)
+        {
+            ZLibNative.ErrorCode error;
+            try
+            {
+                error = ZLibNative.CreateZLibStreamForInflate(out _zlibStream, windowBits);
+            }
+            catch (Exception exception) // could not load the ZLib dll
+            {
+                throw new ZLibException(SR.ZLibErrorDLLLoadError, exception);
+            }
+
+            switch (error)
+            {
+                case ZLibNative.ErrorCode.Ok:           // Successful initialization
+                    return;
+
+                case ZLibNative.ErrorCode.MemError:     // Not enough memory
+                    throw new ZLibException(SR.ZLibErrorNotEnoughMemory, "inflateInit2_", (int)error, _zlibStream.GetErrorMessage());
+
+                case ZLibNative.ErrorCode.VersionError: //zlib library is incompatible with the version assumed
+                    throw new ZLibException(SR.ZLibErrorVersionMismatch, "inflateInit2_", (int)error, _zlibStream.GetErrorMessage());
+
+                case ZLibNative.ErrorCode.StreamError:  // Parameters are invalid
+                    throw new ZLibException(SR.ZLibErrorIncorrectInitParameters, "inflateInit2_", (int)error, _zlibStream.GetErrorMessage());
+
+                default:
+                    throw new ZLibException(SR.ZLibErrorUnexpected, "inflateInit2_", (int)error, _zlibStream.GetErrorMessage());
+            }
+        }
+
+        /// <summary>
+        /// Translates the given byte array to a GCHandle so that it can be passed to the ZLib
+        /// Inflate function, then returns the result of that call.
+        /// </summary>
+        private unsafe ZLibNative.ErrorCode ReadInflateOutput(byte[] outputBuffer, int offset, int length, ZLibNative.FlushCode flushCode, out int bytesRead)
+        {
+            lock (_syncLock)
+            {
+                fixed (byte* bufPtr = outputBuffer)
+                {
+                    _zlibStream.NextOut = (IntPtr)bufPtr + offset;
+                    _zlibStream.AvailOut = (uint)length;
+
+                    ZLibNative.ErrorCode errC = Inflate(flushCode);
+                    bytesRead = length - (int)_zlibStream.AvailOut;
+
+                    return errC;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wrapper around the ZLib inflate function
+        /// </summary>
+        [SecuritySafeCritical]
+        private ZLibNative.ErrorCode Inflate(ZLibNative.FlushCode flushCode)
+        {
+            ZLibNative.ErrorCode errC;
+            try
+            {
+                errC = _zlibStream.Inflate(flushCode);
+            }
+            catch (Exception cause) // could not load the Zlib DLL correctly
+            {
+                throw new ZLibException(SR.ZLibErrorDLLLoadError, cause);
+            }
+            switch (errC)
+            {
+                case ZLibNative.ErrorCode.Ok:           // progress has been made inflating
+                case ZLibNative.ErrorCode.StreamEnd:    // The end of the input stream has been reached
+                    return errC;
+
+                case ZLibNative.ErrorCode.BufError:     // No room in the output buffer - inflate() can be called again with more space to continue
+                    return errC;
+
+                case ZLibNative.ErrorCode.MemError:     // Not enough memory to complete the operation
+                    throw new ZLibException(SR.ZLibErrorNotEnoughMemory, "inflate_", (int)errC, _zlibStream.GetErrorMessage());
+
+                case ZLibNative.ErrorCode.DataError:    // The input data was corrupted (input stream not conforming to the zlib format or incorrect check value)
+                    throw new InvalidDataException(SR.UnsupportedCompression);
+
+                case ZLibNative.ErrorCode.StreamError:  //the stream structure was inconsistent (for example if next_in or next_out was NULL),
+                    throw new ZLibException(SR.ZLibErrorInconsistentStream, "inflate_", (int)errC, _zlibStream.GetErrorMessage());
+
+                default:
+                    throw new ZLibException(SR.ZLibErrorUnexpected, "inflate_", (int)errC, _zlibStream.GetErrorMessage());
+            }
+        }
+
+        /// <summary>
+        /// Frees the GCHandle being used to store the input buffer
+        /// </summary>
+        private void DeallocateInputBufferHandle()
+        {
+            Debug.Assert(_inputBufferHandle.IsAllocated);
+
+            lock (_syncLock)
+            {
+                _zlibStream.AvailIn = 0;
+                _zlibStream.NextIn = ZLibNative.ZNullPtr;
+                _inputBufferHandle.Free();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.IO.Compression/src/System/IO/Compression/ZLibNative.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZLibNative.cs
@@ -403,6 +403,29 @@ namespace System.IO.Compression
                 return errC;
             }
 
+            /// <summary>
+            /// This function is equivalent to inflateEnd followed by inflateInit.
+            /// The stream will keep attributes that may have been set by inflateInit2.
+            /// </summary>
+            [SecurityCritical]
+            public ErrorCode InflateReset(int windowBits)
+            {
+                EnsureNotDisposed();
+                EnsureState(State.InitializedForInflate);
+
+                ErrorCode errC = Interop.zlib.InflateEnd(ref _zStream);
+                if (errC != ErrorCode.Ok)
+                {
+                    _initializationState = State.Disposed;
+                    return errC;
+                }
+
+                errC = Interop.zlib.InflateInit2_(ref _zStream, windowBits, ZLibVersion);
+                _initializationState = State.InitializedForInflate;
+
+                return errC;
+            }
+
 
             [SecurityCritical]
             public string GetErrorMessage()


### PR DESCRIPTION
The DeflateStream class currently uses ZLib for compression (if available) but doesn't use ZLib for decompression. This commit adds support to use either ZLib or the Managed implementation for decompression (inflation).

- Resolves #2024; Added ZLib support in InflaterZLib.cs
- Inflater.cs the old managed implementation is renamed to InflaterManaged.cs
- Extracted interface of necessary Inflater methods into the IInflater interface from which InflaterManaged and InflaterZLib inherit.
- Roughly a 3X speedup for decompression when using the ZLib library instead of the Managed implementation!