### PR TITLE
Fix GetFullPathName wrap.

### DIFF
--- a/src/Common/Common.Tests.sln
+++ b/src/Common/Common.Tests.sln
@@ -7,14 +7,32 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Tests", "tests\Commo
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		FreeBSD_Debug|Any CPU = FreeBSD_Debug|Any CPU
+		FreeBSD_Release|Any CPU = FreeBSD_Release|Any CPU
+		Linux_Debug|Any CPU = Linux_Debug|Any CPU
+		Linux_Release|Any CPU = Linux_Release|Any CPU
+		OSX_Debug|Any CPU = OSX_Debug|Any CPU
+		OSX_Release|Any CPU = OSX_Release|Any CPU
+		Windows_Debug|Any CPU = Windows_Debug|Any CPU
+		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.FreeBSD_Debug|Any CPU.ActiveCfg = FreeBSD_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.FreeBSD_Debug|Any CPU.Build.0 = FreeBSD_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.FreeBSD_Release|Any CPU.ActiveCfg = FreeBSD_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.FreeBSD_Release|Any CPU.Build.0 = FreeBSD_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Linux_Debug|Any CPU.ActiveCfg = Linux_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Linux_Release|Any CPU.Build.0 = Linux_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -8,14 +8,17 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Common.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
@@ -35,15 +38,23 @@
     <Compile Include="..\src\System\IO\TaskHelpers.cs">
       <Link>Common\System\IO\TaskHelpers.cs</Link>
     </Compile>
+    <Compile Include="Tests\System\IO\PathInternal.Tests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+    <Compile Include="Tests\Interop\Windows\mincore\GetFullPathName.Tests.cs" />
     <Compile Include="..\src\System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="..\src\System\IO\PathInternal.CaseSensitive.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitive.cs</Link>
     </Compile>
     <Compile Include="Tests\System\IO\PathInternal.Windows.Tests.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetFullPathNameW.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.GetFullPathNameW.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="..\src\System\IO\PathInternal.Unix.cs">

--- a/src/Common/tests/Tests/Interop/Windows/mincore/GetFullPathName.Tests.cs
+++ b/src/Common/tests/Tests/Interop/Windows/mincore/GetFullPathName.Tests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Tests.Interop.Windows
+{
+    public class GetFullPathNameTests
+    {
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"C:\", @"C:\")]
+        [InlineData(@"C:\.", @"C:\")]
+        [InlineData(@"C:\..", @"C:\")]
+        [InlineData(@"C:\..\..", @"C:\")]
+        [InlineData(@"C:\A\..", @"C:\")]
+        [InlineData(@"C:\..\..\A\..", @"C:\")]
+        public static void GetFullPathName_Windows_RelativeRoot(string path, string expected)
+        {
+            StringBuilder sb = new StringBuilder(256);
+            int result = global::Interop.mincore.GetFullPathName(path, sb.Capacity, sb);
+            Assert.True(result > 0, "GetFullPathName should succeed");
+            Assert.Equal(expected, sb.ToString());
+
+            path = PathInternal.EnsureExtendedPrefix(path);
+            result = global::Interop.mincore.GetFullPathName(path, sb.Capacity, sb);
+            Assert.True(result > 0, "GetFullPathName with extended syntax should succeed");
+            Assert.Equal(PathInternal.EnsureExtendedPrefix(expected), sb.ToString());
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPathName_Windows_LongPath()
+        {
+            // FullPathName handles > MAX_PATH
+            string path = Path.Combine(@"C:\", new string('a', 255), new string('b', 255));
+            StringBuilder sb = new StringBuilder(1024);
+            int result = global::Interop.mincore.GetFullPathName(path, sb.Capacity, sb);
+            Assert.True(result > 0, "GetFullPathName should succeed");
+            Assert.Equal(path, sb.ToString());
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPathName_Windows_LongPathRoot()
+        {
+            // Long paths shouldn't recurse past the root
+            string path = Path.Combine(@"C:\", new string('a', 255), new string('b', 255), "..", "..", "..");
+            StringBuilder sb = new StringBuilder(1024);
+            int result = global::Interop.mincore.GetFullPathName(path, sb.Capacity, sb);
+            Assert.True(result > 0, "GetFullPathName should succeed");
+            Assert.Equal(@"C:\", sb.ToString());
+
+            path = PathInternal.EnsureExtendedPrefix(path);
+            result = global::Interop.mincore.GetFullPathName(path, sb.Capacity, sb);
+            Assert.True(result > 0, "GetFullPathName should succeed");
+            Assert.Equal(@"\\?\C:\", sb.ToString());
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/IO/PathInternal.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Tests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Tests.System.IO
+{
+    public class PathInternalTests
+    {
+        public void CheckInvalidPathChars_ThrowsOnNull(string path, string expected)
+        {
+            Assert.Throws<ArgumentNullException>(() => PathInternal.CheckInvalidPathChars(null));
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using Xunit;
 
 public class PathInternal_Windows_Tests
@@ -16,6 +17,10 @@ public class PathInternal_Windows_Tests
     [PlatformSpecific(PlatformID.Windows)]
     public void EnsureExtendedPrefixTest(string path, string expected)
     {
+        StringBuilder sb = new StringBuilder(path);
+        PathInternal.EnsureExtendedPrefix(sb);
+        Assert.Equal(expected, sb.ToString());
+
         Assert.Equal(expected, PathInternal.EnsureExtendedPrefix(path));
     }
 
@@ -41,6 +46,9 @@ public class PathInternal_Windows_Tests
     [PlatformSpecific(PlatformID.Windows)]
     public void IsRelativeTest(string path, bool expected)
     {
+        StringBuilder sb = new StringBuilder(path);
+        Assert.Equal(expected, PathInternal.IsRelative(sb));
+
         Assert.Equal(expected, PathInternal.IsRelative(path));
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/PathHelper.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/PathHelper.Windows.cs
@@ -211,7 +211,7 @@ namespace System.IO
             else
             {
                 StringBuilder finalBuffer = new StringBuilder(m_capacity + 1);
-                int result = Interop.mincore.GetFullPathName(m_sb.ToString(), m_capacity + 1, finalBuffer, IntPtr.Zero);
+                int result = Interop.mincore.GetFullPathName(m_sb.ToString(), m_capacity + 1, finalBuffer);
 
                 // If success, the return buffer length does not account for the terminating null character.
                 // If in-sufficient buffer, the return buffer length does account for the path + the terminating null character.
@@ -219,7 +219,7 @@ namespace System.IO
                 if (result > m_maxPath)
                 {
                     finalBuffer.Length = result;
-                    result = Interop.mincore.GetFullPathName(m_sb.ToString(), result, finalBuffer, IntPtr.Zero);
+                    result = Interop.mincore.GetFullPathName(m_sb.ToString(), result, finalBuffer);
                 }
 
                 // Fullpath is genuinely long

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -471,6 +471,19 @@ public static class PathTests
     }
 
     [PlatformSpecific(PlatformID.Windows)]
+    [Theory]
+    [InlineData(@"C:\", @"C:\")]
+    [InlineData(@"C:\.", @"C:\")]
+    [InlineData(@"C:\..", @"C:\")]
+    [InlineData(@"C:\..\..", @"C:\")]
+    [InlineData(@"C:\A\..", @"C:\")]
+    [InlineData(@"C:\..\..\A\..", @"C:\")]
+    public static void GetFullPath_Windows_RelativeRoot(string path, string expected)
+    {
+        Assert.Equal(Path.GetFullPath(path), expected);
+    }
+
+    [PlatformSpecific(PlatformID.Windows)]
     [Fact]
     public static void GetFullPath_Windows_StrangeButLegalPaths()
     {


### PR DESCRIPTION
GetFullPathName supports arbitrarily long paths, but doesn't
support extended syntax correctly. Change the wrap to handle
paths correctly and add a number of tests. Fix the common
test solution to honor build system configs.

Also add more StringBuilder overloads for the helpers.

Note that the incorrect wrapping wasn't exposed anywhere yet.
(we normalize out paths that would have created a problem)

@stephentoub, @weshaggard, @Priya91 