### PR TITLE
Fixed a loss of streamed bytes issue.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -832,6 +832,12 @@ namespace System.Xml
                 {
                     if (_node.NodeType != XmlNodeType.Text && _node.NodeType != XmlNodeType.CDATA)
                         break;
+
+                    if (_trailByteCount > 0)
+                    {
+                        break;
+                    }
+
                     if (_value == null)
                     {
                         if (!_node.Value.IsWhitespace())


### PR DESCRIPTION
When reading stream content with `ReadContentAsBase64`, if the buffer size (count) is less than 3, XmlBaseReaders may lost bytes. The cause is that `XmlBaseReader.MoveToContent` may skip bytes in trailing bytes buffer, `_trailBytes`, which is used only when buffer size is less than 3.

The fix is to let `XmlBaseReader.MoveToContent` check if there are any bytes in trailing buffer.