### PR TITLE
Remove problematic ctrl-C System.Console test

### DIFF
--- a/src/System.Console/tests/CancelKeyPress.cs
+++ b/src/System.Console/tests/CancelKeyPress.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.InteropServices;
-using System.Threading;
 using Xunit;
 
 public class CancelKeyPress
@@ -23,45 +21,51 @@ public class CancelKeyPress
         Console.CancelKeyPress -= handler;
     }
 
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public static void InvokingCancelKeyPressHandler()
-    {
-        // On Windows we could use GenerateConsoleCtrlEvent to send a ctrl-C to the process,
-        // however that'll apply to all processes associated with the same group, which will
-        // include processes like the code coverage tool when doing code coverage runs, causing
-        // those other processes to exit.  As such, we test this only on Unix, where we can
-        // send a SIGINT signal to this specific process only.
+    // Commented out InvokingCancelKeyPressHandler test:
+    // While this test works, it also causes problems when run as part of
+    // the xunit harness.  Since it issues a ctrl-c back to itself, xunit's own
+    // CancelKeyPress event handler will likely stop running additional tests
+    // after this test has run.  The test is here and commented out rather than
+    // being deleted in case we want to add something like it back in the future.
+    //
+    //[Fact]
+    //[PlatformSpecific(PlatformID.AnyUnix)]
+    //public static void InvokingCancelKeyPressHandler()
+    //{
+    //    // On Windows we could use GenerateConsoleCtrlEvent to send a ctrl-C to the process,
+    //    // however that'll apply to all processes associated with the same group, which will
+    //    // include processes like the code coverage tool when doing code coverage runs, causing
+    //    // those other processes to exit.  As such, we test this only on Unix, where we can
+    //    // send a SIGINT signal to this specific process only.
+    //
+    //    using (var mres = new ManualResetEventSlim())
+    //    {
+    //        ConsoleCancelEventHandler handler = (sender, e) => {
+    //            e.Cancel = true;
+    //            mres.Set();
+    //        };
+    //
+    //        Console.CancelKeyPress += handler;
+    //        try
+    //        {
+    //            Assert.Equal(0, kill(getpid(), SIGINT));
+    //            Assert.True(mres.Wait(WaitFailTestTimeoutSeconds));
+    //        }
+    //        finally
+    //        {
+    //            Console.CancelKeyPress -= handler;
+    //        }
+    //    }
+    //}
+    //
+    //// P/Invokes included here rather than being pulled from Interop\Unix
+    //// to avoid platform-dependent includes in csproj
+    //[DllImport("libc", SetLastError = true)]
+    //private static extern int kill(int pid, int sig);
+    //
+    //[DllImport("libc")]
+    //private static extern int getpid();
+    //
+    //private const int SIGINT = 2;
 
-        using (var mres = new ManualResetEventSlim())
-        {
-            ConsoleCancelEventHandler handler = (sender, e) => {
-                e.Cancel = true;
-                mres.Set();
-            };
-
-            Console.CancelKeyPress += handler;
-            try
-            {
-                Assert.Equal(0, kill(getpid(), SIGINT));
-                Assert.True(mres.Wait(WaitFailTestTimeoutSeconds));
-            }
-            finally
-            {
-                Console.CancelKeyPress -= handler;
-            }
-        }
-    }
-
-    #region Unix Imports
-    // P/Invokes included here rather than being pulled from Interop\Unix
-    // to avoid platform-dependent includes in csproj
-    [DllImport("libc", SetLastError = true)]
-    private static extern int kill(int pid, int sig);
-
-    [DllImport("libc")]
-    private static extern int getpid();
-
-    private const int SIGINT = 2;
-    #endregion
 }


### PR DESCRIPTION
Our test for ctrl-C handling on Unix generally works fine, but it causes problems when run in xunit, which has its own ctrl-C handler that stops running tests. Since the test doesn't make sense for now but we might want something like it later, I'm commenting it out (added a comment to the code as to why it's commented out) rather than marking it as [ActiveIssue] or deleting it.

cc: @ellismg 