### PR TITLE
Fix passing byref of enum variables initialized to default values.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -98,26 +98,23 @@ namespace System.Linq.Expressions.Interpreter
                     return Int32_1;
                 case 2:
                     return Int32_2;
-                case 3:
-                    return Int32_3;
             }
 
             return i;
         }
         
-        internal static readonly object Int32_m = -1;
-        internal static readonly object Int32_0 = 0;
-        internal static readonly object Int32_1 = 1;
-        internal static readonly object Int32_2 = 2;
-        internal static readonly object Int32_3 = 3;
+        private static readonly object Int32_m = -1;
+        private static readonly object Int32_0 = 0;
+        private static readonly object Int32_1 = 1;
+        private static readonly object Int32_2 = 2;
 
         public static object BooleanToObject(bool b)
         {
             return b ? True : False;
         }
 
-        internal static readonly object True = true;
-        internal static readonly object False = false;
+        private static readonly object True = true;
+        private static readonly object False = false;
 
         internal static object GetPrimitiveDefaultValue(Type type)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -88,37 +88,94 @@ namespace System.Linq.Expressions.Interpreter
     {
         public static object Int32ToObject(int i)
         {
+            switch (i)
+            {
+                case -1:
+                    return Int32_m;
+                case 0:
+                    return Int32_0;
+                case 1:
+                    return Int32_1;
+                case 2:
+                    return Int32_2;
+                case 3:
+                    return Int32_3;
+            }
+
             return i;
         }
+        
+        internal static readonly object Int32_m = -1;
+        internal static readonly object Int32_0 = 0;
+        internal static readonly object Int32_1 = 1;
+        internal static readonly object Int32_2 = 2;
+        internal static readonly object Int32_3 = 3;
+
         public static object BooleanToObject(bool b)
         {
             return b ? True : False;
         }
 
-        internal static object True = true;
-        internal static object False = false;
+        internal static readonly object True = true;
+        internal static readonly object False = false;
 
         internal static object GetPrimitiveDefaultValue(Type type)
         {
+            object result;
+
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(type))
             {
-                case TypeCode.Boolean: return ScriptingRuntimeHelpers.False;
-                case TypeCode.SByte: return default(SByte);
-                case TypeCode.Byte: return default(Byte);
-                case TypeCode.Char: return default(Char);
-                case TypeCode.Int16: return default(Int16);
-                case TypeCode.Int32: return ScriptingRuntimeHelpers.Int32ToObject(0);
-                case TypeCode.Int64: return default(Int64);
-                case TypeCode.UInt16: return default(UInt16);
-                case TypeCode.UInt32: return default(UInt32);
-                case TypeCode.UInt64: return default(UInt64);
-                case TypeCode.Single: return default(Single);
-                case TypeCode.Double: return default(Double);
-                //            case TypeCode.DBNull: return default(DBNull);
-                case TypeCode.DateTime: return default(DateTime);
-                case TypeCode.Decimal: return default(Decimal);
-                default: return null;
+                case TypeCode.Boolean:
+                    result = ScriptingRuntimeHelpers.False;
+                    break;
+                case TypeCode.SByte:
+                    result = default(SByte);
+                    break;
+                case TypeCode.Byte:
+                    result = default(Byte);
+                    break;
+                case TypeCode.Char:
+                    result = default(Char);
+                    break;
+                case TypeCode.Int16:
+                    result = default(Int16);
+                    break;
+                case TypeCode.Int32:
+                    result = ScriptingRuntimeHelpers.Int32_0;
+                    break;
+                case TypeCode.Int64:
+                    result = default(Int64);
+                    break;
+                case TypeCode.UInt16:
+                    result = default(UInt16);
+                    break;
+                case TypeCode.UInt32:
+                    result = default(UInt32);
+                    break;
+                case TypeCode.UInt64:
+                    result = default(UInt64);
+                    break;
+
+                case TypeCode.Single:
+                    return default(Single);
+                case TypeCode.Double:
+                    return default(Double);
+                //            case TypeCode.DBNull: 
+                //                  return default(DBNull); 
+                case TypeCode.DateTime:
+                    return default(DateTime);
+                case TypeCode.Decimal:
+                    return default(Decimal);
+                default:
+                    return null;
             }
+
+            if (type.GetTypeInfo().IsEnum)
+            {
+                result = Enum.ToObject(type, result);
+            }
+
+            return result;
         }
     }
 

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -3780,6 +3780,51 @@ namespace Tests
             Assert.Equal("null", f(null));
         }
 
+        public enum MyEnum
+        {
+            Value
+        }
+
+        public class EnumOutLambdaClass
+        {
+            public static void Bar(out MyEnum o)
+            {
+                o = MyEnum.Value;
+            }
+
+            public static void BarRef(ref MyEnum o)
+            {
+                o = MyEnum.Value;
+            }
+        }
+
+        [Fact]
+        public static void UninitializedEnumOut()
+        {
+            var x = Expression.Variable(typeof(MyEnum), "x");
+
+            var expression = Expression.Lambda<Action>(
+                            Expression.Block(
+                            new[] { x },
+                            Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod("Bar"), x)));
+
+            expression.Compile()();
+        }
+
+        [Fact]
+        public static void DefaultEnumRef()
+        {
+            var x = Expression.Variable(typeof(MyEnum), "x");
+
+            var expression = Expression.Lambda<Action>(
+                            Expression.Block(
+                            new[] { x },
+                            Expression.Assign(x, Expression.Default(typeof(MyEnum))),
+                            Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod("BarRef"), x)));
+
+            expression.Compile()();
+        }
+
         [Fact]
         public static void BinaryOperators()
         {


### PR DESCRIPTION
It came to the type of the default value which was based on the result of GetTypeCode and as such would be underlying value for enums.
Underlying values would be ok when passing byval since underlying types would convert to enum so the problem was not noticed, but when we pass these byref, the type of the value must be the actual enum.

Fixes #3007