### PR TITLE
Fix build.sh build

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00083</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00085</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-12101</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00083" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00085" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-12101" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00083" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00085" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -30,7 +30,7 @@
     <Compile Include="OpenTests.cs" />
     <Compile Include="ImportExportTests.cs" />
     <Compile Include="PropertyTests.cs" />
-    <Compile Include="RSACngTests.cs" />
+    <Compile Include="RsaCngTests.cs" />
     <Compile Include="ECDsaCngTests.cs" />
     <Compile Include="TestData.cs" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -52,7 +52,7 @@
       <Link>CommonTest\Streams\PositionValueStream.cs</Link>
     </Compile>
 
-    <Compile Include="ECDsaOpenSslProvider.cs" />
+    <Compile Include="EcDsaOpenSslProvider.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs</Link>
     </Compile>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -5,6 +5,8 @@
   <ItemGroup>
     <!-- System.Runtime.WindowsRuntime depends on some internal-only paths, disable from corefx build for now -->
     <ExcludeProjects Include="System.Runtime.WindowsRuntime\ref\4.0\System.Runtime.WindowsRuntime.csproj" />
+    <!-- dotnet/corefx#3128 tracks removing this exclusion -->
+    <ExcludeProjects Include="Microsoft.CSharp\src\Microsoft.CSharp.csproj" Condition="'$(OsEnvironment)' == 'Unix'" />
     <Project Include="*\src\*.csproj" Exclude="@(ExcludeProjects)" />
     <Project Include="*\src\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'" Exclude="@(ExcludeProjects)" />
     <Project Include="*\test*\**\*.csproj" Exclude="@(ExcludeProjects)" />


### PR DESCRIPTION
A while back an update to build tools broke building via build.sh on
Linux and OSX. Move to a newer version of build tools which addresses
this issue and fix up a couple of build breaks that have made their way
in since then.