### PR TITLE
Harden implementation of Vector<T>.Count

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -58,17 +58,10 @@ namespace System.Numerics
         {
             get
             {
-                if (Vector.IsHardwareAccelerated)
-                {
-                    throw new NotSupportedException(SR.Reflection_MethodNotSupported);
-                }
-                else
-                {
-                    return count;
-                }
+                return s_count;
             }
         }
-        private static int count = InitializeCount();
+        private static int s_count = InitializeCount();
 
         /// <summary>
         /// Returns a vector containing all zeroes.
@@ -89,25 +82,37 @@ namespace System.Numerics
         #endregion Static Members
 
         #region Static Initialization
-        private static int InitializeCount()
+        private struct VectorSizeHelper
         {
-            Contract.Requires(
-                Vector.IsHardwareAccelerated == false,
-                "InitializeCount cannot be invoked when running under hardware acceleration");
+            internal Vector<T> _placeholder;
+            internal byte _byte;
+        }
+
+		// Calculates the size of this struct in bytes, by computing the offset of a field in a structure
+        private static unsafe int InitializeCount()
+        {
+            VectorSizeHelper vsh;
+            byte* vectorBase = &vsh._placeholder.register.byte_0;
+            byte* byteBase = &vsh._byte;
+            int vectorSizeInBytes = (int)(byteBase - vectorBase);
+
+            int typeSizeInBytes = -1;
 <#    foreach (Type type in supportedTypes)
-    {
+      {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return <#= GetNumFields(type, totalSize) #>;
+                typeSizeInBytes = sizeof(<#=type.Name#>);
             }
 <#
-    }
+      }
 #>
             else
             {
                 throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
+
+            return vectorSizeInBytes / typeSizeInBytes;
         }
         #endregion Static Initialization
 

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -2198,6 +2198,34 @@ namespace System.Numerics.Tests
                 Assert.Equal(vector[g], array[g + offset]);
             }
         }
+
+        [Fact]
+        public void CountViaReflectionConsistencyByte() { TestCountViaReflectionConsistency<Byte>(); }
+        [Fact]
+        public void CountViaReflectionConsistencySByte() { TestCountViaReflectionConsistency<SByte>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyUInt16() { TestCountViaReflectionConsistency<UInt16>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyInt16() { TestCountViaReflectionConsistency<Int16>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyUInt32() { TestCountViaReflectionConsistency<UInt32>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyInt32() { TestCountViaReflectionConsistency<Int32>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyUInt64() { TestCountViaReflectionConsistency<UInt64>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyInt64() { TestCountViaReflectionConsistency<Int64>(); }
+        [Fact]
+        public void CountViaReflectionConsistencySingle() { TestCountViaReflectionConsistency<Single>(); }
+        [Fact]
+        public void CountViaReflectionConsistencyDouble() { TestCountViaReflectionConsistency<Double>(); }
+        private void TestCountViaReflectionConsistency<T>() where T : struct
+        {
+            MethodInfo countMethod = typeof(Vector<T>).GetTypeInfo().GetDeclaredProperty("Count").GetMethod;
+            int valueFromReflection = (int)countMethod.Invoke(null, null);
+            int valueFromNormalCall = Vector<T>.Count;
+            Assert.Equal(valueFromNormalCall, valueFromReflection);
+        }
         #endregion Reflection Tests
 
         #region Helper Methods

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -1600,6 +1600,23 @@ namespace System.Numerics.Tests
                 Assert.Equal(vector[g], array[g + offset]);
             }
         }
+
+<# 
+    foreach (var type in supportedTypes)
+    {
+#>
+        [Fact]
+        public void CountViaReflectionConsistency<#=type.Name#>() { TestCountViaReflectionConsistency<<#=type.Name#>>(); }
+<#
+    }
+#>
+        private void TestCountViaReflectionConsistency<T>() where T : struct
+        {
+            MethodInfo countMethod = typeof(Vector<T>).GetTypeInfo().GetDeclaredProperty("Count").GetMethod;
+            int valueFromReflection = (int)countMethod.Invoke(null, null);
+            int valueFromNormalCall = Vector<T>.Count;
+            Assert.Equal(valueFromNormalCall, valueFromReflection);
+        }
         #endregion Reflection Tests
 
         #region Helper Methods

--- a/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -12,8 +12,6 @@
     <AssemblyName>System.Numerics.Vectors.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>11f13d9c</NuGetPackageImportStamp>
-    <!-- Temporary workaround until tests are fixed on x64 -->
-    <TestArchitecture>x86</TestArchitecture>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
The Vector<T>.Count property, as currently implemented, does not work when called from a Debug version of a user program running against the release build of System.Numerics.Vectors.dll. Because the user code is unoptimized, the IL version of Vector<T>.Count is run, but since System.Numerics.Vectors.dll is optimized, the internal call to Vector.IsHardwareAccelerated returns true, leading to the NotSupportedException, which was intended to only be thrown when called via reflection. This essentially makes it impossible to call the method in Debug-mode user code, when running with RyuJIT.

This change hardens the implementation, fixing the above issue. In addition, it also lets users call the method via reflection (if they wanted to), and also has the nice effect of allowing its use in the
Debugger.

We use a simple helper struct which has two fields, the Vector<T> whose size we want to measure, followed a byte field. We just grab the address of the byte field, and compute its difference from the address of the vector's first byte element. We then divide that total vector size by the size of T. This should be robust to future changes, and should accomodate differing Vector sizes across SIMD instruction sets. Since we are just relying on the layout of the struct, the result should remain correct in the future. New SIMD register sizes will dictate a new size for Vector<T>, and therefore a new layout for our helper structure. The cost for computing this is once per generic type instantiation; the value is cached. I've tested that this performs as expected in a machine with pre-AVX2 support, and with AVX2 support.

I've added a test case that simply verifies the value returned from calling Vector<T>.Count matches the value returned from a regular property access.

I also removed the x86-workaround we had in place; it seems like the latest version of CoreCLR has the JIT fixes in it that were needed to run the tests on the 64-bit runtime.

/cc: @CarolEidt 