### PR TITLE
Avoid blocking CurlHandler read callback

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -185,8 +185,9 @@ internal static partial class Interop
             curl_off_t offset, 
             int origin);
 
+        public const int CURL_READFUNC_ABORT = 0x10000000;
+        public const int CURL_READFUNC_PAUSE = 0x10000001;
         public const int CURL_WRITEFUNC_PAUSE = 0x10000001;
-        public const int CURLPAUSE_ALL = (1 << 2) | (1 << 0);
         public const int CURLPAUSE_CONT = 0;
     }
 }

--- a/src/Common/tests/Streams/DelegateStream.cs
+++ b/src/Common/tests/Streams/DelegateStream.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>Provides a stream whose implementation is supplied by delegates.</summary>
+    internal sealed class DelegateStream : Stream
+    {
+        private readonly Func<bool> _canReadFunc;
+        private readonly Func<bool> _canSeekFunc;
+        private readonly Func<bool> _canWriteFunc;
+        private readonly Action _flushFunc = null;
+        private readonly Func<CancellationToken, Task> _flushAsyncFunc = null;
+        private readonly Func<long> _lengthFunc;
+        private readonly Func<long> _positionGetFunc;
+        private readonly Action<long> _positionSetFunc;
+        private readonly Func<byte[], int, int, int> _readFunc;
+        private readonly Func<byte[], int, int, CancellationToken, Task<int>> _readAsyncFunc;
+        private readonly Func<long, SeekOrigin, long> _seekFunc;
+        private readonly Action<long> _setLengthFunc;
+        private readonly Action<byte[], int, int> _writeFunc;
+        private readonly Func<byte[], int, int, CancellationToken, Task> _writeAsyncFunc;
+
+        public DelegateStream(
+            Func<bool> canReadFunc = null,
+            Func<bool> canSeekFunc = null,
+            Func<bool> canWriteFunc = null,
+            Action flushFunc = null,
+            Func<CancellationToken, Task> flushAsyncFunc = null,
+            Func<long> lengthFunc = null,
+            Func<long> positionGetFunc = null,
+            Action<long> positionSetFunc = null,
+            Func<byte[], int, int, int> readFunc = null,
+            Func<byte[], int, int, CancellationToken, Task<int>> readAsyncFunc = null,
+            Func<long, SeekOrigin, long> seekFunc = null,
+            Action<long> setLengthFunc = null,
+            Action<byte[], int, int> writeFunc = null,
+            Func<byte[], int, int, CancellationToken, Task> writeAsyncFunc = null)
+        {
+            _canReadFunc = canReadFunc ?? (() => false);
+            _canSeekFunc = canSeekFunc ?? (() => false);
+            _canWriteFunc = canWriteFunc ?? (() => false);
+
+            _flushFunc = flushFunc ?? (() => { });
+            _flushAsyncFunc = flushAsyncFunc ?? (token => base.FlushAsync(token));
+
+            _lengthFunc = lengthFunc ?? (() => { throw new NotSupportedException(); });
+            _positionSetFunc = positionSetFunc ?? (_ => { throw new NotSupportedException(); });
+            _positionGetFunc = positionGetFunc ?? (() => { throw new NotSupportedException(); });
+
+            _readFunc = readFunc ?? ((buffer, offset, count) => readAsyncFunc(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult());
+            _readAsyncFunc = readAsyncFunc ?? ((buffer, offset, count, token) => base.ReadAsync(buffer, offset, count, token));
+
+            _seekFunc = seekFunc ?? ((_, __) => { throw new NotSupportedException(); });
+            _setLengthFunc = setLengthFunc ?? (_ => { throw new NotSupportedException(); });
+
+            _writeFunc = writeFunc ?? ((buffer, offset, count) => writeAsyncFunc(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult());
+            _writeAsyncFunc = writeAsyncFunc ?? ((buffer, offset, count, token) => base.WriteAsync(buffer, offset, count, token));
+        }
+
+        public override bool CanRead { get { return _canReadFunc(); } }
+        public override bool CanSeek { get { return _canSeekFunc(); } }
+        public override bool CanWrite { get { return _canWriteFunc(); } }
+
+        public override void Flush() { _flushFunc(); }
+        public override Task FlushAsync(CancellationToken cancellationToken) { return _flushAsyncFunc(cancellationToken); }
+
+        public override long Length { get { return _lengthFunc(); } }
+        public override long Position { get { return _positionGetFunc(); } set { _positionSetFunc(value); } }
+
+        public override int Read(byte[] buffer, int offset, int count) { return _readFunc(buffer, offset, count); }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { return _readAsyncFunc(buffer, offset, count, cancellationToken); }
+
+        public override long Seek(long offset, SeekOrigin origin) { return _seekFunc(offset, origin); }
+        public override void SetLength(long value) { _setLengthFunc(value); }
+
+        public override void Write(byte[] buffer, int offset, int count) { _writeFunc(buffer, offset, count); }
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { return _writeAsyncFunc(buffer, offset, count, cancellationToken); }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -181,7 +181,6 @@ namespace System.Net.Http
                     if (_remainingDataCount > 0 || _pendingReadRequest == null)
                     {
                         VerboseTrace("Pausing due to _remainingDataCount: " + _remainingDataCount + ", _pendingReadRequest: " + (_pendingReadRequest != null));
-                        _easy._paused = EasyRequest.PauseState.Paused;
                         return Interop.libcurl.CURL_WRITEFUNC_PAUSE;
                     }
 
@@ -342,24 +341,8 @@ namespace System.Net.Http
                         VerboseTrace("Created pending read");
                     }
 
-                    RequestUnpause();
+                    _easy._associatedMultiAgent.RequestUnpause(_easy);
                     return _pendingReadRequest.Task;
-                }
-            }
-
-            /// <summary>Requests that libcurl unpause the connection associated with this request.</summary>
-            private void RequestUnpause()
-            {
-                if (_easy._paused == EasyRequest.PauseState.Paused)
-                {
-                    VerboseTrace("Issuing unpause request");
-                    _easy._paused = EasyRequest.PauseState.UnpauseRequestIssued;
-                    _easy._associatedMultiAgent.Queue(
-                        new MultiAgent.IncomingRequest { Easy = _easy, Type = MultiAgent.IncomingRequestType.Unpause });
-                }
-                else
-                {
-                    VerboseTrace("Not issuing unpause request with state " + _easy._paused);
                 }
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -26,32 +26,43 @@ namespace System.Net.Http
             internal readonly HttpRequestMessage _requestMessage;
             internal readonly CurlResponseMessage _responseMessage;
             internal readonly CancellationToken _cancellationToken;
-            internal readonly SafeCurlHandle _easyHandle;
+
+            internal SafeCurlHandle _easyHandle;
             private SafeCurlSlistHandle _requestHeaders;
 
             internal Stream _requestContentStream;
             internal NetworkCredential _networkCredential;
 
             internal MultiAgent _associatedMultiAgent;
-            internal PauseState _paused = PauseState.Unpaused;
+            internal SendTransferState _sendTransferState;
 
             public EasyRequest(CurlHandler handler, HttpRequestMessage requestMessage, CancellationToken cancellationToken) :
                 base(TaskCreationOptions.RunContinuationsAsynchronously)
             {
-                // Store supplied arguments
                 _handler = handler;
                 _requestMessage = requestMessage;
                 _responseMessage = new CurlResponseMessage(this);
                 _cancellationToken = cancellationToken;
+            }
 
+            /// <summary>
+            /// Initialize the underlying libcurl support for this EasyRequest.
+            /// This is separated out of the constructor so that we can take into account
+            /// any additional configuration needed based on the request message
+            /// after the EasyRequest is configured and so that error handling
+            /// can be better handled in the caller.
+            /// </summary>
+            internal void InitializeCurl()
+            {
                 // Create the underlying easy handle
-                _easyHandle = Interop.libcurl.curl_easy_init();
-                if (_easyHandle.IsInvalid)
+                SafeCurlHandle easyHandle = Interop.libcurl.curl_easy_init();
+                if (easyHandle.IsInvalid)
                 {
                     throw new OutOfMemoryException();
                 }
+                _easyHandle = easyHandle;
 
-                // Configure the easy handle
+                // Configure the handle
                 SetUrl();
                 SetDebugging();
                 SetMultithreading();
@@ -391,14 +402,23 @@ namespace System.Net.Http
                 ThrowIfCURLEError(Interop.libcurl.curl_easy_setopt(_easyHandle, option, value));
             }
 
-            internal enum PauseState
+            internal sealed class SendTransferState
             {
-                /// <summary>The operation may be processed by libcurl.</summary>
-                Unpaused = 0,
-                /// <summary>libcurl should not process the operation.</summary>
-                Paused,
-                /// <summary>A request has been made to the MultiAgent to unpause the operation.</summary>
-                UnpauseRequestIssued
+                internal readonly byte[] _buffer = new byte[RequestBufferSize]; // PERF TODO: Determine if this should be optimized to start smaller and grow
+                internal int _offset;
+                internal int _count;
+                internal Task<int> _task;
+
+                internal void Update(Task<int> task, int offset, int count)
+                {
+                    Debug.Assert(offset >= 0, "Offset should never be negative");
+                    Debug.Assert(count >= 0, "Count should never be negative");
+                    Debug.Assert(offset <= count, "Offset should never be greater than count");
+
+                    _task = task;
+                    _offset = offset;
+                    _count = count;
+                }
             }
 
             [Conditional(VerboseDebuggingConditional)]

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -409,7 +409,7 @@ namespace System.Net.Http
                 internal int _count;
                 internal Task<int> _task;
 
-                internal void Update(Task<int> task, int offset, int count)
+                internal void SetTaskOffsetCount(Task<int> task, int offset, int count)
                 {
                     Debug.Assert(offset >= 0, "Offset should never be negative");
                     Debug.Assert(count >= 0, "Count should never be negative");

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -39,9 +39,14 @@ namespace System.Net.Http
          
             /// <summary>Map of activeOperations, indexed by a GCHandle ptr.</summary>
             private readonly Dictionary<IntPtr, ActiveRequest> _activeOperations = new Dictionary<IntPtr, ActiveRequest>();
-            
-            /// <summary>Buffer used to transfer data from a request content stream to libcurl.</summary>
-            private readonly byte[] _transferBuffer = new byte[RequestBufferSize];
+
+            /// <summary>
+            /// Lazily-initialized buffer used to transfer data from a request content stream to libcurl.
+            /// This buffer may be shared amongst all of the connections associated with
+            /// this multi agent, as long as those operations are performed synchronously on the thread
+            /// associated with the multi handle. Asynchronous operation must use a separate buffer.
+            /// </summary>
+            private byte[] _transferBuffer;
 
             /// <summary>
             /// Special file descriptor used to wake-up curl_multi_wait calls.  This is the read
@@ -110,7 +115,7 @@ namespace System.Net.Http
                         try
                         {
                             // Do the actual processing
-                            thisRef.Process();
+                            thisRef.WorkerLoop();
                         }
                         catch (Exception exc)
                         {
@@ -187,7 +192,14 @@ namespace System.Net.Http
                 VerboseTraceIf(bytesRead > 1, "Read more than one byte from wakeup pipe: " + bytesRead);
             }
 
-            private void Process()
+            /// <summary>Requests that libcurl unpause the connection associated with this request.</summary>
+            internal void RequestUnpause(EasyRequest easy)
+            {
+                VerboseTrace(easy: easy);
+                Queue(new IncomingRequest { Easy = easy, Type = IncomingRequestType.Unpause });
+            }
+
+            private void WorkerLoop()
             {
                 Debug.Assert(!Monitor.IsEntered(_incomingRequests), "No locks should be held while invoking Process");
                 Debug.Assert(_runningWorker != null && _runningWorker.Id == Task.CurrentId, "This is the worker, so it must be running");
@@ -356,9 +368,7 @@ namespace System.Net.Http
                             IntPtr gcHandlePtr;
                             ActiveRequest ar;
                             Debug.Assert(FindActiveRequest(easy, out gcHandlePtr, out ar), "Couldn't find active request for unpause");
-                            Debug.Assert(easy._paused == EasyRequest.PauseState.UnpauseRequestIssued, "Unpause requests only make sense when a request has been issued");
 
-                            easy._paused = EasyRequest.PauseState.Unpaused;
                             int unpauseResult = Interop.libcurl.curl_easy_pause(easy._easyHandle, Interop.libcurl.CURLPAUSE_CONT);
                             if (unpauseResult != CURLcode.CURLE_OK)
                             {
@@ -582,7 +592,6 @@ namespace System.Net.Http
                 {
                     try
                     {
-                        Debug.Assert(easy._paused == EasyRequest.PauseState.Unpaused, "We shouldn't be getting callbacks for a paused request.");
                         if (!(easy.Task.IsCanceled || easy.Task.IsFaulted))
                         {
                             // Complete the task if it hasn't already been.  This will make the
@@ -611,8 +620,9 @@ namespace System.Net.Http
             private static size_t CurlSendCallback(IntPtr buffer, size_t size, size_t nitems, IntPtr context)
             {
                 CurlHandler.VerboseTrace("size: " + size + ", nitems: " + nitems);
-                size *= nitems;
-                if (size == 0)
+                int length = checked((int)(size * nitems));
+                Debug.Assert(length <= RequestBufferSize, "length " + length + " should not be larger than RequestBufferSize " + RequestBufferSize);
+                if (length == 0)
                 {
                     return 0;
                 }
@@ -626,15 +636,22 @@ namespace System.Net.Http
                     // Transfer data from the request's content stream to libcurl
                     try
                     {
-                        byte[] arr = easy._associatedMultiAgent._transferBuffer;
-                        int numBytes = easy._requestContentStream.Read(arr, 0, Math.Min(arr.Length, (int)size)); // TODO: Fix potential blocking here
-                        Debug.Assert(numBytes >= 0 && (ulong)numBytes <= size, "Read more bytes than requested");
-                        if (numBytes > 0)
+                        if (easy._requestContentStream is MemoryStream)
                         {
-                            Marshal.Copy(arr, 0, buffer, numBytes);
+                            // If the request content stream is a memory stream (a very common case, as it's the default
+                            // stream type used by the base HttpContent type), then we can simply perform the read synchronously 
+                            // knowing that it won't block.
+                            return (size_t)TransferDataFromRequestMemoryStream(buffer, length, easy);
                         }
-
-                        return (size_t)numBytes;
+                        else
+                        {
+                            // Otherwise, we need to be concerned about blocking, due to this being called from the only thread able to 
+                            // service the multi agent (a multi handle can only be accessed by one thread at a time).  The whole 
+                            // operation, across potentially many callbacks, will be performed asynchronously: we issue the request
+                            // asynchronously, and if it's not completed immediately, we pause the connection until the data
+                            // is ready to be consumed by libcurl.
+                            return TransferDataFromRequestStream(buffer, length, easy);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -643,7 +660,163 @@ namespace System.Net.Http
                 }
 
                 // Something went wrong.
-                return CURLcode.CURLE_ABORTED_BY_CALLBACK;
+                return Interop.libcurl.CURL_READFUNC_ABORT;
+            }
+
+            /// <summary>
+            /// Transfers up to <paramref name="length"/> data from the <paramref name="easy"/>'s
+            /// request content memory stream to the buffer.
+            /// </summary>
+            /// <returns>The number of bytes transferred.</returns>
+            private static int TransferDataFromRequestMemoryStream(IntPtr buffer, int length, EasyRequest easy)
+            {
+                Debug.Assert(easy._requestContentStream is MemoryStream, "Must only be used when the request stream is a memory stream");
+                Debug.Assert(easy._sendTransferState == null, "We should never have initialized the transfer state if the request stream is in memory");
+
+                MultiAgent multi = easy._associatedMultiAgent;
+
+                byte[] arr = multi._transferBuffer ?? (multi._transferBuffer = new byte[RequestBufferSize]);
+                int numBytes = easy._requestContentStream.Read(arr, 0, Math.Min(arr.Length, length));
+                Debug.Assert(numBytes >= 0 && numBytes <= length, "Read more bytes than requested");
+                if (numBytes > 0)
+                {
+                    Marshal.Copy(arr, 0, buffer, numBytes);
+                }
+
+                multi.VerboseTrace("Transferred " + numBytes + " from memory stream", easy: easy);
+                return numBytes;
+            }
+
+            /// <summary>
+            /// Transfers up to <paramref name="length"/> data from the <paramref name="easy"/>'s
+            /// request content (non-memory) stream to the buffer.
+            /// </summary>
+            /// <returns>The number of bytes transferred.</returns>
+            private static size_t TransferDataFromRequestStream(IntPtr buffer, int length, EasyRequest easy)
+            {
+                Debug.Assert(!(easy._requestContentStream is MemoryStream), "Memory streams should use TransferFromRequestMemoryStreamToBuffer.");
+
+                MultiAgent multi = easy._associatedMultiAgent;
+
+                // First check to see whether there's any data available from a previous asynchronous read request.
+                // If there is, the transfer state's Task field will be non-null, with its Result representing
+                // the number of bytes read.  The Buffer will then contain all of that read data.  If the Count
+                // is 0, then this is the first time we're checking that Task, and so we populate the Count
+                // from that read result.  After that, we can transfer as much data remains between Offset and
+                // Count.  Multiple callbacks may pull from that one read.
+
+                EasyRequest.SendTransferState sts = easy._sendTransferState;
+                if (sts != null)
+                {
+                    // Is there a previous read that may still have data to be consumed?
+                    if (sts._task != null)
+                    {
+                        Debug.Assert(sts._task.IsCompleted, "The task must have completed if we're getting called back.");
+
+                        // Determine how many bytes were read on the last asynchronous read.
+                        // If nothing was read, then we're done and can simply return 0 to indicate
+                        // the end of the stream.
+                        int bytesRead = sts._task.GetAwaiter().GetResult(); // will throw if read failed
+                        Debug.Assert(bytesRead >= 0 && bytesRead <= sts._buffer.Length, "ReadAsync returned an invalid result length: " + bytesRead);
+                        if (bytesRead == 0)
+                        {
+                            multi.VerboseTrace("End of stream from stored task", easy: easy);
+                            sts.Update(null, 0, 0);
+                            return 0;
+                        }
+
+                        // If Count is still 0, then this is the first time after the task completed
+                        // that we're examining the data: transfer the bytesRead to the Count.
+                        if (sts._count == 0)
+                        {
+                            multi.VerboseTrace("ReadAsync completed with bytes: " + bytesRead, easy: easy);
+                            sts._count = bytesRead;
+                        }
+
+                        // Now Offset and Count are both accurate.  Determine how much data we can copy to libcurl...
+                        int availableData = sts._count - sts._offset;
+                        Debug.Assert(availableData > 0, "There must be some data still available.");
+
+                        // ... and copy as much of that as libcurl will allow.
+                        int bytesToCopy = Math.Min(availableData, length);
+                        Marshal.Copy(sts._buffer, sts._offset, buffer, bytesToCopy);
+                        multi.VerboseTrace("Copied " + bytesRead + " bytes from request stream", easy: easy);
+
+                        // Update the offset.  If we've gone through all of the data, reset the state 
+                        // so that the next time we're called back we'll do a new read.
+                        sts._offset += bytesToCopy;
+                        Debug.Assert(sts._offset <= sts._count, "Offset should never exceed count");
+                        if (sts._offset == sts._count)
+                        {
+                            sts.Update(null, 0, 0);
+                        }
+
+                        // Return the amount of data copied
+                        Debug.Assert(bytesToCopy > 0, "We should never return 0 bytes here.");
+                        return (size_t)bytesToCopy;
+                    }
+
+                    // sts was non-null but sts.Task was null, meaning there was no previous task/data
+                    // from which to satisfy any of this request.
+                }
+                else // sts == null
+                {
+                    // Allocate a transfer state object to use for the remainder of this request.
+                    easy._sendTransferState = sts = new EasyRequest.SendTransferState();
+                }
+
+                Debug.Assert(sts != null, "By this point we should have a transfer object");
+                Debug.Assert(sts._task == null, "There shouldn't be a task now.");
+
+                // If we get here, there was no previously read data available to copy.
+                // Initiate a new asynchronous read.
+                Task<int> asyncRead = easy._requestContentStream.ReadAsync(
+                    sts._buffer, 0, Math.Min(sts._buffer.Length, length), easy._cancellationToken);
+                Debug.Assert(asyncRead != null, "Badly implemented stream returned a null task from ReadAsync");
+
+                // Even though it's "Async", it's possible this read could complete synchronously or extremely quickly.  
+                // Check to see if it did, in which case we can also satisfy the libcurl request synchronously in this callback.
+                if (asyncRead.IsCompleted)
+                {
+                    multi.VerboseTrace("ReadAsync completed immediately", easy: easy);
+
+                    // Get the amount of data read.
+                    int bytesRead = asyncRead.GetAwaiter().GetResult(); // will throw if read failed
+                    if (bytesRead == 0)
+                    {
+                        multi.VerboseTrace("End of stream from quick returning ReadAsync", easy: easy);
+                        return 0;
+                    }
+
+                    // Copy as much as we can.
+                    int bytesToCopy = Math.Min(bytesRead, length);
+                    Debug.Assert(bytesToCopy > 0 && bytesToCopy <= sts._buffer.Length, "ReadAsync quickly returned an invalid result length: " + bytesToCopy);
+                    Marshal.Copy(sts._buffer, 0, buffer, bytesToCopy);
+                    multi.VerboseTrace("Copied " + bytesToCopy + " from quick returning ReadAsync", easy: easy);
+
+                    // If we read more than we were able to copy, stash it away for the next read.
+                    if (bytesToCopy < bytesRead)
+                    {
+                        multi.VerboseTrace("Stashing away " + (bytesRead - bytesToCopy) + " bytes for next read.", easy: easy);
+                        sts.Update(asyncRead, bytesToCopy, bytesRead);
+                    }
+
+                    // Return the number of bytes read.
+                    return (size_t)bytesToCopy;
+                }
+
+                // Otherwise, the read completed asynchronously.  Store the task, and hook up a continuation 
+                // such that the connection will be unpaused once the task completes.
+                sts.Update(asyncRead, 0, 0);
+                asyncRead.ContinueWith((t, s) =>
+                {
+                    EasyRequest easyRef = (EasyRequest)s;
+                    easyRef._associatedMultiAgent.RequestUnpause(easyRef);
+                }, easy, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+                // Then pause the connection.
+                multi.VerboseTrace("Pausing the connection", easy: easy);
+                return Interop.libcurl.CURL_READFUNC_PAUSE;
             }
 
             private static int CurlSeekCallback(IntPtr context, long offset, int origin)
@@ -727,6 +900,14 @@ namespace System.Net.Http
                 CurlHandler.VerboseTrace(text, memberName, easy, agent: this);
             }
 
+            [Conditional(VerboseDebuggingConditional)]
+            private void VerboseTraceIf(bool condition, string text = null, [CallerMemberName] string memberName = null, EasyRequest easy = null)
+            {
+                if (condition)
+                {
+                    CurlHandler.VerboseTrace(text, memberName, easy, agent: this);
+                }
+            }
 
             /// <summary>Represents an active request currently being processed by the agent.</summary>
             private struct ActiveRequest
@@ -743,7 +924,7 @@ namespace System.Net.Http
             }
 
             /// <summary>The type of an incoming request to be processed by the agent.</summary>
-            internal enum IncomingRequestType
+            internal enum IncomingRequestType : byte
             {
                 /// <summary>A new request that's never been submitted to an agent.</summary>
                 New,

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -627,6 +627,12 @@ namespace System.Net.Http
                     request.Headers.TransferEncodingChunked = false;
                 }
             }
+            else if (!chunkedMode)
+            {
+                // Make sure Transfer-Encoding: chunked header is set, 
+                // as we have content to send but no known length for it.
+                request.Headers.TransferEncodingChunked = true;
+            }
         }
 
         #endregion

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -317,8 +317,22 @@ namespace System.Net.Http
             else
             {
                 // Otherwise, just submit the request.
-                _agent.Queue(new MultiAgent.IncomingRequest { Easy = easy, Type = MultiAgent.IncomingRequestType.New });
+                ConfigureAndQueue(easy);
                 return easy.Task;
+            }
+        }
+
+        private void ConfigureAndQueue(EasyRequest easy)
+        {
+            try
+            {
+                easy.InitializeCurl();
+                _agent.Queue(new MultiAgent.IncomingRequest { Easy = easy, Type = MultiAgent.IncomingRequestType.New });
+            }
+            catch (Exception exc)
+            {
+                easy.FailRequest(exc);
+                easy.Cleanup(); // no active processing remains, so we can cleanup
             }
         }
 
@@ -338,7 +352,7 @@ namespace System.Net.Http
             }
             else
             {
-                _agent.Queue(new MultiAgent.IncomingRequest { Easy = easy, Type = MultiAgent.IncomingRequestType.New });
+                ConfigureAndQueue(easy);
             }
             return await easy.Task.ConfigureAwait(false);
         }
@@ -464,20 +478,21 @@ namespace System.Net.Http
             {
                 agent = easy._associatedMultiAgent;
             }
+            int? agentId = agent != null ? agent.RunningWorkerId : null;
 
             // Get an ID string that provides info about which MultiAgent worker and which EasyRequest this trace is about
             string ids = "";
-            if (agent != null || easy != null)
+            if (agentId != null || easy != null)
             {
                 ids = "(" +
-                    (agent != null ? "M#" + agent.RunningWorkerId : "") +
-                    (agent != null && easy != null ? ", " : "") +
+                    (agentId != null ? "M#" + agentId : "") +
+                    (agentId != null && easy != null ? ", " : "") +
                     (easy != null ? "E#" + easy.Task.Id : "") +
                     ")";
             }
 
             // Create the message and trace it out
-            string msg = string.Format("[{0, -25}]{1, -16}: {2}", memberName, ids, text);
+            string msg = string.Format("[{0, -30}]{1, -16}: {2}", memberName, ids, text);
             Interop.libc.printf("%s\n", msg);
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Tests.csproj
@@ -23,7 +23,7 @@
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\Streams\DelegateStream.cs">
-      <Link>Common\Streams\DelegateReadStream.cs</Link>
+      <Link>Common\Streams\DelegateStream.cs</Link>
     </Compile>
     <Compile Include="HttpClientHandlerTest.cs" />
     <Compile Include="HttpClientTest.cs" />

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Tests.csproj
@@ -22,6 +22,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Streams\DelegateStream.cs">
+      <Link>Common\Streams\DelegateReadStream.cs</Link>
+    </Compile>
     <Compile Include="HttpClientHandlerTest.cs" />
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpMethodTest.cs" />


### PR DESCRIPTION
PR #3105 addressed the issue we were facing with libcurl and the write callback used when libcurl has response body data available.  We were blocking libcurl's callback until a reader was available to consume the data, resulting in both significant scalability issues as well as the potential for easy deadlock.  This was fixed by making the whole operation async via libcurl's ability to pause connections.

The same issue exists for libcurl's read callback, used by libcurl to read data from the request stream to send as part of the request.  The issue here isn't as impactful as on the write side, because a) a common case has no request stream or has a MemoryStream that serves up its data immediately, and b) other streams (e.g. FileStream) typically serve their data quickly even if blocking is involved and don't interact with the HttpClient in a way that could lead to deadlock.  However, it's still an issue, and it's still possible to construct cases where deadlock is possible, e.g. if the output stream of one request is used as the input stream of another request associated with the same libcurl multi handle.

This commit addresses the read callback case by relying on the same pause mechanism used for the write callback.  When libcurl requests data, if the source is a memory stream, we just do the read and hand back the data. Otherwise, we issue a ReadAsync on the stream.  If the operation completes immediately, we synchronously hand the data back to libcurl, storing any extra beyond what libcurl asked for.  If the operation didn't complete immediately, we store it for later, and pause the connection, requesting an unpause when the read operation completes.  Subsequent read requests from libcurl first try to be satisfied from any previous ReadAsync with
data remaining.

As part of this, I also removed the pause state tracking I'd previously added.  In my previous PR as part of adding support for pausing, I added a field to EasyRequest to attempt to mirror the current paused state as known by libcurl.  This was done to try to avoid requesting unpausing in cases where we'd like to be unpaused but have already requested it. However, this appears to have been premature optimization, as the case is relatively rare, the overheads relatively low for processing the extra request, and it causes additional headaches once we're able to pause sending/receiving individually.

I added several tests for different kinds of streams.  This required fixing #3136, which was preventing any data from being sent from non-seekable request streams.

Fixes #3136 
Fixes #3137 
cc: @vijaykota, @kapilash, @davidsh, @pgavlin, @CIPop