### PR TITLE
Rename Threading tests "Tests" namespace to "System.Threading.Tests"

### DIFF
--- a/src/System.Threading/tests/BarrierCancellationTests.cs
+++ b/src/System.Threading/tests/BarrierCancellationTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public static class BarrierCancellationTests
     {

--- a/src/System.Threading/tests/BarrierTests.cs
+++ b/src/System.Threading/tests/BarrierTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     /// <summary>
     /// Barrier unit tests

--- a/src/System.Threading/tests/CountdownEventCancellationTests.cs
+++ b/src/System.Threading/tests/CountdownEventCancellationTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public static class CountdownEventCancellationTests
     {

--- a/src/System.Threading/tests/CountdownEventTests.cs
+++ b/src/System.Threading/tests/CountdownEventTests.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public class CountdownEventTests
     {

--- a/src/System.Threading/tests/EtwTests.cs
+++ b/src/System.Threading/tests/EtwTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.Tracing;
-using System.Threading;
 using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public class EtwTests
     {

--- a/src/System.Threading/tests/ManualResetEventSlimCancellationTests.cs
+++ b/src/System.Threading/tests/ManualResetEventSlimCancellationTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public static class ManualResetEventCancellationTests
     {

--- a/src/System.Threading/tests/ManualResetEventSlimTests.cs
+++ b/src/System.Threading/tests/ManualResetEventSlimTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public class ManualResetEventSlimTests
     {

--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public static class ReaderWriterLockSlimTests
     {

--- a/src/System.Threading/tests/SemaphoreSlimCancellationTests.cs
+++ b/src/System.Threading/tests/SemaphoreSlimCancellationTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public static class SemaphoreSlimCancellationTests
     {

--- a/src/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/System.Threading/tests/SemaphoreSlimTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     /// <summary>
     /// SemaphoreSlim unit tests

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public class SemaphoreTests
     {

--- a/src/System.Threading/tests/SpinLockTests.cs
+++ b/src/System.Threading/tests/SpinLockTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     /// <summary>
     /// SpinLock unit tests

--- a/src/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/System.Threading/tests/ThreadLocalTests.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
 
-namespace Test
+namespace System.Threading.Tests
 {
     /// <summary>The class that contains the unit tests of the ThreadLocal.</summary>
     public static class ThreadLocalTests


### PR DESCRIPTION
A bunch of the tests in System.Threading.Tests were in a "Tests" namespace rather than "System.Threading.Tests".  Fixed all those. There are still several test classes that don't have a namespace.

cc: @akoeplinger, @mellinoe 
Contributes to https://github.com/dotnet/corefx/issues/2898