### PR TITLE
Fix TestEnvironmentOfChildProcess to set output encoding

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -10,6 +10,7 @@ using System.Security.Principal;
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using Xunit;
+using System.Text;
 
 namespace System.Diagnostics.ProcessTests
 {
@@ -184,61 +185,71 @@ namespace System.Diagnostics.ProcessTests
         [Fact]
         public void TestEnvironmentOfChildProcess()
         {
-            var expectedEnv = new HashSet<string>();
-            var actualEnv = new HashSet<string>();
-            Process p = CreateProcess(() =>
+            const string UnicodeEnvVar = "TestEnvironmentOfChildProcess";
+            Environment.SetEnvironmentVariable(UnicodeEnvVar, "\x1234\x5678"); // ensure some Unicode characters are in the output
+            try
             {
+                var expectedEnv = new HashSet<string>();
+                var actualEnv = new HashSet<string>();
+                Process p = CreateProcess(() =>
+                {
+                    foreach (DictionaryEntry envVar in Environment.GetEnvironmentVariables())
+                    {
+                        Console.WriteLine(envVar.Key + "=" + envVar.Value);
+                    }
+
+                    return SuccessExitCode;
+                });
+                p.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+
+                p.StartInfo.RedirectStandardOutput = true;
+                p.OutputDataReceived += (s, e) =>
+                {
+                    if (e.Data != null)
+                    {
+                        expectedEnv.Add(e.Data);
+                    }
+                };
+
+                p.Start();
+                p.BeginOutputReadLine();
+
+                foreach (KeyValuePair<string, string> envVar in p.StartInfo.Environment)
+                {
+                    actualEnv.Add(envVar.Key + "=" + envVar.Value);
+                }
+
+                Assert.True(p.WaitForExit(WaitInMS));
+                p.WaitForExit(); // This ensures async event handlers are finished processing.
+
+                // Validate against StartInfo.Environment
+                if (!expectedEnv.SetEquals(actualEnv))
+                {
+                    var expected = string.Join(", ", expectedEnv.Except(actualEnv));
+                    var actual = string.Join(", ", actualEnv.Except(expectedEnv));
+
+                    Assert.True(false, string.Format("Expected: {0}{1}Actual: {2}", expected, Environment.NewLine, actual));
+                }
+
+                // Validate against current process
+                var currentProcEnv = new HashSet<string>();
                 foreach (DictionaryEntry envVar in Environment.GetEnvironmentVariables())
                 {
-                    Console.WriteLine(envVar.Key + "=" + envVar.Value);
+                    currentProcEnv.Add(envVar.Key + "=" + envVar.Value);
                 }
 
-                return SuccessExitCode;
-            });
-
-            p.StartInfo.RedirectStandardOutput = true;
-            p.OutputDataReceived += (s, e) =>
-            {
-                if (e.Data != null)
-                {
-                    expectedEnv.Add(e.Data);
-                }
-            };
-
-            p.Start();
-            p.BeginOutputReadLine();
-
-            foreach (KeyValuePair<string, string> envVar in p.StartInfo.Environment)
-            {
-                actualEnv.Add(envVar.Key + "=" + envVar.Value);
+                // Profilers / code coverage tools can add own environment variables but we start
+                // child process without them. Thus the set of variables from child process will
+                // compose subset of variables from current process.
+                // But in case if tests running directly through the Xunit runner, sets will be equal
+                // and Assert.ProperSubset will throw. We add null to avoid this.
+                currentProcEnv.Add(null);
+                Assert.ProperSubset(currentProcEnv, actualEnv);
             }
-
-            Assert.True(p.WaitForExit(WaitInMS));
-            p.WaitForExit(); // This ensures async event handlers are finished processing.
-
-            // Validate against StartInfo.Environment
-            if (!expectedEnv.SetEquals(actualEnv))
+            finally
             {
-                var expected = string.Join(", ", expectedEnv.Except(actualEnv));
-                var actual = string.Join(", ", actualEnv.Except(expectedEnv));
-
-                Assert.True(false, string.Format("Expected: {0}{1}Actual: {2}", expected, Environment.NewLine, actual));
+                Environment.SetEnvironmentVariable(UnicodeEnvVar, null);
             }
-
-            // Validate against current process
-            var currentProcEnv = new HashSet<string>();
-            foreach (DictionaryEntry envVar in Environment.GetEnvironmentVariables())
-            {
-                currentProcEnv.Add(envVar.Key + "=" + envVar.Value);
-            }
-
-            // Profilers / code coverage tools can add own environment variables but we start
-            // child process without them. Thus the set of variables from child process will
-            // compose subset of variables from current process.
-            // But in case if tests running directly through the Xunit runner, sets will be equal
-            // and Assert.ProperSubset will throw. We add null to avoid this.
-            currentProcEnv.Add(null);
-            Assert.ProperSubset(currentProcEnv, actualEnv);
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="ProcessTestBase.cs" />
     <Compile Include="ProcessThreadTests.cs" />
     <Compile Include="ProcessWaitingTests.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Diagnostics.Process/tests/XunitAssemblyAttributes.cs
+++ b/src/System.Diagnostics.Process/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+// Process tests can conflict with each other, as they modify ambient state 
+// like the console code page and environment variables
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
Three issues all conspiring together:
- On many machines, none of the environment variables would have non-ASCII characters.
- Some of the Process tests mutate the ambient console encoding on Windows
- The default standard output encoding on Windows results in Unicode characters getting lost in translation

The net effect of this is that the test would fail randomly.

The fix:
- Adds an environment variable that includes non-ASCII characters to force the issue
- Adds an xunit attribute to prevent parallelization of the Process tests
- Forces the test to use UTF8 for the standard output encoding

cc: @akoeplinger, @Maxwe11 
I believe this fixes #3075 and can replace #3090.
The change looks larger than it actually is due to adding a try/catch and adding lots of indentation as a result.