### PR TITLE
HttpClient xplat: Fix bugs in polling and callback logic

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.SafeCurlHandle.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.SafeCurlHandle.cs
@@ -117,7 +117,7 @@ internal static partial class Interop
                     // Whenever an fd is added/removed in _fdSet, a write happens to the
                     // write end of the pipe thus causing the poll to return.
                     pollFds[0].fd = _specialFds[libc.ReadEndOfPipe];
-                    pollFds[0].events = PollFlags.POLLIN | PollFlags.POLLOUT;
+                    pollFds[0].events = PollFlags.POLLIN;
                     int i = 1;
                     foreach (int fd in _fdSet)
                     {
@@ -176,7 +176,6 @@ internal static partial class Interop
             internal void SignalFdSetChange(int fd, bool isRemove)
             {
                 Debug.Assert(Monitor.IsEntered(this));
-
                 bool changed = isRemove ? _fdSet.Remove(fd) : _fdSet.Add(fd);
                 if (!changed)
                 {
@@ -227,6 +226,7 @@ internal static partial class Interop
                 {
                     return -1;
                 }
+                Debug.Assert((revents & PollFlags.POLLIN) != 0);
                 int pipeReadFd = _specialFds[libc.ReadEndOfPipe];
                 int bytesRead = 0;
                 unsafe

--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl.cs
@@ -25,13 +25,13 @@ internal static partial class Interop
         public static extern void curl_multi_cleanup(
             IntPtr handle);
 
-        [DllImport(Interop.Libraries.LibCurl, CharSet = CharSet.Ansi)]
+        [DllImport(Interop.Libraries.LibCurl)]
         public static extern int curl_multi_setopt(
             SafeCurlMultiHandle multi_handle,
             int option,
             curl_socket_callback value);
 
-        [DllImport(Interop.Libraries.LibCurl, CharSet = CharSet.Ansi)]
+        [DllImport(Interop.Libraries.LibCurl)]
         public static extern int curl_multi_setopt(
             SafeCurlMultiHandle multi_handle,
             int option,
@@ -155,5 +155,5 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.LibCurl)]
         public static extern IntPtr curl_version_info(int curlVersionStamp);
-    }
+ }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlCallbacks.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlCallbacks.cs
@@ -371,8 +371,6 @@ namespace System.Net.Http
                 }
             }
 
-            CheckForCompletedTransfers(state.SessionHandle);
-
             return retVal;
         }
 


### PR DESCRIPTION
- On OSX, the read end of the pipe sometimes wakes up the poll
  with a POLLOUT. Since we are interested in only reading on it,
  scoping down to POLLIN prevents this from happening. Else we
  attempt a read on it which fails

- CheckForCompletedTransfers was being unnecessarily called from the
  socket callback. We are only interested in MSG_DONE after the socket
  callback indicates removal. This will anyway wake up PollFunction which
  calls CheckForCompletedTransfers. This race is also causing a seg fault
  sometimes because curl_multi_socket_action has been called on an fd
  that was getting cleaned up via curl_easy_cleanup (call sequence is
  CurlSocketCallback --> CheckForCompletedTransfers --> EndRequest)

- Also removed some unnecessary CharSet attributes

cc: @stephentoub @davidsh @CIPop @SidharthNabar @pgavlin