### PR TITLE
Separate ToArray specialisation from Enumerable.Iterator

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -106,14 +106,9 @@ namespace System.Linq
 
             public IEnumerator<TSource> GetEnumerator()
             {
-                if (state == 0 && _threadId == Environment.CurrentManagedThreadId)
-                {
-                    state = 1;
-                    return this;
-                }
-                Iterator<TSource> duplicate = Clone();
-                duplicate.state = 1;
-                return duplicate;
+                Iterator<TSource> enumerator = state == 0 && _threadId == Environment.CurrentManagedThreadId ? this : Clone();
+                enumerator.state = 1;
+                return enumerator;
             }
 
             public abstract bool MoveNext();
@@ -413,7 +408,7 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
-                if (_predicate != null) return null;
+                if (_predicate != null && _source.Length != 0) return null;
 
                 var results = new TResult[_source.Length];
                 for (int i = 0; i < results.Length; i++)
@@ -479,7 +474,7 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
-                if (_predicate != null) return null;
+                if (_predicate != null && _source.Count != 0) return null;
 
                 var results = new TResult[_source.Count];
                 for (int i = 0; i < results.Length; i++)
@@ -1004,6 +999,12 @@ namespace System.Linq
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
+            IArrayProvider<TSource> arrayProvider = source as IArrayProvider<TSource>;
+            if (arrayProvider != null)
+            {
+                TSource[] array = arrayProvider.ToArray();
+                if (array != null) return array;
+            }
             return new Buffer<TSource>(source).ToArray();
         }
 
@@ -1428,23 +1429,134 @@ namespace System.Linq
         {
             long max = ((long)start) + count - 1;
             if (count < 0 || max > Int32.MaxValue) throw Error.ArgumentOutOfRange("count");
-            return RangeIterator(start, count);
+            return new RangeIterator(start, count);
         }
 
-        private static IEnumerable<int> RangeIterator(int start, int count)
+        private sealed class RangeIterator : Iterator<int>, IArrayProvider<int>
         {
-            for (int end = start + count; start != end; start++) yield return start;
+            private readonly int _start;
+            private readonly int _end;
+            
+            public RangeIterator(int start, int count)
+            {
+                _start = start;
+                _end = start + count;
+            }
+            
+            public override Iterator<int> Clone()
+            {
+                return new RangeIterator(_start, _end - _start);
+            }
+            
+            public override bool MoveNext()
+            {
+                switch(state)
+                {
+                    case 1:
+                        if (_start == _end) break;
+                        current = _start;
+                        state = 2;
+                        return true;
+                    case 2:
+                        if (++current == _end)
+                        {
+                            --current; // Not crucial but maintains compatibility with previous versions. 
+                            break;
+                        }
+                        return true;
+                }
+                state = -1;
+                return false;
+            }
+            
+            public override void Dispose()
+            {
+                state = -1; // Don't reset current
+            }
+
+            public override IEnumerable<TResult> Select<TResult>(Func<int, TResult> selector)
+            {
+                return new WhereSelectEnumerableIterator<int, TResult>(this, null, selector);
+            }
+
+            public override IEnumerable<int> Where(Func<int, bool> predicate)
+            {
+                return new WhereEnumerableIterator<int>(this, predicate);
+            }
+
+            public int[] ToArray()
+            {
+                int[] array = new int[_end - _start];
+                int cur = _start;
+                for (int i = 0; i != array.Length; ++i)
+                {
+                    array[i] = cur;
+                    ++cur;
+                }
+
+                return array;
+            }
         }
 
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)
         {
             if (count < 0) throw Error.ArgumentOutOfRange("count");
-            return RepeatIterator<TResult>(element, count);
+            return new RepeatIterator<TResult>(element, count);
         }
 
-        private static IEnumerable<TResult> RepeatIterator<TResult>(TResult element, int count)
+        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IArrayProvider<TResult>
         {
-            for (int i = 0; i < count; i++) yield return element;
+            private readonly int _count;
+            private int _sent;
+
+            public RepeatIterator(TResult element, int count)
+            {
+                current = element;
+                _count = count;
+            }
+            
+            public override Iterator<TResult> Clone()
+            {
+                return new RepeatIterator<TResult>(current, _count);
+            }
+            
+            public override void Dispose()
+            {
+                // Don't let base Dispose wipe current.
+                state = -1;
+            }
+            
+            public override bool MoveNext()
+            {
+                if (state == 1 & _sent != _count)
+                {
+                    ++_sent;
+                    return true;
+                }
+                state = -1;
+                return false;
+            }
+
+            public override IEnumerable<TSelected> Select<TSelected>(Func<TResult, TSelected> selector)
+            {
+                return new WhereSelectEnumerableIterator<TResult, TSelected>(this, null, selector);
+            }
+
+            public override IEnumerable<TResult> Where(Func<TResult, bool> predicate)
+            {
+                return new WhereEnumerableIterator<TResult>(this, predicate);
+            }
+            
+            public TResult[] ToArray()
+            {
+                TResult[] array = new TResult[_count];
+                if (current != null)
+                {
+                    for (int i = 0; i != array.Length; ++i) array[i] = current;
+                }
+
+                return array;
+            }
         }
 
         public static IEnumerable<TResult> Empty<TResult>()
@@ -2759,8 +2871,15 @@ namespace System.Linq
         }
     }
 
+    /// <summary>
+    /// An iterator that can (or sometimes can) produce an array through an optimized path.
+    /// </summary>
     internal interface IArrayProvider<TElement>
     {
+        /// <summary>
+        /// Produce an array of the sequence through an optimized path, if possible.
+        /// </summary>
+        /// <returns>The array, or null if an optimized path isn't possible, and default behaviour should be used.</returns>
         TElement[] ToArray();
     }
 
@@ -2789,7 +2908,7 @@ namespace System.Linq
         bool Contains(TKey key);
     }
 
-    public class Lookup<TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, ILookup<TKey, TElement>
+    public class Lookup<TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, ILookup<TKey, TElement>, IArrayProvider<IGrouping<TKey, TElement>>
     {
         private IEqualityComparer<TKey> _comparer;
         private Grouping<TKey, TElement>[] _groupings;
@@ -2858,6 +2977,23 @@ namespace System.Linq
                     yield return g;
                 } while (g != _lastGrouping);
             }
+        }
+        
+        public IGrouping<TKey, TElement>[] ToArray()
+        {
+            IGrouping<TKey, TElement>[] array = new IGrouping<TKey, TElement>[_count];
+            int index = 0;
+            Grouping<TKey, TElement> g = _lastGrouping;
+            if (g != null)
+            {
+                do
+                {
+                    g = g.next;
+                    array[index] = g;
+                    ++index;
+                } while (g != _lastGrouping);
+            }
+            return array;
         }
 
         public IEnumerable<TResult> ApplyResultSelector<TResult>(Func<TKey, IEnumerable<TElement>, TResult> resultSelector)
@@ -3193,7 +3329,7 @@ namespace System.Linq
         }
     }
 
-    internal class GroupedEnumerable<TSource, TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>
+    internal class GroupedEnumerable<TSource, TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, IArrayProvider<IGrouping<TKey, TElement>>
     {
         private IEnumerable<TSource> _source;
         private Func<TSource, TKey> _keySelector;
@@ -3220,22 +3356,44 @@ namespace System.Linq
         {
             return GetEnumerator();
         }
+        
+        public IGrouping<TKey, TElement>[] ToArray()
+        {
+            return Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer).ToArray();
+        }
     }
 
-    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>
+    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IArrayProvider<TElement>
     {
         internal IEnumerable<TElement> source;
+        
+        private int[] SortedMap(Buffer<TElement> buffer)
+        {
+            return GetEnumerableSorter(null).Sort(buffer.items, buffer.count);
+        }
 
         public IEnumerator<TElement> GetEnumerator()
         {
             Buffer<TElement> buffer = new Buffer<TElement>(source);
             if (buffer.count > 0)
             {
-                EnumerableSorter<TElement> sorter = GetEnumerableSorter(null);
-                int[] map = sorter.Sort(buffer.items, buffer.count);
-                sorter = null;
+                int[] map = SortedMap(buffer);
                 for (int i = 0; i < buffer.count; i++) yield return buffer.items[map[i]];
             }
+        }
+        
+        public TElement[] ToArray()
+        {
+            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            int count = buffer.count;
+            TElement[] array = new TElement[count];
+            if (count > 0)
+            {
+                int[] map = SortedMap(buffer);
+                for (int i = 0; i != array.Length; i++) array[i] = buffer.items[map[i]];
+            }
+
+            return array;
         }
 
         internal abstract EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement> next);

--- a/src/System.Linq/tests/LegacyTests/GroupByTests.cs
+++ b/src/System.Linq/tests/LegacyTests/GroupByTests.cs
@@ -1151,5 +1151,23 @@ namespace System.Linq.Tests.LegacyTests
                 Assert.Equal(0, Main());
             }
         }
+        
+        [Fact]
+        public void GroupingToArray()
+        {
+            Record[] source = new Record[]
+            {
+                new Record{ Name = "Tim", Score = 55 },
+                new Record{ Name = "Chris", Score = 49 },
+                new Record{ Name = "Robert", Score = -100 },
+                new Record{ Name = "Chris", Score = 24 },
+                new Record{ Name = "Prakash", Score = 9 },
+                new Record{ Name = "Tim", Score = 25 }
+            };
+            
+            IGrouping<string, Record>[] groupedArray = source.GroupBy(r => r.Name).ToArray();
+            Assert.Equal(4, groupedArray.Length);
+            Assert.Equal(source.GroupBy(r => r.Name), groupedArray);
+        }
     }
 }

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -162,6 +162,31 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.OrderBy(e => e.Score));
         }
 
+        [Fact]
+        public void OrderedToArray()
+        {
+            Record[] source = new Record[]
+            {
+                new Record{ Name = "Tim", Score = 90 },
+                new Record{ Name = "Robert", Score = 90 },
+                new Record{ Name = "Prakash", Score = 90 },
+                new Record{ Name = "Jim", Score = 90 },
+                new Record{ Name = "John", Score = 90 },
+                new Record{ Name = "Albert", Score = 90 },
+            };
+            Record[] expected = new Record[]
+            {
+                new Record{ Name = "Tim", Score = 90 },
+                new Record{ Name = "Robert", Score = 90 },
+                new Record{ Name = "Prakash", Score = 90 },
+                new Record{ Name = "Jim", Score = 90 },
+                new Record{ Name = "John", Score = 90 },
+                new Record{ Name = "Albert", Score = 90 },
+            };
+
+            Assert.Equal(expected, source.OrderBy(e => e.Score).ToArray());
+        }
+
         //FIXME: This will hang with a larger source. Do we want to deal with that case?
         [Fact]
         public void SurviveBadComparerAlwaysReturnsPositive()

--- a/src/System.Linq/tests/RangeTests.cs
+++ b/src/System.Linq/tests/RangeTests.cs
@@ -133,5 +133,18 @@ namespace System.Linq.Tests
 
             Assert.Equal(expected, Enumerable.Range(start, count));
         }
+        
+        [Fact]
+        public void RangeAsEnumeratorStartsZeroEndsAtLast()
+        {
+            // The behaviour here is not specified, but any change that breaks this is
+            // not strictly non-breaking, and while a dependency on it is perhaps unlikely
+            // such a change should be noted.
+            var ra = Enumerable.Range(4, 3);
+            var asEn = (IEnumerator<int>)ra;
+            Assert.Equal(0, asEn.Current);
+            ra.All(i => i > 0);
+            Assert.Equal(6, asEn.Current);
+        }
     }
 }


### PR DESCRIPTION
Enumerable.Iterator has a virtual ToArray that is overridden to provide
optimised array-creation & buffer-filling when possible.

Most Enumerable.Iterator subclasses don't override the default, which
results in it passing through Buffer's constructor a second time. This can
also happen if those that do override it have a predicate.

Separate out this part of Iterator's interface into a separate interface, for
only those classes that override it, and signal a failure to create an array
by returning null.

Implement this IArrayProvider in OrderedEnumerable, Lookup, GroupedEnumerable,
RangeIterator & RepeatIterator.

Bypass Buffer entirely on ToArray when this allows.