### PR TITLE
Fix several System.Diagnostics.Tracing.Telemetry issues

### DIFF
--- a/src/System.Diagnostics.Tracing.Telemetry/tests/project.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/project.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",
+    "System.Globalization": "4.0.10",
     "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
-    "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0-beta3-*",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -25,12 +25,15 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Globalization/4.0.0": {
+      "System.Globalization/4.0.10": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -339,19 +342,17 @@
         "[Content_Types].xml"
       ]
     },
-    "System.Globalization/4.0.0": {
-      "sha512": "IBJyTo1y7ZtzzoJUA60T1XPvNTyw/wfFmjFoBFtlYfkekIOtD/AzDDIg0YdUa7eNtFEfliED2R7HdppTdU4t5A==",
+    "System.Globalization/4.0.10": {
+      "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "files": [
-        "License.rtf",
-        "System.Globalization.4.0.0.nupkg",
-        "System.Globalization.4.0.0.nupkg.sha512",
+        "System.Globalization.4.0.10.nupkg",
+        "System.Globalization.4.0.10.nupkg.sha512",
         "System.Globalization.nuspec",
+        "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net45/_._",
-        "lib/win8/_._",
-        "lib/wp80/_._",
-        "lib/wpa81/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/System.Globalization.dll",
@@ -367,23 +368,10 @@
         "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net45/_._",
-        "ref/netcore50/System.Globalization.dll",
-        "ref/netcore50/System.Globalization.xml",
-        "ref/netcore50/de/System.Globalization.xml",
-        "ref/netcore50/es/System.Globalization.xml",
-        "ref/netcore50/fr/System.Globalization.xml",
-        "ref/netcore50/it/System.Globalization.xml",
-        "ref/netcore50/ja/System.Globalization.xml",
-        "ref/netcore50/ko/System.Globalization.xml",
-        "ref/netcore50/ru/System.Globalization.xml",
-        "ref/netcore50/zh-hans/System.Globalization.xml",
-        "ref/netcore50/zh-hant/System.Globalization.xml",
-        "ref/win8/_._",
-        "ref/wp80/_._",
-        "ref/wpa81/_._",
+        "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
       ]
     },
     "System.IO/4.0.10": {
@@ -927,13 +915,14 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "System.Runtime >= 4.0.20",
       "System.Collections >= 4.0.10",
       "System.Diagnostics.Debug >= 4.0.10",
+      "System.Globalization >= 4.0.10",
       "System.Reflection >= 4.0.10",
+      "System.Runtime >= 4.0.20",
+      "System.Runtime.Extensions >= 4.0.10",
       "System.Threading >= 4.0.10",
       "System.Threading.Tasks >= 4.0.10",
-      "System.Runtime.Extensions >= 4.0.10",
       "xunit >= 2.1.0-beta3-*",
       "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],


### PR DESCRIPTION
Source:
- Fixes bug where disposal of an AllListeners subscription would fail if the subscription wasn't the most recent.  The linked list walk was looking for the wrong object.
- Fixes bug where double disposal of a subscription to AllListeners would result in OnCompleted for that observer being called multiple times, and in some cases resulting in a NullReferenceException.
- Fixes bug where double disposal of a subscription to a TelemetryListener or to AllListeners would trigger a Debug.Assert
- Marks several fields that could be readonly as such.

Tests:
- Fixes a build warning in the tests project caused by a missing reference in the project.json to the correct version of System.Globalization.
- Changes the locked status of the project.lock.json from false to true so that it's not edited on dev machines any time a build is done.
- Brings line code coverage of System.Diagnostics.Tracing.Telemetry up to 100%.

cc: @vancem 