### PR TITLE
Add /usr/local/include to include path for native shims.

### DIFF
--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -2,6 +2,10 @@ include(CheckFunctionExists)
 include(CheckStructHasMember)
 include(CheckCXXSourceCompiles)
 
+#CMake does not include /usr/local/include into the include search path
+#thus add it manually. This is required on FreeBSD.
+include_directories(/usr/local/include)
+
 check_function_exists(
     stat64
     HAVE_STAT64)


### PR DESCRIPTION
CMake does not add the /usr/local/include to the compiler include search
paths by default. This breaks the build on FreeBSD, where all libraries
are installed in /usr/local instead of /usr. So add /usr/local/include
as include path for all shims.