### PR TITLE
Replace several Contract.Asserts with Debug.Asserts

### DIFF
--- a/src/System.Runtime.Extensions/src/System/IO/PathHelper.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/PathHelper.Windows.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -185,7 +186,7 @@ namespace System.IO
                 if (result >= Path.MaxPath)
                     throw new PathTooLongException(SR.IO_PathTooLong);
 
-                Contract.Assert(result < Path.MaxPath, "did we accidently remove a PathTooLongException check?");
+                Debug.Assert(result < Path.MaxPath, "did we accidently remove a PathTooLongException check?");
                 if (result == 0 && m_arrayPtr[0] != '\0')
                 {
                     throw Win32Marshal.GetExceptionForLastWin32Error();
@@ -226,7 +227,7 @@ namespace System.IO
                 if (result >= m_maxPath)
                     throw new PathTooLongException(SR.IO_PathTooLong);
 
-                Contract.Assert(result < m_maxPath, "did we accidentally remove a PathTooLongException check?");
+                Debug.Assert(result < m_maxPath, "did we accidentally remove a PathTooLongException check?");
                 if (result == 0 && m_sb[0] != '\0')
                 {
                     if (Length >= m_maxPath)

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CspParameters.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CspParameters.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
 using Internal.NativeCrypto;
 
@@ -30,15 +29,15 @@ namespace System.Security.Cryptography
             set
             {
                 int allFlags = 0x00FF; // this should change if more values are added to CspProviderFlags
-                Contract.Assert((CspProviderFlags.UseMachineKeyStore |
-                                CspProviderFlags.UseDefaultKeyContainer |
-                                CspProviderFlags.UseNonExportableKey |
-                                CspProviderFlags.UseExistingKey |
-                                CspProviderFlags.UseArchivableKey |
-                                CspProviderFlags.UseUserProtectedKey |
-                                CspProviderFlags.NoPrompt |
-                                CspProviderFlags.CreateEphemeralKey) == (CspProviderFlags)allFlags, "allFlags does not match all CspProviderFlags");
-                //ToDo : Add above error message to resource file
+                Debug.Assert((CspProviderFlags.UseMachineKeyStore |
+                              CspProviderFlags.UseDefaultKeyContainer |
+                              CspProviderFlags.UseNonExportableKey |
+                              CspProviderFlags.UseExistingKey |
+                              CspProviderFlags.UseArchivableKey |
+                              CspProviderFlags.UseUserProtectedKey |
+                              CspProviderFlags.NoPrompt |
+                              CspProviderFlags.CreateEphemeralKey) == (CspProviderFlags)allFlags, "allFlags does not match all CspProviderFlags");
+
                 int flags = (int)value;
                 if ((flags & ~allFlags) != 0)
                 {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -470,10 +469,10 @@ namespace System.Security.Cryptography
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
         {
             // we're sealed and the base should have checked this already
-            Contract.Assert(data != null);
-            Contract.Assert(count >= 0 && count <= data.Length);
-            Contract.Assert(offset >= 0 && offset <= data.Length - count);
-            Contract.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+            Debug.Assert(data != null);
+            Debug.Assert(count >= 0 && count <= data.Length);
+            Debug.Assert(offset >= 0 && offset <= data.Length - count);
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
 
             using (HashAlgorithm hash = GetHashAlgorithm(hashAlgorithm))
             {
@@ -484,8 +483,8 @@ namespace System.Security.Cryptography
         protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
         {
             // we're sealed and the base should have checked this already
-            Contract.Assert(data != null);
-            Contract.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+            Debug.Assert(data != null);
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
 
             using (HashAlgorithm hash = GetHashAlgorithm(hashAlgorithm))
             {


### PR DESCRIPTION
Following corefx guidelines to standardize on Debug.Assert for debug asserts.

cc: @JeremyKuhne, @AtsushiKan 