### PR TITLE
Remove use of LowLevelList<T> from X509Certificates

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -199,7 +199,7 @@ namespace Internal.Cryptography.Pal
             get
             {
                 int extensionCount = Interop.libcrypto.X509_get_ext_count(_cert);
-                LowLevelListWithIList<X509Extension> extensions = new LowLevelListWithIList<X509Extension>(extensionCount);
+                X509Extension[] extensions = new X509Extension[extensionCount];
 
                 for (int i = 0; i < extensionCount; i++)
                 {
@@ -220,9 +220,8 @@ namespace Internal.Cryptography.Pal
 
                     byte[] extData = Interop.Crypto.GetAsn1StringBytes(dataPtr);
                     bool critical = Interop.libcrypto.X509_EXTENSION_get_critical(ext);
-                    X509Extension extension = new X509Extension(oid, extData, critical);
 
-                    extensions.Add(extension);
+                    extensions[i] = new X509Extension(oid, extData, critical);
                 }
 
                 return extensions;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -354,9 +354,9 @@ namespace Internal.Cryptography.Pal
             {
                 unsafe
                 {
-                    LowLevelListWithIList<X509Extension> extensions = new LowLevelListWithIList<X509Extension>();
                     CERT_INFO* pCertInfo = _certContext.CertContext->pCertInfo;
                     int numExtensions = pCertInfo->cExtension;
+                    X509Extension[] extensions = new X509Extension[numExtensions];
                     for (int i = 0; i < numExtensions; i++)
                     {
                         CERT_EXTENSION* pCertExtension = pCertInfo->rgExtension + i;
@@ -365,8 +365,7 @@ namespace Internal.Cryptography.Pal
                         bool critical = pCertExtension->fCritical != 0;
                         byte[] rawData = pCertExtension->Value.ToByteArray();
 
-                        X509Extension extension = new X509Extension(oid, rawData, critical);
-                        extensions.Add(extension);
+                        extensions[i] = new X509Extension(oid, rawData, critical);
                     }
                     GC.KeepAlive(this);
                     return extensions;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
@@ -32,7 +32,7 @@ namespace Internal.Cryptography.Pal.Native
             // Copy the oid strings to a local list to prevent a security race condition where
             // the OidCollection or individual oids can be modified by another thread and
             // potentially cause a buffer overflow
-            LowLevelListWithIList<byte[]> oidStrings = new LowLevelListWithIList<byte[]>();
+            List<byte[]> oidStrings = new List<byte[]>();
             foreach (Oid oid in oids)
             {
                 byte[] oidString = oid.ValueAsAscii();

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -49,9 +49,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Internal\Cryptography\ICertificatePal.cs" />
-    <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs">
-      <Link>Common\System\Collections\Generic\LowLevelList.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
@@ -103,7 +103,7 @@ namespace System.Security.Cryptography.X509Certificates
             return new X509ExtensionEnumerator(this);
         }
 
-        private LowLevelListWithIList<X509Extension> _list = new LowLevelListWithIList<X509Extension>();
+        private readonly List<X509Extension> _list = new List<X509Extension>();
     }
 }
 


### PR DESCRIPTION
`System.Security.Cryptography.X509Certificates` already has a dependency on `System.Collections` and is already making use of `List<T>`. This PR removes all uses of `LowLevelList<T>` in this assembly. In some cases, switching to an array was sufficient.

cc @bartonjs