### PR TITLE
Added optional capacity parameter to ToArray for performance considerations

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1040,10 +1040,10 @@ namespace System.Linq
             return source;
         }
 
-        public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
+        public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source, int? capacity = null)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            return new Buffer<TSource>(source).ToArray();
+            return new Buffer<TSource>(source, capacity: capacity).ToArray();
         }
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)
@@ -1882,7 +1882,7 @@ namespace System.Linq
             }
             return value;
         }
-        
+
         public static float Min(this IEnumerable<float> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
@@ -1891,7 +1891,7 @@ namespace System.Linq
             {
                 if (!e.MoveNext()) throw Error.NoElements();
                 value = e.Current;
-                while(e.MoveNext())
+                while (e.MoveNext())
                 {
                     float x = e.Current;
                     if (x < value) value = x;
@@ -1947,7 +1947,7 @@ namespace System.Linq
             {
                 if (!e.MoveNext()) throw Error.NoElements();
                 value = e.Current;
-                while(e.MoveNext())
+                while (e.MoveNext())
                 {
                     double x = e.Current;
                     if (x < value) value = x;
@@ -3406,7 +3406,7 @@ namespace System.Linq
         internal TElement[] items;
         internal int count;
 
-        internal Buffer(IEnumerable<TElement> source, bool queryInterfaces = true)
+        internal Buffer(IEnumerable<TElement> source, bool queryInterfaces = true, int? capacity = null)
         {
             TElement[] items = null;
             int count = 0;
@@ -3440,7 +3440,7 @@ namespace System.Linq
                 {
                     if (items == null)
                     {
-                        items = new TElement[4];
+                        items = new TElement[capacity ?? 4];
                     }
                     else if (items.Length == count)
                     {

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1043,6 +1043,7 @@ namespace System.Linq
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source, int? capacity = null)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            if (capacity < 1) throw Error.ArgumentOutOfRange("capacity");
             return new Buffer<TSource>(source, capacity: capacity).ToArray();
         }
 


### PR DESCRIPTION
ToArray can create a number of arrays internally and copy the content many times. Sometimes, we may know an estimated number of elements we may have in IEnumerable. Thus we can add optional parameter to specify the initial size of the internal array, and so improve performance by avoiding excessive memory allocations and copying operations.