### PR TITLE
System.IO.Compression: use consistent namespace name for tests

### DIFF
--- a/src/Common/tests/Compression/Utilities/ZipTestHelper.cs
+++ b/src/Common/tests/Compression/Utilities/ZipTestHelper.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public partial class ZipTest
     {

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public partial class ZipTest
     {

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public partial class ZipTest
     {

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileReadOpenUpdateTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileReadOpenUpdateTests.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public partial class ZipTest
     {

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public partial class ZipTest : IDisposable
     {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public class zip_CreateTests 
     {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public class zip_InvalidParametersAndStrangeFiles
     {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public class zip_ManualAndCompatabilityTests
     {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public class zip_ReadTests 
     {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Compression.Test
+namespace System.IO.Compression.Tests
 {
     public class zip_UpdateTests
     {


### PR DESCRIPTION
As per https://github.com/dotnet/corefx/issues/2898 the convention is `$(Namespace of Type under Test).Tests`
Some tests were in `.Test`, this change renames them to `.Tests`
