### PR TITLE
Remove redundant checks in RegistryKey

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -1202,9 +1202,7 @@ namespace Microsoft.Win32
                         // make sure the string is null terminated before processing the data
                         if (blob.Length > 0 && blob[blob.Length - 1] != (char)0)
                         {
-                            char[] newBlob = new char[blob.Length + 1];
-                            Array.Copy(blob, 0, newBlob, 0, blob.Length);
-                            blob = newBlob;
+                            Array.Resize(ref blob, blob.Length + 1);
                         }
 
                         var strings = new List<String>();

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -1202,18 +1202,9 @@ namespace Microsoft.Win32
                         // make sure the string is null terminated before processing the data
                         if (blob.Length > 0 && blob[blob.Length - 1] != (char)0)
                         {
-                            try
-                            {
-                                char[] newBlob = new char[checked(blob.Length + 1)];
-                                Array.Copy(blob, 0, newBlob, 0, blob.Length);
-                                newBlob[newBlob.Length - 1] = (char)0;
-                                blob = newBlob;
-                            }
-                            catch (OverflowException e)
-                            {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
-                            blob[blob.Length - 1] = (char)0;
+                            char[] newBlob = new char[blob.Length + 1];
+                            Array.Copy(blob, 0, newBlob, 0, blob.Length);
+                            blob = newBlob;
                         }
 
                         var strings = new List<String>();


### PR DESCRIPTION
Summary of changes:

- Checked addition is unnecessary as we'll get an OOME before `blob.Length + 1` overflows
- So we can remove the try/catch clauses
- Memory is already 0-initialized, so we don't need to set it to 0