### PR TITLE
Fix build failure due to conflict between concurrent PRs

### DIFF
--- a/src/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -81,7 +81,7 @@ namespace System.Net
             {
                 if (socket != -1)
                 {
-                    Interop.libc.close(socket);
+                    Interop.Sys.Close(socket);
                 }
             }
         }

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -155,8 +155,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.close.cs">
-      <Link>Interop\Unix\libc\Interop.close.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
+      <Link>Interop\Unix\System.Native\Interop.Close.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.freeaddrinfo.cs">
       <Link>Interop\Unix\libc\Interop.freeaddrinfo.cs</Link>

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.msbuild
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.msbuild
@@ -133,8 +133,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.close.cs">
-      <Link>Interop\Unix\libc\Interop.close.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
+      <Link>Interop\Unix\System.Native\Interop.Close.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.freeaddrinfo.cs">
       <Link>Interop\Unix\libc\Interop.freeaddrinfo.cs</Link>


### PR DESCRIPTION
New usage of Interop.libc.close was added while it was
simultaneously being removed in another PR, which defeated
catching it via CI PR validation.

cc @stephentoub @CIPop 