### PR TITLE
Fix error handling in WinHttpHandler StartRequest

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1255,7 +1255,10 @@ namespace System.Net.Http
 
                 // Clear callback function in WinHTTP to prevent
                 // further native callbacks as we clean up the objects.
-                SetStatusCallback(requestHandle, null);
+                if (requestHandle != null)
+                {
+                    SetStatusCallback(requestHandle, null);
+                }
             }
 
             if (requestStateHandle.IsAllocated)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -58,6 +58,12 @@ internal static partial class Interop
             string proxyBypass,
             uint flags)
         {
+            if (TestControl.Fail.WinHttpOpen)
+            {
+                TestControl.LastWin32Error = (int)Interop.WinHttp.ERROR_INVALID_HANDLE;
+                return new FakeSafeWinHttpHandle(false);
+            }
+            
             if (accessType == Interop.WinHttp.WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY && 
                 !TestControl.WinHttpAutomaticProxySupport)
             {
@@ -156,7 +162,7 @@ internal static partial class Interop
         {
             bytesRead = 0;
 
-            if (TestControl.WinHttpAPIFail)
+            if (TestControl.Fail.WinHttpReadData)
             {
                 return false;
             }
@@ -314,7 +320,7 @@ internal static partial class Interop
             uint bufferSize,
             out uint bytesWritten)
         {
-            if (TestControl.WinHttpAPIFail)
+            if (TestControl.Fail.WinHttpWriteData)
             {
                 bytesWritten = 0;
                 return false;
@@ -501,6 +507,11 @@ internal static partial class Interop
             uint notificationFlags,
             IntPtr reserved)
         {
+            if (handle == null)
+            {
+                throw new ArgumentNullException("handle");
+            }
+            
             return IntPtr.Zero;
         }
     }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestControl.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestControl.cs
@@ -8,13 +8,18 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 {
     public static class TestControl
     {
+        public static class Fail
+        {
+            public static bool WinHttpOpen { get; set; }
+            public static bool WinHttpReadData { get; set; }
+            public static bool WinHttpWriteData { get; set; }
+        }
+        
         public static bool WinHttpAutomaticProxySupport { get; set; }
 
         public static bool WinHttpDecompressionSupport { get; set; }
 
         public static int LastWin32Error { get; set; }
-
-        public static bool WinHttpAPIFail { get; set; }
 
         public static bool PACFileNotDetectedOnNetwork { get; set; }
 
@@ -28,7 +33,9 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             WinHttpDecompressionSupport = true;
 
             LastWin32Error = 0;
-            WinHttpAPIFail = false;
+            Fail.WinHttpOpen = false;
+            Fail.WinHttpReadData = false;
+            Fail.WinHttpWriteData = false;
 
             PACFileNotDetectedOnNetwork = false;
             ResponseDelayTime = 0;

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -151,8 +151,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
             var request = new HttpRequestMessage(HttpMethod.Post, FakeServerEndpoint);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => { HttpResponseMessage response = await client.SendAsync(request); });
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(request));
         }
 
         [Fact]
@@ -287,8 +286,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
             var request = new HttpRequestMessage(HttpMethod.Post, FakeServerEndpoint);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => { HttpResponseMessage response = await client.SendAsync(request); });
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(request));
         }
 
 
@@ -304,8 +302,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
             var request = new HttpRequestMessage(HttpMethod.Post, FakeServerEndpoint);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => { HttpResponseMessage response = await client.SendAsync(request); });
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(request));
         }
 
         [Fact]
@@ -519,8 +516,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
             var request = new HttpRequestMessage(HttpMethod.Post, FakeServerEndpoint);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => { HttpResponseMessage response = await client.SendAsync(request); });
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(request));
         }
 
         // TODO: Need to skip this test due to missing native dependency clrcompression.dll.
@@ -816,8 +812,8 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             var content = new StringContent(new String('a', 1000));
             request.Content = content;
             
-            await Assert.ThrowsAsync<TaskCanceledException>(
-                async () => { await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token); });
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token));
         }
 
         [Fact]
@@ -829,8 +825,8 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Get, FakeServerEndpoint);
             
-            await Assert.ThrowsAsync<TaskCanceledException>(
-                async () => { await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token); });
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token));
         }
 
         [Fact]
@@ -842,10 +838,23 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Get, FakeServerEndpoint);
             
-            await Assert.ThrowsAsync<TaskCanceledException>(
-                async () => { await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token); });
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token));
         }
 
+        [Fact]
+        public async Task SendAsync_WinHttpOpenReturnsError_ExpectHttpRequestException()
+        {
+            var handler = new WinHttpHandler();
+            var client = new HttpClient(handler);
+            var request = new HttpRequestMessage(HttpMethod.Get, FakeServerEndpoint);
+
+            TestControl.Fail.WinHttpOpen = true;
+
+            Exception ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
+            Assert.Equal(typeof(WinHttpException), ex.InnerException.GetType());
+        }
+        
         private HttpResponseMessage SendRequestHelper(WinHttpHandler handler, Action setup)
         {
             return SendRequestHelper(handler, setup, FakeServerEndpoint);

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -217,7 +217,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            TestControl.WinHttpAPIFail = true;
+            TestControl.Fail.WinHttpWriteData = true;
             
             Assert.Throws<IOException>(() => { stream.Write(new byte[1], 0, 1); });
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -206,7 +206,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            TestControl.WinHttpAPIFail = true;
+            TestControl.Fail.WinHttpReadData = true;
             Assert.Throws<IOException>(() => { stream.Read(new byte[1], 0, 1); });
         }
 


### PR DESCRIPTION
Addresses dnu restore exception 2547

https://github.com/aspnet/dnx/issues/2547/

* Fix a code path where `requestHandle` could be `null`.
* Add unit test to simulate this error code path.