### PR TITLE
Allow block expressions to have zero sub-expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -179,6 +179,50 @@ namespace System.Linq.Expressions
     }
 
     #region Specialized Subclasses
+    
+    internal sealed class Block0 : BlockExpression
+    {
+        internal Block0()
+        {
+        }
+        
+        internal override Expression GetExpression(int index)
+        {
+            throw new InvalidOperationException();
+        }
+        
+        internal override int ExpressionCount
+        {
+            get { return 0; }
+        }
+        
+        public override Type Type
+        {
+            get { return typeof(void); }
+        }
+        
+        public override Expression Reduce()
+        {
+            return Expression.Empty();
+        }
+        
+        public override bool CanReduce
+        {
+            get { return true; }
+        }
+        
+        internal override ReadOnlyCollection<Expression> GetOrMakeExpressions()
+        {
+            return EmptyReadOnlyCollection<Expression>.Instance;
+        }
+        
+        internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
+        {
+            Debug.Assert(args.Length == 0);
+            Debug.Assert(variables == null || variables.Count == 0);
+            return new Block0();
+        }
+    }
 
     internal sealed class Block2 : BlockExpression
     {
@@ -781,12 +825,12 @@ namespace System.Linq.Expressions
 
             switch (expressions.Length)
             {
+                case 0: return new Block0();
                 case 2: return Block(expressions[0], expressions[1]);
                 case 3: return Block(expressions[0], expressions[1], expressions[2]);
                 case 4: return Block(expressions[0], expressions[1], expressions[2], expressions[3]);
                 case 5: return Block(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
                 default:
-                    ContractUtils.RequiresNotEmpty(expressions, "expressions");
                     RequiresCanRead(expressions, "expressions");
                     return new BlockN(expressions.Copy());
             }
@@ -858,10 +902,9 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(expressions, "expressions");
             var expressionList = expressions.ToReadOnly();
-            ContractUtils.RequiresNotEmpty(expressionList, "expressions");
             RequiresCanRead(expressionList, "expressions");
 
-            return Block(expressionList.Last().Type, variables, expressionList);
+            return Block(expressionList.Count == 0 ? typeof(void) : expressionList.Last().Type, variables, expressionList);
         }
 
         /// <summary>
@@ -879,20 +922,21 @@ namespace System.Linq.Expressions
             var expressionList = expressions.ToReadOnly();
             var variableList = variables.ToReadOnly();
 
-            ContractUtils.RequiresNotEmpty(expressionList, "expressions");
+            if (type != typeof(void))
+                ContractUtils.RequiresNotEmpty(expressionList, "expressions");
             RequiresCanRead(expressionList, "expressions");
             ValidateVariables(variableList, "variables");
-
-            Expression last = expressionList.Last();
+            
+            Type lastType = expressionList.Count == 0 ? typeof(void) : expressionList.Last().Type;
             if (type != typeof(void))
             {
-                if (!TypeUtils.AreReferenceAssignable(type, last.Type))
+                if (!TypeUtils.AreReferenceAssignable(type, lastType))
                 {
                     throw Error.ArgumentTypesMustMatch();
                 }
             }
 
-            if (!TypeUtils.AreEquivalent(type, last.Type))
+            if (expressionList.Count == 0 || !TypeUtils.AreEquivalent(type, lastType))
             {
                 return new ScopeWithType(variableList, expressionList, type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -598,6 +598,35 @@ namespace System.Linq.Expressions
 
             return new ScopeWithType(ReuseOrValidateVariables(variables), args, _type);
         }
+        
+        public override bool CanReduce
+        {
+            get
+            {
+                switch(ExpressionCount)
+                {
+                    case 0:
+                        return true;
+                    case 1:
+                        return VariableCount == 0;
+                    default:
+                        return false;
+                }
+            }
+        }
+        
+        public override Expression Reduce()
+        {
+            switch(ExpressionCount)
+            {
+                case 0:
+                    return Expression.Empty();
+                case 1:
+                    return VariableCount == 0 ? Expressions[0] : this;
+                default:
+                    return this;
+            }
+        }
     }
 
     #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
@@ -265,6 +265,7 @@ namespace System.Linq.Expressions.Compiler
                     case ExpressionType.Block:
                         // Look in the last significant expression of a block
                         var body = (BlockExpression)expression;
+                        if (body.ExpressionCount == 0) return; // No labels.
                         // omit empty and debuginfo at the end of the block since they
                         // are not going to emit any IL
                         for (int i = body.ExpressionCount - 1; i >= 0; i--)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -20,11 +20,14 @@ namespace System.Linq.Expressions.Compiler
 
         private void Emit(BlockExpression node, CompilationFlags flags)
         {
+            int count = node.ExpressionCount;
+            
+            if (count == 0) return;
+            
             EnterScope(node);
 
             CompilationFlags emitAs = flags & CompilationFlags.EmitAsTypeMask;
 
-            int count = node.ExpressionCount;
             CompilationFlags tailCall = flags & CompilationFlags.EmitAsTailCallMask;
             for (int index = 0; index < count - 1; index++)
             {

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -3935,6 +3935,17 @@ namespace Tests
         }
         
         [Fact]
+        public void EmptyBlockReducible()
+        {
+            var block = Expression.Block();
+            Assert.True(block.CanReduce);
+            var reduced = block.ReduceAndCheck();
+            Assert.Equal(typeof(void), reduced.Type);
+            Action nop = Expression.Lambda<Action>(reduced).Compile();
+            nop();
+        }
+
+        [Fact]
         public void EmptyBlockExplicitType()
         {
             var block = Expression.Block(typeof(void));
@@ -3943,6 +3954,17 @@ namespace Tests
             nop();
         }
         
+        [Fact]
+        public void EmptyBlockExplicitTypeReducible()
+        {
+            var block = Expression.Block(typeof(void));
+            Assert.True(block.CanReduce);
+            var reduced = block.ReduceAndCheck();
+            Assert.Equal(typeof(void), reduced.Type);
+            Action nop = Expression.Lambda<Action>(reduced).Compile();
+            nop();
+        }
+
         [Fact]
         public void EmptyBlockWrongExplicitType()
         {
@@ -3959,11 +3981,33 @@ namespace Tests
         }
 
         [Fact]
+        public void EmptyScopeReducible()
+        {
+            var scope = Expression.Block(new []{ Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.True(scope.CanReduce);
+            var reduced = scope.ReduceAndCheck();
+            Assert.Equal(typeof(void), reduced.Type);
+            Action nop = Expression.Lambda<Action>(reduced).Compile();
+            nop();
+        }
+
+        [Fact]
         public void EmptyScopeExplicitType()
         {
             var scope = Expression.Block(typeof(void), new []{ Expression.Parameter(typeof(int), "x") }, new Expression[0]);
             Assert.Equal(typeof(void), scope.Type);
             Action nop = Expression.Lambda<Action>(scope).Compile();
+            nop();
+        }
+
+        [Fact]
+        public void EmptyScopeExplicitTypeReducible()
+        {
+            var scope = Expression.Block(typeof(void), new []{ Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.True(scope.CanReduce);
+            var reduced = scope.ReduceAndCheck();
+            Assert.Equal(typeof(void), reduced.Type);
+            Action nop = Expression.Lambda<Action>(reduced).Compile();
             nop();
         }
 

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -3924,6 +3924,57 @@ namespace Tests
             Assert.Equal("hello", f("HI"));
             Assert.Equal("null", f(null));
         }
+        
+        [Fact]
+        public void EmptyBlock()
+        {
+            var block = Expression.Block();
+            Assert.Equal(typeof(void), block.Type);
+            Action nop = Expression.Lambda<Action>(block).Compile();
+            nop();
+        }
+        
+        [Fact]
+        public void EmptyBlockExplicitType()
+        {
+            var block = Expression.Block(typeof(void));
+            Assert.Equal(typeof(void), block.Type);
+            Action nop = Expression.Lambda<Action>(block).Compile();
+            nop();
+        }
+        
+        [Fact]
+        public void EmptyBlockWrongExplicitType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int)));
+        }
+        
+        [Fact]
+        public void EmptyScope()
+        {
+            var scope = Expression.Block(new []{ Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.Equal(typeof(void), scope.Type);
+            Action nop = Expression.Lambda<Action>(scope).Compile();
+            nop();
+        }
+
+        [Fact]
+        public void EmptyScopeExplicitType()
+        {
+            var scope = Expression.Block(typeof(void), new []{ Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.Equal(typeof(void), scope.Type);
+            Action nop = Expression.Lambda<Action>(scope).Compile();
+            nop();
+        }
+
+        [Fact]
+        public void EmptyScopeExplicitWrongType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Block(
+                typeof(int),
+                new []{ Expression.Parameter(typeof(int), "x") },
+                new Expression[0]));
+        }
 
         [Fact]
         public static void BinaryOperators()


### PR DESCRIPTION
Fixes #3043

Type of the block is always void. It remains an error to explicitly set it to
anything else.