### PR TITLE
Unblock paths > MAX_PATH without extended syntax.

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.CreateDirectory.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CreateDirectory.cs
@@ -14,7 +14,8 @@ internal partial class Interop
 
         internal static bool CreateDirectory(string path, ref SECURITY_ATTRIBUTES lpSecurityAttributes)
         {
-            path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+            // We always want to add for CreateDirectory to get around the legacy 248 character limitation
+            path = PathInternal.AddExtendedPathPrefix(path);
             return CreateDirectoryPrivate(path, ref lpSecurityAttributes);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetFullPathNameW.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetFullPathNameW.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -9,10 +10,30 @@ partial class Interop
 {
     partial class mincore
     {
+        /// <summary>
+        /// WARNING: This overload does not implicitly handle long paths.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal unsafe static extern int GetFullPathNameW(char* path, int numBufferChars, char* buffer, IntPtr mustBeZero);
 
-        [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        internal static extern int GetFullPathNameW(string path, int numBufferChars, [Out]StringBuilder buffer, IntPtr mustBeZero);
+        [DllImport(Libraries.CoreFile_L1, EntryPoint = "GetFullPathNameW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        private static extern int GetFullPathNameWPrivate(string path, int numBufferChars, [Out]StringBuilder buffer, IntPtr mustBeZero);
+
+        internal static int GetFullPathNameW(string path, int numBufferChars, [Out]StringBuilder buffer, IntPtr mustBeZero)
+        {
+            bool wasExtended = PathInternal.IsExtended(path);
+            if (!wasExtended)
+            {
+                path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+            }
+            int result = GetFullPathNameWPrivate(path, buffer.Capacity, buffer, mustBeZero);
+
+            if (!wasExtended)
+            {
+                // We don't want to give back \\?\ if we possibly added it ourselves
+                PathInternal.RemoveExtendedPathPrefix(buffer);
+            }
+            return result;
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathNameW.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathNameW.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
 
@@ -8,10 +9,30 @@ partial class Interop
 {
     partial class mincore
     {
+        /// <summary>
+        /// WARNING: This overload does not implicitly handle long paths.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal unsafe static extern int GetLongPathNameW(char* path, char* longPathBuffer, int bufferLength);
 
-        [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        internal static extern int GetLongPathNameW(string path, [Out]StringBuilder longPathBuffer, int bufferLength);
+        [DllImport(Libraries.CoreFile_L1, EntryPoint = "GetLongPathNameW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        private static extern int GetLongPathNameWPrivate(string path, [Out]StringBuilder longPathBuffer, int bufferLength);
+
+        internal static int GetLongPathNameW(string path, [Out]StringBuilder longPathBuffer, int bufferLength)
+        {
+            bool wasExtended = PathInternal.IsExtended(path);
+            if (!wasExtended)
+            {
+                path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+            }
+            int result = GetLongPathNameWPrivate(path, longPathBuffer, longPathBuffer.Capacity);
+
+            if (!wasExtended)
+            {
+                // We don't want to give back \\?\ if we possibly added it ourselves
+                PathInternal.RemoveExtendedPathPrefix(longPathBuffer);
+            }
+            return result;
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetTempPathW.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetTempPathW.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
 

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -29,6 +29,8 @@ public class PathInternal_Windows_Tests
         InlineData(@"\\?", false),
         InlineData(@"\\", false),
         InlineData(@"//", false),
+        InlineData(@"\a", true),
+        InlineData(@"/a", true),
         InlineData(@"\", true),
         InlineData(@"/", true),
         InlineData(@"C:Path", true),
@@ -36,6 +38,7 @@ public class PathInternal_Windows_Tests
         InlineData(@"\\?\C:\Path", false),
         InlineData(@"Path", true),
         InlineData(@"X", true)]
+    [PlatformSpecific(PlatformID.Windows)]
     public void IsPathRelative(string path, bool expected)
     {
         Assert.Equal(expected, PathInternal.IsPathRelative(path));

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -210,9 +210,21 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public void DirectoryLongerThanMaxPathAsPath_ThrowsPathTooLongException()
+        public void DirectoryLongerThanMaxPath_Succeeds()
         {
             var paths = IOInputs.GetPathsLongerThanMaxPath();
+            Assert.All(paths, (path) =>
+            {
+                DirectoryInfo result = Create(path);
+                Assert.True(Directory.Exists(result.FullName));
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void DirectoryLongerThanMaxLongPath_ThrowsPathTooLongException()
+        {
+            var paths = IOInputs.GetPathsLongerThanMaxLongPath();
             Assert.All(paths, (path) =>
             {
                 Assert.Throws<PathTooLongException>(() => Create(path));
@@ -221,9 +233,21 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public void ExtendedDirectoryLongerThanLegacyMaxPathSucceeds()
+        public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
         {
-            var paths = IOInputs.GetPathsLongerThanMaxPath(useExtendedSyntax: true, includeExtendedMaxPath: false);
+            var paths = IOInputs.GetPathsLongerThanMaxLongPath(useExtendedSyntax: true);
+            Assert.All(paths, (path) =>
+            {
+                Assert.Throws<PathTooLongException>(() => Create(path));
+            });
+        }
+
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void ExtendedDirectoryLongerThanLegacyMaxPath_Succeeds()
+        {
+            var paths = IOInputs.GetPathsLongerThanMaxPath(useExtendedSyntax: true);
             Assert.All(paths, (path) =>
             {
                 Assert.True(Create(path).Exists);
@@ -232,12 +256,13 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public void DirectoryLongerThanMaxDirectoryAsPath_ThrowsPathTooLongException()
+        public void DirectoryLongerThanMaxDirectoryAsPath_Succeeds()
         {
             var paths = IOInputs.GetPathsLongerThanMaxDirectory();
             Assert.All(paths, (path) =>
             {
-                Assert.Throws<PathTooLongException>(() => Create(path));
+                var result = Create(path);
+                Assert.True(Directory.Exists(result.FullName));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -105,9 +105,9 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        public void DirectoryLongerThanMaxPathAsPath_DoesntThrow()
+        public void DirectoryLongerThanMaxLongPath_DoesntThrow()
         {
-            Assert.All((IOInputs.GetPathsLongerThanMaxPath()), (path) =>
+            Assert.All((IOInputs.GetPathsLongerThanMaxLongPath()), (path) =>
             {
                 Assert.False(Exists(path), path);
             });

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -127,11 +127,11 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        public void Path_Longer_Than_MaxPath_Throws_Exception()
+        public void Path_Longer_Than_MaxLongPath_Throws_Exception()
         {
             string testDir = GetTestFilePath();
             Directory.CreateDirectory(testDir);
-            Assert.All((IOInputs.GetPathsLongerThanMaxPath()), (path) =>
+            Assert.All((IOInputs.GetPathsLongerThanMaxLongPath()), (path) =>
             {
                 Assert.Throws<PathTooLongException>(() => Move(testDir, path));
                 Assert.Throws<PathTooLongException>(() => Move(path, testDir));
@@ -144,14 +144,26 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public void Path_With_Longer_Than_MaxDirectory_Throws_Exception()
+        public void Path_With_Longer_Than_MaxDirectory_Succeeds()
         {
             string testDir = GetTestFilePath();
             Directory.CreateDirectory(testDir);
+            Assert.True(Directory.Exists(testDir), "test directory should exist");
             Assert.All((IOInputs.GetPathsLongerThanMaxDirectory()), (path) =>
             {
-                Assert.Throws<PathTooLongException>(() => Move(testDir, path));
-                Assert.Throws<PathTooLongException>(() => Move(path, testDir));
+                string baseDestinationPath = Path.GetDirectoryName(path);
+                if (!Directory.Exists(baseDestinationPath))
+                {
+                    Directory.CreateDirectory(baseDestinationPath);
+                }
+                Assert.True(Directory.Exists(baseDestinationPath), "base destination path should exist");
+
+                Move(testDir, path);
+                Assert.False(Directory.Exists(testDir), "source directory should exist");
+                Assert.True(Directory.Exists(path), "destination directory should exist");
+                Move(path, testDir);
+                Assert.False(Directory.Exists(path), "source directory should exist");
+                Assert.True(Directory.Exists(testDir), "destination directory should exist");
             });
         }
 

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -144,13 +144,43 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void MaxPath_Windows()
+        {
+            // Create a destination path longer than the traditional Windows limit of 256 characters,
+            // but under the long path limitation (32K).
+
+            string testFileSource = Path.Combine(TestDirectory, GetTestFileName());
+            File.Create(testFileSource).Dispose();
+            Assert.True(File.Exists(testFileSource), "test file should exist");
+
+            Assert.All(IOInputs.GetPathsLongerThanMaxPath(), (path) =>
+            {
+                string baseDestinationPath = Path.GetDirectoryName(path);
+                if (!Directory.Exists(baseDestinationPath))
+                {
+                    Directory.CreateDirectory(baseDestinationPath);
+                }
+                Assert.True(Directory.Exists(baseDestinationPath), "base destination path should exist");
+
+                Move(testFileSource, path);
+                Assert.True(File.Exists(path), "moved test file should exist");
+                File.Delete(testFileSource);
+                Assert.False(File.Exists(testFileSource), "source test file should not exist");
+                Move(path, testFileSource);
+                Assert.True(File.Exists(testFileSource), "restored test file should exist");
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
         public void LongPath()
         {
             //Create a destination path longer than the traditional Windows limit of 256 characters
             string testFileSource = Path.Combine(TestDirectory, GetTestFileName());
             File.Create(testFileSource).Dispose();
 
-            Assert.All(IOInputs.GetPathsLongerThanMaxPath(), (path) =>
+            Assert.All(IOInputs.GetPathsLongerThanMaxLongPath(), (path) =>
             {
                 Assert.Throws<PathTooLongException>(() => Move(testFileSource, path));
                 File.Delete(testFileSource);

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -18,6 +18,7 @@ namespace System.IO
         private static readonly char[] InvalidFileNameChars = { '\0', '/' };
 
         private static readonly int MaxPath = Interop.libc.MaxPath;
+        private static readonly int MaxLongPath = MaxPath;
         private static readonly int MaxComponentLength = Interop.libc.MaxName;
 
         private static bool IsDirectoryOrVolumeSeparator(char c)

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -33,7 +33,7 @@ namespace System.IO
         // For example, D:\<256 char file name> isn't legal, even though it's under 260 chars.
         internal static readonly int MaxPath = 260;
         private static readonly int MaxComponentLength = 255;
-        private const int MaxLongPath = 32000;
+        internal static readonly int MaxLongPath = short.MaxValue;
 
         private static bool IsDirectoryOrVolumeSeparator(char c)
         {
@@ -323,8 +323,10 @@ namespace System.IO
                     }
 
                     int thisPos = newBuffer.Length - 1;
-                    if (thisPos - lastDirectorySeparatorPos > MaxComponentLength)
+                    if (thisPos - lastDirectorySeparatorPos > MaxComponentLength + 1)
                     {
+                        // Components can be up to 255 characters plus an additional null,
+                        // so separators can be 256 characters apart
                         throw new PathTooLongException(SR.IO_PathTooLong);
                     }
                     lastDirectorySeparatorPos = thisPos;
@@ -405,7 +407,8 @@ namespace System.IO
                 index++;
             } // end while
 
-            if (newBuffer.Length - 1 - lastDirectorySeparatorPos > MaxComponentLength)
+            // Components can be up to 255 characters plus an additional null
+            if (newBuffer.Length - lastDirectorySeparatorPos > MaxComponentLength)
             {
                 throw new PathTooLongException(SR.IO_PathTooLong);
             }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -134,21 +134,15 @@ namespace System.IO
         [System.Security.SecuritySafeCritical]  // auto-generated
         private static string NormalizePath(string path, bool fullCheck)
         {
-            return NormalizePath(path, fullCheck, MaxPath);
+            return NormalizePath(path, fullCheck, MaxLongPath, expandShortPaths: true);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         private static string NormalizePath(string path, bool fullCheck, bool expandShortPaths)
         {
-            return NormalizePath(path, fullCheck, MaxPath, expandShortPaths);
+            return NormalizePath(path, fullCheck, MaxLongPath, expandShortPaths);
         }
-
-        [System.Security.SecuritySafeCritical]  // auto-generated
-        private static string NormalizePath(string path, bool fullCheck, int maxPathLength)
-        {
-            return NormalizePath(path, fullCheck, maxPathLength, expandShortPaths: true);
-        }
-
+        
         // Returns the name and extension parts of the given path. The resulting
         // string contains the characters of path that follow the last
         // separator in path. The resulting string is null if path is null.

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -408,7 +408,9 @@ public static class PathTests
         {
             longPath.Append(Path.DirectorySeparatorChar).Append('a').Append(Path.DirectorySeparatorChar).Append('.');
         }
-        Assert.Throws<PathTooLongException>(() => Path.GetFullPath(longPath.ToString()));
+
+        // Now no longer throws unless over ~32K
+        Assert.NotNull(Path.GetFullPath(longPath.ToString()));
     }
 
     [PlatformSpecific(PlatformID.Windows)]
@@ -455,9 +457,17 @@ public static class PathTests
 
     [PlatformSpecific(PlatformID.Windows)]
     [Fact]
+    public static void GetFullPath_Windows_MaxPathNotTooLong()
+    {
+        // Shouldn't throw anymore
+        Path.GetFullPath(@"C:\" + new string('a', 255) + @"\");
+    }
+
+    [PlatformSpecific(PlatformID.Windows)]
+    [Fact]
     public static void GetFullPath_Windows_PathTooLong()
     {
-        Assert.Throws<PathTooLongException>(() => Path.GetFullPath(@"C:\" + new string('a', 255) + @"\"));
+        Assert.Throws<PathTooLongException>(() => Path.GetFullPath(@"C:\" + new string('a', short.MaxValue) + @"\"));
     }
 
     [PlatformSpecific(PlatformID.Windows)]


### PR DESCRIPTION
Also allow directories up to max component length (255) as opening does not
require extended syntax.

@stephentoub, @weshaggard, @Priya91