### PR TITLE
Tighten loops on EnumerableHelpers.ToArray()

### DIFF
--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -7,6 +7,8 @@ namespace System.Collections.Generic
     internal static class EnumerableHelpers
     {
         /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
+        /// <param name="source">The enumerable to convert.</param>
+        /// <returns>The resulting array.</returns>
         internal static T[] ToArray<T>(IEnumerable<T> source)
         {
             int count;
@@ -16,6 +18,7 @@ namespace System.Collections.Generic
         }
 
         /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
+        /// <param name="source">The enumerable to convert.</param>
         /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>
         /// <returns>
         /// The resulting array.  The length of the array may be greater than <paramref name="length"/>,
@@ -23,18 +26,11 @@ namespace System.Collections.Generic
         /// </returns>
         internal static T[] ToArray<T>(IEnumerable<T> source, out int length)
         {
-            T[] arr;
-            int count = 0;
-
             ICollection<T> ic = source as ICollection<T>;
             if (ic != null)
             {
-                count = ic.Count;
-                if (count == 0)
-                {
-                    arr = Array.Empty<T>();
-                }
-                else
+                int count = ic.Count;
+                if (count != 0)
                 {
                     // Allocate an array of the desired size, then copy the elements into it. Note that this has the same 
                     // issue regarding concurrency as other existing collections like List<T>. If the collection size 
@@ -42,53 +38,64 @@ namespace System.Collections.Generic
                     // exception from overrunning the array (if the size went up) or we could end up not filling as many 
                     // items as 'count' suggests (if the size went down).  This is only an issue for concurrent collections 
                     // that implement ICollection<T>, which as of .NET 4.6 is just ConcurrentDictionary<TKey, TValue>.
-                    arr = new T[count];
+                    T[] arr = new T[count];
                     ic.CopyTo(arr, 0);
+                    length = count;
+                    return arr;
                 }
             }
             else
             {
-                arr = Array.Empty<T>();
-                foreach (var item in source)
+                using (var en = source.GetEnumerator())
                 {
-                    if (count == arr.Length)
+                    if (en.MoveNext())
                     {
-                        // MaxArrayLength is defined in Array.MaxArrayLength and in gchelpers in CoreCLR.
-                        // It represents the maximum number of elements that can be in an array where
-                        // the size of the element is greater than one byte; a separate, slightly larger constant,
-                        // is used when the size of the element is one.
-                        const int MaxArrayLength = 0x7FEFFFFF;
-
-                        // This is the same growth logic as in List<T>:
-                        // If the array is currently empty, we make it a default size.  Otherwise, we attempt to 
-                        // double the size of the array.  Doubling will overflow once the size of the array reaches
-                        // 2^30, since doubling to 2^31 is 1 larger than Int32.MaxValue.  In that case, we instead 
-                        // constrain the length to be MaxArrayLength (this overflow check works because of of the 
-                        // cast to uint).  Because a slightly larger constant is used when T is one byte in size, we 
-                        // could then end up in a situation where arr.Length is MaxArrayLength or slightly larger, such 
-                        // that we constrain newLength to be MaxArrayLength but the needed number of elements is actually 
-                        // larger than that.  For that case, we then ensure that the newLength is large enough to hold 
-                        // the desired capacity.  This does mean that in the very rare case where we've grown to such a 
-                        // large size, each new element added after MaxArrayLength will end up doing a resize.
                         const int DefaultCapacity = 4;
-                        int newLength = count == 0 ? DefaultCapacity : count * 2;
-                        if ((uint)newLength > MaxArrayLength)
+                        T[] arr = new T[DefaultCapacity];
+                        arr[0] = en.Current;
+                        int count = 1;
+                        
+                        while (en.MoveNext())
                         {
-                            newLength = MaxArrayLength;
+                            if (count == arr.Length)
+                            {
+                                // MaxArrayLength is defined in Array.MaxArrayLength and in gchelpers in CoreCLR.
+                                // It represents the maximum number of elements that can be in an array where
+                                // the size of the element is greater than one byte; a separate, slightly larger constant,
+                                // is used when the size of the element is one.
+                                const int MaxArrayLength = 0x7FEFFFFF;
+        
+                                // This is the same growth logic as in List<T>:
+                                // If the array is currently empty, we make it a default size.  Otherwise, we attempt to 
+                                // double the size of the array.  Doubling will overflow once the size of the array reaches
+                                // 2^30, since doubling to 2^31 is 1 larger than Int32.MaxValue.  In that case, we instead 
+                                // constrain the length to be MaxArrayLength (this overflow check works because of of the 
+                                // cast to uint).  Because a slightly larger constant is used when T is one byte in size, we 
+                                // could then end up in a situation where arr.Length is MaxArrayLength or slightly larger, such 
+                                // that we constrain newLength to be MaxArrayLength but the needed number of elements is actually 
+                                // larger than that.  For that case, we then ensure that the newLength is large enough to hold 
+                                // the desired capacity.  This does mean that in the very rare case where we've grown to such a 
+                                // large size, each new element added after MaxArrayLength will end up doing a resize.
+                                int newLength = count << 1;
+                                if ((uint)newLength > MaxArrayLength)
+                                {
+                                    newLength = MaxArrayLength <= count ? count + 1 : MaxArrayLength;
+                                }
+        
+                                Array.Resize(ref arr, newLength);
+                            }
+                            
+                            arr[count++] = en.Current;
                         }
-                        if (newLength < count + 1)
-                        {
-                            newLength = count + 1;
-                        }
-
-                        Array.Resize(ref arr, newLength);
+                        
+                        length = count;
+                        return arr;
                     }
-                    arr[count++] = item;
                 }
             }
 
-            length = count;
-            return arr;
+            length = 0;
+            return Array.Empty<T>();
         }
     }
 }

--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -16,6 +16,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+      <Link>System\Collections\Generic\EnumerableHelpers.cs</Link>
+    </Compile>
     <Compile Include="System\Linq\Enumerable.cs" />
     <Compile Include="System\Linq\Errors.cs" />
   </ItemGroup>

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3380,9 +3380,6 @@ namespace System.Linq
 
         internal Buffer(IEnumerable<TElement> source, bool queryInterfaces = true)
         {
-            TElement[] items = null;
-            int count = 0;
-
             if (queryInterfaces)
             {
                 Enumerable.Iterator<TElement> iterator = source as Enumerable.Iterator<TElement>;
@@ -3390,44 +3387,11 @@ namespace System.Linq
                 {
                     items = iterator.ToArray();
                     count = items.Length;
-                }
-                else
-                {
-                    ICollection<TElement> collection = source as ICollection<TElement>;
-                    if (collection != null)
-                    {
-                        count = collection.Count;
-                        if (count > 0)
-                        {
-                            items = new TElement[count];
-                            collection.CopyTo(items, 0);
-                        }
-                    }
+                    return;
                 }
             }
-
-            if (items == null)
-            {
-                using (IEnumerator<TElement> e = source.GetEnumerator())
-                {
-                    if (e.MoveNext())
-                    {
-                        items = new TElement[4];
-                        items[0] = e.Current;
-                        count = 1;
-                        
-                        while (e.MoveNext())
-                        {
-                            if (items.Length == count) Array.Resize(ref items, checked(count * 2));
-                            items[count] = e.Current;
-                            ++count;
-                        }
-                    }
-                }
-            }
-
-            this.items = items;
-            this.count = count;
+            
+            items = EnumerableHelpers.ToArray(source, out count);
         }
 
         internal TElement[] ToArray()


### PR DESCRIPTION
One change is analogous to that in 6cf2b4c in that it removes a check for the
initial state.

Also removes assignment in case where it is just overwritten.

Also moves check for new size being smaller than current size to within branch
that can lead to it.

Reduces number of resizes when between maximum non-single-byte-element array
size and maximum single-byte-element array size.

Use EnumerableHelper.ToArray in Buffer constructor:

Greater code re-use, and gains from EnumerableHelper's better support for
near-upper-limit arrays.