### PR TITLE
Add back WindowsIdentity::.ctor(string)

### DIFF
--- a/src/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
@@ -14,5 +14,6 @@ internal static partial class Interop
         internal const uint STATUS_NONE_MAPPED = 0xC0000073;
         internal const uint STATUS_INSUFFICIENT_RESOURCES = 0xC000009A;
         internal const uint STATUS_ACCESS_DENIED = 0xC0000022;
+        internal const uint STATUS_ACCOUNT_RESTRICTION = 0xc000006e;
     }
 }

--- a/src/Common/src/Interop/Windows/SecurityBase/Interop.AllocateLocallyUniqueId.cs
+++ b/src/Common/src/Interop/Windows/SecurityBase/Interop.AllocateLocallyUniqueId.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SecurityBase
+    {
+        [DllImport(Libraries.SecurityBase)]
+        internal static extern bool AllocateLocallyUniqueId(out LUID Luid);
+    }
+}
+

--- a/src/Common/src/Interop/Windows/sspicli/Interop.AuthenticationPackageNames.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.AuthenticationPackageNames.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        internal static class AuthenticationPackageNames
+        {
+            internal const string MICROSOFT_KERBEROS_NAME_A = "Kerberos";
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.KerbLogonSubmitType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.KerbLogonSubmitType.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        internal enum KERB_LOGON_SUBMIT_TYPE : int
+        {
+            KerbS4ULogon = 12,
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.KerbS4uLogin.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.KerbS4uLogin.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct KERB_S4U_LOGON
+        {
+            internal KERB_LOGON_SUBMIT_TYPE MessageType;
+            internal KerbS4uLogonFlags Flags;
+            internal LSA_UNICODE_STRING ClientUpn;
+            internal LSA_UNICODE_STRING ClientRealm;
+        }
+
+        [Flags]
+        internal enum KerbS4uLogonFlags : int
+        {
+            None = 0x00000000,
+            KERB_S4U_LOGON_FLAG_CHECK_LOGONHOURS = 0x00000002,
+            KERB_S4U_LOGON_FLAG_IDENTITY = 0x00000008,
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.LsaConnectUntrusted.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.LsaConnectUntrusted.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [DllImport(Interop.Libraries.Sspi)]
+        internal static extern int LsaConnectUntrusted(out SafeLsaHandle LsaHandle);
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.LsaDeregisterLogonProcess.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.LsaDeregisterLogonProcess.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [DllImport(Interop.Libraries.Sspi)]
+        internal static extern int LsaDeregisterLogonProcess(IntPtr LsaHandle);
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.LsaLogonUser.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.LsaLogonUser.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [DllImport(Libraries.Sspi)]
+        internal static extern int LsaLogonUser(
+            [In]  SafeLsaHandle LsaHandle,
+            [In]  ref LSA_STRING OriginName,
+            [In]  SECURITY_LOGON_TYPE LogonType,
+            [In]  int AuthenticationPackage,
+            [In]  IntPtr AuthenticationInformation,
+            [In]  int AuthenticationInformationLength,
+            [In]  IntPtr LocalGroups,
+            [In]  ref TOKEN_SOURCE SourceContext,
+            [Out] out SafeLsaReturnBufferHandle ProfileBuffer,
+            [Out] out int ProfileBufferLength,
+            [Out] out LUID LogonId,
+            [Out] out SafeAccessTokenHandle Token,
+            [Out] out QUOTA_LIMITS Quotas,
+            [Out] out int SubStatus
+            );
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.LsaLookupAuthenticationPackage.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.LsaLookupAuthenticationPackage.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [DllImport(Libraries.Sspi)]
+        internal static extern int LsaLookupAuthenticationPackage(SafeLsaHandle LsaHandle, [In] ref LSA_STRING PackageName, out int AuthenticationPackage);
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.LsaString.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.LsaString.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LSA_STRING
+        {
+            internal LSA_STRING(IntPtr pBuffer, ushort length)
+            {
+                Length = length;
+                MaximumLength = length;
+                Buffer = pBuffer;
+            }
+
+            /// <summary>
+            /// Specifies the length, in bytes, of the string in Buffer. This value does not include the terminating null character, if any.
+            /// </summary>
+            internal ushort Length;
+
+            /// <summary>
+            /// Specifies the total size, in bytes, of Buffer. Up to MaximumLength bytes may be written into the buffer without trampling memory.
+            /// </summary>
+            internal ushort MaximumLength;
+
+            /// <summary>
+            /// Pointer to an array of characters. Note that strings returned by the LSA may not be null-terminated.
+            /// </summary>
+            internal IntPtr Buffer;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.LsaUnicodeString.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.LsaUnicodeString.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LSA_UNICODE_STRING
+        {
+            internal LSA_UNICODE_STRING(IntPtr pBuffer, ushort length)
+            {
+                Length = length;
+                MaximumLength = length;
+                Buffer = pBuffer;
+            }
+
+            /// <summary>
+            /// Specifies the length, in bytes, of the string in Buffer. This value does not include the terminating null character, if any.
+            /// </summary>
+            internal ushort Length;
+
+            /// <summary>
+            /// Specifies the total size, in bytes, of Buffer. Up to MaximumLength bytes may be written into the buffer without trampling memory.
+            /// </summary>
+            internal ushort MaximumLength;
+
+            /// <summary>
+            /// Pointer to a wide character string. Note that strings returned by the LSA may not be null-terminated.
+            /// </summary>
+            internal IntPtr Buffer;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.QuotaLimits.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.QuotaLimits.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct QUOTA_LIMITS
+        {
+            internal IntPtr PagedPoolLimit;
+            internal IntPtr NonPagedPoolLimit;
+            internal IntPtr MinimumWorkingSetSize;
+            internal IntPtr MaximumWorkingSetSize;
+            internal IntPtr PagefileLimit;
+            internal long TimeLimit;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.SecurityLogonType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.SecurityLogonType.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        internal enum SECURITY_LOGON_TYPE : int
+        {
+            Network = 3,
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.TokenSource.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.TokenSource.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class SspiCli
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TOKEN_SOURCE
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = TOKEN_SOURCE_LENGTH)]
+            internal byte[] SourceName;
+            internal LUID SourceIdentifier;
+
+            internal const int TOKEN_SOURCE_LENGTH = 8;
+        }
+    }
+}

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeLsaHandle.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeLsaHandle.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafeLsaHandle : SafeHandle
+    {
+        internal SafeLsaHandle()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        protected sealed override bool ReleaseHandle()
+        {
+            int ntStatus = Interop.SspiCli.LsaDeregisterLogonProcess(handle);
+            return ntStatus == 0;
+        }
+
+        public sealed override bool IsInvalid
+        {
+            get
+            {
+                return handle == IntPtr.Zero;
+            }
+        }
+    }
+} 

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -191,6 +191,7 @@ namespace System.Security.Principal
     {
         public WindowsIdentity(System.IntPtr userToken) { }
         public WindowsIdentity(System.IntPtr userToken, string type) { }
+        public WindowsIdentity(string sUserPrincipalName) { }
         public Microsoft.Win32.SafeHandles.SafeAccessTokenHandle AccessToken {[System.Security.SecurityCriticalAttribute]get { return default(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle); } }
         public System.Security.Principal.IdentityReferenceCollection Groups { get { return default(System.Security.Principal.IdentityReferenceCollection); } }
         public System.Security.Principal.TokenImpersonationLevel ImpersonationLevel { get { return default(System.Security.Principal.TokenImpersonationLevel); } }

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -133,9 +133,50 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore_obsolete\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Interop.LocalAlloc.cs</Link>
     </Compile>
-
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.AuthenticationPackageNames.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.AuthenticationPackageNames.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.KerbLogonSubmitType.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.KerbLogonSubmitType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.KerbS4uLogin.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.KerbS4uLogin.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.LsaConnectUntrusted.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.LsaConnectUntrusted.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.LsaDeregisterLogonProcess.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.LsaDeregisterLogonProcess.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.LsaLogonUser.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.LsaLogonUser.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.LsaLookupAuthenticationPackage.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.LsaLookupAuthenticationPackage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.LsaString.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.LsaString.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.LsaUnicodeString.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.LsaUnicodeString.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.QuotaLimits.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.QuotaLimits.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.SecurityLogonType.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.SecurityLogonType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\sspicli\Interop.TokenSource.cs">
+      <Link>Common\Interop\Windows\sspicli\Interop.TokenSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\SecurityBase\Interop.AllocateLocallyUniqueId.cs">
+      <Link>Common\Interop\Windows\SecurityBase\Interop.AllocateLocallyUniqueId.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandlres\SafeLocalAllocHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLsaHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandlres\SafeLsaHandle.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -1,15 +1,23 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Claims;
+using System.Text;
 using System.Threading;
+
+using KERB_LOGON_SUBMIT_TYPE = Interop.SspiCli.KERB_LOGON_SUBMIT_TYPE;
+using KERB_S4U_LOGON = Interop.SspiCli.KERB_S4U_LOGON;
+using KerbS4uLogonFlags = Interop.SspiCli.KerbS4uLogonFlags;
+using LUID = Interop.LUID;
+using LSA_STRING = Interop.SspiCli.LSA_STRING;
+using QUOTA_LIMITS = Interop.SspiCli.QUOTA_LIMITS;
+using SECURITY_LOGON_TYPE = Interop.SspiCli.SECURITY_LOGON_TYPE;
+using TOKEN_SOURCE = Interop.SspiCli.TOKEN_SOURCE;
 
 namespace System.Security.Principal
 {
@@ -41,6 +49,145 @@ namespace System.Security.Principal
             : base(null, null, null, ClaimTypes.Name, ClaimTypes.GroupSid)
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the WindowsIdentity class for the user represented by the specified User Principal Name (UPN).
+        /// </summary>
+        /// <remarks>
+        /// Unlike the desktop version, we connect to Lsa only as an untrusted caller. We do not attempt to explot Tcb privilege or adjust the current
+        /// thread privilege to include Tcb.
+        /// </remarks>
+        public WindowsIdentity(string sUserPrincipalName)
+            : base(null, null, null, ClaimTypes.Name, ClaimTypes.GroupSid)
+        {
+            // Desktop compat: See comments below for why we don't validate sUserPrincipalName.
+
+            using (SafeLsaHandle lsaHandle = ConnectToLsa())
+            {
+                int packageId = LookupAuthenticationPackage(lsaHandle, Interop.SspiCli.AuthenticationPackageNames.MICROSOFT_KERBEROS_NAME_A);
+
+                // 8 byte or less name that indicates the source of the access token. This choice of name is visible to callers through the native GetTokenInformation() api
+                // so we'll use the same name the CLR used even though we're not actually the "CLR."
+                byte[] sourceName = { (byte)'C', (byte)'L', (byte)'R', (byte)0 };
+
+                TOKEN_SOURCE sourceContext;
+                if (!Interop.SecurityBase.AllocateLocallyUniqueId(out sourceContext.SourceIdentifier))
+                    throw new SecurityException(Interop.mincore.GetMessage(Marshal.GetLastWin32Error()));
+                sourceContext.SourceName = new byte[TOKEN_SOURCE.TOKEN_SOURCE_LENGTH];
+                Array.Copy(sourceName, sourceContext.SourceName, sourceName.Length);
+
+                // Desktop compat: Desktop never null-checks sUserPrincipalName. Actual behavior is that the null makes it down to Encoding.Unicode.GetBytes() which then throws
+                // the ArgumentNullException (provided that the prior LSA calls didn't fail first.) To make this compat decision explicit, we'll null check ourselves 
+                // and simulate the exception from Encoding.Unicode.GetBytes().
+                if (sUserPrincipalName == null)
+                    throw new ArgumentNullException("s");
+
+                byte[] upnBytes = Encoding.Unicode.GetBytes(sUserPrincipalName);
+                if (upnBytes.Length > ushort.MaxValue)
+                {
+                    // Desktop compat: LSA only allocates 16 bits to hold the UPN size. We should throw an exception here but unfortunately, the desktop did an unchecked cast to ushort,
+                    // effectively truncating upnBytes to the first (N % 64K) bytes. We'll simulate the same behavior here (albeit in a way that makes it look less accidental.)
+                    Array.Resize(ref upnBytes, upnBytes.Length & ushort.MaxValue);
+                }
+                unsafe
+                {
+                    //
+                    // Build the KERB_S4U_LOGON structure.  Note that the LSA expects this entire
+                    // structure to be contained within the same block of memory, so we need to allocate
+                    // enough room for both the structure itself and the UPN string in a single buffer
+                    // and do the marshalling into this buffer by hand.
+                    //
+                    int authenticationInfoLength = checked(sizeof(KERB_S4U_LOGON) + upnBytes.Length);
+                    using (SafeLocalAllocHandle authenticationInfo = Interop.mincore_obsolete.LocalAlloc(0, new UIntPtr(checked((uint)authenticationInfoLength))))
+                    {
+                        if (authenticationInfo.IsInvalid || authenticationInfo == null)
+                            throw new OutOfMemoryException();
+
+                        KERB_S4U_LOGON* pKerbS4uLogin = (KERB_S4U_LOGON*)(authenticationInfo.DangerousGetHandle());
+                        pKerbS4uLogin->MessageType = KERB_LOGON_SUBMIT_TYPE.KerbS4ULogon;
+                        pKerbS4uLogin->Flags = KerbS4uLogonFlags.None;
+
+                        pKerbS4uLogin->ClientUpn.Length = pKerbS4uLogin->ClientUpn.MaximumLength = checked((ushort)upnBytes.Length);
+
+                        IntPtr pUpnOffset = (IntPtr)(pKerbS4uLogin + 1);
+                        pKerbS4uLogin->ClientUpn.Buffer = pUpnOffset;
+                        Marshal.Copy(upnBytes, 0, pKerbS4uLogin->ClientUpn.Buffer, upnBytes.Length);
+
+                        pKerbS4uLogin->ClientRealm.Length = pKerbS4uLogin->ClientRealm.MaximumLength = 0;
+                        pKerbS4uLogin->ClientRealm.Buffer = IntPtr.Zero;
+
+                        ushort sourceNameLength = checked((ushort)(sourceName.Length));
+                        using (SafeLocalAllocHandle sourceNameBuffer = Interop.mincore_obsolete.LocalAlloc(0, new UIntPtr(sourceNameLength)))
+                        {
+                            if (sourceNameBuffer.IsInvalid || sourceNameBuffer == null)
+                                throw new OutOfMemoryException();
+
+                            Marshal.Copy(sourceName, 0, sourceNameBuffer.DangerousGetHandle(), sourceName.Length);
+                            LSA_STRING lsaOriginName = new LSA_STRING(sourceNameBuffer.DangerousGetHandle(), sourceNameLength);
+
+                            SafeLsaReturnBufferHandle profileBuffer;
+                            int profileBufferLength;
+                            LUID logonId;
+                            SafeAccessTokenHandle accessTokenHandle;
+                            QUOTA_LIMITS quota;
+                            int subStatus;
+                            int ntStatus = Interop.SspiCli.LsaLogonUser(
+                                lsaHandle,
+                                ref lsaOriginName,
+                                SECURITY_LOGON_TYPE.Network,
+                                packageId,
+                                authenticationInfo.DangerousGetHandle(),
+                                authenticationInfoLength,
+                                IntPtr.Zero,
+                                ref sourceContext,
+                                out profileBuffer,
+                                out profileBufferLength,
+                                out logonId,
+                                out accessTokenHandle,
+                                out quota,
+                                out subStatus);
+
+                            if (ntStatus == unchecked((int)Interop.StatusOptions.STATUS_ACCOUNT_RESTRICTION) && subStatus < 0)
+                                ntStatus = subStatus;
+                            if (ntStatus < 0) // non-negative numbers indicate success
+                                throw GetExceptionFromNtStatus(ntStatus);
+                            if (subStatus < 0) // non-negative numbers indicate success
+                                throw GetExceptionFromNtStatus(subStatus);
+
+                            if (profileBuffer != null)
+                                profileBuffer.Dispose();
+
+                            _safeTokenHandle = accessTokenHandle;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static SafeLsaHandle ConnectToLsa()
+        {
+            SafeLsaHandle lsaHandle;
+            int ntStatus = Interop.SspiCli.LsaConnectUntrusted(out lsaHandle);
+            if (ntStatus < 0) // non-negative numbers indicate success
+                throw GetExceptionFromNtStatus(ntStatus);
+            return lsaHandle;
+        }
+
+        private static int LookupAuthenticationPackage(SafeLsaHandle lsaHandle, string packageName)
+        {
+            unsafe
+            {
+                int packageId;
+                byte[] asciiPackageName = Encoding.ASCII.GetBytes(packageName);
+                fixed (byte* pAsciiPackageName = asciiPackageName)
+                {
+                    LSA_STRING lsaPackageName = new LSA_STRING((IntPtr)pAsciiPackageName, checked((ushort)(asciiPackageName.Length)));
+                    int ntStatus = Interop.SspiCli.LsaLookupAuthenticationPackage(lsaHandle, ref lsaPackageName, out packageId);
+                    if (ntStatus < 0) // non-negative numbers indicate success
+                        throw GetExceptionFromNtStatus(ntStatus);
+                }
+                return packageId;
+            }
+        }
 
         public WindowsIdentity(IntPtr userToken) : this(userToken, null, -1) { }
 


### PR DESCRIPTION
cc @bartonjs 

Adding back ctor(string) for WindowsIdentity.

Tested on local machine but the api (like its desktop counterpart) requires a domain-joined machine to work at all, and possibly spams the audit logs too, so the public unit tests are not a suitable place to validate this.

Desktop version also contains a bunch of scary code to add the TCB privilege to the token in case an  operating system that happens to be passing through wants to use this api to exercise its awesome LocalSystem powers. I don't think we need that functionality so I only ported the fallback case where we return a identification token only.
  