### PR TITLE
Add AssemblyExtensions.TryGetRawMetadata to the System.Reflection.Met…

### DIFF
--- a/src/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -5,6 +5,14 @@
 // ------------------------------------------------------------------------------
 
 
+namespace System.Reflection.Metadata
+{
+    public static partial class AssemblyExtensions
+    {
+        [CLSCompliant(false)] // out byte* blob
+        public unsafe static bool TryGetRawMetadata(this System.Reflection.Assembly assembly, out byte* blob, out int length) { blob = default(byte*); length = default(int); return default(bool); }
+    }
+}
 namespace System.Runtime.Loader
 {
     public abstract partial class AssemblyLoadContext

--- a/src/System.Runtime.Loader/ref/System.Runtime.Loader.csproj
+++ b/src/System.Runtime.Loader/ref/System.Runtime.Loader.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Loader.cs" />

--- a/src/System.Runtime.Loader/ref/project.json
+++ b/src/System.Runtime.Loader/ref/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "System.Runtime": "4.0.0",
     "System.Reflection": "4.0.0",
+    "System.Reflection.Primitives": "4.0.0",
     "System.IO": "4.0.0"
   },
   "frameworks": {

--- a/src/System.Runtime.Loader/ref/project.lock.json
+++ b/src/System.Runtime.Loader/ref/project.lock.json
@@ -328,6 +328,7 @@
     "": [
       "System.Runtime >= 4.0.0",
       "System.Reflection >= 4.0.0",
+      "System.Reflection.Primitives >= 4.0.0",
       "System.IO >= 4.0.0"
     ],
     ".NETPlatform,Version=v5.0": []


### PR DESCRIPTION
…adata namespace.

This patch adds the new API to the System.Runtime.Loader reference assembly. Tests will be added separately, once the new API is published and can be consumed.

Part of dotnet/corefx#2768