### PR TITLE
Fix an assert in CurlHandler multi handle release path

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.SafeCurlHandle.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.SafeCurlHandle.cs
@@ -176,10 +176,15 @@ internal static partial class Interop
             internal void SignalFdSetChange(int fd, bool isRemove)
             {
                 Debug.Assert(Monitor.IsEntered(this));
-                bool changed = isRemove ? _fdSet.Remove(fd) : _fdSet.Add(fd);
-                if (!changed)
+
+                // If there is no valid fd, the poll still needs to be unblocked
+                if (-1 != fd)
                 {
-                    return;
+                    bool changed = isRemove ? _fdSet.Remove(fd) : _fdSet.Add(fd);
+                    if (!changed)
+                    {
+                        return;
+                    }
                 }
 
                 unsafe

--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl.cs
@@ -155,5 +155,5 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.LibCurl)]
         public static extern IntPtr curl_version_info(int curlVersionStamp);
- }
+    }
 }

--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -42,13 +42,13 @@ internal static partial class Interop
             internal const int CURLOPT_PROXY = CurlOptionObjectPointBase + 4;
             internal const int CURLOPT_PROXYUSERPWD = CurlOptionObjectPointBase + 6;
             internal const int CURLOPT_READDATA = CurlOptionObjectPointBase + 9;
-            internal const int CURLOPT_POSTFIELDS = CurlOptionObjectPointBase + 15;
             internal const int CURLOPT_COOKIE = CurlOptionObjectPointBase + 22;
             internal const int CURLOPT_HTTPHEADER = CurlOptionObjectPointBase + 23;
             internal const int CURLOPT_HEADERDATA = CurlOptionObjectPointBase + 29;
             internal const int CURLOPT_ACCEPTENCODING = CurlOptionObjectPointBase + 102;
             internal const int CURLOPT_PRIVATE = CurlOptionObjectPointBase + 103;
             internal const int CURLOPT_IOCTLDATA = CurlOptionObjectPointBase + 131;
+            internal const int CURLOPT_COPYPOSTFIELDS = CurlOptionObjectPointBase + 165;
             internal const int CURLOPT_USERNAME = CurlOptionObjectPointBase + 173;
             internal const int CURLOPT_PASSWORD = CurlOptionObjectPointBase + 174;
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlCallbacks.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlCallbacks.cs
@@ -353,7 +353,6 @@ namespace System.Net.Http
             {
                 lock (state.SessionHandle)
                 {
-                    state.SocketFd = -1;
                     state.SessionHandle.SignalFdSetChange(socketFd, true);
                 }
             }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlCallbacks.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlCallbacks.cs
@@ -353,6 +353,7 @@ namespace System.Net.Http
             {
                 lock (state.SessionHandle)
                 {
+                    state.SocketFd = -1;
                     state.SessionHandle.SignalFdSetChange(socketFd, true);
                 }
             }
@@ -367,6 +368,7 @@ namespace System.Net.Http
                         throw new HttpRequestException(SR.net_http_client_execution_error,
                             GetCurlException(result, true));
                     }
+                    state.SocketFd = socketFd;
                     state.SessionHandle.SignalFdSetChange(socketFd, false);
                 }
             }


### PR DESCRIPTION
- If a timeout happens, the socket fd is not removed from _fdSet. When
  SafeCurlMultiHandle is finalized, it checks if _fdSet is empty and
  this assertion was failing. So ensuring that all codepaths of
  EndRequest result in cleanup from _fdSet

cc: @stephentoub @davidsh @CIPop @SidharthNabar @pgavlin