### PR TITLE
Add Queue.Clear test for when Queue is empty

### DIFF
--- a/src/System.Collections/tests/Generic/Queue/QueueTests.cs
+++ b/src/System.Collections/tests/Generic/Queue/QueueTests.cs
@@ -69,6 +69,18 @@ namespace System.Collections.Tests
             Assert.Equal(42, q.Dequeue());
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Clear_Empty(int capacity)
+        {
+            var q = new Queue<int>(capacity);
+            Assert.Equal(0, q.Count);
+            q.Clear();
+            Assert.Equal(0, q.Count);
+        }
+
         [Fact]
         public void Clear_Normal()
         {


### PR DESCRIPTION
A recent change (#3130) added a check to Queue.Clear that special-cases when the queue is already empty.  Turns out we didn't have any dedicated tests for that case.  Adding one.