### PR TITLE
XLinq: Throw ArgumentNullException from Extensions.Nodes immediately instead of lazily

### DIFF
--- a/src/System.Xml.XDocument/src/System/Xml/Linq/Extensions.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/Extensions.cs
@@ -118,6 +118,11 @@ namespace System.Xml.Linq
         public static IEnumerable<XNode> Nodes<T>(this IEnumerable<T> source) where T : XContainer
         {
             if (source == null) throw new ArgumentNullException("source");
+            return NodesIterator(source);
+        }
+
+        private static IEnumerable<XNode> NodesIterator<T>(IEnumerable<T> source) where T : XContainer
+        {
             foreach (XContainer root in source)
             {
                 if (root != null)


### PR DESCRIPTION
I noticed one of the extension methods in `System.Xml.Linq` was throwing `ArgumentNullException` from an iterator method, which means the exception is thrown from the enumerator the first time `MoveNext` is called, rather than the intended behavior of throwing immediately when the extension method is called.

This change fixes the `Nodes` extension method to throw when the method is called, to behave the way it was intended and to be consistent with the behavior of the other extension methods on this class.

This is a minor behavior change, but I think it's worth making in .NET Core because this is a developer error (should not be caught in a try/catch) and this is making the behavior consistent with the behavior of the other extension methods on this class (as well as all the extension methods provided by Linq itself).

I was going to add a test, but wasn't sure where to add it. Maybe open an up-for-grabs issue to add `Assert.Throws` tests for these extension methods, or add a work item to #642?