### PR TITLE
Address various issues in FileSystemWatcher

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem.Watcher/src/Resources/Strings.resx
@@ -174,4 +174,19 @@
   <data name="Argument_InvalidPathChars" xml:space="preserve">
     <value>Illegal characters in path.</value>
   </data>
+  <data name="IOException_INotifyInstanceSystemLimitExceeded" xml:space="preserve">
+    <value>The system limit on the number of inotify instances has been reached.</value>
+  </data>
+  <data name="IOException_INotifyInstanceUserLimitExceeded_Value" xml:space="preserve">
+    <value>The configured user limit ({0}) on the number of inotify instances has been reached.</value>
+  </data>
+  <data name="IOException_INotifyWatchesUserLimitExceeded_Value" xml:space="preserve">
+    <value>The configured user limit ({0}) on the number of inotify watches has been reached.</value>
+  </data>
+  <data name="IOException_INotifyInstanceUserLimitExceeded" xml:space="preserve">
+    <value>The configured user limit on the number of inotify instances has been reached.</value>
+  </data>
+  <data name="IOException_INotifyWatchesUserLimitExceeded" xml:space="preserve">
+    <value>The configured user limit on the number of inotify watches has been reached.</value>
+  </data>
 </root>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -64,6 +64,8 @@ namespace System.IO
         /// <summary>Stop monitoring the current directory.</summary>
         private void StopRaisingEvents()
         {
+            _enabled = false;
+
             // If we're not running, do nothing.
             if (IsHandleInvalid(_directoryHandle))
                 return;
@@ -82,9 +84,6 @@ namespace System.IO
             // check will see a valid handle, unless we also null it out.
             _directoryHandle.Dispose();
             _directoryHandle = null;
-
-            // Set enabled to false
-            _enabled = false;
         }
 
         private void FinalizeDispose()

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -106,7 +106,7 @@ namespace System.IO
 
             // Early check for directory parameter so that an exception can be thrown as early as possible.
             if (path.Length == 0 || !Directory.Exists(path))
-                throw new ArgumentException(SR.InvalidDirName, path);
+                throw new ArgumentException(SR.Format(SR.InvalidDirName, path), "path");
 
             _directory = path;
             _filter = filter;
@@ -152,15 +152,13 @@ namespace System.IO
                     return;
                 }
 
-                _enabled = value;
-
-                if (_enabled)
+                if (value)
                 {
-                    StartRaisingEventsIfNotDisposed();
+                    StartRaisingEventsIfNotDisposed(); // will set _enabled to true once successfully started
                 }
                 else
                 {
-                    StopRaisingEvents();
+                    StopRaisingEvents(); // will set _enabled to false
                 }
             }
         }


### PR DESCRIPTION
- On Linux, FileSystemWatcher is built on top of inotify, which has various limits configured in the system for how many instances and watches can be created.  When these limits are hit, exceptions are generated, but the Linux-provided error messages are cryptic about what the problem is.  This change adds better error messages for those cases.  It also ensures that errors regarding watch limits always come out of OnError rather than sometimes being thrown synchronously from EnableRaisingEvents and other times coming out asynchronously.
- As part of fixing that, I noticed that we had some reliability issues around marking the instance as enabled.  I fixed this up to ensure that we only mark the instance as enabled when we've created everything we need to successfully launch it.
- While doing that, I noticed that on OS X, if we restart an FSW, we were unnecessarily re-creating a delegate.  I changed it to avoid the unnecessary allocation.
- And while doing that, I also noticed that we we had a bad exception message when constructing an FSW with something other than a directory.  I fixed the error message.
- I added tests for all these things.

cc: @sokket, @dougbu