### PR TITLE
Clean naming and disable stack pathhelper

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.CopyFileEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CopyFileEx.cs
@@ -9,6 +9,9 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use CopyFileEx.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L2, EntryPoint = "CopyFileExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool CopyFileExPrivate(
             string src,
@@ -26,8 +29,8 @@ internal partial class Interop
             ref int cancel,
             int flags)
         {
-            src = PathInternal.AddExtendedPathPrefixForLongPaths(src);
-            dst = PathInternal.AddExtendedPathPrefixForLongPaths(dst);
+            src = PathInternal.EnsureExtendedPrefixOverMaxPath(src);
+            dst = PathInternal.EnsureExtendedPrefixOverMaxPath(dst);
             return CopyFileExPrivate(src, dst, progressRoutine, progressData, ref cancel, flags);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.CreateDirectory.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CreateDirectory.cs
@@ -9,13 +9,16 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use CreateDirectory.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "CreateDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool CreateDirectoryPrivate(string path, ref SECURITY_ATTRIBUTES lpSecurityAttributes);
 
         internal static bool CreateDirectory(string path, ref SECURITY_ATTRIBUTES lpSecurityAttributes)
         {
             // We always want to add for CreateDirectory to get around the legacy 248 character limitation
-            path = PathInternal.AddExtendedPathPrefix(path);
+            path = PathInternal.EnsureExtendedPrefix(path);
             return CreateDirectoryPrivate(path, ref lpSecurityAttributes);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.CreateFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CreateFile.cs
@@ -10,6 +10,9 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use CreateFile.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern SafeFileHandle CreateFilePrivate(
             string lpFileName,
@@ -29,7 +32,7 @@ internal partial class Interop
             int dwFlagsAndAttributes,
             IntPtr hTemplateFile)
         {
-            lpFileName = PathInternal.AddExtendedPathPrefixForLongPaths(lpFileName);
+            lpFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(lpFileName);
             return CreateFilePrivate(lpFileName, dwDesiredAccess, dwShareMode, ref securityAttrs, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.DeleteFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.DeleteFile.cs
@@ -9,12 +9,15 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use DeleteFile.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "DeleteFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool DeleteFilePrivate(string path);
 
         internal static bool DeleteFile(string path)
         {
-            path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+            path = PathInternal.EnsureExtendedPrefixOverMaxPath(path);
             return DeleteFilePrivate(path);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.DeleteVolumeMountPoint.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.DeleteVolumeMountPoint.cs
@@ -9,13 +9,16 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use DeleteVolumeMountPoint.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "DeleteVolumeMountPointW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal static extern bool DeleteVolumeMountPointPrivate(string mountPoint);
 
 
         internal static bool DeleteVolumeMountPoint(string mountPoint)
         {
-            mountPoint = PathInternal.AddExtendedPathPrefixForLongPaths(mountPoint);
+            mountPoint = PathInternal.EnsureExtendedPrefixOverMaxPath(mountPoint);
             return DeleteVolumeMountPointPrivate(mountPoint);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.FindFirstFileEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.FindFirstFileEx.cs
@@ -10,12 +10,15 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use FindFirstFile.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "FindFirstFileExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern SafeFindHandle FindFirstFileExPrivate(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, ref WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
 
         internal static SafeFindHandle FindFirstFile(string fileName, ref WIN32_FIND_DATA data)
         {
-            fileName = PathInternal.AddExtendedPathPrefixForLongPaths(fileName);
+            fileName = PathInternal.EnsureExtendedPrefixOverMaxPath(fileName);
 
             // use FindExInfoBasic since we don't care about short name and it has better perf
             return FindFirstFileExPrivate(fileName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0);

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetFileAttributesEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetFileAttributesEx.cs
@@ -10,13 +10,15 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use GetFileAttributesEx.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "GetFileAttributesExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool GetFileAttributesExPrivate(string name, GET_FILEEX_INFO_LEVELS fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
 
-
         internal static bool GetFileAttributesEx(string name, GET_FILEEX_INFO_LEVELS fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation)
         {
-            name = PathInternal.AddExtendedPathPrefixForLongPaths(name);
+            name = PathInternal.EnsureExtendedPrefixOverMaxPath(name);
             return GetFileAttributesExPrivate(name, fileInfoLevel, ref lpFileInformation);
         }
 

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathName.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathName.cs
@@ -9,12 +9,15 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use GetLongPathName.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "GetLongPathNameW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = false)]
         private static extern int GetLongPathNamePrivate(string path, [Out]StringBuilder longPathBuffer, int bufferLength);
 
         internal static int GetLongPathName(string path, [Out]StringBuilder longPathBuffer, int bufferLength)
         {
-            path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+            path = PathInternal.EnsureExtendedPrefixOverMaxPath(path);
             return GetLongPathNamePrivate(path, longPathBuffer, bufferLength);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathNameW.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathNameW.cs
@@ -10,27 +10,30 @@ partial class Interop
     partial class mincore
     {
         /// <summary>
-        /// WARNING: This overload does not implicitly handle long paths.
+        /// WARNING: This method does not implicitly handle long paths. Use GetLongPathName.
         /// </summary>
-        [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        internal unsafe static extern int GetLongPathNameW(char* path, char* longPathBuffer, int bufferLength);
-
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "GetLongPathNameW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        private static extern int GetLongPathNameWPrivate(string path, [Out]StringBuilder longPathBuffer, int bufferLength);
+        internal unsafe static extern int GetLongPathNameUnsafe(char* path, char* longPathBuffer, int bufferLength);
 
-        internal static int GetLongPathNameW(string path, [Out]StringBuilder longPathBuffer, int bufferLength)
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use GetLongPathName.
+        /// </summary>
+        [DllImport(Libraries.CoreFile_L1, EntryPoint = "GetLongPathNameW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        private static extern int GetLongPathNamePrivate(string path, [Out]StringBuilder longPathBuffer, int bufferLength);
+
+        internal static int GetLongPathName(string path, [Out]StringBuilder longPathBuffer, int bufferLength)
         {
             bool wasExtended = PathInternal.IsExtended(path);
             if (!wasExtended)
             {
-                path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+                path = PathInternal.EnsureExtendedPrefixOverMaxPath(path);
             }
-            int result = GetLongPathNameWPrivate(path, longPathBuffer, longPathBuffer.Capacity);
+            int result = GetLongPathNamePrivate(path, longPathBuffer, longPathBuffer.Capacity);
 
             if (!wasExtended)
             {
                 // We don't want to give back \\?\ if we possibly added it ourselves
-                PathInternal.RemoveExtendedPathPrefix(longPathBuffer);
+                PathInternal.RemoveExtendedPrefix(longPathBuffer);
             }
             return result;
         }

--- a/src/Common/src/Interop/Windows/mincore/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MoveFileEx.cs
@@ -9,14 +9,17 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use MoveFile.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L2, EntryPoint = "MoveFileExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        private static extern bool MoveFileEx(string src, string dst, uint flags);
+        private static extern bool MoveFileExPrivate(string src, string dst, uint flags);
 
         internal static bool MoveFile(string src, string dst)
         {
-            src = PathInternal.AddExtendedPathPrefixForLongPaths(src);
-            dst = PathInternal.AddExtendedPathPrefixForLongPaths(dst);
-            return MoveFileEx(src, dst, 2 /* MOVEFILE_COPY_ALLOWED */);
+            src = PathInternal.EnsureExtendedPrefixOverMaxPath(src);
+            dst = PathInternal.EnsureExtendedPrefixOverMaxPath(dst);
+            return MoveFileExPrivate(src, dst, 2 /* MOVEFILE_COPY_ALLOWED */);
         }
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.RemoveDirectory.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.RemoveDirectory.cs
@@ -9,12 +9,15 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use RemoveDirectory.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "RemoveDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool RemoveDirectoryPrivate(string path);
 
         internal static bool RemoveDirectory(string path)
         {
-            path = PathInternal.AddExtendedPathPrefixForLongPaths(path);
+            path = PathInternal.EnsureExtendedPrefixOverMaxPath(path);
             return RemoveDirectoryPrivate(path);
         }
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.SetFileAttributes.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.SetFileAttributes.cs
@@ -8,12 +8,15 @@ internal partial class Interop
 {
     internal partial class mincore
     {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use SetFileAttributes.
+        /// </summary>
         [DllImport(Libraries.CoreFile_L1, EntryPoint = "SetFileAttributesW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool SetFileAttributesPrivate(string name, int attr);
 
         internal static bool SetFileAttributes(string name, int attr)
         {
-            name = PathInternal.AddExtendedPathPrefixForLongPaths(name);
+            name = PathInternal.EnsureExtendedPrefixOverMaxPath(name);
             return SetFileAttributesPrivate(name, attr);
         }
     }

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -78,11 +78,11 @@ namespace System.IO
         /// Adds the extended path prefix (\\?\) if not already present, IF the path is not relative,
         /// AND the path is more than 259 characters. (> MAX_PATH + null)
         /// </summary>
-        internal static string AddExtendedPathPrefixForLongPaths(string path)
+        internal static string EnsureExtendedPrefixOverMaxPath(string path)
         {
             if (path != null && path.Length >= MaxShortPath)
             {
-                return AddExtendedPathPrefix(path);
+                return EnsureExtendedPrefix(path);
             }
             else
             {
@@ -93,9 +93,9 @@ namespace System.IO
         /// <summary>
         /// Adds the extended path prefix (\\?\) if not already present, IF the path is not relative.
         /// </summary>
-        internal static string AddExtendedPathPrefix(string path)
+        internal static string EnsureExtendedPrefix(string path)
         {
-            if (IsExtended(path) || IsPathRelative(path) || IsDevicePath(path))
+            if (IsExtended(path) || IsRelative(path) || IsDevice(path))
                 return path;
 
             // Given \\server\share in longpath becomes \\?\UNC\server\share
@@ -108,7 +108,7 @@ namespace System.IO
         /// <summary>
         /// Removes the extended path prefix (\\?\) if present.
         /// </summary>
-        internal static string RemoveExtendedPathPrefix(string path)
+        internal static string RemoveExtendedPrefix(string path)
         {
             if (!IsExtended(path))
                 return path;
@@ -123,7 +123,7 @@ namespace System.IO
         /// <summary>
         /// Removes the extended path prefix (\\?\) if present.
         /// </summary>
-        internal static StringBuilder RemoveExtendedPathPrefix(StringBuilder path)
+        internal static StringBuilder RemoveExtendedPrefix(StringBuilder path)
         {
             if (!IsExtended(path))
                 return path;
@@ -138,7 +138,7 @@ namespace System.IO
         /// <summary>
         /// Returns true if the path uses the device syntax (\\.\)
         /// </summary>
-        internal static bool IsDevicePath(string path)
+        internal static bool IsDevice(string path)
         {
             return path != null && path.StartsWith(DevicePathPrefix, StringComparison.Ordinal);
         }
@@ -267,7 +267,7 @@ namespace System.IO
         /// for C: (rooted, but relative). "C:\a" is rooted and not relative (the current directory
         /// will not be used to modify the path).
         /// </remarks>
-        internal static bool IsPathRelative(string path)
+        internal static bool IsRelative(string path)
         {
             if (path.Length < 2)
             {

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -14,9 +14,9 @@ public class PathInternal_Windows_Tests
     [InlineData(@"\\.\Foo", @"\\.\Foo")]
     [InlineData(@"\\Server\Share", PathInternal.UncExtendedPathPrefix + @"Server\Share")]
     [PlatformSpecific(PlatformID.Windows)]
-    public void AddExtendedPathPrefixTest(string path, string expected)
+    public void EnsureExtendedPrefixTest(string path, string expected)
     {
-        Assert.Equal(expected, PathInternal.AddExtendedPathPrefix(path));
+        Assert.Equal(expected, PathInternal.EnsureExtendedPrefix(path));
     }
 
     [Theory,
@@ -39,8 +39,8 @@ public class PathInternal_Windows_Tests
         InlineData(@"Path", true),
         InlineData(@"X", true)]
     [PlatformSpecific(PlatformID.Windows)]
-    public void IsPathRelative(string path, bool expected)
+    public void IsRelativeTest(string path, bool expected)
     {
-        Assert.Equal(expected, PathInternal.IsPathRelative(path));
+        Assert.Equal(expected, PathInternal.IsRelative(path));
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -486,7 +486,7 @@ namespace System.IO
 
             // We want extended syntax so we can delete "extended" subdirectories and files
             // (most notably ones with trailing whitespace or periods)
-            RemoveDirectoryHelper(PathInternal.AddExtendedPathPrefix(fullPath), recursive, true);
+            RemoveDirectoryHelper(PathInternal.EnsureExtendedPrefix(fullPath), recursive, true);
         }
 
         [System.Security.SecurityCritical]  // auto-generated

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -176,16 +176,7 @@ namespace System.IO
             // since StringBuilder is used. 
             // 2. IsolatedStorage, which supports paths longer than MaxPath (value given 
             // by maxPathLength.
-            PathHelper newBuffer = null;
-            if (path.Length + 1 <= MaxPath)
-            {
-                char* m_arrayPtr = stackalloc char[MaxPath];
-                newBuffer = new PathHelper(m_arrayPtr, MaxPath);
-            }
-            else
-            {
-                newBuffer = new PathHelper(path.Length + MaxPath, maxPathLength);
-            }
+            PathHelper newBuffer = new PathHelper(path.Length + MaxPath, maxPathLength);
 
             uint numSpaces = 0;
             uint numDots = 0;

--- a/src/System.Runtime.Extensions/src/System/IO/PathHelper.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/PathHelper.Windows.cs
@@ -55,7 +55,10 @@ namespace System.IO
         // Whether to skip calls to Win32Native.GetLongPathName becasue we tried before and failed:
         private bool doNotTryExpandShortFileName;
 
-        // Instantiates a PathHelper with a stack alloc'd array of chars
+        /// <summary>
+        /// Instantiates a PathHelper with a stack alloc'd array of chars.
+        /// NOTE: This cannot grow past the initial length and will always fail if over MAX_PATH.
+        /// </summary>
         [System.Security.SecurityCritical]
         internal PathHelper(char* charArrayPtr, int length)
         {
@@ -166,7 +169,7 @@ namespace System.IO
             if (useStackAlloc)
             {
                 char* finalBuffer = stackalloc char[Path.MaxPath + 1];
-                int result = Interop.mincore.GetFullPathNameW(m_arrayPtr, Path.MaxPath + 1, finalBuffer, IntPtr.Zero);
+                int result = Interop.mincore.GetFullPathNameUnsafe(m_arrayPtr, Path.MaxPath + 1, finalBuffer, IntPtr.Zero);
 
                 // If success, the return buffer length does not account for the terminating null character.
                 // If in-sufficient buffer, the return buffer length does account for the path + the terminating null character.
@@ -175,7 +178,7 @@ namespace System.IO
                 {
                     char* tempBuffer = stackalloc char[result];
                     finalBuffer = tempBuffer;
-                    result = Interop.mincore.GetFullPathNameW(m_arrayPtr, result, finalBuffer, IntPtr.Zero);
+                    result = Interop.mincore.GetFullPathNameUnsafe(m_arrayPtr, result, finalBuffer, IntPtr.Zero);
                 }
 
                 // Full path is genuinely long
@@ -208,7 +211,7 @@ namespace System.IO
             else
             {
                 StringBuilder finalBuffer = new StringBuilder(m_capacity + 1);
-                int result = Interop.mincore.GetFullPathNameW(m_sb.ToString(), m_capacity + 1, finalBuffer, IntPtr.Zero);
+                int result = Interop.mincore.GetFullPathName(m_sb.ToString(), m_capacity + 1, finalBuffer, IntPtr.Zero);
 
                 // If success, the return buffer length does not account for the terminating null character.
                 // If in-sufficient buffer, the return buffer length does account for the path + the terminating null character.
@@ -216,7 +219,7 @@ namespace System.IO
                 if (result > m_maxPath)
                 {
                     finalBuffer.Length = result;
-                    result = Interop.mincore.GetFullPathNameW(m_sb.ToString(), result, finalBuffer, IntPtr.Zero);
+                    result = Interop.mincore.GetFullPathName(m_sb.ToString(), result, finalBuffer, IntPtr.Zero);
                 }
 
                 // Fullpath is genuinely long
@@ -254,7 +257,7 @@ namespace System.IO
                 char* buffer = UnsafeGetArrayPtr();
                 char* shortFileNameBuffer = stackalloc char[Path.MaxPath + 1];
 
-                int r = Interop.mincore.GetLongPathNameW(buffer, shortFileNameBuffer, Path.MaxPath);
+                int r = Interop.mincore.GetLongPathNameUnsafe(buffer, shortFileNameBuffer, Path.MaxPath);
 
                 // If success, the return buffer length does not account for the terminating null character.
                 // If in-sufficient buffer, the return buffer length does account for the path + the terminating null character.
@@ -297,12 +300,12 @@ namespace System.IO
                 bool addedPrefix = false;
                 if (tempName.Length > Path.MaxPath)
                 {
-                    tempName = PathInternal.AddExtendedPathPrefix(tempName);
+                    tempName = PathInternal.EnsureExtendedPrefix(tempName);
                     addedPrefix = true;
                 }
                 sb.Capacity = m_capacity;
                 sb.Length = 0;
-                int r = Interop.mincore.GetLongPathNameW(tempName, sb, m_capacity);
+                int r = Interop.mincore.GetLongPathName(tempName, sb, m_capacity);
 
                 if (r == 0)
                 {
@@ -324,7 +327,10 @@ namespace System.IO
                 }
 
                 if (addedPrefix)
+                {
                     r -= 4;
+                    sb = PathInternal.RemoveExtendedPrefix(sb);
+                }
 
                 // If success, the return buffer length does not account for the terminating null character.
                 // If in-sufficient buffer, the return buffer length does account for the path + the terminating null character.
@@ -332,7 +338,6 @@ namespace System.IO
                 if (r >= m_maxPath)
                     throw new PathTooLongException(SR.IO_PathTooLong);
 
-                sb = PathInternal.RemoveExtendedPathPrefix(sb);
                 Length = sb.Length;
                 return true;
             }


### PR DESCRIPTION
PathHelper doesn't handle growing past MAX_PATH when using
the stackalloc version. #3009 tracks this.

@weshaggard, @stephentoub, @Priya91 