### PR TITLE
Remove sql/ from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,7 +147,6 @@ csx/
 AppPackages/
 
 # Others
-sql/
 *.Cache
 ClientBin/
 [Ss]tyle[Cc]op.*


### PR DESCRIPTION
There is no clear indication of why this folder is excluded (it's
int the "others" section) and it is causing problems for SqlClient.

@khellang This came in from 46bd33b0. Can you shed more light on why we'd want to exclude sql/?

cc @stephentoub @saurabh500 