### PR TITLE
Hide several test libs from code coverage

### DIFF
--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/AssemblyInfo.cs
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
@@ -19,11 +19,15 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Dictionaries\DictionaryExportDescriptorProvider.cs" />
     <Compile Include="Util\Formatters.cs" />
     <Compile Include="OrderedImportManyAttribute.cs" />
     <Compile Include="OrderedCollections\OrderedImportManyExportDescriptorProvider.cs" />
     <Compile Include="KeyByMetadataAttribute.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Composition.AttributedModel\src\System.Composition.AttributedModel.csproj">

--- a/src/System.Composition/scenarios/TestLibrary/TestClass.cs
+++ b/src/System.Composition/scenarios/TestLibrary/TestClass.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+
 namespace TestLibrary
 {
     [Export]

--- a/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
+++ b/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
@@ -21,8 +21,10 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-
     <Compile Include="TestClass.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Composition.AttributedModel\src\System.Composition.AttributedModel.csproj">


### PR DESCRIPTION
Two test libraries recently snuck in for inclusion in our code coverage runs.  Excluding them.