### PR TITLE
Consistently Throw NotSupportedException on Enumerator Reset

### DIFF
--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -16,9 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
-      <Link>Common\System\NotImplemented.cs</Link>
-    </Compile>
     <Compile Include="System\Linq\Enumerable.cs" />
     <Compile Include="System\Linq\Errors.cs" />
   </ItemGroup>

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -139,7 +139,7 @@ namespace System.Linq
 
             void IEnumerator.Reset()
             {
-                throw NotImplemented.ByDesign;
+                throw Error.NotSupported();
             }
         }
 

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -658,7 +658,7 @@ namespace System.Linq.Tests
             var result = source.Select(selector);
             var enumerator = result.GetEnumerator();
 
-            Assert.Throws<NotImplementedException>(() => enumerator.Reset());
+            Assert.Throws<NotSupportedException>(() => enumerator.Reset());
         }
     }
 }

--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -831,7 +831,7 @@ namespace System.Linq.Tests
 
             var enumerator = source.Where(value => true).GetEnumerator();
 
-            Assert.Throws<NotImplementedException>(() => enumerator.Reset());
+            Assert.Throws<NotSupportedException>(() => enumerator.Reset());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #2879

Have Enumerable.Iterator<TSource>'s implementation of IEnumerator.Reset throw
NotSupportedException instead of NotImplementedException as both more
appropriate in itself, and more consistent with other IEnumerator.Reset
implementations.