### PR TITLE
Fix for #3124. CurlHandler sets invalid content-type for POST requests

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -291,7 +291,7 @@ namespace System.Net.Http
 
             private void SetRequestHeaders()
             {
-                HttpHeaders contentHeaders = null;
+                HttpContentHeaders contentHeaders = null;
                 if (_requestMessage.Content != null)
                 {
                     SetChunkedModeForSend(_requestMessage);
@@ -317,6 +317,13 @@ namespace System.Net.Http
                 if (contentHeaders != null)
                 {
                     AddRequestHeaders(contentHeaders, slist);
+                    if (contentHeaders.ContentType == null)
+                    {
+                        if (!Interop.libcurl.curl_slist_append(slist, NoContentType))
+                        {
+                            throw CreateHttpRequestException();
+                        }
+                    }
                 }
 
                 // Since libcurl always adds a Transfer-Encoding header, we need to explicitly block

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -32,6 +32,7 @@ namespace System.Net.Http
 
         private const int RequestBufferSize = 16384; // Default used by libcurl
         private const string NoTransferEncoding = HttpKnownHeaderNames.TransferEncoding + ":";
+        private const string NoContentType = HttpKnownHeaderNames.ContentType + ":";
         private const int CurlAge = 5;
         private const int MinCurlAge = 3;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -455,6 +455,22 @@ namespace System.Net.Http.Tests
             }
         }
 
+        [Theory, MemberData("PostServers")]
+        public async Task PostAsync_CallMethod_StreamContent(Uri remoteServer)
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                byte[] data = new byte[1234];
+                new Random(42).NextBytes(data);
+                HttpContent content = new StreamContent(new MemoryStream(data));
+                HttpResponseMessage response = await client.PostAsync(remoteServer, content);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                string responseContent = await response.Content.ReadAsStringAsync();
+                Assert.Contains(Convert.ToBase64String(data), responseContent);
+            }
+        }
+
         #endregion
 
         #region Put Method Tests


### PR DESCRIPTION
libcurl defaults to a Content-Type:application/x-www-form-urlencoded for
Post operations. This default behavior is inconsistent with dotnet API.
Current PR fixes this issue by overriding the default value.
