### PR TITLE
Increase System.Linq line code coverage to 99.5%

### DIFF
--- a/src/System.Linq/src/Resources/Strings.resx
+++ b/src/System.Linq/src/Resources/Strings.resx
@@ -120,9 +120,6 @@
   <data name="EmptyEnumerable" xml:space="preserve">
     <value>Enumeration yielded no results</value>
   </data>
-  <data name="InvalidOperation_EnumOpCantHappen" xml:space="preserve">
-    <value>Enumeration has either not started or has already finished.</value>
-  </data>
   <data name="MoreThanOneElement" xml:space="preserve">
     <value>Sequence contains more than one element</value>
   </data>

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3188,8 +3188,6 @@ namespace System.Linq
         private int _freeList;
         private IEqualityComparer<TElement> _comparer;
 
-        public Set() : this(null) { }
-
         public Set(IEqualityComparer<TElement> comparer)
         {
             if (comparer == null) comparer = EqualityComparer<TElement>.Default;
@@ -3203,12 +3201,6 @@ namespace System.Linq
         public bool Add(TElement value)
         {
             return !Find(value, true);
-        }
-
-        // Check whether value is in set
-        public bool Contains(TElement value)
-        {
-            return Find(value, false);
         }
 
         // If value is in set, remove it and return true; otherwise return false
@@ -3567,6 +3559,11 @@ namespace System.Linq
         }
     }
 
+    // NOTE: DO NOT DELETE THE FOLLOWING DEBUG VIEW TYPES.
+    // Although it might be tempting due to them not be referenced anywhere in this library,
+    // Visual Studio currently depends on their existence to enable the "Results" view in 
+    // watch windows.
+
     /// <summary>
     /// This class provides the items view for the Enumerable
     /// </summary>
@@ -3624,7 +3621,7 @@ namespace System.Linq
         {
             get
             {
-                return Strings.EmptyEnumerable;
+                return SR.EmptyEnumerable;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Errors.cs
+++ b/src/System.Linq/src/System/Linq/Errors.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace System.Linq
 {
     internal static class Error
@@ -11,23 +9,14 @@ namespace System.Linq
 
         internal static Exception ArgumentOutOfRange(string s) { return new ArgumentOutOfRangeException(s); }
 
-        internal static Exception MoreThanOneElement() { return new InvalidOperationException(Strings.MoreThanOneElement); }
+        internal static Exception MoreThanOneElement() { return new InvalidOperationException(SR.MoreThanOneElement); }
 
-        internal static Exception MoreThanOneMatch() { return new InvalidOperationException(Strings.MoreThanOneMatch); }
+        internal static Exception MoreThanOneMatch() { return new InvalidOperationException(SR.MoreThanOneMatch); }
 
-        internal static Exception NoElements() { return new InvalidOperationException(Strings.NoElements); }
+        internal static Exception NoElements() { return new InvalidOperationException(SR.NoElements); }
 
-        internal static Exception NoMatch() { return new InvalidOperationException(Strings.NoMatch); }
+        internal static Exception NoMatch() { return new InvalidOperationException(SR.NoMatch); }
 
         internal static Exception NotSupported() { return new NotSupportedException(); }
-    }
-
-    internal static class Strings
-    {
-        internal static String EmptyEnumerable { get { return SR.EmptyEnumerable; } }
-        internal static String MoreThanOneElement { get { return SR.MoreThanOneElement; } }
-        internal static String MoreThanOneMatch { get { return SR.MoreThanOneMatch; } }
-        internal static String NoElements { get { return SR.NoElements; } }
-        internal static String NoMatch { get { return SR.NoMatch; } }
     }
 }

--- a/src/System.Linq/tests/EnumerableDebugViewTests.cs
+++ b/src/System.Linq/tests/EnumerableDebugViewTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    // Enumerable contains several *EnumerableDebugView* types that aren't referenced
+    // within the assembly but that are accessed via reflection by other tools.
+    // As such, we test those types via reflection as well.
+
+    public class EnumerableDebugViewTests
+    {
+        [Fact]
+        public void NonGenericEnumerableDebugView_ThrowsForNullSource()
+        {
+            Exception exc = Assert.Throws<TargetInvocationException>(() => CreateSystemCore_EnumerableDebugView(null));
+            ArgumentNullException ane = Assert.IsType<ArgumentNullException>(exc.InnerException);
+            Assert.Equal("enumerable", ane.ParamName);
+        }
+
+        [Fact]
+        public void NonGenericEnumerableDebugView_ThrowsForEmptySource()
+        {
+            IEnumerable source = Enumerable.Range(10, 0);
+            object debugView = CreateSystemCore_EnumerableDebugView(source);
+            Exception exc = Assert.Throws<TargetInvocationException>(() => GetItems<object>(debugView));
+            Assert.NotNull(exc.InnerException);
+            Assert.False(string.IsNullOrEmpty(GetEmptyProperty(exc.InnerException)));
+        }
+
+        [Fact]
+        public void NonGenericEnumerableDebugView_NonEmptySource()
+        {
+            IEnumerable source = Enumerable.Range(10, 5).Select(i => (object)i);
+            object debugView = CreateSystemCore_EnumerableDebugView(source);
+            Assert.Equal<object>(source.Cast<object>().ToArray(), GetItems<object>(debugView));
+        }
+
+        [Fact]
+        public void GenericEnumerableDebugView_ThrowsForNullSource()
+        {
+            Exception exc = Assert.Throws<TargetInvocationException>(() => CreateSystemCore_EnumerableDebugView<int>(null));
+            ArgumentNullException ane = Assert.IsType<ArgumentNullException>(exc.InnerException);
+            Assert.Equal("enumerable", ane.ParamName);
+        }
+
+        [Fact]
+        public void GenericEnumerableDebugView_ThrowsForEmptySource()
+        {
+            IEnumerable<int> source = Enumerable.Range(10, 0);
+            object debugView = CreateSystemCore_EnumerableDebugView(source);
+            Exception exc = Assert.Throws<TargetInvocationException>(() => GetItems<int>(debugView));
+            Assert.NotNull(exc.InnerException);
+            Assert.False(string.IsNullOrEmpty(GetEmptyProperty(exc.InnerException)));
+        }
+
+        [Fact]
+        public void GenericEnumerableDebugView_NonEmptySource()
+        {
+            IEnumerable<int> source = Enumerable.Range(10, 5);
+            object debugView = CreateSystemCore_EnumerableDebugView(source);
+            Assert.Equal(source, GetItems<int>(debugView));
+        }
+
+        private static object CreateSystemCore_EnumerableDebugView(IEnumerable source)
+        {
+            Type edvType = typeof(Enumerable).GetTypeInfo().Assembly.GetType("System.Linq.SystemCore_EnumerableDebugView");
+            ConstructorInfo ctor = edvType.GetTypeInfo().DeclaredConstructors.First();
+            return ctor.Invoke(new object[] { source });
+        }
+
+        private static object CreateSystemCore_EnumerableDebugView<T>(IEnumerable<T> source)
+        {
+            Type edvOpenGenericType = typeof(Enumerable).GetTypeInfo().Assembly.GetType("System.Linq.SystemCore_EnumerableDebugView`1");
+            Type edvClosedGenericType = edvOpenGenericType.MakeGenericType(typeof(T));
+            ConstructorInfo ctor = edvClosedGenericType.GetTypeInfo().DeclaredConstructors.First();
+            return ctor.Invoke(new object[] { source });
+        }
+
+        private static T[] GetItems<T>(object debugView)
+        {
+            PropertyInfo items = debugView.GetType().GetTypeInfo().GetDeclaredProperty("Items");
+            return (T[])items.GetValue(debugView);
+        }
+
+        private static string GetEmptyProperty(Exception exc)
+        {
+            return (string)exc.GetType().GetTypeInfo().GetDeclaredProperty("Empty").GetValue(exc);
+        }
+    }
+}

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class GroupByTests
+    {
+        [Fact]
+        public void Grouping_IList_IsReadOnly()
+        {
+            IEnumerable<IGrouping<bool, int>> oddsEvens = new int[] { 1, 2, 3, 4 }.GroupBy(i => i % 2 == 0);
+            foreach (IList<int> grouping in oddsEvens)
+            {
+                Assert.True(grouping.IsReadOnly);
+            }
+        }
+
+        [Fact]
+        public void Grouping_IList_NotSupported()
+        {
+            IEnumerable<IGrouping<bool, int>> oddsEvens = new int[] { 1, 2, 3, 4 }.GroupBy(i => i % 2 == 0);
+            foreach (IList<int> grouping in oddsEvens)
+            {
+                Assert.Throws<NotSupportedException>(() => grouping.Add(5));
+                Assert.Throws<NotSupportedException>(() => grouping.Clear());
+                Assert.Throws<NotSupportedException>(() => grouping.Insert(0, 1));
+                Assert.Throws<NotSupportedException>(() => grouping.Remove(1));
+                Assert.Throws<NotSupportedException>(() => grouping.RemoveAt(0));
+                Assert.Throws<NotSupportedException>(() => grouping[0] = 1);
+            }
+        }
+
+        [Fact]
+        public void Grouping_IList_IndexerGetter()
+        {
+            IEnumerable<IGrouping<bool, int>> oddsEvens = new int[] { 1, 2, 3, 4 }.GroupBy(i => i % 2 == 0);
+            var e = oddsEvens.GetEnumerator();
+
+            Assert.True(e.MoveNext());
+            IList<int> odds = (IList<int>)e.Current;
+            Assert.Equal(1, odds[0]);
+            Assert.Equal(3, odds[1]);
+
+            Assert.True(e.MoveNext());
+            IList<int> evens = (IList<int>)e.Current;
+            Assert.Equal(2, evens[0]);
+            Assert.Equal(4, evens[1]);
+        }
+
+        [Fact]
+        public void Grouping_ICollection_Contains()
+        {
+            IEnumerable<IGrouping<bool, int>> oddsEvens = new int[] { 1, 2, 3, 4 }.GroupBy(i => i % 2 == 0);
+            var e = oddsEvens.GetEnumerator();
+
+            Assert.True(e.MoveNext());
+            ICollection<int> odds = (IList<int>)e.Current;
+            Assert.True(odds.Contains(1));
+            Assert.True(odds.Contains(3));
+            Assert.False(odds.Contains(2));
+            Assert.False(odds.Contains(4));
+
+            Assert.True(e.MoveNext());
+            ICollection<int> evens = (IList<int>)e.Current;
+            Assert.True(evens.Contains(2));
+            Assert.True(evens.Contains(4));
+            Assert.False(evens.Contains(1));
+            Assert.False(evens.Contains(3));
+        }
+
+        [Fact]
+        public void Grouping_IList_IndexOf()
+        {
+            IEnumerable<IGrouping<bool, int>> oddsEvens = new int[] { 1, 2, 3, 4 }.GroupBy(i => i % 2 == 0);
+            var e = oddsEvens.GetEnumerator();
+
+            Assert.True(e.MoveNext());
+            IList<int> odds = (IList<int>)e.Current;
+            Assert.Equal(0, odds.IndexOf(1));
+            Assert.Equal(1, odds.IndexOf(3));
+            Assert.Equal(-1, odds.IndexOf(2));
+            Assert.Equal(-1, odds.IndexOf(4));
+
+            Assert.True(e.MoveNext());
+            IList<int> evens = (IList<int>)e.Current;
+            Assert.Equal(0, evens.IndexOf(2));
+            Assert.Equal(1, evens.IndexOf(4));
+            Assert.Equal(-1, evens.IndexOf(1));
+            Assert.Equal(-1, evens.IndexOf(3));
+        }
+
+
+    }
+}

--- a/src/System.Linq/tests/LastOrDefaultTests.cs
+++ b/src/System.Linq/tests/LastOrDefaultTests.cs
@@ -15,6 +15,11 @@ namespace System.Linq.Tests.LegacyTests
                 yield return start + i;
         }
 
+        private static IEnumerable<T> ForceNotCollection<T>(IEnumerable<T> source)
+        {
+            foreach (T item in source) yield return item;
+        }
+
         private static bool IsEven(int num)
         {
             return num % 2 == 0;
@@ -140,7 +145,7 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
-        public void EmptySource()
+        public void EmptyIListSource()
         {
             int?[] source = { };
 
@@ -149,7 +154,7 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
-        public void OneElementTruePredicate()
+        public void OneElementIListTruePredicate()
         {
             int[] source = { 4 };
             Func<int, bool> predicate = IsEven;
@@ -159,7 +164,7 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
-        public void ManyElementsPredicateFalseForAll()
+        public void ManyElementsIListPredicateFalseForAll()
         {
             int[] source = { 9, 5, 1, 3, 17, 21 };
             Func<int, bool> predicate = IsEven;
@@ -169,7 +174,7 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
-        public void PredicateTrueOnlyForLast()
+        public void IListPredicateTrueOnlyForLast()
         {
             int[] source = { 9, 5, 1, 3, 17, 21, 50 };
             Func<int, bool> predicate = IsEven;
@@ -179,9 +184,58 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
-        public void PredicateTrueForSome()
+        public void IListPredicateTrueForSome()
         {
             int[] source = { 3, 7, 10, 7, 9, 2, 11, 18, 13, 9 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 18;
+
+            Assert.Equal(expected, source.LastOrDefault(predicate));
+        }
+
+        [Fact]
+        public void EmptyNotIListSource()
+        {
+            IEnumerable<int?> source = Enumerable.Repeat((int?)4, 0);
+
+            Assert.Null(source.LastOrDefault(x => true));
+            Assert.Null(source.LastOrDefault(x => false));
+        }
+
+        [Fact]
+        public void OneElementNotIListTruePredicate()
+        {
+            IEnumerable<int> source = ForceNotCollection(new[] { 4 });
+            Func<int, bool> predicate = IsEven;
+            int expected = 4;
+
+            Assert.Equal(expected, source.LastOrDefault(predicate));
+        }
+
+        [Fact]
+        public void ManyElementsNotIListPredicateFalseForAll()
+        {
+            IEnumerable<int> source = ForceNotCollection(new int[] { 9, 5, 1, 3, 17, 21 });
+            Func<int, bool> predicate = IsEven;
+            int expected = default(int);
+
+            Assert.Equal(expected, source.LastOrDefault(predicate));
+        }
+
+        [Fact]
+        public void NotIListPredicateTrueOnlyForLast()
+        {
+            IEnumerable<int> source = ForceNotCollection(new int[] { 9, 5, 1, 3, 17, 21, 50 });
+            Func<int, bool> predicate = IsEven;
+            int expected = 50;
+
+            Assert.Equal(expected, source.LastOrDefault(predicate));
+        }
+
+        [Fact]
+        public void NotIListPredicateTrueForSome()
+        {
+            IEnumerable<int> source = ForceNotCollection(new int[] { 3, 7, 10, 7, 9, 2, 11, 18, 13, 9 });
             Func<int, bool> predicate = IsEven;
             int expected = 18;
 

--- a/src/System.Linq/tests/LastTests.cs
+++ b/src/System.Linq/tests/LastTests.cs
@@ -15,6 +15,11 @@ namespace System.Linq.Tests
                 yield return start + i;
         }
 
+        private static IEnumerable<T> ForceNotCollection<T>(IEnumerable<T> source)
+        {
+            foreach (T item in source) yield return item;
+        }
+
         private static bool IsEven(int num)
         {
             return num % 2 == 0;
@@ -137,7 +142,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void EmptySource()
+        public void IListEmptySourcePredicate()
         {
             int[] source = { };
 
@@ -146,7 +151,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void OneElementTruePredicate()
+        public void OneElementIListTruePredicate()
         {
             int[] source = { 4 };
             Func<int, bool> predicate = IsEven;
@@ -156,7 +161,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void ManyElementsPredicateFalseForAll()
+        public void ManyElementsIListPredicateFalseForAll()
         {
             int[] source = { 9, 5, 1, 3, 17, 21 };
             Func<int, bool> predicate = IsEven;
@@ -165,7 +170,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void PredicateTrueOnlyForLast()
+        public void IListPredicateTrueOnlyForLast()
         {
             int[] source = { 9, 5, 1, 3, 17, 21, 50 };
             Func<int, bool> predicate = IsEven;
@@ -175,9 +180,57 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void PredicateTrueForSome()
+        public void IListPredicateTrueForSome()
         {
             int[] source = { 3, 7, 10, 7, 9, 2, 11, 18, 13, 9 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 18;
+
+            Assert.Equal(expected, source.Last(predicate));
+        }
+
+        [Fact]
+        public void NotIListIListEmptySourcePredicate()
+        {
+            IEnumerable<int> source = Enumerable.Range(1, 0);
+
+            Assert.Throws<InvalidOperationException>(() => source.Last(x => true));
+            Assert.Throws<InvalidOperationException>(() => source.Last(x => false));
+        }
+
+        [Fact]
+        public void OneElementNotIListTruePredicate()
+        {
+            IEnumerable<int> source = NumList(4, 1);
+            Func<int, bool> predicate = IsEven;
+            int expected = 4;
+            
+            Assert.Equal(expected, source.Last(predicate));
+        }
+
+        [Fact]
+        public void ManyElementsNotIListPredicateFalseForAll()
+        {
+            IEnumerable<int> source = ForceNotCollection(new int[] { 9, 5, 1, 3, 17, 21 });
+            Func<int, bool> predicate = IsEven;
+
+            Assert.Throws<InvalidOperationException>(() => source.Last(predicate));
+        }
+
+        [Fact]
+        public void NotIListPredicateTrueOnlyForLast()
+        {
+            IEnumerable<int> source = ForceNotCollection(new int[] { 9, 5, 1, 3, 17, 21, 50 });
+            Func<int, bool> predicate = IsEven;
+            int expected = 50;
+
+            Assert.Equal(expected, source.Last(predicate));
+        }
+
+        [Fact]
+        public void NotIListPredicateTrueForSome()
+        {
+            IEnumerable<int> source = ForceNotCollection(new int[] { 3, 7, 10, 7, 9, 2, 11, 18, 13, 9 });
             Func<int, bool> predicate = IsEven;
             int expected = 18;
 

--- a/src/System.Linq/tests/LegacyTests/GroupByTests.cs
+++ b/src/System.Linq/tests/LegacyTests/GroupByTests.cs
@@ -1169,5 +1169,24 @@ namespace System.Linq.Tests.LegacyTests
             Assert.Equal(4, groupedArray.Length);
             Assert.Equal(source.GroupBy(r => r.Name), groupedArray);
         }
+
+        [Fact]
+        public void GroupingWithResultsToArray()
+        {
+            Record[] source = new Record[]
+            {
+                new Record{ Name = "Tim", Score = 55 },
+                new Record{ Name = "Chris", Score = 49 },
+                new Record{ Name = "Robert", Score = -100 },
+                new Record{ Name = "Chris", Score = 24 },
+                new Record{ Name = "Prakash", Score = 9 },
+                new Record{ Name = "Tim", Score = 25 }
+            };
+
+            IEnumerable<Record>[] groupedArray = source.GroupBy(r => r.Name, (r, e) => e).ToArray();
+            Assert.Equal(4, groupedArray.Length);
+            Assert.Equal(source.GroupBy(r => r.Name, (r, e) => e), groupedArray);
+        }
+
     }
 }

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -22,11 +22,13 @@
     <Compile Include="AnyTests.cs" />
     <Compile Include="CachedEnumerator.cs" />
     <Compile Include="ConcatTests.cs" />
+    <Compile Include="EnumerableDebugViewTests.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="EmptyEnumerable.cs" />
     <Compile Include="ExceptTests.cs" />
     <Compile Include="FirstOrDefaultTests.cs" />
     <Compile Include="FirstTests.cs" />
+    <Compile Include="GroupByTests.cs" />
     <Compile Include="Helpers\TestCollection.cs" />
     <Compile Include="Helpers\TestEnumerable.cs" />
     <Compile Include="Helpers\TestReadOnlyCollection.cs" />

--- a/src/System.Linq/tests/ThenByDescendingTests.cs
+++ b/src/System.Linq/tests/ThenByDescendingTests.cs
@@ -117,6 +117,23 @@ And Immortality.".Split(new []{ ' ', '\n', '\r', '—' }, StringSplitOptions.Rem
         }
 
         [Fact]
+        public void OrderIsStableCustomComparer()
+        {
+            var source = @"Because I could not stop for Death —
+He kindly stopped for me —
+The Carriage held but just Ourselves —
+And Immortality.".Split(new[] { ' ', '\n', '\r', '—' }, StringSplitOptions.RemoveEmptyEntries);
+            var expected = new[]
+            {
+                "me", "not", "for", "for", "but", "stop", "held", "just", "could", "kindly", "stopped",
+                "I", "He", "The", "And", "Death", "Because", "Carriage", "Ourselves", "Immortality."
+            };
+
+            Assert.Equal(expected, source.OrderBy(word => char.IsUpper(word[0])).ThenByDescending(word => word.Length, Comparer<int>.Create((w1, w2) => w2.CompareTo(w1))));
+        }
+
+
+        [Fact]
         public void NullSource()
         {
             IOrderedEnumerable<int> source = null;


### PR DESCRIPTION
This commit increases LINQ line code coverage as much as is possible given the current code.

New tests:
- There's an existing legacy test that exercises the non-generic IEnumerable.GetEnumerator for IGrouping`3.  I've added the same test but for IGrouping`4.
- IGrouping inherits IList/ICollection, and a bunch of those interface members weren't being exercised.  Added tests for all of them.
- Last and LastOrDefault with predicates weren't being tested with non-IList sources.  Added tests now that do.
- ThenByDescending didn't have a test for a custom comparer.  Added one.
- System.Linq.dll contains some debug view types used by Visual Studio when showing enumerables in the watch window.  I've added tests for those types.

The only lines remaining uncovered are:
- A function from EnumerableHelpers that's not used by this assembly
- An if branch in EnumerableHelpers.ToArray for when trying to allocate an array larger than the maximum array size
- Code in ```Set<T>``` that depends on Add being used after Remove, which never happens in LINQ's code currently

cc: @VSadov, @JonHanna 