### PR TITLE
Add SelectXXXIterator separate to WhereSelectXXXIterator

### DIFF
--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -519,6 +519,20 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void WhereSelectSelect_Array_ReturnsExpectedValues()
+        {
+            int[] source = new[] { 1, 2, 3, 4, 5 };
+            Func<int, bool> evenPredicate = (value) => value % 2 == 0;
+            Func<int, int> addSelector = (value) => value + 1;
+
+            IEnumerable<int> result = source.Where(evenPredicate).Select(i => i).Select(addSelector);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(3, result.ElementAt(0));
+            Assert.Equal(5, result.ElementAt(1));
+        }
+
+        [Fact]
         public void WhereSelect_List_ReturnsExpectedValues()
         {
             List<int> source = new List<int> { 1, 2, 3, 4, 5 };
@@ -526,6 +540,20 @@ namespace System.Linq.Tests
             Func<int, int> addSelector = (value) => value + 1;
 
             IEnumerable<int> result = source.Where(evenPredicate).Select(addSelector);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(3, result.ElementAt(0));
+            Assert.Equal(5, result.ElementAt(1));
+        }
+
+        [Fact]
+        public void WhereSelectSelect_List_ReturnsExpectedValues()
+        {
+            List<int> source = new List<int> { 1, 2, 3, 4, 5 };
+            Func<int, bool> evenPredicate = (value) => value % 2 == 0;
+            Func<int, int> addSelector = (value) => value + 1;
+
+            IEnumerable<int> result = source.Where(evenPredicate).Select(i => i).Select(addSelector);
 
             Assert.Equal(2, result.Count());
             Assert.Equal(3, result.ElementAt(0));
@@ -547,6 +575,20 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void WhereSelectSelect_IReadOnlyCollection_ReturnsExpectedValues()
+        {
+            IReadOnlyCollection<int> source = new ReadOnlyCollection<int>(new List<int> { 1, 2, 3, 4, 5 });
+            Func<int, bool> evenPredicate = (value) => value % 2 == 0;
+            Func<int, int> addSelector = (value) => value + 1;
+
+            IEnumerable<int> result = source.Where(evenPredicate).Select(i => i).Select(addSelector);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(3, result.ElementAt(0));
+            Assert.Equal(5, result.ElementAt(1));
+        }
+
+        [Fact]
         public void WhereSelect_ICollection_ReturnsExpectedValues()
         {
             ICollection<int> source = new LinkedList<int>(new List<int> { 1, 2, 3, 4, 5 });
@@ -561,6 +603,20 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void WhereSelectSelect_ICollection_ReturnsExpectedValues()
+        {
+            ICollection<int> source = new LinkedList<int>(new List<int> { 1, 2, 3, 4, 5 });
+            Func<int, bool> evenPredicate = (value) => value % 2 == 0;
+            Func<int, int> addSelector = (value) => value + 1;
+
+            IEnumerable<int> result = source.Where(evenPredicate).Select(i => i).Select(addSelector);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(3, result.ElementAt(0));
+            Assert.Equal(5, result.ElementAt(1));
+        }
+
+        [Fact]
         public void WhereSelect_IEnumerable_ReturnsExpectedValues()
         {
             IEnumerable<int> source = Enumerable.Range(1, 5);
@@ -568,6 +624,20 @@ namespace System.Linq.Tests
             Func<int, int> addSelector = (value) => value + 1;
 
             IEnumerable<int> result = source.Where(evenPredicate).Select(addSelector);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(3, result.ElementAt(0));
+            Assert.Equal(5, result.ElementAt(1));
+        }
+
+        [Fact]
+        public void WhereSelectSelect_IEnumerable_ReturnsExpectedValues()
+        {
+            IEnumerable<int> source = Enumerable.Range(1, 5);
+            Func<int, bool> evenPredicate = (value) => value % 2 == 0;
+            Func<int, int> addSelector = (value) => value + 1;
+
+            IEnumerable<int> result = source.Where(evenPredicate).Select(i => i).Select(addSelector);
 
             Assert.Equal(2, result.Count());
             Assert.Equal(3, result.ElementAt(0));


### PR DESCRIPTION
`WhereSelectXXXIterator` classes can no longer have a null predicate, so that case need no longer be checked for. (Add readonly and assertions to ensure this assumption is true.)

Add IList<T>-based Select specialised class, on same basis; increases cases covered by optimised `ToArray()`, also reduces number of branches non-ilist sources (likely most common case) go
through though at cost of one more for array or list.

IArrayProvider<TElement>.ToArray() will now never return null, so don't test for the case that it may have.