### PR TITLE
Fix HttpClientHandler timeouts

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -150,6 +150,13 @@ namespace System.Net.Http
             // WPAD protocol and PAC file. So, for app-compat, we will do the same for the default proxy setting.
             _winHttpHandler.WindowsProxyUsePolicy = WindowsProxyUsePolicy.UseWinInetProxy;
             _winHttpHandler.Proxy = null;
+            
+            // Since the granular WinHttpHandler timeout properties are not exposed via the HttpClientHandler API,
+            // we need to set them to infinite and allow the HttpClient.Timeout property to have precedence.
+            _winHttpHandler.ConnectTimeout = Timeout.InfiniteTimeSpan;
+            _winHttpHandler.ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan;
+            _winHttpHandler.ReceiveDataTimeout = Timeout.InfiniteTimeSpan;
+            _winHttpHandler.SendTimeout = Timeout.InfiniteTimeSpan;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Tests;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Tests
+{
+    public class HttpClientTest
+    {
+        [Fact]
+        [OuterLoop]
+        public void Timeout_SetTo60AndGetResponseFromServerWhichTakes40_Success()
+        {
+            // TODO: This server path will change once the final test infrastructure is in place (Issue #1477).
+            const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
+            
+            using (var client = new HttpClient())
+            {
+                client.Timeout = TimeSpan.FromSeconds(60);
+                var response = client.GetAsync(SlowServer).GetAwaiter().GetResult();
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Tests.csproj
@@ -23,6 +23,7 @@
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
     <Compile Include="HttpClientHandlerTest.cs" />
+    <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
   </ItemGroup>


### PR DESCRIPTION
Since HttpClientHandler doesn't expose all the timeout used by the
underlying WinHttpHandler, we need to disable those timeouts in favor of
the HttpClient.Timeout property.

Addresses issue #2857.