### PR TITLE
Avoid calling Array.Clear on the entire _array when Queue is already empty

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -101,17 +101,21 @@ namespace System.Collections.Generic
         /// <include file='doc\Queue.uex' path='docs/doc[@for="Queue.Clear"]/*' />
         public void Clear()
         {
-            if (_head < _tail)
-                Array.Clear(_array, _head, _size);
-            else
+            if (_size != 0)
             {
-                Array.Clear(_array, _head, _array.Length - _head);
-                Array.Clear(_array, 0, _tail);
+                if (_head < _tail)
+                    Array.Clear(_array, _head, _size);
+                else
+                {
+                    Array.Clear(_array, _head, _array.Length - _head);
+                    Array.Clear(_array, 0, _tail);
+                }
+
+                _size = 0;
             }
 
             _head = 0;
             _tail = 0;
-            _size = 0;
             _version++;
         }
 


### PR DESCRIPTION
This was a perf bug. Calling Queue<T>.Clear repeatedly on an empty Queue was always Array.Clear'ing the entire _array which caused significant perf impact when capacity is big.