### PR TITLE
Shim chmod, mkdir, mkfifo to make permission handling consistent

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ChMod.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ChMod.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Runtime.InteropServices;
 
-using mode_t = System.Int32;
-
 internal static partial class Interop
 {
-    internal static partial class libc
+    internal static partial class Sys
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern int chmod(string path, mode_t mode);
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern int ChMod(string path, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Runtime.InteropServices;
 
-using mode_t = System.Int32;
-
 internal static partial class Interop
 {
-    internal static partial class libc
+    internal static partial class Sys
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern int mkdir(string pathname, mode_t mode);
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern int MkDir(string path, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MkFifo.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MkFifo.cs
@@ -3,13 +3,11 @@
 
 using System.Runtime.InteropServices;
 
-using mode_t = System.Int32;
-
 internal static partial class Interop
 {
-    internal static partial class libc
+    internal static partial class Sys
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern int mkfifo(string pathname, mode_t mode);
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern int MkFifo(string path, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Permissions.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Permissions.cs
@@ -5,7 +5,7 @@ using System;
 
 internal static partial class Interop
 {
-    internal static partial class libc
+    internal static partial class Sys
     {
         [Flags]
         internal enum Permissions

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -357,3 +357,21 @@ int32_t FcntlSetPipeSz(int32_t fd, int32_t size)
     return -1;
 #endif
 }
+
+extern "C"
+int32_t MkDir(const char* path, int32_t mode)
+{
+    return mkdir(path, mode);
+}
+
+extern "C"
+int32_t ChMod(const char* path, int32_t mode)
+{
+    return chmod(path, mode);
+}
+
+extern "C"
+int32_t MkFifo(const char* path, int32_t mode)
+{
+    return mkfifo(path, mode);
+}

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -279,3 +279,33 @@ extern "C"
 int32_t FcntlSetPipeSz(
     int32_t fd,
     int32_t size);
+
+/**
+ * Create a directory. Implemented as a shim to mkdir(2).
+ *
+ * Returns 0 for success, -1 for failure. Sets errno for failure.
+ */    
+extern "C"
+int32_t MkDir(
+    const char* path,
+    int32_t mode);
+
+/**
+ * Change permissions of a file. Implemented as a shim to chmod(2).
+ *
+ * Returns 0 for success, -1 for failure. Sets errno for failure.
+ */
+extern "C"
+int32_t ChMod(
+    const char* path,
+    int32_t mode);
+
+/**
+ * Create a FIFO (named pipe). Implemented as a shim to mkfifo(3).
+ *
+ * Returns 0 for success, -1 for failure. Sets errno for failure.
+ */    
+extern "C"
+int32_t MkFifo(
+    const char* path,
+    int32_t mode);

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -262,8 +262,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.chdir.cs">
       <Link>Common\Interop\Unix\Interop.chdir.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.chmod.cs">
-      <Link>Common\Interop\Unix\Interop.chmod.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ChMod.cs">
+      <Link>Common\Interop\Unix\Interop.ChMod.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
@@ -292,13 +292,13 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek.cs">
       <Link>Common\Interop\Unix\Interop.lseek64.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mkdir.cs">
-      <Link>Common\Interop\Unix\Interop.mkdir.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MkDir.cs">
+      <Link>Common\Interop\Unix\Interop.MkDir.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.pathconf.cs">
       <Link>Common\Interop\Unix\Interop.pathconf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.read.cs">

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -106,21 +106,21 @@ namespace System.IO
         {
             get
             {
-                Interop.libc.Permissions readBit, writeBit;
+                Interop.Sys.Permissions readBit, writeBit;
                 if (_fileStatus.Uid == Interop.Sys.GetEUid())      // does the user effectively own the file?
                 {
-                    readBit  = Interop.libc.Permissions.S_IRUSR;
-                    writeBit = Interop.libc.Permissions.S_IWUSR;
+                    readBit  = Interop.Sys.Permissions.S_IRUSR;
+                    writeBit = Interop.Sys.Permissions.S_IWUSR;
                 }
                 else if (_fileStatus.Gid == Interop.Sys.GetEGid()) // does the user belong to a group that effectively owns the file?
                 {
-                    readBit  = Interop.libc.Permissions.S_IRGRP;
-                    writeBit = Interop.libc.Permissions.S_IWGRP;
+                    readBit  = Interop.Sys.Permissions.S_IRGRP;
+                    writeBit = Interop.Sys.Permissions.S_IWGRP;
                 }
                 else                                              // everyone else
                 {
-                    readBit  = Interop.libc.Permissions.S_IROTH;
-                    writeBit = Interop.libc.Permissions.S_IWOTH;
+                    readBit  = Interop.Sys.Permissions.S_IROTH;
+                    writeBit = Interop.Sys.Permissions.S_IWOTH;
                 }
 
                 return
@@ -133,19 +133,19 @@ namespace System.IO
                 if (value) // true if going from writable to readable, false if going from readable to writable
                 {
                     // Take away all write permissions from user/group/everyone
-                    newMode &= ~(int)(Interop.libc.Permissions.S_IWUSR | Interop.libc.Permissions.S_IWGRP | Interop.libc.Permissions.S_IWOTH);
+                    newMode &= ~(int)(Interop.Sys.Permissions.S_IWUSR | Interop.Sys.Permissions.S_IWGRP | Interop.Sys.Permissions.S_IWOTH);
                 }
-                else if ((newMode & (int)Interop.libc.Permissions.S_IRUSR) != 0)
+                else if ((newMode & (int)Interop.Sys.Permissions.S_IRUSR) != 0)
                 {
                     // Give write permission to the owner if the owner has read permission
-                    newMode |= (int)Interop.libc.Permissions.S_IWUSR;
+                    newMode |= (int)Interop.Sys.Permissions.S_IWUSR;
                 }
 
                 // Change the permissions on the file
                 if (newMode != _fileStatus.Mode)
                 {
                     bool isDirectory = this is DirectoryInfo;
-                    while (Interop.CheckIo(Interop.libc.chmod(FullPath, newMode), FullPath, isDirectory)) ;
+                    while (Interop.CheckIo(Interop.Sys.ChMod(FullPath, newMode), FullPath, isDirectory)) ;
                 }
             }
         }

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -85,7 +85,7 @@ namespace System.IO
 
             // Translate the arguments into arguments for an open call
             Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, access, options); // FileShare currently ignored
-            Interop.libc.Permissions openPermissions = Interop.libc.Permissions.S_IRWXU; // creator has read/write/execute permissions; no permissions for anyone else
+            Interop.Sys.Permissions openPermissions = Interop.Sys.Permissions.S_IRWXU; // creator has read/write/execute permissions; no permissions for anyone else
 
             // Open the file and store the safe handle. Subsequent code in this method expects the safe handle to be initialized.
             _fileHandle = SafeFileHandle.Open(path, openFlags, (int)openPermissions);

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -45,8 +45,8 @@ namespace System.IO
             // Now copy over relevant read/write/execute permissions from the source to the destination
             Interop.Sys.FileStatus status;
             while (Interop.CheckIo(Interop.Sys.Stat(sourceFullPath, out status), sourceFullPath)) ;
-            int newMode = status.Mode & (int)Interop.libc.Permissions.Mask;
-            while (Interop.CheckIo(Interop.libc.chmod(destFullPath, newMode), destFullPath)) ;
+            int newMode = status.Mode & (int)Interop.Sys.Permissions.Mask;
+            while (Interop.CheckIo(Interop.Sys.ChMod(destFullPath, newMode), destFullPath)) ;
         }
 
         public override void MoveFile(string sourceFullPath, string destFullPath)
@@ -183,7 +183,7 @@ namespace System.IO
                 }
 
                 Interop.ErrorInfo errorInfo = default(Interop.ErrorInfo);
-                while ((result = Interop.libc.mkdir(name, (int)Interop.libc.Permissions.S_IRWXU)) < 0 && (errorInfo = Interop.Sys.GetLastErrorInfo()).Error == Interop.Error.EINTR) ;
+                while ((result = Interop.Sys.MkDir(name, (int)Interop.Sys.Permissions.S_IRWXU)) < 0 && (errorInfo = Interop.Sys.GetLastErrorInfo()).Error == Interop.Error.EINTR) ;
                 if (result < 0 && firstError.Error == 0)
                 {
                     // While we tried to avoid creating directories that don't

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -140,7 +140,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.OpenFlags.cs">
       <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.sysconf.cs">

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_Memory.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.BackingObject_Memory.cs
@@ -20,13 +20,13 @@ namespace System.IO.MemoryMappedFiles
             flags |= Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_EXCL; // CreateNew
 
             // Determine the permissions with which to create the file
-            Interop.libc.Permissions perms = default(Interop.libc.Permissions);
+            Interop.Sys.Permissions perms = default(Interop.Sys.Permissions);
             if ((protections & Interop.libc.MemoryMappedProtections.PROT_READ) != 0)
-                perms |= Interop.libc.Permissions.S_IRUSR;
+                perms |= Interop.Sys.Permissions.S_IRUSR;
             if ((protections & Interop.libc.MemoryMappedProtections.PROT_WRITE) != 0)
-                perms |= Interop.libc.Permissions.S_IWUSR;
+                perms |= Interop.Sys.Permissions.S_IWUSR;
             if ((protections & Interop.libc.MemoryMappedProtections.PROT_EXEC) != 0)
-                perms |= Interop.libc.Permissions.S_IXUSR;
+                perms |= Interop.Sys.Permissions.S_IXUSR;
 
             // Create the shared memory object.
             int fd;

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -162,11 +162,11 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gethostname.cs">
       <Link>Common\Interop\Unix\Interop.gethostname.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mkdir.cs">
-      <Link>Common\Interop\Unix\Interop.mkdir.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MkDir.cs">
+      <Link>Common\Interop\Unix\Interop.MkDir.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mkfifo.cs">
-      <Link>Common\Interop\Unix\Interop.mkfifo.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MkFifo.cs">
+      <Link>Common\Interop\Unix\Interop.MkFifo.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.cs">
       <Link>Common\Interop\Unix\Interop.Open.cs</Link>
@@ -174,7 +174,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.OpenFlags.cs">
       <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Pipe.cs">

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -29,7 +29,7 @@ namespace System.IO.Pipes
                 var clientHandle = Microsoft.Win32.SafeHandles.SafePipeHandle.Open(
                     _normalizedPipePath, 
                     TranslateFlags(_direction, _pipeOptions, _inheritability),
-                    (int)Interop.libc.Permissions.S_IRWXU);
+                    (int)Interop.Sys.Permissions.S_IRWXU);
 
                 // Pipe successfully opened.  Store our client handle.
                 InitializeHandle(clientHandle, isExposed: false, isAsync: (_pipeOptions & PipeOptions.Asynchronous) != 0);

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -46,7 +46,7 @@ namespace System.IO.Pipes
             _path = GetPipePath(".", pipeName);
             while (true)
             {
-                int result = Interop.libc.mkfifo(_path, (int)Interop.libc.Permissions.S_IRWXU);
+                int result = Interop.Sys.MkFifo(_path, (int)Interop.Sys.Permissions.S_IRWXU);
                 if (result == 0)
                 {
                     // The FIFO was successfully created - note that although we create the FIFO here, we don't
@@ -98,7 +98,7 @@ namespace System.IO.Pipes
             var serverHandle = Microsoft.Win32.SafeHandles.SafePipeHandle.Open(
                 _path, 
                 TranslateFlags(_direction, _options, _inheritability), 
-                (int)Interop.libc.Permissions.S_IRWXU);
+                (int)Interop.Sys.Permissions.S_IRWXU);
 
             InitializeBufferSize(serverHandle, _outBufferSize); // there's only one capacity on Linux; just use the out buffer size
             InitializeHandle(serverHandle, isExposed: false, isAsync: (_options & PipeOptions.Asynchronous) != 0);

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -280,7 +280,7 @@ namespace System.IO.Pipes
         {
             while (true)
             {
-                int result = Interop.libc.mkdir(directoryPath, (int)Interop.libc.Permissions.S_IRWXU);
+                int result = Interop.Sys.MkDir(directoryPath, (int)Interop.Sys.Permissions.S_IRWXU);
 
                 // If successful created, we're done.
                 if (result >= 0)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -298,15 +298,15 @@ namespace Internal.Cryptography.Pal
 
 #if DEBUG
                 // Verify that we're creating files with u+rw and o-rw, g-rw.
-                const Interop.libc.Permissions requiredPermissions =
-                    Interop.libc.Permissions.S_IRUSR |
-                    Interop.libc.Permissions.S_IWUSR;
+                const Interop.Sys.Permissions requiredPermissions =
+                    Interop.Sys.Permissions.S_IRUSR |
+                    Interop.Sys.Permissions.S_IWUSR;
 
-                const Interop.libc.Permissions forbiddenPermissions =
-                    Interop.libc.Permissions.S_IROTH |
-                    Interop.libc.Permissions.S_IWOTH |
-                    Interop.libc.Permissions.S_IRGRP |
-                    Interop.libc.Permissions.S_IWGRP;
+                const Interop.Sys.Permissions forbiddenPermissions =
+                    Interop.Sys.Permissions.S_IROTH |
+                    Interop.Sys.Permissions.S_IWOTH |
+                    Interop.Sys.Permissions.S_IRGRP |
+                    Interop.Sys.Permissions.S_IWGRP;
 
                 Interop.Sys.FileStatus stat;
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -149,8 +149,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
-      <Link>Common\Interop\Unix\libc\Interop.Permissions.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.Permissions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ASN1.cs</Link>


### PR DESCRIPTION
We were mixing Interop.libc.Permissions with Interop.Sys.Stat. This
is not incorrect because the numeric values are fixed by POSIX, but
it was inconsistent and confusing.

We now have shims for all functions taking mode_t.