### PR TITLE
Improve SafeWinHttpHandle reference counting logic to prevent leaks

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -27,6 +27,11 @@ namespace System.Net.Http
             _chunkedMode = chunkedMode;
         }
 
+        ~WinHttpRequestStream()
+        {
+            Dispose(false);
+        }
+        
         public override bool CanRead
         {
             get
@@ -134,13 +139,12 @@ namespace System.Net.Http
         
         protected override void Dispose(bool disposing)
         {
-            if (disposing && !_disposed)
+            if (!_disposed)
             {
                 _disposed = true;
 
                 _requestHandle.DangerousRelease();
-
-                SafeWinHttpHandle.DisposeAndClearHandle(ref _requestHandle);
+                _requestHandle = null;
             }
 
             base.Dispose(disposing);

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -32,6 +32,11 @@ namespace System.Net.Http
             _requestHandle = requestHandle;
         }
 
+        ~WinHttpResponseStream()
+        {
+            Dispose(false);
+        }
+        
         public override bool CanRead
         {
             get
@@ -145,17 +150,16 @@ namespace System.Net.Http
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && !_disposed)
+            if (!_disposed)
             {
                 _disposed = true;
 
                 _requestHandle.DangerousRelease();
+                _requestHandle = null;
                 _connectHandle.DangerousRelease();
+                _connectHandle = null;
                 _sessionHandle.DangerousRelease();
-
-                SafeWinHttpHandle.DisposeAndClearHandle(ref _requestHandle);
-                SafeWinHttpHandle.DisposeAndClearHandle(ref _connectHandle);
-                SafeWinHttpHandle.DisposeAndClearHandle(ref _sessionHandle);
+                _sessionHandle = null;
             }
 
             base.Dispose(disposing);

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -82,6 +82,8 @@ internal static partial class Interop
 
         public static bool WinHttpCloseHandle(IntPtr sessionHandle)
         {
+            Marshal.FreeHGlobal(sessionHandle);
+
             return true;
         }
 

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Xunit;
+
+namespace System.Net.Http.WinHttpHandlerUnitTests
+{
+    public class SafeWinHttpHandleTest : IDisposable
+    {
+        public SafeWinHttpHandleTest()
+        {
+        }
+
+        public void Dispose()
+        {
+            // This runs after every test and makes sure that we run any finalizers to free all eligible handles.
+            FakeSafeWinHttpHandle.ForceGarbageCollection();
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+
+        [Fact]
+        public void CreateAddRefDispose_HandleIsNotClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.Dispose();
+            
+            Assert.False(safeHandle.IsClosed, "closed");
+            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandle to keep outstanding handles at zero.
+            safeHandle.DangerousRelease();
+        }
+        
+        [Fact]
+        public void CreateAddRefDisposeDispose_HandleIsNotClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.Dispose();
+            safeHandle.Dispose();
+            
+            Assert.False(safeHandle.IsClosed, "closed");
+            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandle to keep outstanding handles at zero.
+            safeHandle.DangerousRelease();
+        }
+        
+        [Fact]
+        public void CreateAddRefDisposeRelease_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.Dispose();
+            safeHandle.DangerousRelease();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+
+        [Fact]
+        public void CreateAddRefRelease_HandleIsNotClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.DangerousRelease();
+            
+            Assert.False(safeHandle.IsClosed, "closed");
+            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandle to keep outstanding handles at zero.
+            safeHandle.DangerousRelease();
+        }
+
+        [Fact]
+        public void CreateAddRefReleaseDispose_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.DangerousRelease();
+            safeHandle.Dispose();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+
+        [Fact]
+        public void CreateAddRefReleaseRelease_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.DangerousRelease();
+            safeHandle.DangerousRelease();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+        
+        [Fact]
+        public void CreateAddRefReleaseReleaseDispose_HandleIsClosedAndDisposeIsNoop()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.DangerousRelease();
+            safeHandle.DangerousRelease();
+            safeHandle.Dispose();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+        
+        [Fact]
+        public void CreateDispose_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+        }
+
+        [Fact]
+        public void CreateDisposeDispose_HandleIsClosedAndSecondDisposeIsNoop()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            safeHandle.Dispose();
+            Assert.True(safeHandle.IsClosed, "closed");
+        }
+        
+        [Fact]
+        public void CreateDisposeAddRef_ThrowsObjectDisposedException()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => 
+                { bool ignore = false; safeHandle.DangerousAddRef(ref ignore); });
+        }
+        
+        [Fact]
+        public void CreateDisposeRelease_ThrowsObjectDisposedException()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => safeHandle.DangerousRelease());
+        }
+        
+        [Fact]
+        public void CreateRelease_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.DangerousRelease();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+        }
+        
+        [Fact]
+        public void CreateReleaseDispose_HandleIsClosedAndDisposeIsNoop()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.DangerousRelease();
+            safeHandle.Dispose();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+        }
+
+        [Fact]
+        public void CreateReleaseRelease_ThrowsObjectDisposedException()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.DangerousRelease();
+            Assert.Throws<ObjectDisposedException>(() => safeHandle.DangerousRelease());
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="FakeMarshal.cs" />
     <Compile Include="FakeRegistry.cs" />
     <Compile Include="FakeSafeWinHttpHandle.cs" />
+    <Compile Include="SafeWinHttpHandleTest.cs" />
     <Compile Include="TestServer.cs" />
     <Compile Include="TestControl.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -13,9 +13,9 @@ using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class WinHttpRequestStreamTests
+    public class WinHttpRequestStreamTest
     {
-        public WinHttpRequestStreamTests()
+        public WinHttpRequestStreamTest()
         {
             TestControl.ResetAll();
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -10,9 +10,9 @@ using Xunit;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class WinHttpResponseStreamTests
+    public class WinHttpResponseStreamTest
     {
-        public WinHttpResponseStreamTests()
+        public WinHttpResponseStreamTest()
         {
             TestControl.ResetAll();
         }


### PR DESCRIPTION
This PR mainly addresses "handle leaks" #2963, #2762, #2793. In investigating the leaks, I discovered that our use of the SafeHandle pattern was not quite right. In addition, SafeHandle has some rather quirky lifetime management aspects with respect to the Dispose() and DangerousRelease() methods. After reviewing the source code for SafeHandle itself, I discovered a better pattern to using. Native Windows WinHTTP handles wrapped by SafeHandle need additional lifetime management protection. I also needed to add finalizers to the WinHttpHandler, WinHttpRequestStream and WinHttpResponseStream classes. Finally, I added unit tests to validate our behavior assumptions and to track leaks in the WinHttpHandler logic.

This change does not affect the SafeWinHttpHandleWithCallback class that is used by System.Net.WebSocket.Client. But that class is incorrectly using the SafeHandle pattern w.r.t. Dispose() and I will be fixing that in a later PR.