### PR TITLE
Stop interface ToArray method from being public on public class.

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1436,18 +1436,18 @@ namespace System.Linq
         {
             private readonly int _start;
             private readonly int _end;
-            
+
             public RangeIterator(int start, int count)
             {
                 _start = start;
                 _end = start + count;
             }
-            
+
             public override Iterator<int> Clone()
             {
                 return new RangeIterator(_start, _end - _start);
             }
-            
+
             public override bool MoveNext()
             {
                 switch(state)
@@ -1458,17 +1458,13 @@ namespace System.Linq
                         state = 2;
                         return true;
                     case 2:
-                        if (++current == _end)
-                        {
-                            --current; // Not crucial but maintains compatibility with previous versions. 
-                            break;
-                        }
+                        if (++current == _end) break;
                         return true;
                 }
                 state = -1;
                 return false;
             }
-            
+
             public override void Dispose()
             {
                 state = -1; // Don't reset current
@@ -1514,18 +1510,18 @@ namespace System.Linq
                 current = element;
                 _count = count;
             }
-            
+
             public override Iterator<TResult> Clone()
             {
                 return new RepeatIterator<TResult>(current, _count);
             }
-            
+
             public override void Dispose()
             {
                 // Don't let base Dispose wipe current.
                 state = -1;
             }
-            
+
             public override bool MoveNext()
             {
                 if (state == 1 & _sent != _count)
@@ -1546,7 +1542,7 @@ namespace System.Linq
             {
                 return new WhereEnumerableIterator<TResult>(this, predicate);
             }
-            
+
             public TResult[] ToArray()
             {
                 TResult[] array = new TResult[_count];
@@ -1900,7 +1896,7 @@ namespace System.Linq
                     int? cur = e.Current;
                     int x = cur.GetValueOrDefault();
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                    // unless nulls either never happen or always happen. 
+                    // unless nulls either never happen or always happen.
                     if (cur.HasValue & x < valueVal)
                     {
                         valueVal = x;
@@ -1945,7 +1941,7 @@ namespace System.Linq
                     long? cur = e.Current;
                     long x = cur.GetValueOrDefault();
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                    // unless nulls either never happen or always happen. 
+                    // unless nulls either never happen or always happen.
                     if (cur.HasValue & x < valueVal)
                     {
                         valueVal = x;
@@ -1955,7 +1951,7 @@ namespace System.Linq
             }
             return value;
         }
-        
+
         public static float Min(this IEnumerable<float> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
@@ -2250,7 +2246,7 @@ namespace System.Linq
                         int? cur = e.Current;
                         int x = cur.GetValueOrDefault();
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                        // unless nulls either never happen or always happen. 
+                        // unless nulls either never happen or always happen.
                         if (cur.HasValue & x > valueVal)
                         {
                             valueVal = x;
@@ -2311,7 +2307,7 @@ namespace System.Linq
                         long? cur = e.Current;
                         long x = cur.GetValueOrDefault();
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                        // unless nulls either never happen or always happen. 
+                        // unless nulls either never happen or always happen.
                         if (cur.HasValue & x > valueVal)
                         {
                             valueVal = x;
@@ -2372,7 +2368,7 @@ namespace System.Linq
                     double? cur = e.Current;
                     double x = cur.GetValueOrDefault();
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                    // unless nulls either never happen or always happen. 
+                    // unless nulls either never happen or always happen.
                     if (cur.HasValue & x > valueVal)
                     {
                         valueVal = x;
@@ -2428,7 +2424,7 @@ namespace System.Linq
                     float? cur = e.Current;
                     float x = cur.GetValueOrDefault();
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                    // unless nulls either never happen or always happen. 
+                    // unless nulls either never happen or always happen.
                     if (cur.HasValue & x > valueVal)
                     {
                         valueVal = x;
@@ -2879,7 +2875,7 @@ namespace System.Linq
         /// <summary>
         /// Produce an array of the sequence through an optimized path, if possible.
         /// </summary>
-        /// <returns>The array, or null if an optimized path isn't possible, and default behaviour should be used.</returns>
+        /// <returns>The array, or null if an optimized path isn't possible, and default behavior should be used.</returns>
         TElement[] ToArray();
     }
 
@@ -2978,8 +2974,8 @@ namespace System.Linq
                 } while (g != _lastGrouping);
             }
         }
-        
-        public IGrouping<TKey, TElement>[] ToArray()
+
+        IGrouping<TKey, TElement>[] IArrayProvider<IGrouping<TKey, TElement>>.ToArray()
         {
             IGrouping<TKey, TElement>[] array = new IGrouping<TKey, TElement>[_count];
             int index = 0;
@@ -3356,17 +3352,18 @@ namespace System.Linq
         {
             return GetEnumerator();
         }
-        
+
         public IGrouping<TKey, TElement>[] ToArray()
         {
-            return Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer).ToArray();
+            IArrayProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer);
+            return lookup.ToArray();
         }
     }
 
     internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IArrayProvider<TElement>
     {
         internal IEnumerable<TElement> source;
-        
+
         private int[] SortedMap(Buffer<TElement> buffer)
         {
             return GetEnumerableSorter(null).Sort(buffer.items, buffer.count);
@@ -3381,7 +3378,7 @@ namespace System.Linq
                 for (int i = 0; i < buffer.count; i++) yield return buffer.items[map[i]];
             }
         }
-        
+
         public TElement[] ToArray()
         {
             Buffer<TElement> buffer = new Buffer<TElement>(source);
@@ -3543,7 +3540,7 @@ namespace System.Linq
                     return;
                 }
             }
-            
+
             items = EnumerableHelpers.ToArray(source, out count);
         }
 

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -215,7 +215,7 @@ namespace System.Linq.Tests
             var outOfOrder = new[] { 7, 1, 0, 9, 3, 5, 4, 2, 8, 6 };
             Assert.Equal(Enumerable.Range(0, 10), outOfOrder.OrderBy(i => i, new ExtremeComparer()));
         }
-        
+
         [Fact]
         public void NullSource()
         {

--- a/src/System.Linq/tests/RangeTests.cs
+++ b/src/System.Linq/tests/RangeTests.cs
@@ -106,14 +106,14 @@ namespace System.Linq.Tests
             int[] expected = { Int32.MaxValue - 3, Int32.MaxValue - 2, Int32.MaxValue - 1, Int32.MaxValue };
             Assert.Equal(expected, rangeEnumerable);
         }
-        
+
         [Fact]
         public void RepeatedCallsSameResults()
         {
             Assert.Equal(Enumerable.Range(-1, 2), Enumerable.Range(-1, 2));
             Assert.Equal(Enumerable.Range(0, 0), Enumerable.Range(0, 0));
         }
-        
+
         [Fact]
         public void NegativeStart()
         {
@@ -132,19 +132,6 @@ namespace System.Linq.Tests
             int[] expected = { 12, 13, 14, 15, 16, 17 };
 
             Assert.Equal(expected, Enumerable.Range(start, count));
-        }
-        
-        [Fact]
-        public void RangeAsEnumeratorStartsZeroEndsAtLast()
-        {
-            // The behaviour here is not specified, but any change that breaks this is
-            // not strictly non-breaking, and while a dependency on it is perhaps unlikely
-            // such a change should be noted.
-            var ra = Enumerable.Range(4, 3);
-            var asEn = (IEnumerator<int>)ra;
-            Assert.Equal(0, asEn.Current);
-            ra.All(i => i > 0);
-            Assert.Equal(6, asEn.Current);
         }
     }
 }


### PR DESCRIPTION
Also change en-IE spellings in comments to en-US spelling, remove trailing
whitespace, and cruft path in iterator movenext.