### PR TITLE
Fix WrappedStream.ThrowIfCantRead

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -87,8 +87,8 @@ namespace System.IO.Compression
         }
         private void ThrowIfCantRead()
         {
-            if (!CanWrite)
-                throw new NotSupportedException(SR.WritingNotSupported);
+            if (!CanRead)
+                throw new NotSupportedException(SR.ReadingNotSupported);
         }
         private void ThrowIfCantWrite()
         {


### PR DESCRIPTION
Currently `ThrowIfCantRead` checks `CanWrite` property which looks incorrect.
Actually throw line not covered by tests and seems to me it's a potential dead code
because `ZipArchive.Init` ensures that stream is readable.