### PR TITLE
Add tests for stability of ThenBy and ThenByDescending

### DIFF
--- a/src/System.Linq/tests/ThenByDescendingTests.cs
+++ b/src/System.Linq/tests/ThenByDescendingTests.cs
@@ -101,6 +101,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void OrderIsStable()
+        {
+            var source = @"Because I could not stop for Death —
+He kindly stopped for me —
+The Carriage held but just Ourselves —
+And Immortality.".Split(new []{ ' ', '\n', '\r', '—' }, StringSplitOptions.RemoveEmptyEntries);
+            var expected = new []
+            {
+                "stopped", "kindly", "could", "stop", "held", "just", "not", "for", "for", "but", "me",
+                "Immortality.", "Ourselves", "Carriage", "Because", "Death", "The", "And", "He", "I"   
+            };
+            
+            Assert.Equal(expected, source.OrderBy(word => char.IsUpper(word[0])).ThenByDescending(word => word.Length));
+        }
+
+        [Fact]
         public void NullSource()
         {
             IOrderedEnumerable<int> source = null;

--- a/src/System.Linq/tests/ThenByTests.cs
+++ b/src/System.Linq/tests/ThenByTests.cs
@@ -119,6 +119,22 @@ namespace System.Linq.Tests.LegacyTests
 
             Assert.Equal(expected, source.OrderBy((e) => e.Name).ThenBy((e) => e.City, null));
         }
+        
+        [Fact]
+        public void OrderIsStable()
+        {
+            var source = @"Because I could not stop for Death —
+He kindly stopped for me —
+The Carriage held but just Ourselves —
+And Immortality.".Split(new []{ ' ', '\n', '\r', '—' }, StringSplitOptions.RemoveEmptyEntries);
+            var expected = new []
+            {
+                "me", "not", "for", "for", "but", "stop", "held", "just", "could", "kindly", "stopped",
+                "I", "He", "The", "And", "Death", "Because", "Carriage", "Ourselves", "Immortality."
+            };
+            
+            Assert.Equal(expected, source.OrderBy(word => char.IsUpper(word[0])).ThenBy(word => word.Length));
+        }
 
         [Fact]
         public void NullSource()


### PR DESCRIPTION
ThenBy and ThenByDescending are both specified as having a stable sort order
with linq-to-objects. Add tests verifying this.