### PR TITLE
Short-circuit on SequenceEqual

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -979,6 +979,14 @@ namespace System.Linq
             if (comparer == null) comparer = EqualityComparer<TSource>.Default;
             if (first == null) throw Error.ArgumentNull("first");
             if (second == null) throw Error.ArgumentNull("second");
+
+            ICollection<TSource> firstCol = first as ICollection<TSource>;
+            if (firstCol != null)
+            {
+                ICollection<TSource> secondCol = second as ICollection<TSource>;
+                if (secondCol != null && firstCol.Count != secondCol.Count) return false;
+            }
+
             using (IEnumerator<TSource> e1 = first.GetEnumerator())
             using (IEnumerator<TSource> e2 = second.GetEnumerator())
             {
@@ -986,9 +994,8 @@ namespace System.Linq
                 {
                     if (!(e2.MoveNext() && comparer.Equals(e1.Current, e2.Current))) return false;
                 }
-                if (e2.MoveNext()) return false;
+                return !e2.MoveNext();
             }
-            return true;
         }
 
         public static IEnumerable<TSource> AsEnumerable<TSource>(this IEnumerable<TSource> source)

--- a/src/System.Linq/tests/SequenceEqualTests.cs
+++ b/src/System.Linq/tests/SequenceEqualTests.cs
@@ -37,6 +37,16 @@ namespace System.Linq.Tests
             }
         }
         
+        private static IEnumerable<T> ForceNotCollection<T>(IEnumerable<T> source)
+        {
+            foreach (T item in source) yield return item;
+        }
+        
+        private static IEnumerable<T> FlipIsCollection<T>(IEnumerable<T> source)
+        {
+            return source is ICollection<T> ? ForceNotCollection(source) : new List<T>(source);
+        }
+        
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
         {
@@ -66,6 +76,9 @@ namespace System.Linq.Tests
             int[] second = { };
 
             Assert.True(first.SequenceEqual(second));
+            Assert.True(FlipIsCollection(first).SequenceEqual(second));
+            Assert.True(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.True(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -75,6 +88,9 @@ namespace System.Linq.Tests
             int?[] second = { 1, 2, 6, 4 };
             
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -84,6 +100,9 @@ namespace System.Linq.Tests
             string[] second = { "Bbo", "mTi", "rishC" };
 
             Assert.False(first.SequenceEqual(second, null));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second, null));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second), null));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second), null));
         }
 
         [Fact]
@@ -93,6 +112,9 @@ namespace System.Linq.Tests
             string[] second = { "Bbo", "mTi", "rishC" };
 
             Assert.True(first.SequenceEqual(second, new AnagramEqualityComparer()));
+            Assert.True(FlipIsCollection(first).SequenceEqual(second, new AnagramEqualityComparer()));
+            Assert.True(first.SequenceEqual(FlipIsCollection(second), new AnagramEqualityComparer()));
+            Assert.True(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second), new AnagramEqualityComparer()));
         }
 
         [Fact]
@@ -102,6 +124,9 @@ namespace System.Linq.Tests
             string[] second = { null };
             
             Assert.True(first.SequenceEqual(second, StringComparer.Ordinal));
+            Assert.True(FlipIsCollection(first).SequenceEqual(second, StringComparer.Ordinal));
+            Assert.True(first.SequenceEqual(FlipIsCollection(second), StringComparer.Ordinal));
+            Assert.True(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second), StringComparer.Ordinal));
         }
 
         [Fact]
@@ -111,6 +136,9 @@ namespace System.Linq.Tests
             int?[] second = { -6, null, 0, -4, 9, 10, 20 };
 
             Assert.True(first.SequenceEqual(second));
+            Assert.True(FlipIsCollection(first).SequenceEqual(second));
+            Assert.True(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.True(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -120,6 +148,9 @@ namespace System.Linq.Tests
             int?[] second = { 2, 3, 4 };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -129,6 +160,9 @@ namespace System.Linq.Tests
             int?[] second = { };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -138,6 +172,9 @@ namespace System.Linq.Tests
             int?[] second = { 4 };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -147,6 +184,9 @@ namespace System.Linq.Tests
             int?[] second = { 2, 2, 3, 4, 5 };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
 
@@ -157,6 +197,9 @@ namespace System.Linq.Tests
             int?[] second = { 1, 2, 3, 4, 5 };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -166,6 +209,9 @@ namespace System.Linq.Tests
             int?[] second = { 1, 2, 3, 4, 4 };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]
@@ -175,6 +221,9 @@ namespace System.Linq.Tests
             int?[] second = { 1, 2, 3, 4 };
 
             Assert.False(first.SequenceEqual(second));
+            Assert.False(FlipIsCollection(first).SequenceEqual(second));
+            Assert.False(first.SequenceEqual(FlipIsCollection(second)));
+            Assert.False(FlipIsCollection(first).SequenceEqual(FlipIsCollection(second)));
         }
 
         [Fact]


### PR DESCRIPTION
Short-circuit to false on both sequences are ICollection<T> and different Count