### PR TITLE
Implement TelemetrySource/TelemetryListener for Rich Diagnostics in ASP.NET 5 

### DIFF
--- a/src/System.Diagnostics.Tracing.Telemetry/System.Diagnostics.Tracing.Telemetry.sln
+++ b/src/System.Diagnostics.Tracing.Telemetry/System.Diagnostics.Tracing.Telemetry.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23103.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tracing.Telemetry", "src\System.Diagnostics.Tracing.Telemetry.csproj", "{F24D3391-2928-4E83-AADE-B34423498750}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tracing.Telemetry.Tests", "tests\System.Diagnostics.Tracing.Telemetry.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Diagnostics.Tracing.Telemetry/ref/System.Diagnostics.Tracing.Telemetry.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/ref/System.Diagnostics.Tracing.Telemetry.cs
@@ -3,7 +3,7 @@ namespace System.Diagnostics.Tracing {
     public TelemetryListener(string name) { }
     public static System.Diagnostics.Tracing.TelemetryListener DefaultListener { get { return default(System.Diagnostics.Tracing.TelemetryListener); } }
     public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { return default(string); } }
-    public static event System.Action<System.Diagnostics.Tracing.TelemetryListener> AllListeners { add { } remove { } }
+    public static IObservable<TelemetryListener> AllListeners { get; } 
     public virtual void Dispose() { }
     public override bool IsEnabled(string telemetryName) { return default(bool); }
     public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { return default(System.IDisposable); }

--- a/src/System.Diagnostics.Tracing.Telemetry/ref/System.Diagnostics.Tracing.Telemetry.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/ref/System.Diagnostics.Tracing.Telemetry.cs
@@ -1,0 +1,20 @@
+namespace System.Diagnostics.Tracing {
+  public partial class TelemetryListener : System.Diagnostics.Tracing.TelemetrySource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>> {
+    public TelemetryListener(string name) { }
+    public static System.Diagnostics.Tracing.TelemetryListener DefaultListener { get { return default(System.Diagnostics.Tracing.TelemetryListener); } }
+    public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { return default(string); } }
+    public static event System.Action<System.Diagnostics.Tracing.TelemetryListener> AllListeners { add { } remove { } }
+    public virtual void Dispose() { }
+    public override bool IsEnabled(string telemetryName) { return default(bool); }
+    public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { return default(System.IDisposable); }
+    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { return default(System.IDisposable); }
+    public override void WriteTelemetry(string telemetryName, object parameters) { }
+  }
+  public abstract partial class TelemetrySource {
+    protected TelemetrySource() { }
+    public static System.Diagnostics.Tracing.TelemetrySource DefaultSource { get { return default(System.Diagnostics.Tracing.TelemetrySource); } }
+    public abstract bool IsEnabled(string telemetryName);
+    public abstract void WriteTelemetry(string telemetryName, object parameters);
+  }
+}
+

--- a/src/System.Diagnostics.Tracing.Telemetry/ref/System.Diagnostics.Tracing.Telemetry.csproj
+++ b/src/System.Diagnostics.Tracing.Telemetry/ref/System.Diagnostics.Tracing.Telemetry.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Diagnostics.Tracing.Telemetry.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing.Telemetry/ref/project.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/ref/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/ref/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/ref/project.lock.json
@@ -1,0 +1,68 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    ".NETPlatform,Version=v5.0": {
+      "System.Runtime/4.0.0": {
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Runtime/4.0.0": {
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
+      "files": [
+        "License.rtf",
+        "System.Runtime.4.0.0.nupkg",
+        "System.Runtime.4.0.0.nupkg.sha512",
+        "System.Runtime.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Runtime >= 4.0.0"
+    ],
+    ".NETPlatform,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System.Diagnostics.Tracing.Telemetry.csproj
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System.Diagnostics.Tracing.Telemetry.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <ProjectGuid>{F24D3391-2928-4E83-AADE-B34423498750}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Diagnostics.Tracing.Telemetry</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System\Diagnostics\Tracing\TelemetrySource.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TelemetryListener.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System.Diagnostics.Tracing.Telemetry.csproj
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System.Diagnostics.Tracing.Telemetry.csproj
@@ -12,8 +12,10 @@
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <NoWarn>0420</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <NoWarn>0420</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Tracing\TelemetrySource.cs" />

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetryListener.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetryListener.cs
@@ -179,7 +179,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public override bool IsEnabled(string telemetryName)
         {
-            for (var curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
+            for (Subscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
                 if (curSubscription.IsEnabled == null || curSubscription.IsEnabled(telemetryName))
                     return true;
@@ -192,7 +192,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public override void WriteTelemetry(string telemetryName, object parameters)
         {
-            for (var curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
+            for (Subscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
                 curSubscription.Observer.OnNext(new KeyValuePair<string, object>(telemetryName, parameters));
         }
 
@@ -248,7 +248,10 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        private volatile Subscription _subscriptions;
+        // TODO _subscriptions should be volatile but we get a warning (which gets treated as an error) that 
+        // when it gets passed as ref to Interlock.* functions that its volatileness disappears.    We really should
+        // just be suppressing the warning.    We can get away without the volatile because we only read it once 
+        private /* volatile */ Subscription _subscriptions;
         private TelemetryListener _next;               // We keep a linked list of all NotificationListeners (s_allListeners)
         private bool _disposed;                        // Has Dispose been called?
 

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetryListener.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetryListener.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Threading;
+using System.Collections.Generic;
+
+namespace System.Diagnostics.Tracing
+{
+    /// <summary>
+    /// A TelemetryListener something that forwards on events written with TelemetrySource.
+    /// It is an IObservable (has Subscribe method), and it also has a Subscribe overload that
+    /// lets you specify a 'IsEnabled' precicate that users of TelemetrySource will use for 
+    /// 'quick checks'.   
+    /// 
+    /// The item in the stream is a KeyValuePair[string, object] where the string is the name
+    /// of the telemetry item and the object is the payload (typically an anonumous type).  
+    /// 
+    /// There may be many TelemetryListeners in the system, but we encourage the use of
+    /// The TelemetrySource.DefaultSource which goes to the TelemetryListener.DefaultListener.
+    /// 
+    /// If you need to see 'everything' you can subscribe to the 'AllListeners' event that
+    /// will fire for every live TelemetryListener in the appdomain (past or present). 
+    /// </summary>
+    public class TelemetryListener : TelemetrySource, IObservable<KeyValuePair<string, object>>, IDisposable
+    {
+        /// <summary>
+        /// When a TelemetryListener is created it is given a name.   Return this.  
+        /// </summary>
+        public string Name { get; private set; }
+        /// <summary>
+        /// This is the TelemetryListener that is used by default by the class library.   
+        /// Generally you don't want to make your own but rather have everyone use this one, which
+        /// insures that everyone who wished to subscribe gets the callbacks.  
+        /// The main reason not to us this one is that you WANT isolation from other 
+        /// events in the system (e.g. multi-tenancy).  
+        /// </summary>
+        public static TelemetryListener DefaultListener { get { return s_default; } }
+
+        /// <summary>
+        /// When you subscribe to this you get callbacks for all NotificationListeners in the appdomain
+        /// as well as those that occured in the past, and all future Listeners created in the future. 
+        /// </summary>
+        public static event Action<TelemetryListener> AllListeners
+        {
+            add
+            {
+                lock (DefaultListener)
+                {
+                    s_allListenersCallback = (Action<TelemetryListener>)Delegate.Combine(s_allListenersCallback, value);
+
+                    // Call back for each existing listener on the new callback.  
+                    for (TelemetryListener cur = s_allListeners; cur != null; cur = cur.m_next)
+                        value(cur);
+                }
+            }
+            remove
+            {
+                s_allListenersCallback = (Action<TelemetryListener>)Delegate.Remove(s_allListenersCallback, value);
+            }
+        }
+
+        // Subscription implementation 
+        /// <summary>
+        /// Add a subscriber (Observer).  If 'IsEnabled' == null (or not present), then the Source's IsEnabled 
+        /// will always return true.  
+        /// </summary>
+        virtual public IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<string> isEnabled)
+        {
+            // If we have been disposed, we silently ingore any subscriptions.  
+            if (m_disposed)
+                return new Subscription() { Owner = this };
+
+            Subscription newSubscription = new Subscription() { Observer = observer, IsEnabled = isEnabled, Owner = this, Next = m_subscriptions };
+            while (Interlocked.CompareExchange(ref m_subscriptions, newSubscription, newSubscription.Next) != newSubscription.Next)
+                newSubscription.Next = m_subscriptions;
+            return newSubscription;
+        }
+        /// <summary>
+        /// Same as other Subscribe overload where the predicate is assumed to always return true.  
+        /// </summary>
+        public IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer)
+        {
+            return Subscribe(observer, null);
+        }
+
+        /// <summary>
+        /// Make a new TelemetryListener, it is a NotificationSource, which means the returned result can be used to 
+        /// log notifications, but it also has a Subscribe method so notifications can be forwarded
+        /// arbitrarily.  Thus its job is to forward things from the producer to all the listeners
+        /// (multi-casting).    Generally you should not be making your own TelemetryListener but use the
+        /// TelemetryListener.Default, so that notifications are as 'public' as possible.  
+        /// </summary>
+        public TelemetryListener(string name)
+        {
+            Name = name;
+            // To avoid allocating an explicit lock object I lock the Default TelemetryListener.   However there is a 
+            // chicken and egg problem because I need to call this code to initialize Default.   
+            var lockObj = DefaultListener;
+            if (lockObj == null)
+                lockObj = this;
+
+            // Insert myself into the list of all Listeners.   
+            lock (lockObj)
+            {
+                // Issue the callback for this new telemetry listener. 
+                var callback = s_allListenersCallback;
+                if (callback != null)
+                    callback(this);
+
+                // And add it to the list of all past listeners.  
+                m_next = s_allListeners;
+                s_allListeners = this;
+            }
+        }
+
+        /// <summary>
+        /// Clean up the NotificationListeners.   Notification listeners do NOT DIE ON THEIR OWN
+        /// because they are in a global list (for discoverability).  You must dispose them explicitly. 
+        /// Note that we do not do the Dispose(bool) pattern because we frankly don't want to support
+        /// subclasses that have non-managed state.   
+        /// </summary>
+        virtual public void Dispose()
+        {
+            // Remove myself from the list if all listeners.  
+            lock (DefaultListener)
+            {
+                m_disposed = true;
+                if (s_allListeners == this)
+                    s_allListeners = s_allListeners.m_next;
+                else
+                {
+                    var cur = s_allListeners;
+                    while (cur != null)
+                    {
+                        if (cur.m_next == this)
+                        {
+                            cur.m_next = this.m_next;
+                            break;
+                        }
+                        cur = cur.m_next;
+                    }
+                }
+                m_next = null;
+            }
+
+            // Indicate completion to all subscribers.  
+            Subscription subscriber = null;
+            Interlocked.Exchange(ref subscriber, m_subscriptions);
+            while (subscriber != null)
+            {
+                subscriber.Observer.OnCompleted();
+                subscriber = subscriber.Next;
+            }
+            // The code above also nulled out all subscriptions. 
+        }
+
+        /// <summary>
+        /// Return the name for the ToString() to aid in debugging.  
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        #region private
+
+        // NotificationSource implementation
+        /// <summary>
+        /// Override 
+        /// </summary>
+        public override bool IsEnabled(string telemetryName)
+        {
+            for (var curSubscription = m_subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
+            {
+                if (curSubscription.IsEnabled == null || curSubscription.IsEnabled(telemetryName))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Override 
+        /// </summary>
+        public override void WriteTelemetry(string telemetryName, object parameters)
+        {
+            for (var curSubscription = m_subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
+                curSubscription.Observer.OnNext(new KeyValuePair<string, object>(telemetryName, parameters));
+        }
+
+        // Note that Subscriptions are READ ONLY.   This means you never update any fields (even on removal!)
+        private class Subscription : IDisposable
+        {
+            internal IObserver<KeyValuePair<string, object>> Observer;
+            internal Predicate<string> IsEnabled;
+            internal TelemetryListener Owner;          // The TelemetryListener this is a subscription for.  
+            internal Subscription Next;                // Linked list of subscribers
+
+            public void Dispose()
+            {
+                // TO keep this lock free and easy to analyze, the linked list is READ ONLY.   Thus we copy
+                for (;;)
+                {
+                    Subscription subscriptions = Owner.m_subscriptions;
+                    Subscription newSubscriptions = Remove(subscriptions, this);    // Make a new list, with myself removed.  
+
+                    // try to update, but if someone beat us to it, then retry.  
+                    if (Interlocked.CompareExchange(ref Owner.m_subscriptions, newSubscriptions, subscriptions) == subscriptions)
+                    {
+#if DEBUG
+                        var cur = subscriptions;
+                        while (cur != null)
+                        {
+                            if (cur.Observer == this)
+                                throw new Exception("Did not remove subscription!");
+                            cur = cur.Next;
+                        }
+#endif
+                        break;
+                    }
+                }
+            }
+
+            // Create a new linked list where 'subscription has been removed from the linked list of 'subscriptions'. 
+            private static Subscription Remove(Subscription subscriptions, Subscription subscription)
+            {
+                if (subscriptions == null)
+                {
+#if DEBUG
+                    throw new Exception("Could not find subscription");
+#else
+                    return null;
+#endif
+                }
+
+                if (subscriptions.Observer == subscription.Observer && subscriptions.IsEnabled == subscription.IsEnabled)
+                    return subscriptions.Next;
+#if DEBUG
+                // Delay a bit.  This makes it more likely that races will happen. 
+                for (int i = 0; i < 100; i++)
+                    GC.KeepAlive("");
+#endif 
+                return new Subscription() { Observer = subscriptions.Observer, Owner = subscriptions.Owner, IsEnabled = subscriptions.IsEnabled,  Next = Remove(subscriptions.Next, subscription) };
+            }
+        }
+
+        Subscription m_subscriptions;
+        TelemetryListener m_next;               // We keep a linked list of all NotificationListeners (s_allListeners)
+        bool m_disposed;                        // Has Dispose been called?
+
+        static Action<TelemetryListener> s_allListenersCallback;    // The list of clients to call back when a new TelemetryListener is created.  
+        static TelemetryListener s_allListeners;                    // As a service, we keep track of all instances of NotificationListeners.  
+        static TelemetryListener s_default = new TelemetryListener("TelemetryListener.Default");
+
+#endregion
+    }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetrySource.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetrySource.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace System.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetrySource.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetrySource.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics.Tracing
     {
         /// <summary>
         /// The NotificationSource that you should be writing to by default.  This is what
-        /// most of the class library does.   Data written here goss to DefaultListener
+        /// most of the class library does.   Data written here goes to DefaultListener
         /// which dispatches to all its subscribers.  
         /// </summary>
         public static TelemetrySource DefaultSource { get { return TelemetryListener.DefaultListener; } }
@@ -24,7 +24,7 @@ namespace System.Diagnostics.Tracing
         /// that gives the information to pass to the notification, which is arbitrary.  
         /// 
         /// The Telemetry name should be short (so don't use fully qualified names unless you have to
-        /// to avoid ambiguity), but you want the name to be globally unique.  Typicaly your componentName.eventName
+        /// to avoid ambiguity), but you want the name to be globally unique.  Typically your componentName.eventName
         /// where componentName and eventName are strings less than 10 characters are a good compromise.  
         /// evnetNames should NOT have '.' in them because component names have dots and for them both
         /// to have dots would lead to ambiguity.   The suggestion is to use _ instead.  It is assumed 

--- a/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetrySource.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/System/Diagnostics/Tracing/TelemetrySource.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace System.Diagnostics.Tracing
+{
+    /// <summary>
+    /// This is the basic API to 'hook' parts of the framework.   It is like an EventSource
+    /// (which can also write object), but is intended to log complex objects that can't be serialized.
+    /// </summary>
+    public abstract class TelemetrySource
+    {
+        /// <summary>
+        /// The NotificationSource that you should be writing to by default.  This is what
+        /// most of the class library does.   Data written here goss to DefaultListener
+        /// which dispatches to all its subscribers.  
+        /// </summary>
+        public static TelemetrySource DefaultSource { get { return TelemetryListener.DefaultListener; } }
+
+        /// <summary>
+        /// WriteData is a generic way of logging complex payloads.  Each notification
+        /// is given a name, which identifies it as well as a object (typically an anonymous type)
+        /// that gives the information to pass to the notification, which is arbitrary.  
+        /// 
+        /// The Telemetry name should be short (so don't use fully qualified names unless you have to
+        /// to avoid ambiguity), but you want the name to be globally unique.  Typicaly your componentName.eventName
+        /// where componentName and eventName are strings less than 10 characters are a good compromise.  
+        /// evnetNames should NOT have '.' in them because component names have dots and for them both
+        /// to have dots would lead to ambiguity.   The suggestion is to use _ instead.  It is assumed 
+        /// that listeners will use string prefixing to filter groups, thus having hierarchy in component 
+        /// names is good.  
+        /// </summary>
+        public abstract void WriteTelemetry(string telemetryName, object parameters);
+
+        /// <summary>
+        /// Optional: if there is expensive setup for the notification, you can call IsEnabled
+        /// before doing this setup.   Consumers should not be assuming that they only get notifications
+        /// for which IsEnabled is true however, it is optional for producers to call this API. 
+        /// The telemetryName should be the same as what is passed to WriteTelemetry.   
+        /// </summary>
+        public abstract bool IsEnabled(string telemetryName);
+    }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/src/project.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0",
+    "System.Threading": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/src/project.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/project.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "System.Runtime": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Threading": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Diagnostics.Tracing.Telemetry/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {

--- a/src/System.Diagnostics.Tracing.Telemetry/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/project.lock.json
@@ -3,6 +3,14 @@
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "System.Diagnostics.Debug/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        }
+      },
       "System.Runtime/4.0.0": {
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -28,6 +36,53 @@
     }
   },
   "libraries": {
+    "System.Diagnostics.Debug/4.0.0": {
+      "sha512": "AYJsLLGDVTC/nyURjgAo7Lpye0+HuSkcQujUf+NgQVdC/C/ky5NyamQHCforHJzgqspitMMtBe8B4UBdGXy1zQ==",
+      "files": [
+        "License.rtf",
+        "System.Diagnostics.Debug.4.0.0.nupkg",
+        "System.Diagnostics.Debug.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Debug.dll",
+        "ref/netcore50/System.Diagnostics.Debug.xml",
+        "ref/netcore50/de/System.Diagnostics.Debug.xml",
+        "ref/netcore50/es/System.Diagnostics.Debug.xml",
+        "ref/netcore50/fr/System.Diagnostics.Debug.xml",
+        "ref/netcore50/it/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ja/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ko/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ru/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
     "System.Runtime/4.0.0": {
       "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
       "files": [
@@ -176,7 +231,8 @@
   "projectFileDependencyGroups": {
     "": [
       "System.Runtime >= 4.0.0",
-      "System.Threading >= 4.0.0"
+      "System.Threading >= 4.0.0",
+      "System.Diagnostics.Debug >= 4.0.0"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Diagnostics.Tracing.Telemetry/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/src/project.lock.json
@@ -1,0 +1,183 @@
+{
+  "locked": false,
+  "version": -9996,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Runtime/4.0.0": {
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      },
+      "System.Threading/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Runtime/4.0.0": {
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "package/services/metadata/core-properties/c5db97a122ad42aeb8e429022c1d1ab8.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading/4.0.0": {
+      "sha512": "H6O/9gUrjPDNYanh/7OFGAZHjVXvEuITD0RcnjfvIV04HOGrOPqUBU0kmz9RIX/7YGgCQn1o1S2DX6Cuv8kVGQ==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Threading.dll",
+        "ref/netcore50/System.Threading.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/netcore50/zh-hant/System.Threading.xml",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/netcore50/de/System.Threading.xml",
+        "ref/dotnet/System.Threading.xml",
+        "ref/netcore50/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/netcore50/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/netcore50/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/netcore50/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/netcore50/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/netcore50/ru/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/netcore50/zh-hans/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/netcore50/es/System.Threading.xml",
+        "package/services/metadata/core-properties/bec033e95dbf4d6ba6595d2be7bb7e25.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0": {
+      "sha512": "dA3y1B6Pc8mNt9obhEWWGGpvEakS51+nafXpmM/Z8IF847GErLXGTjdfA+AYEKszfFbH7SVLWUklXhYeeSQ1lw==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.Tasks.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/netcore50/de/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/netcore50/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/netcore50/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/netcore50/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/netcore50/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/netcore50/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/netcore50/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/netcore50/es/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/e45094f04ec149d1ba36afbb03ce2e9e.psmdcp",
+        "[Content_Types].xml"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Runtime >= 4.0.0",
+      "System.Threading >= 4.0.0"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/System.Diagnostics.Tracing.Telemetry.Tests.csproj
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/System.Diagnostics.Tracing.Telemetry.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Diagnostics.Tracing.Telemetry.Tests</AssemblyName>
+    <RootNamespace>System.Diagnostics.Tracing.Telemetry.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TelemetryTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Diagnostics.Tracing.Telemetry.csproj">
+      <Project>{F24D3391-2928-4E83-AADE-B34423498750}</Project>
+      <Name>System.Diagnostics.Tracing.Telemetry</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
@@ -1,0 +1,553 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using System.Threading.Tasks;
+using TelemData = System.Collections.Generic.KeyValuePair<string, object>;
+
+namespace System.Diagnostics.Tracing.Telemetry.Tests
+{
+    /// <summary>
+    /// Tests for TelemetrySource and TelemetryListener
+    /// </summary>
+    public class TelemetryTest
+    {
+        /// <summary>
+        /// Trivial example of passing an integer
+        /// </summary>
+        [Fact]
+        public void IntPayload()
+        {
+            var result = new List<KeyValuePair<string, object>>();
+            var observer = new ObserverToList<TelemData>(result);
+            using (TelemetryListener.DefaultListener.Subscribe(new ObserverToList<TelemData>(result)))
+            {
+                TelemetrySource.DefaultSource.WriteTelemetry("IntPayload", 5);
+                Assert.Equal(1, result.Count);
+                Assert.Equal("IntPayload", result[0].Key);
+                Assert.Equal(5, result[0].Value);
+            }   // unsubscribe
+
+            // Make sure that after unsubscribing, we don't get more events. 
+            TelemetrySource.DefaultSource.WriteTelemetry("IntPayload", 5);
+            Assert.Equal(1, result.Count);
+        }
+
+        /// <summary>
+        /// slightly less trivial of passing a structure with a couple of fields 
+        /// </summary>
+        [Fact]
+        public void StructPayload()
+        {
+            var result = new List<KeyValuePair<string, object>>();
+            using (TelemetryListener.DefaultListener.Subscribe(new ObserverToList<TelemData>(result)))
+            {
+                TelemetrySource.DefaultSource.WriteTelemetry("StructPayload", new Payload() { Name = "Hi", Id = 67 });
+                Assert.Equal(1, result.Count);
+                Assert.Equal("StructPayload", result[0].Key);
+                var payload = (Payload)result[0].Value;
+
+                Assert.Equal(67, payload.Id);
+                Assert.Equal("Hi", payload.Name);
+            }
+
+            TelemetrySource.DefaultSource.WriteTelemetry("StructPayload", new Payload() { Name = "Hi", Id = 67 });
+            Assert.Equal(1, result.Count);
+        }
+
+        /// <summary>
+        /// Tests the IObserver OnCompleted callback. 
+        /// </summary>
+        [Fact]
+        public void Completed()
+        {
+            var result = new List<KeyValuePair<string, object>>();
+            var observer = new ObserverToList<TelemData>(result);
+            var listener = new TelemetryListener("MyListener");
+            var subscription = listener.Subscribe(observer);
+
+            listener.WriteTelemetry("IntPayload", 5);
+            Assert.Equal(1, result.Count);
+            Assert.Equal("IntPayload", result[0].Key);
+            Assert.Equal(5, result[0].Value);
+            Assert.False(observer.Completed);
+
+            // The listener dies
+            listener.Dispose();
+            Assert.True(observer.Completed);
+
+            // We can unsubscribe without blowing up 
+            subscription.Dispose();
+
+            // If we resubscribe after dispose, but it does not do anything.  
+            subscription = listener.Subscribe(observer);
+
+            listener.WriteTelemetry("IntPayload", 5);
+            Assert.Equal(1, result.Count);
+        }
+
+        /// <summary>
+        /// Simple tests for the IsEnabled method.
+        /// </summary>
+        [Fact]
+        public void BasicIsEnabled()
+        {
+            var result = new List<KeyValuePair<string, object>>();
+
+            bool seenUninteresting = false;
+            bool seenStructPayload = false;
+            Predicate<string> predicate = delegate (string telemetryName)
+            {
+                if (telemetryName == "Uninteresting")
+                    seenUninteresting = true;
+                if (telemetryName == "StructPayload")
+                    seenStructPayload = true;
+
+                return telemetryName == "StructPayload";
+            };
+
+            using (TelemetryListener.DefaultListener.Subscribe(new ObserverToList<TelemData>(result), predicate))
+            {
+
+                Assert.False(TelemetrySource.DefaultSource.IsEnabled("Uninteresting"));
+                Assert.True(TelemetrySource.DefaultSource.IsEnabled("StructPayload"));
+
+                Assert.True(seenUninteresting);
+                Assert.True(seenStructPayload);
+            }
+        }
+
+        /// <summary>
+        /// Test if it works when you have two subscribers active simultaneously
+        /// </summary>
+        [Fact]
+        public void MultiSubscriber()
+        {
+            var subscriber1Result = new List<KeyValuePair<string, object>>();
+            Predicate<string> subscriber1Predicate = telemetryName => (telemetryName == "DataForSubscriber1");
+            var subscriber1Oberserver = new ObserverToList<TelemData>(subscriber1Result);
+
+            var subscriber2Result = new List<KeyValuePair<string, object>>();
+            Predicate<string> subscriber2Predicate = telemetryName => (telemetryName == "DataForSubscriber2");
+            var subscriber2Oberserver = new ObserverToList<TelemData>(subscriber2Result);
+
+            // Get two subscribers going.  
+            using (var subscription1 = TelemetryListener.DefaultListener.Subscribe(subscriber1Oberserver, subscriber1Predicate))
+            {
+                using (var subscription2 = TelemetryListener.DefaultListener.Subscribe(subscriber2Oberserver, subscriber2Predicate))
+                {
+                    // Things that neither subscribe to get filtered out. 
+                    if (TelemetryListener.DefaultListener.IsEnabled("DataToFilterOut"))
+                        TelemetryListener.DefaultListener.WriteTelemetry("DataToFilterOut", -1);
+
+                    Assert.Equal(0, subscriber1Result.Count);
+                    Assert.Equal(0, subscriber2Result.Count);
+
+                    /****************************************************/
+                    // If a Source does not use the IsEnabled, then every subscriber gets it.  
+                    subscriber1Result.Clear();
+                    subscriber2Result.Clear();
+                    TelemetryListener.DefaultListener.WriteTelemetry("UnfilteredData", 3);
+
+                    Assert.Equal(1, subscriber1Result.Count);
+                    Assert.Equal("UnfilteredData", subscriber1Result[0].Key);
+                    Assert.Equal(3, (int)subscriber1Result[0].Value);
+
+                    Assert.Equal(1, subscriber2Result.Count);
+                    Assert.Equal("UnfilteredData", subscriber2Result[0].Key);
+                    Assert.Equal(3, (int)subscriber2Result[0].Value);
+
+                    /****************************************************/
+                    // Filters not filter out everything, they are just a performance optimization.  
+                    // Here you actually get more than you want even though you use a filter 
+                    subscriber1Result.Clear();
+                    subscriber2Result.Clear();
+                    if (TelemetryListener.DefaultListener.IsEnabled("DataForSubscriber1"))
+                        TelemetryListener.DefaultListener.WriteTelemetry("DataForSubscriber1", 1);
+
+                    Assert.Equal(1, subscriber1Result.Count);
+                    Assert.Equal("DataForSubscriber1", subscriber1Result[0].Key);
+                    Assert.Equal(1, (int)subscriber1Result[0].Value);
+
+                    // Subscriber 2 happens to get it 
+                    Assert.Equal(1, subscriber2Result.Count);
+                    Assert.Equal("DataForSubscriber1", subscriber2Result[0].Key);
+                    Assert.Equal(1, (int)subscriber2Result[0].Value);
+
+                    /****************************************************/
+                    subscriber1Result.Clear();
+                    subscriber2Result.Clear();
+                    if (TelemetryListener.DefaultListener.IsEnabled("DataForSubscriber2"))
+                        TelemetryListener.DefaultListener.WriteTelemetry("DataForSubscriber2", 2);
+
+                    // Subscriber 1 happens to get it 
+                    Assert.Equal(1, subscriber1Result.Count);
+                    Assert.Equal("DataForSubscriber2", subscriber1Result[0].Key);
+                    Assert.Equal(2, (int)subscriber1Result[0].Value);
+
+                    Assert.Equal(1, subscriber2Result.Count);
+                    Assert.Equal("DataForSubscriber2", subscriber2Result[0].Key);
+                    Assert.Equal(2, (int)subscriber2Result[0].Value);
+                }   // subscriber2 drops out
+
+                /*********************************************************************/
+                /* Only Subscriber 1 is left */
+                /*********************************************************************/
+
+                // Things that neither subscribe to get filtered out. 
+                subscriber1Result.Clear();
+                subscriber2Result.Clear();
+                if (TelemetryListener.DefaultListener.IsEnabled("DataToFilterOut"))
+                    TelemetryListener.DefaultListener.WriteTelemetry("DataToFilterOut", -1);
+
+                Assert.Equal(0, subscriber1Result.Count);
+                Assert.Equal(0, subscriber2Result.Count);
+
+                /****************************************************/
+                // If a Source does not use the IsEnabled, then every subscriber gets it.  
+                subscriber1Result.Clear();
+                TelemetryListener.DefaultListener.WriteTelemetry("UnfilteredData", 3);
+
+                Assert.Equal(1, subscriber1Result.Count);
+                Assert.Equal("UnfilteredData", subscriber1Result[0].Key);
+                Assert.Equal(3, (int)subscriber1Result[0].Value);
+
+                // Subscriber 2 has dropped out.
+                Assert.Equal(0, subscriber2Result.Count);
+
+                /****************************************************/
+                // Filters not filter out everything, they are just a performance optimization.  
+                // Here you actually get more than you want even though you use a filter 
+                subscriber1Result.Clear();
+                if (TelemetryListener.DefaultListener.IsEnabled("DataForSubscriber1"))
+                    TelemetryListener.DefaultListener.WriteTelemetry("DataForSubscriber1", 1);
+
+                Assert.Equal(1, subscriber1Result.Count);
+                Assert.Equal("DataForSubscriber1", subscriber1Result[0].Key);
+                Assert.Equal(1, (int)subscriber1Result[0].Value);
+
+                // Subscriber 2 has dropped out.
+                Assert.Equal(0, subscriber2Result.Count);
+
+                /****************************************************/
+                subscriber1Result.Clear();
+                if (TelemetryListener.DefaultListener.IsEnabled("DataForSubscriber2"))
+                    TelemetryListener.DefaultListener.WriteTelemetry("DataForSubscriber2", 2);
+
+                // Subscriber 1 filters
+                Assert.Equal(0, subscriber1Result.Count);
+                // Subscriber 2 has dropped out
+                Assert.Equal(0, subscriber2Result.Count);
+            } // subscriber1 drops out  
+
+            /*********************************************************************/
+            /* No Subscribers are left */
+            /*********************************************************************/
+
+            // Things that neither subscribe to get filtered out. 
+            subscriber1Result.Clear();
+            subscriber2Result.Clear();
+            if (TelemetryListener.DefaultListener.IsEnabled("DataToFilterOut"))
+                TelemetryListener.DefaultListener.WriteTelemetry("DataToFilterOut", -1);
+
+            Assert.Equal(0, subscriber1Result.Count);
+            Assert.Equal(0, subscriber2Result.Count);
+
+            /****************************************************/
+            // If a Source does not use the IsEnabled, then every subscriber gets it.  
+
+            TelemetryListener.DefaultListener.WriteTelemetry("UnfilteredData", 3);
+
+            // No one subscribing
+            Assert.Equal(0, subscriber1Result.Count);
+            Assert.Equal(0, subscriber2Result.Count);
+
+            /****************************************************/
+            // Filters not filter out everything, they are just a performance optimization.  
+            // Here you actually get more than you want even though you use a filter 
+            if (TelemetryListener.DefaultListener.IsEnabled("DataForSubscriber1"))
+                TelemetryListener.DefaultListener.WriteTelemetry("DataForSubscriber1", 1);
+
+            // No one subscribing
+            Assert.Equal(0, subscriber1Result.Count);
+            Assert.Equal(0, subscriber2Result.Count);
+
+            /****************************************************/
+            if (TelemetryListener.DefaultListener.IsEnabled("DataForSubscriber2"))
+                TelemetryListener.DefaultListener.WriteTelemetry("DataForSubscriber2", 2);
+
+            // No one subscribing
+            Assert.Equal(0, subscriber1Result.Count);
+            Assert.Equal(0, subscriber2Result.Count);
+        }
+
+        /// <summary>
+        /// Stresses the Subscribtion routine by having many threads subscribe and
+        /// unsubscribe concurrently
+        /// </summary>
+        [Fact]
+        public void MultiSubscriberStress()
+        {
+            var random = new Random();
+            //  Beat on the default listener by subscribing and unsubscribing on many threads simultaneously. 
+            var factory = new TaskFactory();
+
+            // To the whole stress test 10 times.  This keesp the task array size needed down while still
+            // having lots of concurrency.   
+            for (int j = 0; j < 20; j++)
+            {
+                // Spawn off lots of concurrnet activity
+                var tasks = new Task[1000];
+                for (int i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = factory.StartNew(delegate (object taskData)
+                    {
+                        int taskNum = (int)taskData;
+                        var taskName = "Task" + taskNum;
+                        var result = new List<KeyValuePair<string, object>>();
+                        Predicate<string> predicate = (name) => name == taskName;
+                        Predicate<KeyValuePair<string, object>> filter = (keyValue) => keyValue.Key == taskName;
+
+                    // set up the observer to only see events set with the task name as the telemetry nname.  
+                    var observer = new ObserverToList<TelemData>(result, filter, taskName);
+                        using (TelemetryListener.DefaultListener.Subscribe(observer, predicate))
+                        {
+                            TelemetrySource.DefaultSource.WriteTelemetry(taskName, taskNum);
+
+                            Assert.Equal(1, result.Count);
+                            Assert.Equal(taskName, result[0].Key);
+                            Assert.Equal(taskNum, result[0].Value);
+
+                        // Spin a bit randomly.  This mixes of the lifetimes of the subscriptions and makes it 
+                        // more stressfull 
+                        var cnt = random.Next(10, 100) * 1000;
+                            while (0 < --cnt)
+                                GC.KeepAlive("");
+
+                        }   // Unsubscribe
+
+                    // Send the telemetry again, to see if it now does NOT come through (count remains unchanged). 
+                    TelemetrySource.DefaultSource.WriteTelemetry(taskName, -1);
+                        Assert.Equal(1, result.Count);
+                    }, i);
+                }
+                Task.WaitAll(tasks);
+            }
+        }
+
+        /// <summary>
+        /// Tests if as we create new TelemetryListerns, we get callbacks for them 
+        /// </summary>
+        [Fact]
+        public void AllListenersAddRemove()
+        {
+            // This callback will return the listener that happens on the callback  
+            TelemetryListener returnedListener = null;
+            Action<TelemetryListener> onNewListener = delegate (TelemetryListener listener)
+            {
+                Assert.Null(returnedListener);
+                Assert.NotNull(listener);
+                returnedListener = listener;
+            };
+
+            // Subscribe, which delivers catchup event for the Default listener 
+            TelemetryListener.AllListeners += onNewListener;
+            Assert.Equal(TelemetryListener.DefaultListener, returnedListener);
+            returnedListener = null;
+
+            // Now we unsubscribe
+            TelemetryListener.AllListeners -= onNewListener;
+
+            // Create an dispose a listener, but we won't get a callback for it.  
+            using (new TelemetryListener("TestListen"))
+            { }
+
+            Assert.Null(returnedListener);          // No callback was made 
+
+            // Resubscribe  
+            TelemetryListener.AllListeners += onNewListener;
+            Assert.Equal(TelemetryListener.DefaultListener, returnedListener);
+            returnedListener = null;
+
+            // add two new subscribers
+            using (var listener1 = new TelemetryListener("TestListen1"))
+            {
+                Assert.Equal(listener1.Name, "TestListen1");
+                Assert.Equal(listener1, returnedListener);
+                returnedListener = null;
+
+                using (var listener2 = new TelemetryListener("TestListen2"))
+                {
+                    Assert.Equal(listener2.Name, "TestListen2");
+                    Assert.Equal(listener2, returnedListener);
+                    returnedListener = null;
+                }   // Dispose of listener2
+            }   // Dispose of listener1
+
+            // Unsubscribe 
+            TelemetryListener.AllListeners -= onNewListener;
+
+            // Check that we are back to just the DefaultListener. 
+            TelemetryListener.AllListeners += onNewListener;
+            Assert.Equal(TelemetryListener.DefaultListener, returnedListener);
+            returnedListener = null;
+
+            TelemetryListener.AllListeners -= onNewListener;  // cleanup
+        }
+
+        /// <summary>
+        /// Tests that the 'catchupList' of active listeners is accurate even as we 
+        /// add and remove TelemetryListeners randomly.  
+        /// </summary>
+        [Fact]
+        public void AllListenersCheckCatchupList()
+        {
+            var expected = new List<TelemetryListener>();
+            var list = GetActiveNonDefaultListeners();
+            Assert.Equal(list, expected);
+
+            for (int i = 0; i < 50; i++)
+            {
+                expected.Insert(0, (new TelemetryListener("TestListener" + i)));
+                list = GetActiveNonDefaultListeners();
+                Assert.Equal(list, expected);
+            }
+
+            // Remove the element randomly.  
+            var random = new Random(0);
+            while (0 < expected.Count)
+            {
+                var toRemoveIdx = random.Next(0, expected.Count - 1);     // Always leave the Default listener.  
+                var toRemoveListener = expected[toRemoveIdx];
+                toRemoveListener.Dispose();     // Kill it (which removes it from the list)
+                expected.RemoveAt(toRemoveIdx);
+                list = GetActiveNonDefaultListeners();
+                Assert.Equal(list.Count, expected.Count);
+                Assert.Equal(list, expected);
+            }
+        }
+
+        /// <summary>
+        /// Stresses the AllListeners by having many threads be added and removed.
+        /// </summary>
+        [Fact]
+        public void AllSubscriberStress()
+        {
+            var list = GetActiveNonDefaultListeners();
+            Assert.Equal(0, list.Count);
+
+            var factory = new TaskFactory();
+            var tasks = new Task[200];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = (factory.StartNew(delegate ()
+                {
+            // Create a lset of TelemetryListeners (which add themselves to the AllListeners list. 
+            var listeners = new List<TelemetryListener>();
+                    for (int j = 0; j < 200; j++)
+                        listeners.Insert(0, (new TelemetryListener("Task " + i + " TestListener" + j)));
+
+            // They are all in the list
+            list = GetActiveNonDefaultListeners();
+                    foreach (var listener in listeners)
+                        Assert.Contains(listener, list);
+
+            // Dispose them all 
+            foreach (var listener in listeners)
+                        listener.Dispose();
+
+            // And now they are not in the list.  
+            list = GetActiveNonDefaultListeners();
+                    foreach (var listener in listeners)
+                        Assert.DoesNotContain(listener, list);
+                }));
+            }
+            // Wait for all the tasks to finish.  
+            Task.WaitAll(tasks);
+
+            // There should be no listeners left.  
+            list = GetActiveNonDefaultListeners();
+            Assert.Equal(0, list.Count);
+        }
+
+        // Helper functions. 
+        /// <summary>
+        /// Returns the list of active Telelemtry listeners.  
+        /// </summary>
+        /// <returns></returns>
+        static List<TelemetryListener> GetActiveNonDefaultListeners()
+        {
+            var ret = new List<TelemetryListener>();
+            var seenDefault = false;
+            Action<TelemetryListener> onNewListener = delegate (TelemetryListener listener)
+            {
+                if (listener == TelemetryListener.DefaultListener)
+                {
+                    Assert.False(seenDefault);
+                    seenDefault = true;
+                }
+                else
+                    ret.Add(listener);
+            };
+
+            // Subscribe, which gives you the list
+            TelemetryListener.AllListeners += onNewListener;
+            Assert.True(seenDefault);
+            // Unsubscribe to remove side effects.  
+            TelemetryListener.AllListeners -= onNewListener;
+            return ret;
+        }
+    }
+
+
+    // Takes an IObserver and returns a List<T> that are the elements obsverved.
+    // Will assert on error and 'Completed' is set if the 'OnCompleted' callback
+    // is issued.  
+    class ObserverToList<T> : IObserver<T>
+    {
+        public ObserverToList(List<T> output, Predicate<T> filter = null, string name = null)
+        {
+            m_output = output;
+            m_output.Clear();
+            m_filter = filter;
+            m_name = name;
+        }
+
+        public bool Completed { get; private set; }
+
+        #region private
+
+        public void OnCompleted()
+        {
+            Completed = true;
+        }
+
+        public void OnError(Exception error)
+        {
+            Assert.True(false, "Error happened on IObserver");
+        }
+
+        public void OnNext(T value)
+        {
+            Assert.False(Completed);
+            if (m_filter == null || m_filter(value))
+                m_output.Add(value);
+        }
+
+        List<T> m_output;
+        Predicate<T> m_filter;
+        string m_name;  // for debugging 
+        #endregion
+    }
+
+    /// <summary>
+    /// Trivial class used for payloads.  (Usuallly anonymous types are used.  
+    /// </summary>
+    class Payload
+    {
+        public string Name { get; set; }
+        public int Id { get; set; }
+    }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
@@ -78,7 +78,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
             listener.Dispose();
             Assert.True(observer.Completed);
 
-            // We can unsubscribe without blowing up 
+            // confirm that we can unsubscribe without crashing 
             subscription.Dispose();
 
             // If we resubscribe after dispose, but it does not do anything.  
@@ -110,7 +110,6 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
 
             using (TelemetryListener.DefaultListener.Subscribe(new ObserverToList<TelemData>(result), predicate))
             {
-
                 Assert.False(TelemetrySource.DefaultSource.IsEnabled("Uninteresting"));
                 Assert.True(TelemetrySource.DefaultSource.IsEnabled("StructPayload"));
 
@@ -310,8 +309,8 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
                         Predicate<string> predicate = (name) => name == taskName;
                         Predicate<KeyValuePair<string, object>> filter = (keyValue) => keyValue.Key == taskName;
 
-                    // set up the observer to only see events set with the task name as the telemetry nname.  
-                    var observer = new ObserverToList<TelemData>(result, filter, taskName);
+                        // set up the observer to only see events set with the task name as the telemetry nname.  
+                        var observer = new ObserverToList<TelemData>(result, filter, taskName);
                         using (TelemetryListener.DefaultListener.Subscribe(observer, predicate))
                         {
                             TelemetrySource.DefaultSource.WriteTelemetry(taskName, taskNum);
@@ -320,16 +319,15 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
                             Assert.Equal(taskName, result[0].Key);
                             Assert.Equal(taskNum, result[0].Value);
 
-                        // Spin a bit randomly.  This mixes of the lifetimes of the subscriptions and makes it 
-                        // more stressfull 
-                        var cnt = random.Next(10, 100) * 1000;
+                            // Spin a bit randomly.  This mixes of the lifetimes of the subscriptions and makes it 
+                            // more stressfull 
+                            var cnt = random.Next(10, 100) * 1000;
                             while (0 < --cnt)
                                 GC.KeepAlive("");
-
                         }   // Unsubscribe
 
-                    // Send the telemetry again, to see if it now does NOT come through (count remains unchanged). 
-                    TelemetrySource.DefaultSource.WriteTelemetry(taskName, -1);
+                        // Send the telemetry again, to see if it now does NOT come through (count remains unchanged). 
+                        TelemetrySource.DefaultSource.WriteTelemetry(taskName, -1);
                         Assert.Equal(1, result.Count);
                     }, i);
                 }
@@ -444,22 +442,22 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
             {
                 tasks[i] = (factory.StartNew(delegate ()
                 {
-            // Create a lset of TelemetryListeners (which add themselves to the AllListeners list. 
-            var listeners = new List<TelemetryListener>();
+                    // Create a lset of TelemetryListeners (which add themselves to the AllListeners list. 
+                    var listeners = new List<TelemetryListener>();
                     for (int j = 0; j < 200; j++)
                         listeners.Insert(0, (new TelemetryListener("Task " + i + " TestListener" + j)));
 
-            // They are all in the list
-            list = GetActiveNonDefaultListeners();
+                    // They are all in the list
+                    list = GetActiveNonDefaultListeners();
                     foreach (var listener in listeners)
                         Assert.Contains(listener, list);
 
-            // Dispose them all 
-            foreach (var listener in listeners)
+                    // Dispose them all 
+                    foreach (var listener in listeners)
                         listener.Dispose();
 
-            // And now they are not in the list.  
-            list = GetActiveNonDefaultListeners();
+                    // And now they are not in the list.  
+                    list = GetActiveNonDefaultListeners();
                     foreach (var listener in listeners)
                         Assert.DoesNotContain(listener, list);
                 }));
@@ -477,7 +475,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
         /// Returns the list of active Telelemtry listeners.  
         /// </summary>
         /// <returns></returns>
-        static List<TelemetryListener> GetActiveNonDefaultListeners()
+        private static List<TelemetryListener> GetActiveNonDefaultListeners()
         {
             var ret = new List<TelemetryListener>();
             var seenDefault = false;
@@ -505,14 +503,14 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
     // Takes an IObserver and returns a List<T> that are the elements obsverved.
     // Will assert on error and 'Completed' is set if the 'OnCompleted' callback
     // is issued.  
-    class ObserverToList<T> : IObserver<T>
+    internal class ObserverToList<T> : IObserver<T>
     {
         public ObserverToList(List<T> output, Predicate<T> filter = null, string name = null)
         {
-            m_output = output;
-            m_output.Clear();
-            m_filter = filter;
-            m_name = name;
+            _output = output;
+            _output.Clear();
+            _filter = filter;
+            _name = name;
         }
 
         public bool Completed { get; private set; }
@@ -532,20 +530,20 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
         public void OnNext(T value)
         {
             Assert.False(Completed);
-            if (m_filter == null || m_filter(value))
-                m_output.Add(value);
+            if (_filter == null || _filter(value))
+                _output.Add(value);
         }
 
-        List<T> m_output;
-        Predicate<T> m_filter;
-        string m_name;  // for debugging 
+        private List<T> _output;
+        private Predicate<T> _filter;
+        private string _name;  // for debugging 
         #endregion
     }
 
     /// <summary>
     /// Trivial class used for payloads.  (Usuallly anonymous types are used.  
     /// </summary>
-    class Payload
+    internal class Payload
     {
         public string Name { get; set; }
         public int Id { get; set; }

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
@@ -283,7 +283,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
         }
 
         /// <summary>
-        /// Stresses the Subscribtion routine by having many threads subscribe and
+        /// Stresses the Subscription routine by having many threads subscribe and
         /// unsubscribe concurrently
         /// </summary>
         [Fact]
@@ -293,11 +293,11 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
             //  Beat on the default listener by subscribing and unsubscribing on many threads simultaneously. 
             var factory = new TaskFactory();
 
-            // To the whole stress test 10 times.  This keesp the task array size needed down while still
+            // To the whole stress test 10 times.  This keeps the task array size needed down while still
             // having lots of concurrency.   
             for (int j = 0; j < 20; j++)
             {
-                // Spawn off lots of concurrnet activity
+                // Spawn off lots of concurrent activity
                 var tasks = new Task[1000];
                 for (int i = 0; i < tasks.Length; i++)
                 {
@@ -320,7 +320,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
                             Assert.Equal(taskNum, result[0].Value);
 
                             // Spin a bit randomly.  This mixes of the lifetimes of the subscriptions and makes it 
-                            // more stressfull 
+                            // more stressful 
                             var cnt = random.Next(10, 100) * 1000;
                             while (0 < --cnt)
                                 GC.KeepAlive("");
@@ -350,7 +350,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
                 returnedListener = listener;
             };
 
-            // Subscribe, which delivers catchup event for the Default listener 
+            // Subscribe, which delivers catch-up event for the Default listener 
             TelemetryListener.AllListeners += onNewListener;
             Assert.Equal(TelemetryListener.DefaultListener, returnedListener);
             returnedListener = null;
@@ -442,7 +442,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
             {
                 tasks[i] = (factory.StartNew(delegate ()
                 {
-                    // Create a lset of TelemetryListeners (which add themselves to the AllListeners list. 
+                    // Create a set of TelemetryListeners (which add themselves to the AllListeners list. 
                     var listeners = new List<TelemetryListener>();
                     for (int j = 0; j < 200; j++)
                         listeners.Insert(0, (new TelemetryListener("Task " + i + " TestListener" + j)));
@@ -472,7 +472,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
 
         // Helper functions. 
         /// <summary>
-        /// Returns the list of active Telelemtry listeners.  
+        /// Returns the list of active telemetry listeners.  
         /// </summary>
         /// <returns></returns>
         private static List<TelemetryListener> GetActiveNonDefaultListeners()
@@ -500,7 +500,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
     }
 
 
-    // Takes an IObserver and returns a List<T> that are the elements obsverved.
+    // Takes an IObserver and returns a List<T> that are the elements observed.
     // Will assert on error and 'Completed' is set if the 'OnCompleted' callback
     // is issued.  
     internal class ObserverToList<T> : IObserver<T>
@@ -541,7 +541,7 @@ namespace System.Diagnostics.Tracing.Telemetry.Tests
     }
 
     /// <summary>
-    /// Trivial class used for payloads.  (Usuallly anonymous types are used.  
+    /// Trivial class used for payloads.  (Usually anonymous types are used.  
     /// </summary>
     internal class Payload
     {

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/project.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/project.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.20",
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Reflection": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "System.Runtime.Extensions": "4.0.10",
+    "xunit": "2.1.0-beta3-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/project.lock.json
@@ -1,0 +1,942 @@
+{
+  "locked": false,
+  "version": -9996,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Globalization/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "xunit/2.1.0-beta3-build3029": {
+        "dependencies": {
+          "xunit.core": "[2.1.0-beta3-build3029]",
+          "xunit.assert": "[2.1.0-beta3-build3029]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "compile": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-beta3-build3029": {
+        "compile": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-beta3-build3029": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-beta3-build3029]",
+          "xunit.extensibility.execution": "[2.1.0-beta3-build3029]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-beta3-build3029": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0]"
+        },
+        "compile": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-beta3-build3029": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-beta3-build3029]"
+        },
+        "compile": {
+          "lib/dnxcore50/xunit.execution.dnx.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/xunit.execution.dnx.dll": {}
+        }
+      },
+      "xunit.netcore.extensions/1.0.0-prerelease-00080": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "xunit": "2.1.0-beta3-build3029"
+        },
+        "compile": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Collections/4.0.10": {
+      "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
+      "files": [
+        "_rels/.rels",
+        "System.Collections.nuspec",
+        "lib/netcore50/System.Collections.dll",
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10": {
+      "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
+      "files": [
+        "_rels/.rels",
+        "System.Diagnostics.Debug.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Globalization/4.0.0": {
+      "sha512": "IBJyTo1y7ZtzzoJUA60T1XPvNTyw/wfFmjFoBFtlYfkekIOtD/AzDDIg0YdUa7eNtFEfliED2R7HdppTdU4t5A==",
+      "files": [
+        "License.rtf",
+        "System.Globalization.4.0.0.nupkg",
+        "System.Globalization.4.0.0.nupkg.sha512",
+        "System.Globalization.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Globalization.dll",
+        "ref/netcore50/System.Globalization.xml",
+        "ref/netcore50/de/System.Globalization.xml",
+        "ref/netcore50/es/System.Globalization.xml",
+        "ref/netcore50/fr/System.Globalization.xml",
+        "ref/netcore50/it/System.Globalization.xml",
+        "ref/netcore50/ja/System.Globalization.xml",
+        "ref/netcore50/ko/System.Globalization.xml",
+        "ref/netcore50/ru/System.Globalization.xml",
+        "ref/netcore50/zh-hans/System.Globalization.xml",
+        "ref/netcore50/zh-hant/System.Globalization.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO/4.0.10": {
+      "serviceable": true,
+      "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
+      "files": [
+        "System.IO.4.0.10.nupkg",
+        "System.IO.4.0.10.nupkg.sha512",
+        "System.IO.nuspec",
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "serviceable": true,
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "System.Linq.4.0.0.nupkg",
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec",
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Private.Uri/4.0.0": {
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "files": [
+        "_rels/.rels",
+        "System.Private.Uri.nuspec",
+        "lib/netcore50/System.Private.Uri.dll",
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection/4.0.10": {
+      "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.nuspec",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.Primitives.nuspec",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "_rels/.rels",
+        "System.Resources.ResourceManager.nuspec",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime/4.0.20": {
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.nuspec",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10": {
+      "serviceable": true,
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "files": [
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0": {
+      "serviceable": true,
+      "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "files": [
+        "System.Runtime.Handles.4.0.0.nupkg",
+        "System.Runtime.Handles.4.0.0.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20": {
+      "serviceable": true,
+      "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "files": [
+        "System.Runtime.InteropServices.4.0.20.nupkg",
+        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
+      ]
+    },
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+      "serviceable": true,
+      "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
+      "files": [
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23213.nupkg",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23213.nupkg.sha512",
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
+        "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+      ]
+    },
+    "System.Threading/4.0.10": {
+      "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.nuspec",
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/netcore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "serviceable": true,
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "System.Threading.Tasks.4.0.10.nupkg",
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
+      ]
+    },
+    "xunit/2.1.0-beta3-build3029": {
+      "sha512": "NMFXV0ePe/GrfhMSPGAlWmiUZCzjaatpdAGcavf2B6vYTRyMTpyJT01LI6jemMV/VSDXLrtHp0Ov9xZyR1cLLg==",
+      "files": [
+        "xunit.2.1.0-beta3-build3029.nupkg",
+        "xunit.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.nuspec"
+      ]
+    },
+    "xunit.abstractions/2.0.0": {
+      "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
+      "files": [
+        "xunit.abstractions.2.0.0.nupkg",
+        "xunit.abstractions.2.0.0.nupkg.sha512",
+        "xunit.abstractions.nuspec",
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml"
+      ]
+    },
+    "xunit.assert/2.1.0-beta3-build3029": {
+      "sha512": "AMS7Fv77DayXVRCBMmVEDwOXPcbxk8dCBA/iACsve+6+UQqopMtNyAynyIcXPFRK/peeitUKID4ChOXWisJmUw==",
+      "files": [
+        "xunit.assert.2.1.0-beta3-build3029.nupkg",
+        "xunit.assert.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.assert.nuspec",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.pdb",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.xml"
+      ]
+    },
+    "xunit.core/2.1.0-beta3-build3029": {
+      "sha512": "uDUBbwZSRx226BMwj6VylzXQPVpEIelNIulT+LxbSEH52y2a4btR9d5ptQmkSVjmJXP5/hGCc4cu1DSCu0pgUA==",
+      "files": [
+        "xunit.core.2.1.0-beta3-build3029.nupkg",
+        "xunit.core.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.core.nuspec",
+        "build/monoandroid/xunit.core.props",
+        "build/monoandroid/xunit.execution.MonoAndroid.dll",
+        "build/monotouch/xunit.core.props",
+        "build/monotouch/xunit.execution.MonoTouch.dll",
+        "build/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.props",
+        "build/portable-win81+wpa81/xunit.core.props",
+        "build/portable-win81+wpa81/xunit.core.targets",
+        "build/portable-win81+wpa81/xunit.execution.universal.dll",
+        "build/portable-win81+wpa81/xunit.execution.universal.pri",
+        "build/wp8/xunit.core.props",
+        "build/wp8/xunit.core.targets",
+        "build/wp8/xunit.execution.wp8.dll",
+        "build/Xamarin.iOS/xunit.core.props",
+        "build/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
+        "build/_Desktop/xunit.execution.desktop.dll"
+      ]
+    },
+    "xunit.extensibility.core/2.1.0-beta3-build3029": {
+      "sha512": "lsPro5U3NLasHI/RwqjKzXiRlh9N0IOlR3cluwXYVtihXbGtySeSnU/Fh5MTcWYxh+MVpoNop5zDD0/A2nrHsA==",
+      "files": [
+        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg",
+        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.extensibility.core.nuspec",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll.tdnet",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.pdb",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.xml",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.tdnet.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll"
+      ]
+    },
+    "xunit.extensibility.execution/2.1.0-beta3-build3029": {
+      "sha512": "WuUYamK4RHrHxihvNuX7NkryMhQrpH1+ziJ/mPIQbm18zevSgre8BwUuVZvmLZa8uVob3xS4dvAah2+HCgLiXg==",
+      "files": [
+        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg",
+        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.extensibility.execution.nuspec",
+        "lib/dnx451/xunit.execution.dnx.dll",
+        "lib/dnx451/xunit.execution.dnx.pdb",
+        "lib/dnx451/xunit.execution.dnx.xml",
+        "lib/dnxcore50/xunit.execution.dnx.dll",
+        "lib/dnxcore50/xunit.execution.dnx.pdb",
+        "lib/dnxcore50/xunit.execution.dnx.xml",
+        "lib/monoandroid/xunit.execution.MonoAndroid.dll",
+        "lib/monoandroid/xunit.execution.MonoAndroid.pdb",
+        "lib/monoandroid/xunit.execution.MonoAndroid.xml",
+        "lib/monotouch/xunit.execution.MonoTouch.dll",
+        "lib/monotouch/xunit.execution.MonoTouch.pdb",
+        "lib/monotouch/xunit.execution.MonoTouch.xml",
+        "lib/net45/xunit.execution.desktop.dll",
+        "lib/net45/xunit.execution.desktop.pdb",
+        "lib/net45/xunit.execution.desktop.xml",
+        "lib/portable-wpa81+win81/xunit.execution.universal.dll",
+        "lib/portable-wpa81+win81/xunit.execution.universal.pdb",
+        "lib/portable-wpa81+win81/xunit.execution.universal.pri",
+        "lib/portable-wpa81+win81/xunit.execution.universal.xml",
+        "lib/wp8/xunit.execution.wp8.dll",
+        "lib/wp8/xunit.execution.wp8.pdb",
+        "lib/wp8/xunit.execution.wp8.xml",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.pdb",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.xml"
+      ]
+    },
+    "xunit.netcore.extensions/1.0.0-prerelease-00080": {
+      "serviceable": true,
+      "sha512": "dHxf1OsXnrMolLeT2eqdyhi3wxQMwZG43jpmjpggXpyhLE3q7cSM7Chk8UWVx/JquqLSAWKg4yk+tPEQ7uz7bw==",
+      "files": [
+        "xunit.netcore.extensions.1.0.0-prerelease-00080.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00080.nupkg.sha512",
+        "xunit.netcore.extensions.nuspec",
+        "lib/dotnet/Xunit.NetCore.Extensions.dll"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Runtime >= 4.0.20",
+      "System.Collections >= 4.0.10",
+      "System.Diagnostics.Debug >= 4.0.10",
+      "System.Reflection >= 4.0.10",
+      "System.Threading >= 4.0.10",
+      "System.Threading.Tasks >= 4.0.10",
+      "System.Runtime.Extensions >= 4.0.10",
+      "xunit >= 2.1.0-beta3-*",
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}


### PR DESCRIPTION
The ASP.NET team has been working with diagnostic tools teams on support for Rich diagnostics.   Basically what is needed is the ability to instrument various points in the runtime (and ASP.NET) and pass rich types (e.g. a HTTP context, or a whole HTTP Message).   Existing offerings (e.g. EventSource) are insufficient because of the desired richness (EventSource requires that what is passed to it be serializable, which in turn requires that you pick an choose what is important to you to keep the size reasonable).   In this API there is no expectation of serialization (the tool will inject code and inspect the rich objects and IT WILL DECIDE what is important FOR THAT INSTANCE.   

There was a prototype built by the ASP.NET team (See aspnet/EventNotfication).   This is effectively a counter proposal by the runtime team.  We removed everything that did not absolutely need to be in the framework (thus it is just a subscription service, and does very little), because the rest can be done by the subscribers to the rich events (they have a Duck typing scheme).   

This API has been through about a week's worth of discussion trying to keep it as simple and clean as possible.   It will be its own package.    There are only two classes (see TelemetrySource.cs and TelemetryListener.cs) and only the Listener has any implementation.  

This class has to be pushed through ASAP so that the ASP.NET team can use it to instrument all the necessary places in their framework.      