### PR TITLE
Replace try…catch with Assert.Throws in many Linq.Expressions tests

### DIFF
--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyByteAdd(byte a, byte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte>> e =
-                    Expression.Lambda<Func<byte>>(
-                        Expression.Add(
-                            Expression.Constant(a, typeof(byte)),
-                            Expression.Constant(b, typeof(byte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte));
+            Expression bExp = Expression.Constant(b, typeof(byte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
         }
 
         private static void VerifySByteAdd(sbyte a, sbyte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte>> e =
-                    Expression.Lambda<Func<sbyte>>(
-                        Expression.Add(
-                            Expression.Constant(a, typeof(sbyte)),
-                            Expression.Constant(b, typeof(sbyte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte));
+            Expression bExp = Expression.Constant(b, typeof(sbyte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
         }
 
         private static void VerifyUShortAdd(ushort a, ushort b)
@@ -648,23 +620,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyCharAdd(char a, char b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char>> e =
-                    Expression.Lambda<Func<char>>(
-                        Expression.Add(
-                            Expression.Constant(a, typeof(char)),
-                            Expression.Constant(b, typeof(char))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char));
+            Expression bExp = Expression.Constant(b, typeof(char));
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyByteDivide(byte a, byte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte>> e =
-                    Expression.Lambda<Func<byte>>(
-                        Expression.Divide(
-                            Expression.Constant(a, typeof(byte)),
-                            Expression.Constant(b, typeof(byte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte));
+            Expression bExp = Expression.Constant(b, typeof(byte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Divide(aExp, bExp));
         }
 
         private static void VerifySByteDivide(sbyte a, sbyte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte>> e =
-                    Expression.Lambda<Func<sbyte>>(
-                        Expression.Divide(
-                            Expression.Constant(a, typeof(sbyte)),
-                            Expression.Constant(b, typeof(sbyte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte));
+            Expression bExp = Expression.Constant(b, typeof(sbyte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Divide(aExp, bExp));
         }
 
         private static void VerifyUShortDivide(ushort a, ushort b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyCharDivide(char a, char b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char>> e =
-                    Expression.Lambda<Func<char>>(
-                        Expression.Divide(
-                            Expression.Constant(a, typeof(char)),
-                            Expression.Constant(b, typeof(char))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char));
+            Expression bExp = Expression.Constant(b, typeof(char));
+            Assert.Throws<InvalidOperationException>(() => Expression.Divide(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyByteModulo(byte a, byte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte>> e =
-                    Expression.Lambda<Func<byte>>(
-                        Expression.Modulo(
-                            Expression.Constant(a, typeof(byte)),
-                            Expression.Constant(b, typeof(byte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte));
+            Expression bExp = Expression.Constant(b, typeof(byte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Modulo(aExp, bExp));
         }
 
         private static void VerifySByteModulo(sbyte a, sbyte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte>> e =
-                    Expression.Lambda<Func<sbyte>>(
-                        Expression.Modulo(
-                            Expression.Constant(a, typeof(sbyte)),
-                            Expression.Constant(b, typeof(sbyte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte));
+            Expression bExp = Expression.Constant(b, typeof(sbyte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Modulo(aExp, bExp));
         }
 
         private static void VerifyUShortModulo(ushort a, ushort b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyCharModulo(char a, char b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char>> e =
-                    Expression.Lambda<Func<char>>(
-                        Expression.Modulo(
-                            Expression.Constant(a, typeof(char)),
-                            Expression.Constant(b, typeof(char))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char));
+            Expression bExp = Expression.Constant(b, typeof(char));
+            Assert.Throws<InvalidOperationException>(() => Expression.Modulo(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyByteMultiply(byte a, byte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte>> e =
-                    Expression.Lambda<Func<byte>>(
-                        Expression.Multiply(
-                            Expression.Constant(a, typeof(byte)),
-                            Expression.Constant(b, typeof(byte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte));
+            Expression bExp = Expression.Constant(b, typeof(byte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
         }
 
         private static void VerifySByteMultiply(sbyte a, sbyte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte>> e =
-                    Expression.Lambda<Func<sbyte>>(
-                        Expression.Multiply(
-                            Expression.Constant(a, typeof(sbyte)),
-                            Expression.Constant(b, typeof(sbyte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte));
+            Expression bExp = Expression.Constant(b, typeof(sbyte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
         }
 
         private static void VerifyUShortMultiply(ushort a, ushort b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyCharMultiply(char a, char b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char>> e =
-                    Expression.Lambda<Func<char>>(
-                        Expression.Multiply(
-                            Expression.Constant(a, typeof(char)),
-                            Expression.Constant(b, typeof(char))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char));
+            Expression bExp = Expression.Constant(b, typeof(char));
+            Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableByteAdd(byte? a, byte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte?>> e =
-                    Expression.Lambda<Func<byte?>>(
-                        Expression.Add(
-                            Expression.Constant(a, typeof(byte?)),
-                            Expression.Constant(b, typeof(byte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte?));
+            Expression bExp = Expression.Constant(b, typeof(byte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
         }
 
         private static void VerifyNullableSByteAdd(sbyte? a, sbyte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte?>> e =
-                    Expression.Lambda<Func<sbyte?>>(
-                        Expression.Add(
-                            Expression.Constant(a, typeof(sbyte?)),
-                            Expression.Constant(b, typeof(sbyte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte?));
+            Expression bExp = Expression.Constant(b, typeof(sbyte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
         }
 
         private static void VerifyNullableUShortAdd(ushort? a, ushort? b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableCharAdd(char? a, char? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char?>> e =
-                    Expression.Lambda<Func<char?>>(
-                        Expression.Add(
-                            Expression.Constant(a, typeof(char?)),
-                            Expression.Constant(b, typeof(char?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char?));
+            Expression bExp = Expression.Constant(b, typeof(char?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableByteDivide(byte? a, byte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte?>> e =
-                    Expression.Lambda<Func<byte?>>(
-                        Expression.Divide(
-                            Expression.Constant(a, typeof(byte?)),
-                            Expression.Constant(b, typeof(byte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte?));
+            Expression bExp = Expression.Constant(b, typeof(byte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Divide(aExp, bExp));
         }
 
         private static void VerifyNullableSByteDivide(sbyte? a, sbyte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte?>> e =
-                    Expression.Lambda<Func<sbyte?>>(
-                        Expression.Divide(
-                            Expression.Constant(a, typeof(sbyte?)),
-                            Expression.Constant(b, typeof(sbyte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte?));
+            Expression bExp = Expression.Constant(b, typeof(sbyte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Divide(aExp, bExp));
         }
 
         private static void VerifyNullableUShortDivide(ushort? a, ushort? b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableCharDivide(char? a, char? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char?>> e =
-                    Expression.Lambda<Func<char?>>(
-                        Expression.Divide(
-                            Expression.Constant(a, typeof(char?)),
-                            Expression.Constant(b, typeof(char?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char?));
+            Expression bExp = Expression.Constant(b, typeof(char?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Divide(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableByteModulo(byte? a, byte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte?>> e =
-                    Expression.Lambda<Func<byte?>>(
-                        Expression.Modulo(
-                            Expression.Constant(a, typeof(byte?)),
-                            Expression.Constant(b, typeof(byte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte?));
+            Expression bExp = Expression.Constant(b, typeof(byte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Modulo(aExp, bExp));
         }
 
         private static void VerifyNullableSByteModulo(sbyte? a, sbyte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte?>> e =
-                    Expression.Lambda<Func<sbyte?>>(
-                        Expression.Modulo(
-                            Expression.Constant(a, typeof(sbyte?)),
-                            Expression.Constant(b, typeof(sbyte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte?));
+            Expression bExp = Expression.Constant(b, typeof(sbyte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Modulo(aExp, bExp));
         }
 
         private static void VerifyNullableUShortModulo(ushort? a, ushort? b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableCharModulo(char? a, char? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char?>> e =
-                    Expression.Lambda<Func<char?>>(
-                        Expression.Modulo(
-                            Expression.Constant(a, typeof(char?)),
-                            Expression.Constant(b, typeof(char?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char?));
+            Expression bExp = Expression.Constant(b, typeof(char?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Modulo(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableByteMultiply(byte? a, byte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte?>> e =
-                    Expression.Lambda<Func<byte?>>(
-                        Expression.Multiply(
-                            Expression.Constant(a, typeof(byte?)),
-                            Expression.Constant(b, typeof(byte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte?));
+            Expression bExp = Expression.Constant(b, typeof(byte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
         }
 
         private static void VerifyNullableSByteMultiply(sbyte? a, sbyte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte?>> e =
-                    Expression.Lambda<Func<sbyte?>>(
-                        Expression.Multiply(
-                            Expression.Constant(a, typeof(sbyte?)),
-                            Expression.Constant(b, typeof(sbyte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte?));
+            Expression bExp = Expression.Constant(b, typeof(sbyte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
         }
 
         private static void VerifyNullableUShortMultiply(ushort? a, ushort? b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableCharMultiply(char? a, char? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char?>> e =
-                    Expression.Lambda<Func<char?>>(
-                        Expression.Multiply(
-                            Expression.Constant(a, typeof(char?)),
-                            Expression.Constant(b, typeof(char?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char?));
+            Expression bExp = Expression.Constant(b, typeof(char?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableByteSubtract(byte? a, byte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte?>> e =
-                    Expression.Lambda<Func<byte?>>(
-                        Expression.Subtract(
-                            Expression.Constant(a, typeof(byte?)),
-                            Expression.Constant(b, typeof(byte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte?));
+            Expression bExp = Expression.Constant(b, typeof(byte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
         }
 
         private static void VerifyNullableSByteSubtract(sbyte? a, sbyte? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte?>> e =
-                    Expression.Lambda<Func<sbyte?>>(
-                        Expression.Subtract(
-                            Expression.Constant(a, typeof(sbyte?)),
-                            Expression.Constant(b, typeof(sbyte?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte?));
+            Expression bExp = Expression.Constant(b, typeof(sbyte?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
         }
 
         private static void VerifyNullableUShortSubtract(ushort? a, ushort? b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyNullableCharSubtract(char? a, char? b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char?>> e =
-                    Expression.Lambda<Func<char?>>(
-                        Expression.Subtract(
-                            Expression.Constant(a, typeof(char?)),
-                            Expression.Constant(b, typeof(char?))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char?));
+            Expression bExp = Expression.Constant(b, typeof(char?));
+            Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -174,44 +174,16 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyByteSubtract(byte a, byte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<byte>> e =
-                    Expression.Lambda<Func<byte>>(
-                        Expression.Subtract(
-                            Expression.Constant(a, typeof(byte)),
-                            Expression.Constant(b, typeof(byte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(byte));
+            Expression bExp = Expression.Constant(b, typeof(byte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
         }
 
         private static void VerifySByteSubtract(sbyte a, sbyte b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<sbyte>> e =
-                    Expression.Lambda<Func<sbyte>>(
-                        Expression.Subtract(
-                            Expression.Constant(a, typeof(sbyte)),
-                            Expression.Constant(b, typeof(sbyte))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(sbyte));
+            Expression bExp = Expression.Constant(b, typeof(sbyte));
+            Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
         }
 
         private static void VerifyUShortSubtract(ushort a, ushort b)
@@ -639,23 +611,9 @@ namespace Tests.ExpressionCompiler.Binary
 
         private static void VerifyCharSubtract(char a, char b)
         {
-            bool failed = false;
-            try
-            {
-                Expression<Func<char>> e =
-                    Expression.Lambda<Func<char>>(
-                        Expression.Subtract(
-                            Expression.Constant(a, typeof(char)),
-                            Expression.Constant(b, typeof(char))),
-                        Enumerable.Empty<ParameterExpression>());
-            }
-            catch (InvalidOperationException)
-            {
-                // this is expected
-                failed = true;
-            }
-
-            Assert.True(failed);
+            Expression aExp = Expression.Constant(a, typeof(char));
+            Expression bExp = Expression.Constant(b, typeof(char));
+            Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -182,17 +182,8 @@ namespace Tests
         [Fact]
         public static void Contains_SourceNull()
         {
-            try
-            {
-                IEnumerable<string> source = null;
-                string value = null;
-
-                source.Contains(value);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException)
-            {
-            }
+            IEnumerable<string> source = null;
+            Assert.Throws<ArgumentNullException>("source", () => source.Contains(null));
         }
 
         public static IEnumerable<string> Contains_Source1()
@@ -458,66 +449,31 @@ namespace Tests
         [Fact]
         public static void RangeNegativeCount()
         {
-            try
-            {
-                Enumerable.Range(0, -1).ToList();
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-            }
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(0, -1));
         }
 
         [Fact]
         public static void MaxEmpty()
         {
-            try
-            {
-                Enumerable.Empty<int>().Max();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().Max());
         }
 
         [Fact]
         public static void MinEmpty()
         {
-            try
-            {
-                Enumerable.Empty<int>().Min();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().Min());
         }
 
         [Fact]
         public static void MaxNullSource()
         {
-            try
-            {
-                Enumerable.Max((IEnumerable<int>)null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException)
-            {
-            }
+            Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).Max());
         }
 
         [Fact]
         public static void MinNullSource()
         {
-            try
-            {
-                Enumerable.Min((IEnumerable<int>)null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException)
-            {
-            }
+            Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).Min());
         }
 
         [Fact]
@@ -702,23 +658,10 @@ namespace Tests
             ConstantExpression init1 = Expression.Constant(4, typeof(int));
             Expression[] inits = new Expression[] { null, init1 };
 
-            try
-            {
-                ListInitExpression result = Expression.ListInit(newExpr, inits);
-            }
-            catch (ArgumentNullException ane)
-            {
-                Assert.Equal("argument", ane.ParamName);
-            }
+            Assert.Throws<ArgumentNullException>("argument", () => Expression.ListInit(newExpr, inits));
 
             ElementInit[] einits = new ElementInit[] { };
-            try
-            {
-                ListInitExpression result1 = Expression.ListInit(newExpr, einits);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => Expression.ListInit(newExpr, einits));
         }
 
         public void Add(ref int i)
@@ -731,13 +674,7 @@ namespace Tests
             MethodInfo mi1 = typeof(Expression_Tests).GetMethod("Add");
             ConstantExpression ce1 = Expression.Constant(4, typeof(int));
 
-            try
-            {
-                ElementInit ei1 = Expression.ElementInit(mi1, new Expression[] { ce1 });
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(mi1, new Expression[] { ce1 }));
         }
 
         public class Atom
@@ -764,14 +701,9 @@ namespace Tests
         [Fact]
         public static void EqualityBetweenStructAndIterfaceFails()
         {
-            try
-            {
-                Expression.Equal(Expression.Constant(5), Expression.Constant(null, typeof(IComparable)));
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            Expression expStruct = Expression.Constant(5);
+            Expression expIface = Expression.Constant(null, typeof(IComparable));
+            Assert.Throws<InvalidOperationException>(() => Expression.Equal(expStruct, expIface));
         }
 
         [Fact]
@@ -889,14 +821,7 @@ namespace Tests
         [Fact]
         public static void ConstantNullWithValueTypeIsInvalid()
         {
-            try
-            {
-                Expression.Constant(null, typeof(int));
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(int)));
         }
 
         [Fact]
@@ -1176,27 +1101,13 @@ namespace Tests
         [Fact]
         public static void TestGetFuncTypeWithNullFails()
         {
-            try
-            {
-                Expression.GetFuncType(null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException)
-            {
-            }
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetFuncType(null));
         }
 
         [Fact]
         public static void TestGetFuncTypeWithTooManyArgsFails()
         {
-            try
-            {
-                Expression.GetFuncType(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) });
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => Expression.GetFuncType(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) }));
         }
 
         [Fact]
@@ -1996,13 +1907,7 @@ namespace Tests
             Assert.Equal(f2().Value.Name, "lhs");
 
             var constant = Expression.Constant(1.0, typeof(double));
-            try
-            {
-                Expression<Func<double?>> e = Expression.Lambda<Func<double?>>(constant, null);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => Expression.Lambda<Func<double?>>(constant, null));
         }
 
         public static int GetBound()
@@ -3067,15 +2972,8 @@ namespace Tests
         [Fact]
         public static void InvokeNonTypedLambdaFails()
         {
-            try
-            {
-                Expression call = Expression.Call(null, typeof(Compiler_Tests).GetMethod("ComputeDynamicLambda", BindingFlags.Static | BindingFlags.Public), new Expression[] { });
-                InvocationExpression ie = Expression.Invoke(call, null);
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Expression call = Expression.Call(null, typeof(Compiler_Tests).GetMethod("ComputeDynamicLambda", BindingFlags.Static | BindingFlags.Public), new Expression[] { });
+            Assert.Throws<ArgumentException>(() => Expression.Invoke(call, null));
         }
 
         public static LambdaExpression ComputeDynamicLambda()
@@ -3086,15 +2984,8 @@ namespace Tests
         [Fact]
         public static void InvokeNonTypedDelegateFails()
         {
-            try
-            {
-                Expression call = Expression.Call(null, typeof(Compiler_Tests).GetMethod("ComputeDynamicDelegate", BindingFlags.Static | BindingFlags.Public), new Expression[] { });
-                InvocationExpression ie = Expression.Invoke(call, null);
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Expression call = Expression.Call(null, typeof(Compiler_Tests).GetMethod("ComputeDynamicDelegate", BindingFlags.Static | BindingFlags.Public), new Expression[] { });
+            Assert.Throws<ArgumentException>(() => Expression.Invoke(call, null));
         }
 
         public static Delegate ComputeDynamicDelegate()
@@ -3454,37 +3345,15 @@ namespace Tests
         [Fact]
         public static void StructStructMemberInitializationThroughPropertyThrowsException()
         {
-            try
-            {
-                Expression<Func<int, StructX>> f = GetExpressionTreeForMemberInitializationThroughProperty<StructX>();
-                var d = f.Compile();
-                StructX x = d(5);
-                Assert.Equal(5, x.A);
-                Assert.Equal(6, x.B);
-                Assert.Equal(7, x.SY.B);
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            Expression<Func<int, StructX>> f = GetExpressionTreeForMemberInitializationThroughProperty<StructX>();
+            Assert.Throws<InvalidOperationException>(() => f.Compile());
         }
 
         [Fact]
         public static void ClassStructMemberInitializationThroughPropertyThrowsException()
         {
-            try
-            {
-                Expression<Func<int, ClassX>> f = GetExpressionTreeForMemberInitializationThroughProperty<ClassX>();
-                var d = f.Compile();
-                ClassX x = d(5);
-                Assert.Equal(5, x.A);
-                Assert.Equal(6, x.B);
-                Assert.Equal(7, x.SY.B);
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            Expression<Func<int, ClassX>> f = GetExpressionTreeForMemberInitializationThroughProperty<ClassX>();
+            Assert.Throws<InvalidOperationException>(() => f.Compile());
         }
 
 
@@ -3654,36 +3523,22 @@ namespace Tests
         [Fact]
         public static void ConvertUnsignedToSigned()
         {
-            Func<sbyte> f2 = Expression.Lambda<Func<sbyte>>(Expression.Convert(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).Compile();
-            Assert.Equal((sbyte)-1, f2());
+            Func<sbyte> f = Expression.Lambda<Func<sbyte>>(Expression.Convert(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).Compile();
+            Assert.Equal((sbyte)-1, f());
         }
 
         [Fact]
         public static void ConvertCheckedSignedToUnsigned()
         {
-            try
-            {
-                Func<ulong> f = Expression.Lambda<Func<ulong>>(Expression.ConvertChecked(Expression.Constant((sbyte)-1), typeof(ulong))).Compile();
-                ulong result = f();
-                Assert.False(true);
-            }
-            catch (OverflowException)
-            {
-            }
+            Func<ulong> f = Expression.Lambda<Func<ulong>>(Expression.ConvertChecked(Expression.Constant((sbyte)-1), typeof(ulong))).Compile();
+            Assert.Throws<OverflowException>(() => f());
         }
 
         [Fact]
         public static void ConvertCheckedUnsignedToSigned()
         {
-            try
-            {
-                Func<sbyte> f2 = Expression.Lambda<Func<sbyte>>(Expression.ConvertChecked(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).Compile();
-                sbyte result = f2();
-                Assert.False(true);
-            }
-            catch (OverflowException)
-            {
-            }
+            Func<sbyte> f = Expression.Lambda<Func<sbyte>>(Expression.ConvertChecked(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).Compile();
+            Assert.Throws<OverflowException>(() => f());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -108,34 +108,12 @@ namespace Tests.ExpressionCompiler.Unary
 
         private static void VerifyArithmeticNegateNullableByte(byte? value)
         {
-            try
-            {
-                Expression<Func<byte?>> e =
-                   Expression.Lambda<Func<byte?>>(
-                       Expression.Negate(Expression.Constant(value, typeof(byte?))),
-                       Enumerable.Empty<ParameterExpression>());
-                Assert.False(true); // shouldn't get here
-            }
-            catch (InvalidOperationException)
-            {
-                // success
-            }
+            Assert.Throws<InvalidOperationException>(() => Expression.Negate(Expression.Constant(value, typeof(byte?))));
         }
 
         private static void VerifyArithmeticNegateNullableChar(char? value)
         {
-            try
-            {
-                Expression<Func<char?>> e =
-                   Expression.Lambda<Func<char?>>(
-                       Expression.Negate(Expression.Constant(value, typeof(char?))),
-                       Enumerable.Empty<ParameterExpression>());
-                Assert.False(true); // shouldn't get here
-            }
-            catch (InvalidOperationException)
-            {
-                // success
-            }
+            Assert.Throws<InvalidOperationException>(() => Expression.Negate(Expression.Constant(value, typeof(char?))));
         }
 
         private static void VerifyArithmeticNegateNullableDecimal(decimal? value)
@@ -190,18 +168,7 @@ namespace Tests.ExpressionCompiler.Unary
 
         private static void VerifyArithmeticNegateNullableSByte(sbyte? value)
         {
-            try
-            {
-                Expression<Func<sbyte?>> e =
-                   Expression.Lambda<Func<sbyte?>>(
-                       Expression.Negate(Expression.Constant(value, typeof(sbyte?))),
-                       Enumerable.Empty<ParameterExpression>());
-                Assert.False(true); // shouldn't get here
-            }
-            catch (InvalidOperationException)
-            {
-                // success
-            }
+            Assert.Throws<InvalidOperationException>(() => Expression.Negate(Expression.Constant(value, typeof(sbyte?))));
         }
 
         private static void VerifyArithmeticNegateNullableShort(short? value)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -108,34 +108,12 @@ namespace Tests.ExpressionCompiler.Unary
 
         private static void VerifyArithmeticNegateByte(byte value)
         {
-            try
-            {
-                Expression<Func<byte>> e =
-                   Expression.Lambda<Func<byte>>(
-                       Expression.Negate(Expression.Constant(value, typeof(byte))),
-                       Enumerable.Empty<ParameterExpression>());
-                Assert.False(true); // shouldn't get here
-            }
-            catch (InvalidOperationException)
-            {
-                // success
-            }
+            Assert.Throws<InvalidOperationException>(() => Expression.Negate(Expression.Constant(value, typeof(byte))));
         }
 
         private static void VerifyArithmeticNegateChar(char value)
         {
-            try
-            {
-                Expression<Func<char>> e =
-                   Expression.Lambda<Func<char>>(
-                       Expression.Negate(Expression.Constant(value, typeof(char))),
-                       Enumerable.Empty<ParameterExpression>());
-                Assert.False(true); // shouldn't get here
-            }
-            catch (InvalidOperationException)
-            {
-                // success
-            }
+            Assert.Throws<InvalidOperationException>(() => Expression.Negate(Expression.Constant(value, typeof(char))));
         }
 
         private static void VerifyArithmeticNegateDecimal(decimal value)
@@ -190,18 +168,7 @@ namespace Tests.ExpressionCompiler.Unary
 
         private static void VerifyArithmeticNegateSByte(sbyte value)
         {
-            try
-            {
-                Expression<Func<sbyte>> e =
-                   Expression.Lambda<Func<sbyte>>(
-                       Expression.Negate(Expression.Constant(value, typeof(sbyte))),
-                       Enumerable.Empty<ParameterExpression>());
-                Assert.False(true); // shouldn't get here
-            }
-            catch (InvalidOperationException)
-            {
-                // success
-            }
+            Assert.Throws<InvalidOperationException>(() => Expression.Negate(Expression.Constant(value, typeof(sbyte))));
         }
 
         private static void VerifyArithmeticNegateShort(short value)


### PR DESCRIPTION
More idiomatic, test tighter to the throw, and in a few cases narrower
exception type test or parameter name test added.