### PR TITLE
Throw correct exception when Enumerable.Cast null to non-nullable

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1122,7 +1122,16 @@ namespace System.Linq
 
         private static IEnumerable<TResult> CastIterator<TResult>(IEnumerable source)
         {
-            foreach (object obj in source) yield return (TResult)obj;
+            if (default(TResult) == null)
+                foreach (object obj in source) yield return (TResult)obj;
+            else
+            {
+                foreach (object obj in source)
+                {
+                    if (obj == null) throw new InvalidCastException();
+                    yield return (TResult)obj;
+                }
+            }
         }
 
         public static TSource First<TSource>(this IEnumerable<TSource> source)

--- a/src/System.Linq/tests/CastTests.cs
+++ b/src/System.Linq/tests/CastTests.cs
@@ -196,5 +196,22 @@ namespace System.Linq.Tests
             IEnumerable<long?> cast = source.Cast<long?>();
             Assert.Throws<InvalidCastException>(() => cast.ToList());
         }
+
+        [Fact]
+        public void CastingNullToNonnullableIsInvalidCastException()
+        {
+            int?[] source = new int?[] { -4, 1, null, 3 };
+            IEnumerable<int> cast = source.Cast<int>();
+            Assert.Throws<InvalidCastException>(() => cast.ToList());
+        }
+        
+        [Fact]
+        public void CastingNullToNullableTypeIsNull()
+        {
+            object[] source = new object[] { "abc", null, "def" };
+            string[] expected = new string[] { "abc", null, "def" };
+            
+            Assert.Equal(expected, source.Cast<string>());
+        }
     }
 }


### PR DESCRIPTION
Fixes #2947 