### PR TITLE
Fix for #3045. Fixing  WebException.Status on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.CURLcode.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.CURLcode.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class libcurl
+    {
+        // Class for constants defined for the enum CURLcode in curl.h
+        internal static partial class CURLcode
+        {
+            internal const int CURLE_OK = 0;
+            internal const int CURLE_UNSUPPORTED_PROTOCOL  =  1;
+            internal const int CURLE_COULDNT_RESOLVE_PROXY =  5;
+            internal const int CURLE_COULDNT_RESOLVE_HOST  =  6;
+            internal const int CURLE_ABORTED_BY_CALLBACK = 42;
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -70,13 +70,6 @@ internal static partial class Interop
             internal const int CURLPROXY_HTTP = 0;
         }
 
-        // Class for constants defined for the enum CURLcode in curl.h
-        internal static partial class CURLcode
-        {
-            internal const int CURLE_OK = 0;
-            internal const int CURLE_ABORTED_BY_CALLBACK = 42;
-        }
-
         // Class for constants defined for the enum CURLMcode in multi.h
         internal static partial class CURLMcode
         {

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -141,7 +141,11 @@
     <Compile Include="System\Net\Http\Unix\CurlHandler.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.EasyRequest.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.MultiAgent.cs" />
+    <Compile Include="System\Net\Http\Unix\CurlException.cs" />
     <Compile Include="System\Net\Http\Unix\CurlResponseMessage.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\libcurl\Interop.CURLcode.cs">
+      <Link>Common\Interop\Unix\libcurl\Interop.CURLcode.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlException.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+
+namespace System.Net.Http
+{
+    internal sealed class CurlException : Exception
+    {
+        internal CurlException(int error, string message) : base(message)
+        {
+            HResult = error;
+        }
+
+        internal CurlException(int error, bool isMulti) : this(error, GetCurlErrorString(error, isMulti))
+        {
+        }
+
+        internal static string GetCurlErrorString(int code, bool isMulti)
+        {
+            IntPtr ptr = isMulti ? Interop.libcurl.curl_multi_strerror(code) : Interop.libcurl.curl_easy_strerror(code);
+            return Marshal.PtrToStringAnsi(ptr);
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -440,7 +440,7 @@ namespace System.Net.Http
                         completedOperation.EnsureResponseMessagePublished();
                         break;
                     default:
-                        completedOperation.FailRequest(CreateHttpRequestException(GetCurlException(messageResult)));
+                        completedOperation.FailRequest(CreateHttpRequestException(new CurlException(messageResult, false)));
                         break;
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -440,7 +440,7 @@ namespace System.Net.Http
                         completedOperation.EnsureResponseMessagePublished();
                         break;
                     default:
-                        completedOperation.FailRequest(CreateHttpRequestException(new CurlException(messageResult, false)));
+                        completedOperation.FailRequest(CreateHttpRequestException(new CurlException(messageResult, isMulti: false)));
                         break;
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -419,22 +419,11 @@ namespace System.Net.Http
             }
         }
 
-        private static string GetCurlErrorString(int code, bool isMulti = false)
-        {
-            IntPtr ptr = isMulti ? Interop.libcurl.curl_multi_strerror(code) : Interop.libcurl.curl_easy_strerror(code);
-            return Marshal.PtrToStringAnsi(ptr);
-        }
-
-        private static Exception GetCurlException(int code, bool isMulti = false)
-        {
-            return new Exception(GetCurlErrorString(code, isMulti));
-        }
-
         private static void ThrowIfCURLEError(int error)
         {
             if (error != CURLcode.CURLE_OK)
             {
-                throw CreateHttpRequestException(GetCurlException(error));
+                throw CreateHttpRequestException(new CurlException(error, isMulti: false));
             }
         }
 
@@ -442,7 +431,7 @@ namespace System.Net.Http
         {
             if (error != CURLMcode.CURLM_OK)
             {
-                string msg = GetCurlErrorString(error, isMulti: true);
+                string msg = CurlException.GetCurlErrorString(error, true);
                 switch (error)
                 {
                     case CURLMcode.CURLM_ADDED_ALREADY:
@@ -456,7 +445,7 @@ namespace System.Net.Http
                         throw new OutOfMemoryException(msg);
                     case CURLMcode.CURLM_INTERNAL_ERROR:
                     default:
-                        throw CreateHttpRequestException(new Exception(msg));
+                        throw CreateHttpRequestException(new CurlException(error, msg));
                 }
             }
         }

--- a/src/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/System.Net.Requests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -34,9 +34,6 @@
     <Compile Include="System\Net\WebHeaderCollection.cs" />
     <Compile Include="System\Net\WebRequest.cs" />
     <Compile Include="System\Net\WebResponse.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\wininet\Interop.wininet_errors.cs">
-      <Link>Common\Interop\Windows\wininet\Interop.wininet_errors.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
@@ -49,6 +46,18 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Windows\wininet\Interop.wininet_errors.cs">
+      <Link>Common\Interop\Windows\wininet\Interop.wininet_errors.cs</Link>
+    </Compile>
+    <Compile Include="System\Net\WebExceptionPal.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Unix\libcurl\Interop.CURLcode.cs">
+      <Link>Common\Interop\Unix\libcurl\Interop.CURLcode.cs</Link>
+    </Compile>
+    <Compile Include="System\Net\WebExceptionPal.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 
 namespace System.Net
 {
-    public class WebException : InvalidOperationException
+    public partial class WebException : InvalidOperationException
     {
         private const WebExceptionStatus DefaultStatus = WebExceptionStatus.UnknownError;
 
@@ -62,30 +62,6 @@ namespace System.Net
             {
                 return _response;
             }
-        }
-
-        internal static WebExceptionStatus GetStatusFromException(HttpRequestException ex)
-        {
-            WebExceptionStatus status;
-
-            // Issue 2384: update WebException.GetStatusFromException after System.Net.Http API changes
-            //
-            // For now, we use the .HResult of the exception to help us map to a suitable
-            // WebExceptionStatus enum value.  The .HResult is set into this exception by
-            // the underlying .NET Core and .NET Native versions of the System.Net.Http stack.
-            // In the future, the HttpRequestException will have its own .Status property that is
-            // an enum type that is more compatible directly with the WebExceptionStatus enum.
-            switch (ex.HResult)
-            {
-                case Interop.WININET_E_NAME_NOT_RESOLVED:
-                    status = WebExceptionStatus.NameResolutionFailure;
-                    break;
-                default:
-                    status = WebExceptionStatus.UnknownError;
-                    break;
-            }
-
-            return status;
         }
 
         internal static Exception CreateCompatibleException(Exception exception)

--- a/src/System.Net.Requests/src/System/Net/WebExceptionPal.Unix.cs
+++ b/src/System.Net.Requests/src/System/Net/WebExceptionPal.Unix.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http;
+
+namespace System.Net
+{
+    public partial class WebException : InvalidOperationException
+    {
+        internal static WebExceptionStatus GetStatusFromException(HttpRequestException ex)
+        {
+            WebExceptionStatus status;
+
+            // Issue 2384: update WebException.GetStatusFromException after System.Net.Http API changes
+            //
+            // For now, we use the .HResult of the exception to help us map to a suitable
+            // WebExceptionStatus enum value.  The .HResult is set into this exception by
+            // the underlying .NET Core and .NET Native versions of the System.Net.Http stack.
+            // In the future, the HttpRequestException will have its own .Status property that is
+            // an enum type that is more compatible directly with the WebExceptionStatus enum.
+            switch (ex.HResult)
+            {
+                case Interop.libcurl.CURLcode.CURLE_COULDNT_RESOLVE_HOST:
+                    status = WebExceptionStatus.NameResolutionFailure;
+                    break;
+                default:
+                    status = WebExceptionStatus.UnknownError;
+                    break;
+            }
+
+            return status;
+        }
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/WebExceptionPal.Windows.cs
+++ b/src/System.Net.Requests/src/System/Net/WebExceptionPal.Windows.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http;
+
+namespace System.Net
+{
+    public partial class WebException : InvalidOperationException
+    {
+        internal static WebExceptionStatus GetStatusFromException(HttpRequestException ex)
+        {
+            WebExceptionStatus status;
+
+            // Issue 2384: update WebException.GetStatusFromException after System.Net.Http API changes
+            //
+            // For now, we use the .HResult of the exception to help us map to a suitable
+            // WebExceptionStatus enum value.  The .HResult is set into this exception by
+            // the underlying .NET Core and .NET Native versions of the System.Net.Http stack.
+            // In the future, the HttpRequestException will have its own .Status property that is
+            // an enum type that is more compatible directly with the WebExceptionStatus enum.
+            switch (ex.HResult)
+            {
+                case Interop.WININET_E_NAME_NOT_RESOLVED:
+                    status = WebExceptionStatus.NameResolutionFailure;
+                    break;
+                default:
+                    status = WebExceptionStatus.UnknownError;
+                    break;
+            }
+
+            return status;
+        }
+    }
+}

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -387,7 +387,6 @@ namespace System.Net.Requests.Test
             WebResponse response = request.GetResponseAsync().Result;
         }
 
-        [ActiveIssue(3045, PlatformID.AnyUnix)]
         [Fact]
         public void GetResponseAsync_ServerNameNotInDns_ThrowsWebException()
         {

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -160,6 +160,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.BIO.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.BIO.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcurl\Interop.CURLcode.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.CURLcode.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.d2i.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.d2i.cs</Link>


### PR DESCRIPTION
This commit fixes #3045.
WebExecption class currently looks at the value of underlying HResult to
set the value of the Status.
We need to set the value of HttpRequestMessage.HResult to appropriate
CURLcode in case of errors. WebException maps this to the relevant
WebExceptionStatus