### PR TITLE
Implement ReadAsync on CurlHandler response stream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -521,7 +521,7 @@ namespace System.Net.Http
                             //       until a reader is ready to read, at which point we could unpause.
                             if (size != 0)
                             {
-                                easy.ResponseMessage.ContentStream.WaitAndSignalReaders(buffer, (long)size);
+                                easy.ResponseMessage.ContentStream.WriteDataAndWaitForConsumption(buffer, (long)size);
                             }
 
                             return size;

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseMessage.cs
@@ -351,6 +351,8 @@ namespace System.Net.Http
         private int ConsumePublishedData(byte[] buffer, int offset, int count)
         {
             Debug.Assert(Monitor.IsEntered(LockObject), "Published data must only be accessed while holding the lock");
+            Debug.Assert(_availableData != IntPtr.Zero, "Expected available data pointer");
+            Debug.Assert(_availableDataLength > 0, "Expected positive length for available data");
 
             // Copy the data into the read buffer
             int bytesToRead = (int)Math.Min(_availableDataLength, count);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseMessage.cs
@@ -4,13 +4,15 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
     internal sealed class CurlResponseMessage : HttpResponseMessage
     {
-        private readonly CurlResponseStream _responseStream = new CurlResponseStream();
+        private readonly SingleBlockingWriterSingleReaderStream _responseStream = new SingleBlockingWriterSingleReaderStream();
 
         internal CurlResponseMessage(HttpRequestMessage request)
         {
@@ -18,32 +20,68 @@ namespace System.Net.Http
             Content = new StreamContent(_responseStream);
         }
 
-        internal CurlResponseStream ContentStream
+        internal SingleBlockingWriterSingleReaderStream ContentStream
         {
             get { return _responseStream; }
         }
     }
 
-    internal sealed class CurlResponseStream : Stream
+    /// <summary>
+    /// Provides a rendezvous stream that allows a writer to handoff data to a reader.
+    /// A call from a writer provides data and blocks until all of the provided data
+    /// has been consumed by a reader, which may make multiple calls to consume the data
+    /// and which may wait for data either synchronously or asynchronously. Only one
+    /// writer and one reader are supported concurrently.
+    /// </summary>
+    internal sealed class SingleBlockingWriterSingleReaderStream : Stream
     {
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private readonly ManualResetEventSlim _readerRequestingDataEvent = new ManualResetEventSlim(false);
-        private readonly ManualResetEventSlim _writerHasDataEvent = new ManualResetEventSlim(false);
-        private readonly ManualResetEventSlim _readerReadAllDataEvent = new ManualResetEventSlim(false);
+        /// <summary>Stores whether Dispose has been called on the stream.</summary>
         private volatile bool _disposed = false;
-        private Stream _innerStream;
+
+        /// <summary>
+        /// CancellationTokenSource that has cancellation requested when the Stream is being shutdown,
+        /// either due to the writer not having any more data or due to a failure in the request/response processing.
+        /// </summary>
+        private readonly CancellationTokenSource _completionSignal = new CancellationTokenSource();
+
+        /// <summary>
+        /// A semaphore used as an auto-reset event to communicate when the writer has published data
+        /// to be consumed by the reader.  0 count available means unset / no data, and 1 count available means set / data.
+        /// SemaphoreSlim is used instead of ManualResetEventSlim because SemaphoreSlim supports both
+        /// synchronous and asynchronous waiting.
+        /// </summary>
+        private readonly SemaphoreSlim _writerPublishedDataEvent = new SemaphoreSlim(0, 1);
+
+        /// <summary>
+        /// A manual reset event used to communicate when all of the data published by the writer has
+        /// been consumed by the reader.  The writer will block and not return to the libcurl callback
+        /// until this event is set by the reader.
+        /// </summary>
+        private readonly ManualResetEventSlim _readerConsumedAllDataEvent = new ManualResetEventSlim();
+
+        /// <summary>A pointer to the data published by the writer, or IntPtr.Zero if no data is available.</summary>
+        private IntPtr _availableData;
+
+        /// <summary>The length of the remaining data available via <see cref="_availableData"/>.  May be 0 if no data is available.</summary>
+        private long _availableDataLength;
+
+        /// <summary>If not null, represents an exception object that should be propagated to any reader.</summary>
         private ExceptionDispatchInfo _storedException;
 
+        /// <summary>Gets the lock object used to protect the available data.</summary>
         private object LockObject
         {
-            get { return _cancellationTokenSource; }
+            get { return _completionSignal; }
         }
 
+        /// <summary>Notifies the stream that no more data will be written.</summary>
         internal void SignalComplete()
         {
-            _cancellationTokenSource.Cancel();
+            _completionSignal.Cancel();
         }
 
+        /// <summary>Notifies the stream that a failure has occurred and that no more data will be written.</summary>
+        /// <param name="error">An exception for the failure and that should be propagated to any readers.</param>
         internal void SignalFailure(ExceptionDispatchInfo error)
         {
             if (_storedException == null)
@@ -51,31 +89,6 @@ namespace System.Net.Http
                 _storedException = error;
             }
             SignalComplete();
-        }
-
-        internal unsafe void WaitAndSignalReaders(IntPtr pointer, long length)
-        {
-            try
-            {
-                CheckDisposed();
-                _readerRequestingDataEvent.Wait(Timeout.InfiniteTimeSpan, _cancellationTokenSource.Token);
-                lock (LockObject)
-                {
-                    _innerStream = new UnmanagedMemoryStream((byte*)pointer, length);
-                    _readerReadAllDataEvent.Reset();
-                    _readerRequestingDataEvent.Reset();
-                    _writerHasDataEvent.Set();
-                }
-                _readerReadAllDataEvent.Wait(Timeout.InfiniteTimeSpan, _cancellationTokenSource.Token);
-            }
-            finally
-            {
-                if (_innerStream != null)
-                {
-                    _innerStream.Dispose();
-                    _innerStream = null;
-                }
-            }
         }
 
         public override bool CanRead
@@ -126,73 +139,6 @@ namespace System.Net.Http
             }
         }
 
-        public override void Flush()
-        {
-            // Nothing to do.
-        }
-
-        //public override Task<int> ReadAsync(byte[] buffer, int offset, int count)
-        //{
-        //    // TODO: Consider proper implementation here using AsyncTaskMethodBuilder
-        //    return base.ReadAsync(buffer, offset, count);
-        //}
-
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException("buffer");
-            }
-
-            if (offset < 0)
-            {
-                throw new ArgumentOutOfRangeException("offset");
-            }
-
-            if (count < 0)
-            {
-                throw new ArgumentOutOfRangeException("count");
-            }
-
-            if ((long) offset + (long) count > (long) buffer.Length)
-            {
-                throw new ArgumentException("buffer");
-            }
-
-            CheckDisposed();
-
-            do
-            {
-                lock (LockObject)
-                {
-                    // Wait till data is available
-                    if (_innerStream == null)
-                    {
-                        SignalWriter();
-                        continue;
-                    }
-
-                    // Since this is under lock, make sure the Read is non-blocking
-                    Debug.Assert((_innerStream is MemoryStream) || (_innerStream is UnmanagedMemoryStream), "_innerStream was an invalid type");
-
-                    int bytesRead = _innerStream.Read(buffer, offset, (int)Math.Min((long)count, _innerStream.Length));
-                    if (_innerStream.Position == _innerStream.Length)
-                    {
-                        _innerStream.Dispose();
-                        _innerStream = null;
-                        _readerReadAllDataEvent.Set();
-                    }
-
-                    ThrowStoredExceptionIfExists();
-                    return bytesRead;
-                }
-            }
-            while (WaitForWriter());
-
-            ThrowStoredExceptionIfExists();
-            return 0;
-        }
-
         public override long Seek(long offset, SeekOrigin origin)
         {
             CheckDisposed();
@@ -211,31 +157,227 @@ namespace System.Net.Http
             throw new NotSupportedException();
         }
 
+        public override void Flush()
+        {
+            // Nothing to do.
+        }
+
+        /// <summary>
+        /// Writes the <paramref name="length"/> bytes starting at <paramref name="pointer"/>
+        /// to the stream, and waits for a reader to consume all of the data before returning.
+        /// </summary>
+        internal void WriteDataAndWaitForConsumption(IntPtr pointer, long length)
+        {
+            Debug.Assert(pointer != IntPtr.Zero, "Expected a non-null pointer");
+            Debug.Assert(length >= 0, "Expected a non-negative length");
+            Debug.Assert(_availableData == IntPtr.Zero, "Expected no existing data in the stream");
+            Debug.Assert(_availableDataLength == 0, "Expected length of existing data in the stream to be 0");
+            Debug.Assert(_writerPublishedDataEvent.CurrentCount == 0, "Expected semaphore to reflect no published data");
+
+            CheckDisposed();
+
+            if (length == 0)
+            {
+                // No data to write; bail.
+                return;
+            }
+
+            lock (LockObject)
+            {
+                // libcurl's data write callback is synchronous, such that it expects
+                // all of the data it provides to have been consumed by the time
+                // the callback returns. As such, we'll need to block until all of the data 
+                // has been read by a reader.  To enable that, reset the event that'll be set 
+                // by the reader when the data has been entirely consumed.
+                _readerConsumedAllDataEvent.Reset();
+
+                // Store the supplied data, to make it available to the reader.  The reader will 
+                // consume this data, potentially in multiple calls to Read/ReadAsync.
+                _availableData = pointer;
+                _availableDataLength = length;
+
+                // With the data now published, let a current or future reader know about the data.
+                _writerPublishedDataEvent.Release();
+            }
+
+            try
+            {
+                // Wait for all of the published data to be consumed.
+                _readerConsumedAllDataEvent.Wait(_completionSignal.Token);
+            }
+            finally
+            {
+                // At this point, either all of the data has been consumed, or cancellation
+                // was requested due to the stream shutting down.  Null out the data, but 
+                // do so synchronizing with any potential concurrent reader to ensure we don't let 
+                // libcurl deallocate the data while it's still being used by a reader.
+                lock (LockObject)
+                {
+                    ClearPublishedData();
+                }
+            }
+        }
+
+        /// <summary>Clears the published data and associated state.</summary>
+        private void ClearPublishedData()
+        {
+            Debug.Assert(Monitor.IsEntered(LockObject), "Published data must only be accessed while holding the lock");
+            _availableData = IntPtr.Zero;
+            _availableDataLength = 0;
+            _writerPublishedDataEvent.Wait(0); // poll the semaphore to ensure it has no count (effectively Reset)
+            Debug.Assert(_writerPublishedDataEvent.CurrentCount == 0, "Reset semaphore should not have any count");
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateReadArguments(buffer, offset, count);
+
+            // If there's any data left over from a previous Read call, grab as much
+            // of it as remains (or as we're asking for) and return it.
+            lock (LockObject)
+            {
+                if (_availableDataLength > 0)
+                {
+                    return ConsumePublishedData(buffer, offset, count);
+                }
+            }
+
+            // There wasn't any data, so wait for the writer to publish more.
+            try
+            {
+                _writerPublishedDataEvent.Wait(_completionSignal.Token);
+            }
+            catch (OperationCanceledException) { }
+
+            // Now either cancellation should have been requested or
+            // we should have data to read and return.
+            return ReadDataAfterWaitingForWriter(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateReadArguments(buffer, offset, count);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            // If there's any data left over from a previous call, grab as much
+            // of it as remains (or as we're asking for) and return it.
+            lock (LockObject)
+            {
+                if (_availableDataLength > 0)
+                {
+                    return Task.FromResult(ConsumePublishedData(buffer, offset, count));
+                }
+            }
+
+            // There wasn't any data, so wait for the writer to publish more
+            // and then read it.  Unlike in Read, this is separated out in a separated
+            // async method to allow for ValidateReadArguments to propagate any arg exceptions
+            // synchronously and for a fast-path read in the case of data already being available.
+            return ReadAsyncCore(buffer, offset, count, cancellationToken);
+        }
+
+        private async Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // There wasn't any data, so wait for the writer to publish more.
+            try
+            {
+                await _writerPublishedDataEvent.WaitAsync(_completionSignal.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { }
+
+            // Now either cancellation should have been requested or
+            // we should have data to read and return.
+            return ReadDataAfterWaitingForWriter(buffer, offset, count);
+        }
+
+        /// <summary>
+        /// Common routine used by both Read and ReadAsync to read available data after waiting
+        /// for the writer to publish.
+        /// </summary>
+        private int ReadDataAfterWaitingForWriter(byte[] buffer, int offset, int count)
+        {
+            // We should now have data to read, as long as cancellation hasn't been requested.
+            if (!_completionSignal.IsCancellationRequested)
+            {
+                Debug.Assert(_writerPublishedDataEvent.CurrentCount == 0, "Since cancellation wasn't requested, expected semaphore to have 0 count");
+                lock (LockObject)
+                {
+                    Debug.Assert(_completionSignal.IsCancellationRequested || _availableData != IntPtr.Zero, "Expected writer to publish non-null pointer");
+                    Debug.Assert(_completionSignal.IsCancellationRequested || _availableDataLength > 0, "Expected writer to publish positive amount of data");
+                    if (_availableDataLength > 0)
+                    {
+                        return ConsumePublishedData(buffer, offset, count);
+                    }
+                }
+            }
+
+            // There's no more data to read due to the stream shutting down.  If we shut down due to a failure,
+            // propagate the exception.  Otherwise, return 0 to indicate that the stream is complete.
+            Debug.Assert(_completionSignal.IsCancellationRequested, "Cancellation must have been requested to get here");
+            ExceptionDispatchInfo edi = _storedException;
+            if (edi != null)
+            {
+                edi.Throw();
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Copies at most <paramref name="count"/> bytes from the published data into the 
+        /// supplied buffer at the specified offset.  The published data is then updated
+        /// accordingly to reflect the consumed data.
+        /// </summary>
+        /// <returns>The number of bytes copied.</returns>
+        private int ConsumePublishedData(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(Monitor.IsEntered(LockObject), "Published data must only be accessed while holding the lock");
+
+            // Copy the data into the read buffer
+            int bytesToRead = (int)Math.Min(_availableDataLength, count);
+            Marshal.Copy(_availableData, buffer, offset, bytesToRead);
+
+            // Update how much remains
+            _availableData = _availableData + bytesToRead;
+            _availableDataLength -= bytesToRead;
+
+            // If none is left, clear out the ptr and let
+            // the writer know it's all be consumed.
+            if (_availableDataLength == 0)
+            {
+                ClearPublishedData();
+                _readerConsumedAllDataEvent.Set();
+            }
+
+            // Finally, return how much was read.
+            return bytesToRead;
+        }
+
+        /// <summary>Performs validation for calls to Read and ReadAsync.</summary>
+        private void ValidateReadArguments(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null) throw new ArgumentNullException("buffer");
+            if (offset < 0) throw new ArgumentOutOfRangeException("offset");
+            if (count < 0) throw new ArgumentOutOfRangeException("count");
+            if (offset > buffer.Length - count) throw new ArgumentException("buffer");
+            CheckDisposed();
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing && !_disposed)
             {
-                // Cancel any pending operations
-                SignalComplete();
-
                 _disposed = true;
-                lock (LockObject)
-                {
-                    if (_innerStream != null)
-                    {
-                        _innerStream.Dispose();
-                        _innerStream = null;
-                    }
-                }
-                _readerRequestingDataEvent.Dispose();
-                _writerHasDataEvent.Dispose();
-                _readerReadAllDataEvent.Dispose();
+                SignalComplete(); // Wake-up any blocked waits
+
+                // Don't Dispose of the events as they may still be in use by Waits. Since 
+                // we're not accessing their WaitHandle's, Dispose would be a nop, anyway.
             }
 
             base.Dispose(disposing);
         }
-
-        #region Private
 
         private void CheckDisposed()
         {
@@ -245,45 +387,5 @@ namespace System.Net.Http
             }
         }
 
-        private bool WaitForWriter()
-        {
-            try
-            {
-                _writerHasDataEvent.Wait(Timeout.InfiniteTimeSpan, _cancellationTokenSource.Token);
-                return true;
-            }
-            catch (OperationCanceledException)
-            {
-                if (_writerHasDataEvent.Wait(TimeSpan.Zero))
-                {
-                    // If both are set, unblock the reader based on data availability
-                    lock (LockObject)
-                    {
-                        return (_innerStream != null);
-                    }
-                }
-                return false;
-            }
-        }
-
-        private void SignalWriter()
-        {
-            Debug.Assert(Monitor.IsEntered(LockObject), "lock wasn't held");
-            _writerHasDataEvent.Reset();
-            _readerRequestingDataEvent.Set();
-        }
-
-        private void ThrowStoredExceptionIfExists()
-        {
-            // We may have been canceled to indicate some other failure, in which case
-            // we should propagate that failure.
-            ExceptionDispatchInfo edi = _storedException;
-            if (edi != null)
-            {
-                edi.Throw();
-            }
-        }
-
-        #endregion
     }
 }

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -6,7 +6,6 @@
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.Compression": "4.0.0",
-    "System.IO.UnmanagedMemoryStream": "4.0.0",
     "System.Net.Primitives": "4.0.10",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime.Extensions": "4.0.10",

--- a/src/System.Net.Http/src/project.lock.json
+++ b/src/System.Net.Http/src/project.lock.json
@@ -198,23 +198,6 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
-        }
-      },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
           "System.Private.Networking": "4.0.0"
@@ -1037,37 +1020,6 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "System.IO.UnmanagedMemoryStream/4.0.0": {
-      "serviceable": true,
-      "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
-      "files": [
-        "System.IO.UnmanagedMemoryStream.4.0.0.nupkg",
-        "System.IO.UnmanagedMemoryStream.4.0.0.nupkg.sha512",
-        "System.IO.UnmanagedMemoryStream.nuspec",
-        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
-      ]
-    },
     "System.Net.Primitives/4.0.10": {
       "serviceable": true,
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
@@ -1729,7 +1681,6 @@
       "System.Globalization >= 4.0.10",
       "System.IO >= 4.0.10",
       "System.IO.Compression >= 4.0.0",
-      "System.IO.UnmanagedMemoryStream >= 4.0.0",
       "System.Net.Primitives >= 4.0.10",
       "System.Resources.ResourceManager >= 4.0.0",
       "System.Runtime.Extensions >= 4.0.10",


### PR DESCRIPTION
Today, CurlHandler provides a response content stream that doesn't override ReadAsync.  As such, any consumers reading data using ReadAsync will actually end up blocking a thread pool thread doing a synchronous Read.

This commit fixes that by implementing ReadAsync to be truly asynchronous with no additional threads blocked.  If data is already available, a task is returned immediately.  Otherwise, the reader asynchronously waits for the writer to publish data and then consumes that data.

The overall design of the response stream remains the same as it was.  However, there are some notable changes:
- A SemaphoreSlim is now used instead of a ManualResetEventSlim for the _writerPublishedDataEvent.  This was done because SemaphoreSlim supports both synchronous and asynchronous waiting.
- The _readerRequestingDataEvent was removed, as it was no longer necessary.
- We no longer allocate an UnmanagedMemoryStream per write operation, instead simply storing the IntPtr buffer and long length on the response stream.
- Additional reorganization was done, primarily to share logic between Read and ReadAsync.
- A bunch of comments and debug asserts were added.

A second commit enables the asynchronous wait to be canceled by either the internal shutdown CancellationToken or by the CancellationToken provided by the caller to ReadAsync.

Fixes #3067 
cc: @vijaykota, @kapilash, @davidsh, @pgavlin, @CIPop 