### PR TITLE
Hmackey

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
@@ -19,9 +19,10 @@ namespace Internal.Cryptography
     //
     internal sealed class HMACCommon
     {
-        public HMACCommon(String hashAlgorithmId, byte[] key)
+        public HMACCommon(String hashAlgorithmId, byte[] key, int BlockSize)
         {
             _hashAlgorithmId = hashAlgorithmId;
+            _blockSize = BlockSize;
             ChangeKey(key);
         }
 
@@ -35,12 +36,27 @@ namespace Internal.Cryptography
 
         public void ChangeKey(byte[] key)
         {
+            if (key.Length > _blockSize)
+            {
+                // Perform RFC 2104, section 2 key adjustment.
+                if (_lazyHashProvider == null)
+                    _lazyHashProvider = HashProviderDispenser.CreateHashProvider(_hashAlgorithmId);
+                _lazyHashProvider.AppendHashData(key, 0, key.Length);
+                key = _lazyHashProvider.FinalizeHashAndReset();
+            }
+
             HashProvider oldHashProvider = _hMacProvider;
             _hMacProvider = null;
             if (oldHashProvider != null)
                 oldHashProvider.Dispose(true);
             _hMacProvider = HashProviderDispenser.CreateMacProvider(_hashAlgorithmId, key);
+
+            ActualKey = key;
         }
+
+        // The actual key used for hashing. This will not be the same as the original key passed to ChangeKey() if the original key exceeded the
+        // hash algorithm's block size. (See RFC 2104, section 2)
+        public byte[] ActualKey { get; private set; }
 
         // Adds new data to be hashed. This can be called repeatedly in order to hash data from incontiguous sources.
         public void AppendHashData(byte[] data, int offset, int count)
@@ -66,5 +82,8 @@ namespace Internal.Cryptography
 
         private readonly String _hashAlgorithmId;
         private HashProvider _hMacProvider;
+        private volatile HashProvider _lazyHashProvider;
+
+        private readonly int _blockSize;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
@@ -29,42 +29,42 @@ namespace Internal.Cryptography
         {
             get
             {
-                return _hashProvider.HashSizeInBytes * 8;
+                return _hMacProvider.HashSizeInBytes * 8;
             }
         }
 
         public void ChangeKey(byte[] key)
         {
-            HashProvider oldHashProvider = _hashProvider;
-            _hashProvider = null;
+            HashProvider oldHashProvider = _hMacProvider;
+            _hMacProvider = null;
             if (oldHashProvider != null)
                 oldHashProvider.Dispose(true);
-            _hashProvider = HashProviderDispenser.CreateMacProvider(_hashAlgorithmId, key);
+            _hMacProvider = HashProviderDispenser.CreateMacProvider(_hashAlgorithmId, key);
         }
 
         // Adds new data to be hashed. This can be called repeatedly in order to hash data from incontiguous sources.
         public void AppendHashData(byte[] data, int offset, int count)
         {
-            _hashProvider.AppendHashData(data, offset, count);
+            _hMacProvider.AppendHashData(data, offset, count);
         }
 
         // Compute the hash based on the appended data and resets the HashProvider for more hashing.
         public byte[] FinalizeHashAndReset()
         {
-            return _hashProvider.FinalizeHashAndReset();
+            return _hMacProvider.FinalizeHashAndReset();
         }
 
         public void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (_hashProvider != null)
-                    _hashProvider.Dispose(true);
-                _hashProvider = null;
+                if (_hMacProvider != null)
+                    _hMacProvider.Dispose(true);
+                _hMacProvider = null;
             }
         }
 
         private readonly String _hashAlgorithmId;
-        private HashProvider _hashProvider;
+        private HashProvider _hMacProvider;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
@@ -17,15 +17,15 @@ namespace System.Security.Cryptography
     public class HMACMD5 : HMAC
     {
         public HMACMD5()
-            : this(Helpers.GenerateRandom(64))
+            : this(Helpers.GenerateRandom(BlockSize))
         {
         }
 
         public HMACMD5(byte[] key)
         {
             this.HashName = HashAlgorithmNames.MD5;
-            _hMacCommon = new HMACCommon(HashAlgorithmNames.MD5, key);
-            base.Key = key;
+            _hMacCommon = new HMACCommon(HashAlgorithmNames.MD5, key, BlockSize);
+            base.Key = _hMacCommon.ActualKey;
         }
 
         public override int HashSize
@@ -44,8 +44,8 @@ namespace System.Security.Cryptography
             }
             set
             {
-                base.Key = value;
                 _hMacCommon.ChangeKey(value);
+                base.Key = _hMacCommon.ActualKey;
             }
         }
 
@@ -79,5 +79,6 @@ namespace System.Security.Cryptography
         }
 
         private HMACCommon _hMacCommon;
+        private const int BlockSize = 64;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -17,15 +17,15 @@ namespace System.Security.Cryptography
     public class HMACSHA1 : HMAC
     {
         public HMACSHA1()
-            : this(Helpers.GenerateRandom(64))
+            : this(Helpers.GenerateRandom(BlockSize))
         {
         }
 
         public HMACSHA1(byte[] key)
         {
             this.HashName = HashAlgorithmNames.SHA1;
-            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA1, key);
-            base.Key = key;
+            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA1, key, BlockSize);
+            base.Key = _hMacCommon.ActualKey; 
         }
 
         public override int HashSize
@@ -44,8 +44,8 @@ namespace System.Security.Cryptography
             }
             set
             {
-                base.Key = value;
                 _hMacCommon.ChangeKey(value);
+                base.Key = _hMacCommon.ActualKey;
             }
         }
 
@@ -79,5 +79,6 @@ namespace System.Security.Cryptography
         }
 
         private HMACCommon _hMacCommon;
+        private const int BlockSize = 64;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
@@ -17,15 +17,15 @@ namespace System.Security.Cryptography
     public class HMACSHA256 : HMAC
     {
         public HMACSHA256()
-            : this(Helpers.GenerateRandom(64))
+            : this(Helpers.GenerateRandom(BlockSize))
         {
         }
 
         public HMACSHA256(byte[] key)
         {
             this.HashName = HashAlgorithmNames.SHA256;
-            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA256, key);
-            base.Key = key;
+            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA256, key, BlockSize);
+            base.Key = _hMacCommon.ActualKey;
         }
 
         public override int HashSize
@@ -44,8 +44,8 @@ namespace System.Security.Cryptography
             }
             set
             {
-                base.Key = value;
                 _hMacCommon.ChangeKey(value);
+                base.Key = _hMacCommon.ActualKey;
             }
         }
 
@@ -79,5 +79,6 @@ namespace System.Security.Cryptography
         }
 
         private HMACCommon _hMacCommon;
+        private const int BlockSize = 64;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
@@ -17,15 +17,15 @@ namespace System.Security.Cryptography
     public class HMACSHA384 : HMAC
     {
         public HMACSHA384()
-            : this(Helpers.GenerateRandom(128))
+            : this(Helpers.GenerateRandom(BlockSize))
         {
         }
 
         public HMACSHA384(byte[] key)
         {
             this.HashName = HashAlgorithmNames.SHA384;
-            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA384, key);
-            base.Key = key;
+            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA384, key, BlockSize);
+            base.Key = _hMacCommon.ActualKey;
         }
 
         public override int HashSize
@@ -44,8 +44,8 @@ namespace System.Security.Cryptography
             }
             set
             {
-                base.Key = value;
                 _hMacCommon.ChangeKey(value);
+                base.Key = _hMacCommon.ActualKey;
             }
         }
 
@@ -79,5 +79,6 @@ namespace System.Security.Cryptography
         }
 
         private HMACCommon _hMacCommon;
+        private const int BlockSize = 128;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
@@ -17,15 +17,15 @@ namespace System.Security.Cryptography
     public class HMACSHA512 : HMAC
     {
         public HMACSHA512()
-            : this(Helpers.GenerateRandom(128))
+            : this(Helpers.GenerateRandom(BlockSize))
         {
         }
 
         public HMACSHA512(byte[] key)
         {
             this.HashName = HashAlgorithmNames.SHA512;
-            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA512, key);
-            base.Key = key;
+            _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA512, key, BlockSize);
+            base.Key = _hMacCommon.ActualKey;
         }
 
         public override int HashSize
@@ -44,8 +44,8 @@ namespace System.Security.Cryptography
             }
             set
             {
-                base.Key = value;
                 _hMacCommon.ChangeKey(value);
+                base.Key = _hMacCommon.ActualKey;
             }
         }
 
@@ -79,5 +79,6 @@ namespace System.Security.Cryptography
         }
 
         private HMACCommon _hMacCommon;
+        private const int BlockSize = 128;
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacMD5Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacMD5Tests.cs
@@ -30,6 +30,13 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return new HMACMD5();
         }
 
+        protected override HashAlgorithm CreateHashAlgorithm()
+        {
+            return MD5.Create();
+        }
+
+        protected override int BlockSize { get { return 64; } }
+
         [Fact]
         public void HmacMD5_Rfc2202_1()
         {
@@ -70,6 +77,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         public void HmacMD5_Rfc2202_7()
         {
             VerifyHmac(7, "6f630fad67cda0ee1fb1f562db3aa53e");
+        }
+
+        [Fact]
+        public void HMacMD5_Rfc2104_2()
+        {
+            VerifyHmacRfc2104_2();
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
@@ -30,6 +30,13 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return new HMACSHA1();
         }
 
+        protected override HashAlgorithm CreateHashAlgorithm()
+        {
+            return SHA1.Create();
+        }
+
+        protected override int BlockSize { get { return 64; } }
+
         [Fact]
         public void HmacSha1_Rfc2202_1()
         {
@@ -70,6 +77,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         public void HmacSha1_Rfc2202_7()
         {
             VerifyHmac(7, "e8e99d0f45237d786d6bbaa7965c7808bbff1a91");
+        }
+
+        [Fact]
+        public void HMacSha1_Rfc2104_2()
+        {
+            VerifyHmacRfc2104_2();
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha256Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha256Tests.cs
@@ -12,6 +12,13 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return new HMACSHA256();
         }
 
+        protected override HashAlgorithm CreateHashAlgorithm()
+        {
+            return SHA256.Create();
+        }
+
+        protected override int BlockSize { get { return 64; } }
+
         [Fact]
         public void HmacSha256_Rfc4231_1()
         {
@@ -53,6 +60,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         public void HmacSha256_Rfc4231_7()
         {
             VerifyHmac(7, "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2");
+        }
+
+        [Fact]
+        public void HMacSha256_Rfc2104_2()
+        {
+            VerifyHmacRfc2104_2();
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
@@ -12,6 +12,13 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return new HMACSHA384();
         }
 
+        protected override HashAlgorithm CreateHashAlgorithm()
+        {
+            return SHA384.Create();
+        }
+
+        protected override int BlockSize { get { return 128; } }
+
         [Fact]
         public void HmacSha384_Rfc4231_1()
         {
@@ -53,6 +60,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         public void HmacSha384_Rfc4231_7()
         {
             VerifyHmac(7, "6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e");
+        }
+
+        [Fact]
+        public void HMacSha384_Rfc2104_2()
+        {
+            VerifyHmacRfc2104_2();
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
@@ -12,6 +12,13 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return new HMACSHA512();
         }
 
+        protected override HashAlgorithm CreateHashAlgorithm()
+        {
+            return SHA512.Create();
+        }
+
+        protected override int BlockSize { get { return 128; } }
+
         [Fact]
         public void HmacSha512_Rfc4231_1()
         {
@@ -53,6 +60,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         public void HmacSha512_Rfc4231_7()
         {
             VerifyHmac(7, "e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58");
+        }
+
+        [Fact]
+        public void HMacSha512_Rfc2104_2()
+        {
+            VerifyHmacRfc2104_2();
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
@@ -22,6 +22,10 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
         protected abstract HMAC Create();
 
+        protected abstract HashAlgorithm CreateHashAlgorithm();
+
+        protected abstract int BlockSize { get; }
+
         protected void VerifyHmac(
             int testCaseId,
             string digest,
@@ -56,6 +60,37 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             }
 
             Assert.Equal(digestBytes, computedDigest);
+        }
+
+        protected void VerifyHmacRfc2104_2()
+        {
+            // Ensure that keys shorter than the threshold don't get altered.
+            using (HMAC hmac = Create())
+            {
+                byte[] key = new byte[BlockSize];
+                hmac.Key = key;
+                byte[] retrievedKey = hmac.Key;
+                Assert.Equal<byte>(key, retrievedKey);
+            }
+
+            // Ensure that keys longer than the threshold are adjusted via Rfc2104 Section 2.
+            using (HMAC hmac = Create())
+            {
+                byte[] overSizedKey = new byte[BlockSize + 1];
+                hmac.Key = overSizedKey;
+                byte[] actualKey = hmac.Key;
+                byte[] expectedKey = CreateHashAlgorithm().ComputeHash(overSizedKey);
+                Assert.Equal<byte>(expectedKey, actualKey);
+
+                // Also ensure that the hashing operation uses the adjusted key.
+                byte[] data = new byte[100];
+                hmac.Key = expectedKey;
+                byte[] expectedHash = hmac.ComputeHash(data);
+
+                hmac.Key = overSizedKey;
+                byte[] actualHash = hmac.ComputeHash(data);
+                Assert.Equal<byte>(expectedHash, actualHash);
+            }
         }
     }
 }


### PR DESCRIPTION
This is split into two commits for easier reviewing. The first commit renames an internal field which had a slightly unspecific/misleading name - renaming because the next commit adds a new field which elevates this from being "annoying" to "dangerous."

The second commit contains the meat of the change and adds code to replace incoming lengthy keys with a hash as specified by Rfc2014 section 2. 

