### PR TITLE
Issue#2930: Make GetRSAPrivateKey prefer CNG

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -456,7 +456,7 @@ namespace Internal.Cryptography.Pal.Native
 
     internal enum CryptDecodeObjectStructType : int
     {
-        RSA_CSP_PUBLICKEYBLOB = 19,
+        CNG_RSA_PUBLIC_KEY_BLOB = 72,
         X509_DSS_PUBLICKEY = 38,
         X509_DSS_PARAMETERS = 39,
         X509_KEY_USAGE = 14,

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -31,10 +31,9 @@ namespace Internal.Cryptography.Pal
                 case AlgId.CALG_RSA_KEYX:
                 case AlgId.CALG_RSA_SIGN:
                     {
-                        byte[] keyBlob = DecodeKeyBlob(CryptDecodeObjectStructType.RSA_CSP_PUBLICKEYBLOB, encodedKeyValue);
-                        RSACryptoServiceProvider rsa = new RSACryptoServiceProvider();
-                        rsa.ImportCspBlob(keyBlob);
-                        return rsa;
+                        byte[] keyBlob = DecodeKeyBlob(CryptDecodeObjectStructType.CNG_RSA_PUBLIC_KEY_BLOB, encodedKeyValue);
+                        CngKey cngKey = CngKey.Import(keyBlob, CngKeyBlobFormat.GenericPublicBlob);
+                        return new RSACng(cngKey);
                     }
 
                 case AlgId.CALG_DSS_SIGN:

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -30,6 +30,10 @@
       <Project>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</Project>
       <Name>System.Security.Cryptography.Algorithms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Security.Cryptography.Cng\src\System.Security.Cryptography.Cng.csproj">
+      <Project>{4C1BD451-6A99-45E7-9339-79C77C42EE9E}</Project>
+      <Name>System.Security.Cryptography.Cng</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <ProjectReference Include="..\..\System.Security.Cryptography.Csp\src\System.Security.Cryptography.Csp.csproj">

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
@@ -27,9 +27,6 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             PublicKey publicKey = certificate.PublicKey;
-
-            // When the CNG contract comes online this needs to return an RsaCng on Windows, unless CNG reports
-            // an error, then try falling back to CAPI (for CAPI-only smartcards).
             return (RSA)X509Pal.Instance.DecodePublicKey(
                 publicKey.Oid,
                 publicKey.EncodedKeyValue.RawData,
@@ -50,8 +47,6 @@ namespace System.Security.Cryptography.X509Certificates
                 return null;
             }
 
-            // When the CNG contract comes online this needs to return an RsaCng on Windows, unless CNG reports
-            // an error, then try falling back to CAPI (for CAPI-only smartcards).
             return certificate.Pal.GetRSAPrivateKey();
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -101,30 +101,29 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(expectedParameters, pk.EncodedParameters.RawData);
         }
 
-        /*
-         * TODO: Move the spirit of this method to a GetRSAPublicKey test
         [Fact]
         public static void TestKey_RSA()
         {
-            PublicKey pk = GetTestRsaKey();
-            RSA rsa = (RSA)pk.Key;
-            RSAParameters rsaParameters = rsa.ExportParameters(false);
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                RSA rsa = cert.GetRSAPublicKey();
+                RSAParameters rsaParameters = rsa.ExportParameters(false);
 
-            byte[] expectedModulus = (
-                "E8AF5CA2200DF8287CBC057B7FADEEEB76AC28533F3ADB407DB38E33E6573FA5" +
-                "51153454A5CFB48BA93FA837E12D50ED35164EEF4D7ADB137688B02CF0595CA9" +
-                "EBE1D72975E41B85279BF3F82D9E41362B0B40FBBE3BBAB95C759316524BCA33" +
-                "C537B0F3EB7EA8F541155C08651D2137F02CBA220B10B1109D772285847C4FB9" +
-                "1B90B0F5A3FE8BF40C9A4EA0F5C90A21E2AAE3013647FD2F826A8103F5A935DC" +
-                "94579DFB4BD40E82DB388F12FEE3D67A748864E162C4252E2AAE9D181F0E1EB6" +
-                "C2AF24B40E50BCDE1C935C49A679B5B6DBCEF9707B280184B82A29CFBFA90505" +
-                "E1E00F714DFDAD5C238329EBC7C54AC8E82784D37EC6430B950005B14F6571C5").HexToByteArray();
+                byte[] expectedModulus = (
+                    "E8AF5CA2200DF8287CBC057B7FADEEEB76AC28533F3ADB407DB38E33E6573FA5" +
+                    "51153454A5CFB48BA93FA837E12D50ED35164EEF4D7ADB137688B02CF0595CA9" +
+                    "EBE1D72975E41B85279BF3F82D9E41362B0B40FBBE3BBAB95C759316524BCA33" +
+                    "C537B0F3EB7EA8F541155C08651D2137F02CBA220B10B1109D772285847C4FB9" +
+                    "1B90B0F5A3FE8BF40C9A4EA0F5C90A21E2AAE3013647FD2F826A8103F5A935DC" +
+                    "94579DFB4BD40E82DB388F12FEE3D67A748864E162C4252E2AAE9D181F0E1EB6" +
+                    "C2AF24B40E50BCDE1C935C49A679B5B6DBCEF9707B280184B82A29CFBFA90505" +
+                    "E1E00F714DFDAD5C238329EBC7C54AC8E82784D37EC6430B950005B14F6571C5").HexToByteArray();
 
-            byte[] expectedExponent = new byte[] { 0x01, 0x00, 0x01 };
+                byte[] expectedExponent = new byte[] { 0x01, 0x00, 0x01 };
 
-            Assert.Equal(expectedModulus, rsaParameters.Modulus);
-            Assert.Equal(expectedExponent, rsaParameters.Exponent);
+                Assert.Equal(expectedModulus, rsaParameters.Modulus);
+                Assert.Equal(expectedExponent, rsaParameters.Exponent);
+            }
         }
-        */
     }
 }


### PR DESCRIPTION
This brings these two extension methods into the age
of CNG:

- GetRSAPublicKey() - now returns an RSACng object
  rather than an RSACryptoServiceProvider object.

- GetRSAPrivateKey() - returns an RSACng object
  if a stored CNG key is available for the certificate's
  public key. Prior behavior was that it blindly
  asked CAPI to open a CNG KSP name and key name, and
  dumped the resulting CryptoException into the caller's
  lap.

Fixes #2930.