### PR TITLE
BitVector32.CreateSection - add missing validation

### DIFF
--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
@@ -172,16 +172,15 @@ namespace System.Collections.Specialized
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidValue, "maxValue", 0), "maxValue");
             }
 #if DEBUG
-            int maskCheck = CreateMaskFromHighValue(maxValue);
-            int offsetCheck = priorOffset + CountBitsSet(priorMask);
-            Debug.Assert(maskCheck <= short.MaxValue && offsetCheck < 32, "Overflow on BitVector32");
+            Debug.Assert(CreateMaskFromHighValue(maxValue) <= short.MaxValue, "Mask out of range");
 #endif
             short offset = (short)(priorOffset + CountBitsSet(priorMask));
-            if (offset >= 32)
+            short mask = CreateMaskFromHighValue(maxValue);
+            if (offset >= 32 || offset + CountBitsSet(mask) > 32)
             {
                 throw new InvalidOperationException(SR.BitVectorFull);
             }
-            return new Section(CreateMaskFromHighValue(maxValue), offset);
+            return new Section(mask, offset);
         }
 
         public override bool Equals(object o)

--- a/src/System.Collections.Specialized/tests/BitVector32/CreateSectionShortSectionTests.cs
+++ b/src/System.Collections.Specialized/tests/BitVector32/CreateSectionShortSectionTests.cs
@@ -69,8 +69,8 @@ namespace System.Collections.Specialized.Tests
 
             sectionArgument = section;
             expected = 30;                  //expected offset
-            section = BitVector32.CreateSection(maxValue, sectionArgument);
-            if (section.Mask != maxValue || section.Offset != expected)
+            section = BitVector32.CreateSection(3, sectionArgument);
+            if (section.Mask != 3 || section.Offset != expected)
             {
                 Assert.False(true, string.Format("  Error, returned ({1}, {2}) instead of expected ({0}, {3})", maxValue, section.Mask, section.Offset, expected));
             }
@@ -158,6 +158,22 @@ namespace System.Collections.Specialized.Tests
             bv32 = new BitVector32(-1);
             sectionArgument = BitVector32.CreateSection(maxValue);
             section = BitVector32.CreateSection(maxValue, sectionArgument);
+        }
+
+        [Theory]
+        [InlineData(1, short.MaxValue)]
+        [InlineData(short.MaxValue, 1)]
+        [InlineData(short.MaxValue, short.MaxValue)]
+        [InlineData(byte.MaxValue, byte.MaxValue / 2 + 1)]
+        public static void CreateSection_Full(short prior, short invalid)
+        {
+            // BV32 can hold just over two shorts, so fill all but short.MaxValue first....
+            BitVector32.Section initial = BitVector32.CreateSection(short.MaxValue, BitVector32.CreateSection(2));
+            BitVector32.Section next = BitVector32.CreateSection(prior, initial);
+            Assert.NotNull(initial);
+            Assert.Equal(17, next.Offset);
+
+            Assert.Throws<InvalidOperationException>(() => BitVector32.CreateSection(invalid, next));
         }
     }
 }


### PR DESCRIPTION
`BitVector32.CreateSection` claims, [in documentation](https://msdn.microsoft.com/en-us/library/530d8529(v=vs.110).aspx), to validate a given `maxValue` will fit, but not only does it not do so, the overflow check it does have is occluded in debug.  Attempting to test/verify that expected exceptions were being thrown was failing.

(For whatever reason, `Debug.Assert` is causing something in the stack to just up and die when run from a command prompt, which sent me off in the wrong direction initially.  I would have expected a message....)

This PR fixes the two issues, by removing that part of the debug check, and adding an extra check for the overflow.

This is a breaking change, in that such a `Section` can no longer be created.  However, any such 'invalid' `Section` would be dangerous; it silently truncates any data that wouldn't fit in the leftover space.  You'd get (sometimes **very**) different results out on read!