### PR TITLE
Using SIMD Acceleration for System.Linq Operations

### DIFF
--- a/src/System.Linq/System.Linq.sln
+++ b/src/System.Linq/System.Linq.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Linq", "src\System.Linq.csproj", "{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}"
 EndProject
@@ -18,7 +18,6 @@ Global
 		{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7C70BB15-870B-4946-8098-625DACD645A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7C70BB15-870B-4946-8098-625DACD645A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C70BB15-870B-4946-8098-625DACD645A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C70BB15-870B-4946-8098-625DACD645A6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/src/System.Linq/src/project.json
+++ b/src/System.Linq/src/project.json
@@ -1,9 +1,10 @@
-{
+﻿{
   "dependencies": {
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
+    "System.Numerics.Vectors": "4.1.0",
     "System.Reflection": "4.0.10",
     "System.Reflection.Primitives": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -171,6 +172,57 @@ namespace System.Linq.Tests
                 "namespace",
                 "namespace",
             });
+        }
+
+        [Fact]
+        public void VectorAddition()
+        {
+            int ARRAY_SIZE = 10000;
+            int[] array = RandomizeArray(ARRAY_SIZE);
+
+            int sum = 0;
+            int simdSum = 0;
+            // Sum those numbers using the tradition LINQ
+            Stopwatch sw = Stopwatch.StartNew();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                // hard-coding in the "traditional" addition method from IEnumerable<int>.Sum()
+                foreach (int num in array)
+                    sum += num;
+            }
+
+            sw.Stop();
+            
+            double linqMS = sw.Elapsed.TotalMilliseconds;
+            Debug.WriteLine("LINQ Method: " + sw.Elapsed.TotalMilliseconds.ToString() + "ms");
+
+            // Sum those numbers using SIMD (must have x64-release mode turned on for RyuJIT)
+            sw = Stopwatch.StartNew();
+            for (int j = 0; j < 1000; j++)
+                simdSum = array.Sum();
+            sw.Stop();
+
+            // Verify that the numbers are the same using the traditional way and the SIMD way
+            Assert.Equal(simdSum, sum);
+
+            double simdMS = sw.Elapsed.TotalMilliseconds;
+            Debug.WriteLine("SIMD Method: " + sw.Elapsed.TotalMilliseconds.ToString() + "ms");
+            
+        }
+
+        private int[] RandomizeArray(int arraySize)
+        {
+            Random random = new Random();
+            // Generate random array
+            int[] array = new int[arraySize];
+
+            for (int i = 0; i < arraySize; i++)
+            {
+                array[i] = random.Next(arraySize * -1, arraySize * 10);
+            }
+
+            return array;
         }
     }
 }

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -6,9 +6,12 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Console": "4.0.0-beta-*",
-    "xunit": "2.1.0-beta3-*",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+    "xunit": "2.1.0-beta4-*",
+    "xunit.runner.dnx": "2.1.0-beta4*"
   },
+   "commands":{
+          "test": "xunit.runner.dnx"
+       },
   "frameworks": {
     "dnxcore50": {}
   }


### PR DESCRIPTION
As a  sample, I've made a modificatioin to the System.Linq.Enumerable.Add<int>() method to show 2-4x speedup when using SIMD for large enumerable sources.  I've done this only for the integer addition, and I'd like to do it for the other primitive types if this acceptable.