### PR TITLE
Improve WinHttpHandler and SafeWinHttpHandle reference counting logic

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -21,8 +21,6 @@ namespace System.Net.Http
 
         internal WinHttpRequestStream(SafeWinHttpHandle requestHandle, bool chunkedMode)
         {
-            bool ignore = false;
-            requestHandle.DangerousAddRef(ref ignore);
             _requestHandle = requestHandle;
             _chunkedMode = chunkedMode;
         }
@@ -134,13 +132,9 @@ namespace System.Net.Http
         
         protected override void Dispose(bool disposing)
         {
-            if (disposing && !_disposed)
+            if (!_disposed)
             {
                 _disposed = true;
-
-                _requestHandle.DangerousRelease();
-
-                SafeWinHttpHandle.DisposeAndClearHandle(ref _requestHandle);
             }
 
             base.Dispose(disposing);

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -82,6 +82,8 @@ internal static partial class Interop
 
         public static bool WinHttpCloseHandle(IntPtr sessionHandle)
         {
+            Marshal.FreeHGlobal(sessionHandle);
+
             return true;
         }
 

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Xunit;
+
+namespace System.Net.Http.WinHttpHandlerUnitTests
+{
+    public class SafeWinHttpHandleTest : IDisposable
+    {
+        public SafeWinHttpHandleTest()
+        {
+        }
+
+        public void Dispose()
+        {
+            // This runs after every test and makes sure that we run any finalizers to free all eligible handles.
+            FakeSafeWinHttpHandle.ForceGarbageCollection();
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+
+        [Fact]
+        public void CreateAddRefDispose_HandleIsNotClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.Dispose();
+            
+            Assert.False(safeHandle.IsClosed, "closed");
+            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandle to keep outstanding handles at zero.
+            safeHandle.DangerousRelease();
+        }
+
+        [Fact]
+        public void CreateAddRefDisposeDispose_HandleIsNotClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.Dispose();
+            safeHandle.Dispose();
+            
+            Assert.False(safeHandle.IsClosed, "closed");
+            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandle to keep outstanding handles at zero.
+            safeHandle.DangerousRelease();
+        }
+
+        [Fact]
+        public void CreateAddRefDisposeRelease_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.Dispose();
+            safeHandle.DangerousRelease();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+
+        [Fact]
+        public void CreateAddRefRelease_HandleIsNotClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.DangerousRelease();
+            
+            Assert.False(safeHandle.IsClosed, "closed");
+            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandle to keep outstanding handles at zero.
+            safeHandle.Dispose();
+        }
+
+        [Fact]
+        public void CreateAddRefReleaseDispose_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            bool success = false;
+            safeHandle.DangerousAddRef(ref success);
+            Assert.True(success, "DangerousAddRef");
+            safeHandle.DangerousRelease();
+            safeHandle.Dispose();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
+        }
+
+        [Fact]
+        public void CreateDispose_HandleIsClosed()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            
+            Assert.True(safeHandle.IsClosed, "closed");
+        }
+
+        [Fact]
+        public void CreateDisposeDispose_HandleIsClosedAndSecondDisposeIsNoop()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            safeHandle.Dispose();
+            Assert.True(safeHandle.IsClosed, "closed");
+        }
+
+        [Fact]
+        public void CreateDisposeAddRef_ThrowsObjectDisposedException()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => 
+                { bool ignore = false; safeHandle.DangerousAddRef(ref ignore); });
+        }
+
+        [Fact]
+        public void CreateDisposeRelease_ThrowsObjectDisposedException()
+        {
+            var safeHandle = new FakeSafeWinHttpHandle(true);
+            safeHandle.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => safeHandle.DangerousRelease());
+        }
+
+        [Fact]
+        public void SetParentHandle_CreateParentCreateChildDisposeParent_ParentNotClosed()
+        {
+            var parentHandle = new FakeSafeWinHttpHandle(true);
+            var childHandle = new FakeSafeWinHttpHandle(true);
+            childHandle.SetParentHandle(parentHandle);
+            parentHandle.Dispose();
+            
+            Assert.False(parentHandle.IsClosed, "closed");
+            Assert.Equal(2, FakeSafeWinHttpHandle.HandlesOpen);
+            
+            // Clean up safeHandles to keep outstanding handles at zero.
+            childHandle.Dispose();
+        }
+
+        [Fact]
+        public void SetParentHandle_CreateParentCreateChildDisposeParentDisposeChild_HandlesClosed()
+        {
+            var parentHandle = new FakeSafeWinHttpHandle(true);
+            var childHandle = new FakeSafeWinHttpHandle(true);
+            childHandle.SetParentHandle(parentHandle);
+            parentHandle.Dispose();
+            childHandle.Dispose();
+            
+            Assert.True(parentHandle.IsClosed, "closed");
+            Assert.True(childHandle.IsClosed, "closed");
+        }
+
+        [Fact]
+        public void SetParentHandle_CreateParentCreateChildDisposeChildDisposeParent_HandlesClosed()
+        {
+            var parentHandle = new FakeSafeWinHttpHandle(true);
+            var childHandle = new FakeSafeWinHttpHandle(true);
+            childHandle.SetParentHandle(parentHandle);
+            childHandle.Dispose();
+            parentHandle.Dispose();
+            
+            Assert.True(parentHandle.IsClosed, "closed");
+            Assert.True(childHandle.IsClosed, "closed");
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Net.Http.WinHttpHandler.Unit.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>..\..\src\Resources\Strings.resx</StringResourcesPath>
+    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   
   <!-- Help VS understand available configurations -->
@@ -75,6 +76,7 @@
     <Compile Include="FakeMarshal.cs" />
     <Compile Include="FakeRegistry.cs" />
     <Compile Include="FakeSafeWinHttpHandle.cs" />
+    <Compile Include="SafeWinHttpHandleTest.cs" />
     <Compile Include="TestServer.cs" />
     <Compile Include="TestControl.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -13,9 +13,9 @@ using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class WinHttpRequestStreamTests
+    public class WinHttpRequestStreamTest
     {
-        public WinHttpRequestStreamTests()
+        public WinHttpRequestStreamTest()
         {
             TestControl.ResetAll();
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -10,9 +10,9 @@ using Xunit;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class WinHttpResponseStreamTests
+    public class WinHttpResponseStreamTest
     {
-        public WinHttpResponseStreamTests()
+        public WinHttpResponseStreamTest()
         {
             TestControl.ResetAll();
         }
@@ -252,11 +252,9 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
         internal Stream MakeResponseStream()
         {
-            var sessionHandle = new FakeSafeWinHttpHandle(true);
-            var connectHandle = new FakeSafeWinHttpHandle(true);
             var requestHandle = new FakeSafeWinHttpHandle(true);
 
-            return new WinHttpResponseStream(sessionHandle, connectHandle, requestHandle);
+            return new WinHttpResponseStream(requestHandle);
         }
     }
 }


### PR DESCRIPTION
This PR mainly addresses "handle leaks" #2963, #2762, #2793. In investigating the leaks, I discovered that our use of the SafeHandle pattern was not quite right. Native Windows WinHTTP handles wrapped by SafeHandle need additional lifetime management protection to preserve parent-child relationships. Closing the parent handle too early will invalidate the child handle. So, added a SetParentHandle() method to SafeWinHttpHandle to protect against this. This also simplified the passing of handles to the WinHttpResponseStream class.

I added finalizers to the WinHttpHandler and WinHttpResponseStream classes. Note that the WinHttpRequestStream class doesn't need a finalizer because its lifetime is short within the processing of the SendAsync() method.

Finally, I added unit tests to validate the behavior assumptions and to track leaks in the WinHttpHandler logic.

This change does not affect the SafeWinHttpHandleWithCallback class that is used by System.Net.WebSocket.Client. But that class is incorrectly using the SafeHandle pattern w.r.t. Dispose() and I will be fixing that in a later PR.