### PR TITLE
Fix TaskCancelWaitTest to not randomly fail

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
@@ -368,7 +368,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
                     double maxLimit = 1.65;
 
                     if (ti.Result < minLimit || ti.Result > maxLimit)
-                        Assert.True(ti.Task.IsCanceled,
+                        Assert.True(ti.Task.IsCanceled || ti.Task.IsFaulted,
                             string.Format(
                                 "Expected Result to lie between {0} and {1} for completed task. Actual Result {2}. Using n={3} IsCanceled={4}",
                                 minLimit,


### PR DESCRIPTION
This whole set of TaskCancelWait tests is a bit of a mess, and it's not clear exactly what behavior(s) it's trying to test.  That said, this commit is a small tactical fix to address the sporadic failures we've seen in CI.  I was able to repro it only once out of every 4K-5K runs, and only when there was heavy load on the machine.

The test is using a CountdownEvent to signal when it's done creating all of the tasks in the "task tree" (where tasks create other tasks).  The main test thread waits for all of the tasks to be created by waiting on that event.  However, it also tries to enable concurrent cancellation of that tree creation, and as part of that it tries to force the CountdownEvent down to 0.  This is inherently racy, as other tasks could concurrently be trying to Signal the event as well.  In an apparent attempt to "solve" this race condition, the test is guarding calls to Signal with calls to IsSet, but that only reduces the window of opportunity for an error.  As such, sporadically one of the tasks will try to Signal the event when it's already 0, causing the task to fault with an exception.  The test results verification is then checking whether the task completed, and is confirming that it either has the expected computed result or was canceled, but isn't factoring in the possibility that the task failed.

The tactical fix is to just add that check for failure as well (the longer term fix is probably to figure out the intended purpose of this test and either rewrite it or delete it).

Fixes #2914
cc: @mellinoe, @ellismg