### PR TITLE
Added performance MicroBenchmarks

### DIFF
--- a/src/Common/tests/Performance/PerfTestBase.cs
+++ b/src/Common/tests/Performance/PerfTestBase.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.IO;
+
+namespace System
+{
+    /// <summary>Base class for performance test classes</summary>
+    public abstract class PerfTestBase
+    {
+        /// <summary>
+        /// Helper method to create a string containing a number of random
+        /// characters equal to the specified length
+        /// </summary>
+        public static string CreateString(int length)
+        {
+            StringBuilder builder = new StringBuilder();
+            StringBuilder empty = new StringBuilder();
+            while (builder.Length < length)
+            {
+                string toAppend = Guid.NewGuid().ToString();
+                int toAppendLength = Math.Min(toAppend.Length, length - builder.Length);
+                builder.Append(toAppend, 0, toAppendLength);
+            }
+            return builder.ToString();
+        }
+
+        /// <summary>Gets a test file full path that is associated with the call site.</summary>
+        /// <param name="index">An optional index value to use as a suffix on the file name.  Typically a loop index.</param>
+        /// <param name="memberName">The member name of the function calling this method.</param>
+        /// <param name="lineNumber">The line number of the function calling this method.</param>
+        protected string GetTestFilePath(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            return Path.Combine(Path.GetTempPath(), string.Format(
+                index.HasValue ? "{0}_{1}_{2}_{3}_{4}" : "{0}_{1}_{2}_{3}",
+                memberName ?? "TestBase", lineNumber, GetType().Name, Path.GetRandomFileName(), 
+                index.GetValueOrDefault()));
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
+++ b/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+using System.Collections.Generic;
+
+namespace System.Collections.Tests
+{
+    public class Perf_HashTable : PerfTestBase
+    {
+        private IEnumerable<Hashtable> TestHashtables()
+        {
+            yield return CreateHashtable(100);
+            yield return CreateHashtable(1000);
+        }
+
+        private Hashtable CreateHashtable(int size)
+        {
+            Hashtable ht = new Hashtable();
+            for (int i = 0; i < size; i++)
+                ht.Add(CreateString(50), CreateString(50));
+            return ht;
+        }
+
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new Hashtable();
+        }
+
+        [Benchmark]
+        [MemberData("TestHashtables")]
+        public void GetItem(Hashtable table)
+        {
+            object result;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                table.Add("key", "value");
+                using (iteration.StartMeasurement())
+                    result = table["key"];
+                table.Remove("key");
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestHashtables")]
+        public void Add(Hashtable table)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    table.Add("key", "value");
+                table.Remove("key");
+            }
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -89,6 +91,7 @@
     <Compile Include="Hashtable\PropertyValuesTests.cs" />
     <Compile Include="Hashtable\RemoveTests.cs" />
     <Compile Include="Hashtable\SynchronizedTests.cs" />
+    <Compile Include="Performance\Perf.HashTable.cs" />
     <Compile Include="Queue\Queue_Clone.cs" />
     <Compile Include="Queue\Queue_Contains.cs" />
     <Compile Include="Queue\Queue_ctor.cs" />
@@ -144,6 +147,9 @@
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-beta-*",
     "System.Diagnostics.Debug": "4.0.10",
@@ -16,6 +17,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Collections/tests/Performance/Perf.Dictionary.cs
+++ b/src/System.Collections/tests/Performance/Perf.Dictionary.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Collections.Tests
+{
+    public class Perf_Dictionary : PerfTestBase
+    {
+        /// <summary>
+        /// Yields several Dictionaries containing increasing amounts of string-string
+        /// guid pairs can be used as MemberData input to performance tests for Dictionary
+        /// </summary>
+        /// <remarks>This could be greatly speeded up by caching the created dictionaries, but
+        /// I fear that it may be too vulnerable to tampering in the future if so e.g. A Theory
+        /// is written that modifies the test dictionaries and alters the results of the other tests.
+        /// </remarks>
+        private IEnumerable<Dictionary<string, string>> TestDictionaries()
+        {
+            yield return CreateDictionary(100);
+            yield return CreateDictionary(1000);
+        }
+
+        /// <summary>
+        /// Creates a Dictionary of string-string with the specified number of pairs
+        /// </summary>
+        private Dictionary<string, string> CreateDictionary(int size)
+        {
+            Dictionary<string, string> dict = new Dictionary<string, string>();
+            for (int i = 0; i < size; i++)
+            {
+                dict.Add(CreateString(50), CreateString(50));
+            }
+            return dict;
+        }
+
+        [Benchmark]
+        [MemberData("TestDictionaries")]
+        public void Add(Dictionary<string, string> dict)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    dict.Add("key", "string");
+                dict.Remove("key");
+            }
+        }
+
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new Dictionary<int, string>();
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public void ctor_int(int size)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new Dictionary<int, string>(size);
+        }
+
+        [Benchmark]
+        [MemberData("TestDictionaries")]
+        public void GetItem(Dictionary<string, string> dict)
+        {
+            // Setup
+            string retrieved;
+            dict.Add("key", "value");
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    retrieved = dict["key"];
+                dict.Remove("key");
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestDictionaries")]
+        public void SetItem(Dictionary<string, string> dict)
+        {
+            // Setup
+            dict.Add("key", "value");
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    dict["key"] = "newValue";
+                dict.Remove("key");
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestDictionaries")]
+        public void GetKeys(Dictionary<string, string> dict)
+        {
+            IEnumerable<string> result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = dict.Keys;
+        }
+
+        [Benchmark]
+        [MemberData("TestDictionaries")]
+        public void TryGetValue(Dictionary<string, string> dict)
+        {
+            // Setup
+            string retrieved;
+            dict.Add("key", "value");
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    dict.TryGetValue("key", out retrieved);
+                dict.Remove("key");
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestDictionaries")]
+        public void ContainsKey(Dictionary<string, string> dict)
+        {
+            // Setup
+            dict.Add("key", "value");
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    dict.ContainsKey("key");
+                dict.Remove("key");
+            }
+        }
+    }
+}

--- a/src/System.Collections/tests/Performance/Perf.List.cs
+++ b/src/System.Collections/tests/Performance/Perf.List.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Collections.Tests
+{
+    public class Perf_List
+    {
+        /// <summary>
+        /// Yields several Lists containing increasing amounts of strings as objects that 
+        /// can be used as MemberData input to performance tests for List
+        /// </summary>
+        private IEnumerable<List<object>> TestLists()
+        {
+            yield return CreateList(100);
+            yield return CreateList(1000);
+        }
+
+        /// <summary>
+        /// Creates a list containing a number of elements equal to the specified size
+        /// </summary>
+        private List<object> CreateList(int size)
+        {
+            List<object> list = new List<object>();
+            for (int i = 0; i < size; i++)
+                list.Add(Guid.NewGuid());
+            return list;
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void Add(List<object> list)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                string obj = Guid.NewGuid().ToString();
+
+                using (iteration.StartMeasurement())
+                    list.Add(obj);
+
+                list.Remove(obj);
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void AddRange(List<object> list)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                List<object> emptyList = new List<object>();
+
+                using (iteration.StartMeasurement())
+                    emptyList.AddRange(list);
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void Clear(List<object> list)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Create a local hard copy so that future iterations arent affected
+                var copy = new List<object>(list);
+                using (iteration.StartMeasurement())
+                    copy.Clear();
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void Contains(List<object> list)
+        {
+            object contained = list[0];
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    list.Contains(contained);
+        }
+
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new List<object>();
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void ctor_IEnumerable(List<object> list)
+        {
+            var array = list.ToArray();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new List<object>(array);
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void GetCount(List<object> list)
+        {
+            int temp;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    temp = list.Count;
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void GetItem(List<object> list)
+        {
+            object temp;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    temp = list[50];
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void GetEnumerator(List<object> list)
+        {
+            IEnumerator temp;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    temp = list.GetEnumerator();
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void Enumerator_Getcurrent(List<object> list)
+        {
+            object temp;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                IEnumerator enumerator = list.GetEnumerator();
+                using (iteration.StartMeasurement())
+                    temp = enumerator.Current;
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void Enumerator_MoveNext(List<object> list)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                IEnumerator enumerator = list.GetEnumerator();
+                using (iteration.StartMeasurement())
+                    enumerator.MoveNext();
+            }
+        }
+
+        [Benchmark]
+        [MemberData("TestLists")]
+        public void ToArray(List<object> list)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    list.ToArray();
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,6 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
+	<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -139,8 +141,13 @@
     <Compile Include="Generic\SortedSet\SortedSetTest.cs" />
     <Compile Include="Generic\Common\TestDebugger.cs" />
     <Compile Include="Generic\Stack\Stack_GetEnumerator.cs" />
+    <Compile Include="Performance\Perf.Dictionary.cs" />
+    <Compile Include="Performance\Perf.List.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
+	<Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "System.Collections": "4.0.10",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
+	"System.Collections": "4.0.10",
     "System.Console": "4.0.0-beta-*",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
@@ -13,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs
+++ b/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+using System.IO;
+
+namespace System.Diagnostics.ProcessTests
+{
+    public class Perf_Process : ProcessTestBase
+    {
+        [Benchmark]
+        public void Kill()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    proc.Kill();
+        }
+
+        [Benchmark]
+        public void GetProcessesByName()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Process.GetProcessesByName("1");
+        }
+
+        [Benchmark]
+        public void GetId()
+        {
+            int id;
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    id = proc.Id;
+        }
+
+        [Benchmark]
+        public void Create()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                Process proc;
+                using (iteration.StartMeasurement())
+                    proc = new Process();
+                proc.Dispose();
+            }
+        }
+
+        [Benchmark]
+        public void Start()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    proc.Start();
+        }
+
+        [Benchmark]
+        public void GetHasExited()
+        {
+            bool result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    result = proc.HasExited;
+        }
+
+        [Benchmark]
+        public void GetExitCode()
+        {
+            int result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    result = proc.ExitCode;
+        }
+
+        [Benchmark]
+        public void GetStartInfo()
+        {
+            ProcessStartInfo result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    result = proc.StartInfo;
+        }
+
+        [Benchmark]
+        public void WaitForExit()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcess())
+                using (iteration.StartMeasurement())
+                    proc.WaitForExit();
+        }
+
+        [Benchmark]
+        public void WaitForExit_int()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcess())
+                using (iteration.StartMeasurement())
+                    proc.WaitForExit(30);
+        }
+
+        [Benchmark]
+        public void GetStandardOutput()
+        {
+            StreamReader result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (Process proc = CreateProcessInfinite())
+                using (iteration.StartMeasurement())
+                    result = proc.StandardOutput;
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/Performance/Perf.ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/tests/Performance/Perf.ProcessStartInfo.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Diagnostics.ProcessTests
+{
+    public class Perf_ProcessStartInfo : ProcessTestBase
+    {
+        [Benchmark]
+        public void SetArguments()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                ProcessStartInfo info = new ProcessStartInfo();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    info.Arguments = "args";
+            }
+        }
+
+        [Benchmark]
+        public void SetFileName()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                ProcessStartInfo info = new ProcessStartInfo();
+                string currentFileName;
+                using (var proc = Process.GetCurrentProcess())
+                    currentFileName = proc.StartInfo.FileName;
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    info.FileName = currentFileName;
+            }
+        }
+
+        [Benchmark]
+        public void SetRedirectStandardOutput()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                ProcessStartInfo info = new ProcessStartInfo();
+                using (iteration.StartMeasurement())
+                    info.RedirectStandardOutput = true;
+            }
+        }
+
+        [Benchmark]
+        public void SetUseShellExecute()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                ProcessStartInfo info = new ProcessStartInfo();
+                using (iteration.StartMeasurement())
+                    info.UseShellExecute = true;
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -10,6 +10,8 @@
     <AssemblyName>System.Diagnostics.Process.Tests</AssemblyName>
     <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -35,6 +37,8 @@
     <Compile Include="ProcessThreadTests.cs" />
     <Compile Include="ProcessWaitingTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="Performance\Perf.Process.cs" />
+    <Compile Include="Performance\Perf.ProcessStartInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "Microsoft.Win32.Primitives": "4.0.0",
     "Microsoft.Win32.Registry": "4.0.0-beta-*",
     "System.Collections": "4.0.10",
@@ -26,6 +27,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Globalization/tests/Performance/Perf.CultureInfo.cs
+++ b/src/System.Globalization/tests/Performance/Perf.CultureInfo.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Globalization.Tests
+{
+    public class Perf_CultureInfo
+    {
+        [Benchmark]
+        public void GetCurrentCulture()
+        {
+            CultureInfo result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = CultureInfo.CurrentCulture;
+        }
+
+        [Benchmark]
+        public void GetInvariantCulture()
+        {
+            CultureInfo result;   
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -9,6 +9,8 @@
     <RootNamespace>System.Globalization.Tests</RootNamespace>
     <AssemblyName>System.Globalization.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
+	<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -159,6 +161,7 @@
     <Compile Include="TextInfo\TextInfoToUpper1.cs" />
     <Compile Include="TextInfo\TextInfoToUpper2.cs" />
     <Compile Include="UnicodeCategory\UnicodeCategoryTests.cs" />
+    <Compile Include="Performance\Perf.CultureInfo.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.AppContext": "4.0.0",
     "System.Console": "4.0.0-beta-*",
     "System.Globalization": "4.0.10",
@@ -14,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.IO.Compression/tests/Performance/Perf.DeflateStream.cs
+++ b/src/System.IO.Compression/tests/Performance/Perf.DeflateStream.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+using System.Collections.Generic;
+
+namespace System.IO.Compression.Tests
+{
+    public class Perf_DeflateStream : PerfTestBase
+    {
+        /// <summary>
+        /// Yields an Enumerable list of paths to GZTestData files
+        /// </summary>
+        protected static IEnumerable<string> GZTestFiles()
+        {
+            yield return "GZTestData/GZTestDocument.txt.gz";
+            yield return "GZTestData/GZTestDocument.docx.gz";
+        }
+
+        [Benchmark]
+        [MemberData("GZTestFiles")]
+        public async void Decompress(string testFilePath)
+        {
+            int _bufferSize = 1024;
+            var bytes = new Byte[_bufferSize];
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                var gzStream = await LocalMemoryStream.readAppFileAsync(testFilePath);
+                var strippedMs = StripHeaderAndFooter.Strip(gzStream);
+                var zip = new DeflateStream(strippedMs, CompressionMode.Decompress);
+
+                int retCount = -1;
+                using (iteration.StartMeasurement())
+                {
+                    while (retCount != 0)
+                    {
+                        retCount = zip.Read(bytes, 0, _bufferSize);
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        [InlineData(100)]
+        [InlineData(1000)]
+        public void Compress(int numberOfWrites)
+        {
+            var bytes = Text.Encoding.UTF8.GetBytes(CreateString(100));
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                Stream output = File.Create(GetTestFilePath());
+                var zip = new DeflateStream(output, CompressionMode.Compress);
+
+                int writeCount = 0;
+                using (iteration.StartMeasurement())
+                {
+                    while (writeCount < numberOfWrites)
+                    {
+                        zip.Write(bytes, 0, bytes.Length);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -7,6 +7,8 @@
     <ProjectGuid>{BC2E1649-291D-412E-9529-EDDA94FA7AD6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Compression.Tests</AssemblyName>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
@@ -24,6 +26,7 @@
     <Compile Include="Common.cs" />
     <Compile Include="DeflateStreamTests.cs" />
     <Compile Include="GZipStreamTests.cs" />
+    <Compile Include="Performance\Perf.DeflateStream.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="ZipArchive\zip_CreateTests.cs" />
     <Compile Include="ZipArchive\zip_InvalidParametersAndStrangeFiles.cs" />
@@ -46,6 +49,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\Compression\Utilities\ZipTestHelper.cs">
       <Link>Common\Compression\Utilities\ZipTestHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-beta-*",
     "System.Diagnostics.Debug": "4.0.10",
@@ -22,7 +23,9 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   },
   "runtimes": {
     "win7-x86": {},

--- a/src/System.IO.FileSystem/tests/Performance/Perf.Directory.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.Directory.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.IO.FileSystem.Tests
+{
+    public class Perf_Directory : PerfTestBase
+    {
+        [Benchmark]
+        public void GetCurrentDirectory()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Directory.GetCurrentDirectory();
+        }
+
+        [Benchmark]
+        public void CreateDirectory()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                string testFile = GetTestFilePath();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    Directory.CreateDirectory(testFile);
+
+                // Teardown
+                Directory.Delete(testFile);
+            }
+        }
+
+        [Benchmark]
+        public void Exists()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                string testFile = GetTestFilePath();
+                Directory.CreateDirectory(testFile);
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    Directory.Exists(testFile);
+
+                // Teardown
+                Directory.Delete(testFile);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Performance/Perf.File.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.File.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.IO.FileSystem.Tests
+{
+    public class Perf_File : PerfTestBase
+    {
+        [Benchmark]
+        public void Exists()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                string testFile = GetTestFilePath();
+                File.Create(testFile);
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    File.Exists(testFile);
+
+                // Teardown
+                File.Delete(testFile);
+            }
+        }
+
+        [Benchmark]
+        public void Delete()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                string testFile = GetTestFilePath();
+                File.Create(testFile);
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    File.Delete(testFile);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Performance/Perf.FileInfo.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.FileInfo.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.IO.FileSystem.Tests
+{
+    public class Perf_FileInfo : PerfTestBase
+    {
+        [Benchmark]
+        public void ctor_str()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new FileInfo(GetTestFilePath());
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -8,6 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +30,6 @@
       <Name>System.IO.FileSystem</Name>
       <Private>True</Private>
     </ProjectReference>
-
     <!-- 
       Until an updated packages is published, temporarily copy the locally built System.Runtime.Extensions library
       but still reference the contract from the package for compiling.  
@@ -160,9 +161,15 @@
     <Compile Include="FileInfo\ToString.cs" />
     <Compile Include="FileInfo\AppendText.cs" />
     <Compile Include="FileInfo\CopyTo.cs" />
+    <Compile Include="Performance\Perf.Directory.cs" />
+    <Compile Include="Performance\Perf.File.cs" />
+    <Compile Include="Performance\Perf.FileInfo.cs" />
     <!-- Helpers -->
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -1,5 +1,6 @@
-{
+﻿{
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-beta-*",
     "System.Diagnostics.Debug": "4.0.10",
@@ -21,6 +22,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.IO/tests/Performance/Perf.StreamReader.cs
+++ b/src/System.IO/tests/Performance/Perf.StreamReader.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.IO.Tests
+{
+    public class Perf_StreamReader : PerfTestBase
+    {
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new StreamReader();
+        }
+    }
+}

--- a/src/System.IO/tests/Performance/Perf.StreamWriter.cs
+++ b/src/System.IO/tests/Performance/Perf.StreamWriter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.IO.Tests
+{
+    public class Perf_StreamWriter : PerfTestBase
+    {
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new StreamWriter();
+        }
+    }
+}

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -9,6 +9,8 @@
     <AssemblyName>System.IO.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -19,6 +21,8 @@
     <Compile Include="BinaryWriter\BinaryWriterTests.cs" />
     <Compile Include="InvalidDataException\InvalidDataExceptionTests.cs" />
     <Compile Include="MemoryStream\MemoryStream_TryGetBufferTests.cs" />
+    <Compile Include="Performance\Perf.StreamReader.cs" />
+    <Compile Include="Performance\Perf.StreamWriter.cs" />
     <Compile Include="StreamReader\StreamReaderCtorTests.cs" />
     <Compile Include="StreamReader\StreamReaderTests.cs" />
     <Compile Include="StreamWriter\BaseStream.cs" />
@@ -33,6 +37,9 @@
     <Compile Include="Stream\TimeoutTests.cs" />
     <Compile Include="StringReader\StringReaderCtorTests.cs" />
     <Compile Include="StringWriter\StringWriterTests.cs" />
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <!-- Compile tests against the contract, but copy our local-built implementation for testing -->

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.IO": "4.0.10",
     "System.Globalization": "4.0.10",
     "System.Text.Encoding.CodePages": "4.0.0",
@@ -7,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Environment.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Environment.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+using System.Runtime.InteropServices;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class Perf_Environment : PerfTestBase
+    {
+        [Benchmark]
+        public void GetEnvironmentVariable()
+        {
+            string env = CreateString(15);
+            try
+            {
+                // setup the environment variable so we can read it
+                Environment.SetEnvironmentVariable(env, "value");
+
+                // read the valid environment variable for the test
+                foreach (var iteration in Benchmark.Iterations)
+                    using (iteration.StartMeasurement())
+                        Environment.GetEnvironmentVariable(env);
+            }
+            finally
+            {
+                // clear the variable that we set
+                Environment.SetEnvironmentVariable(env, null);
+            }
+        }
+
+        [Benchmark]
+        public void GetNewLine()
+        {
+            string line;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    line = Environment.NewLine;
+        }
+
+        [Benchmark]
+        public void ExpandEnvironmentVariables()
+        {
+            string env = CreateString(15);
+            try
+            {
+                // setup the environment variable so we can read it
+                Environment.SetEnvironmentVariable(env, "value");
+
+                // read the valid environment variable
+                foreach (var iteration in Benchmark.Iterations)
+                    using (iteration.StartMeasurement())
+                        Environment.ExpandEnvironmentVariables("%" + env + "%");
+            }
+            finally
+            {
+                // clear the variable that we set
+                Environment.SetEnvironmentVariable(env, null);
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class Perf_Path : PerfTestBase
+    {
+        [Benchmark]
+        public void Combine()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                string testPath1 = GetTestFilePath();
+                string testPath2 = Guid.NewGuid().ToString();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    Path.Combine(testPath1, testPath2);
+            }
+        }
+
+        [Benchmark]
+        public void GetFileName()
+        {
+            string testPath = GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Path.GetFileName(testPath);
+        }
+
+        [Benchmark]
+        public void GetDirectoryName()
+        {
+            string testPath = GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Path.GetDirectoryName(testPath);
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Random.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Random.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class Perf_Random : PerfTestBase
+    {
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new Random();
+        }
+
+        [Benchmark]
+        public void Next_int()
+        {
+            Random rand = new Random();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    rand.Next(10000);
+        }
+
+        [Benchmark]
+        public void Next_int_int()
+        {
+            Random rand = new Random();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    rand.Next(100, 10000);
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -10,6 +10,8 @@
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -17,6 +19,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Performance\Perf.Environment.cs" />
+    <Compile Include="Performance\Perf.Path.cs" />
+    <Compile Include="Performance\Perf.Random.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\PathTests.cs" />
@@ -54,6 +59,10 @@
     <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
     <Compile Include="System\StringComparer.cs" />
+    <!-- Helpers -->
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Console": "4.0.0-beta-*",
     "System.IO.FileSystem": "4.0.0",
     "System.Globalization": "4.0.10",
@@ -13,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Boolean.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Boolean.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Boolean : PerfTestBase
+    {
+        [Benchmark]
+        public void Parse_str()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Boolean.Parse("True");
+        }
+
+        [Benchmark]
+        public void ToString_()
+        {
+            Boolean boo = true;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    boo.ToString();
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.DateTime.cs
+++ b/src/System.Runtime/tests/Performance/Perf.DateTime.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_DateTime
+    {
+        [Benchmark]
+        public void GetNow()
+        {
+            DateTime dt;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    dt = DateTime.Now;
+        }
+
+        [Benchmark]
+        public void ToString_str()
+        {
+            DateTime dt = DateTime.Now;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    dt.ToString("g");
+        }
+
+        [Benchmark]
+        public void op_Subtraction()
+        {
+            TimeSpan result;
+            DateTime date1 = new DateTime(1996, 6, 3, 22, 15, 0);
+            DateTime date2 = new DateTime(1996, 12, 6, 13, 2, 0);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = date1 - date2;
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.Enum.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Enum.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Enum
+    {
+        private enum testEnum
+        {
+            Red = 1,
+            Blue = 2
+        }
+
+        [Benchmark]
+        public void Parse()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Enum.Parse(typeof(testEnum), "Red");
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.GC.cs
+++ b/src/System.Runtime/tests/Performance/Perf.GC.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+using System.Text;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_GC : PerfTestBase
+    {
+        [Benchmark]
+        public void SuppressFinalize()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // obj has no managed resources to free, so suppressing the finalizer for it is fine.
+                object obj = new object();
+
+                using (iteration.StartMeasurement())
+                    GC.SuppressFinalize(obj);
+            }
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.Guid.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Guid.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+using System.Text;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Guid : PerfTestBase
+    {
+        [Benchmark]
+        public void NewGuid()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Guid.NewGuid();
+        }
+
+        [Benchmark]
+        public void ctor_str()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff");
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.Int32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Int32.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Int32 : PerfTestBase
+    {
+        [Benchmark]
+        public void ToString_()
+        {
+            Int32 i32 = 32;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    i32.ToString();
+        }
+
+        [Benchmark]
+        [InlineData(100)]
+        [InlineData(1000)]
+        public void Parse_str(int length)
+        {
+            string builtString = CreateString(length);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Int32.Parse(builtString);
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.IntPtr.cs
+++ b/src/System.Runtime/tests/Performance/Perf.IntPtr.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_IntPtr
+    {
+        [Benchmark]
+        public void GetZero()
+        {
+            IntPtr ptr;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    ptr = IntPtr.Zero;
+        }
+
+        [Benchmark]
+        public void ctor_int32()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new IntPtr(0);
+        }
+
+        [Benchmark]
+        public void op_Equality_IntPtr_IntPtr()
+        {
+            bool res;
+            IntPtr ptr1 = new IntPtr(0);
+            IntPtr ptr2 = new IntPtr(0);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    res = ptr1 == ptr2;
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.Object.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Object.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Object
+    {
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new Object();
+        }
+
+        [Benchmark]
+        public void GetType_()
+        {
+            Object obj = new Object();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    obj.GetType();
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.String.cs
+++ b/src/System.Runtime/tests/Performance/Perf.String.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_String : PerfTestBase
+    {
+        protected IEnumerable<int> TestStringSizes()
+        {
+            yield return 10;
+            yield return 100;
+            yield return 1000;
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void GetChars(string testString)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.ToCharArray();
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Concat_str_str(int size)
+        {
+            string testString1 = CreateString(size);
+            string testString2 = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    string.Concat(testString1, testString2);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Concat_str_str_str(int size)
+        {
+            string testString1 = CreateString(size);
+            string testString2 = CreateString(size);
+            string testString3 = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    string.Concat(testString1, testString2, testString3);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Concat_str_str_str_str(int size)
+        {
+            string testString1 = CreateString(size);
+            string testString2 = CreateString(size);
+            string testString3 = CreateString(size);
+            string testString4 = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    string.Concat(testString1, testString2, testString3, testString4);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Contains(int size)
+        {
+            string testString = CreateString(size);
+            string subString = testString.Substring(testString.Length / 2, testString.Length / 2 + testString.Length / 4);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.Contains(subString);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Equals(int size)
+        {
+            string testString1 = CreateString(size);
+            string testString2 = new string(testString1.ToCharArray());
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString1.Equals(testString2);
+        }
+
+        [Benchmark]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public void Format(int numberOfObjects)
+        {
+            // Setup the format string and the list of objects to format
+            StringBuilder formatter = new StringBuilder();
+            List<string> objects = new List<string>();
+            for (int i = 0; i < numberOfObjects; i++)
+            {
+                formatter.Append("%s, ");
+                objects.Add(CreateString(10));
+            }
+            string format = formatter.ToString();
+            string[] objectArr = objects.ToArray();
+
+            // Perform the actual formatting
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    string.Format(format, objectArr);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void GetLength(int size)
+        {
+            int result;
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = testString.Length;
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void op_Equality(int size)
+        {
+            bool result;
+            string testString1 = CreateString(size);
+            string testString2 = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = testString1 == testString2;
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Replace(int size)
+        {
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.Replace("-", "1");
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Split(int size)
+        {
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.Split("-");
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void StartsWith(int size)
+        {
+            string testString = CreateString(size);
+            string subString = testString.Substring(0, testString.Length / 4);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.StartsWith(subString);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Empty(int size)
+        {
+            string result;
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = string.Empty;
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Substring_int(int size)
+        {
+            int startIndex = size / 2;
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.Substring(startIndex);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Substring_int_int(int size)
+        {
+            int startIndex = size / 2;
+            int length = size / 4;
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.Substring(startIndex, length);
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void ToLower(int size)
+        {
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.ToLower();
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void ToUpper(int size)
+        {
+            string testString = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.ToUpper();
+        }
+
+        [Benchmark]
+        [MemberData("TestStringSizes")]
+        public void Trim(int size)
+        {
+            string testString = "   " + CreateString(size) + "   ";
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    testString.Trim();
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
+++ b/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_StringBuilder : PerfTestBase
+    {
+        [Benchmark]
+        public void ctor()
+        {
+            StringBuilder builder;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    builder = new StringBuilder();
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(200)]
+        public void Append(int length)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup - Create a string of the specified length
+                string builtString = CreateString(length);
+                StringBuilder empty = new StringBuilder();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    empty.Append(builtString); // Appends a string of length "length" to an empty StringBuilder object
+            }
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.TimeSpan.cs
+++ b/src/System.Runtime/tests/Performance/Perf.TimeSpan.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_TimeSpan
+    {
+        [Benchmark]
+        public void ctor_int_int_int()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new TimeSpan(7, 8, 10);
+        }
+
+        [Benchmark]
+        public void FromSeconds()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    TimeSpan.FromSeconds(50);
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.Type.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Type.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Type
+    {
+        [Benchmark]
+        public void GetTypeFromHandle()
+        {
+            RuntimeTypeHandle type1 = typeof(int).TypeHandle;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    Type.GetTypeFromHandle(type1);
+        }
+
+        [Benchmark]
+        public void op_Equality()
+        {
+            bool result;
+            Type type1 = typeof(int);
+            Type type2 = typeof(string);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    result = type1 == type2;
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.UInt32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.UInt32.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_UInt32
+    {
+        [Benchmark]
+        public void ToString_()
+        {
+            UInt32 i = new UInt32();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    i.ToString();
+        }
+    }
+}

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -11,6 +11,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RestorePackages>true</RestorePackages>
     <NoWarn>1718</NoWarn>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -18,6 +20,15 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Performance\Perf.Boolean.cs" />
+    <Compile Include="Performance\Perf.Enum.cs" />
+    <Compile Include="Performance\Perf.GC.cs" />
+    <Compile Include="Performance\Perf.Guid.cs" />
+    <Compile Include="Performance\Perf.Object.cs" />
+    <Compile Include="Performance\Perf.String.cs" />
+    <Compile Include="Performance\Perf.TimeSpan.cs" />
+    <Compile Include="Performance\Perf.Type.cs" />
+    <Compile Include="Performance\Perf.UInt32.cs" />
     <Compile Include="System\Activator.cs" />
     <Compile Include="System\Array.cs" />
     <Compile Include="System\Array.CustomClassStructTests.cs" />
@@ -88,6 +99,14 @@
     <Compile Include="System\ValueType.cs" />
     <Compile Include="System\Version.cs" />
     <Compile Include="System\WeakReference.cs" />
+    <Compile Include="Performance\Perf.DateTime.cs" />
+    <Compile Include="Performance\Perf.Int32.cs" />
+    <Compile Include="Performance\Perf.IntPtr.cs" />
+    <Compile Include="Performance\Perf.StringBuilder.cs" />
+    <!-- Helpers -->
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Console": "4.0.0-beta-*",
     "System.Globalization": "4.0.10",
     "System.Reflection": "4.0.10",
@@ -13,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Text.Encoding/tests/Performance/Perf.Encoding.cs
+++ b/src/System.Text.Encoding/tests/Performance/Perf.Encoding.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Runtime.Tests
+{
+    public class Perf_Encoding : PerfTestBase
+    {
+        [Benchmark]
+        [InlineData(40)]
+        [InlineData(160)]
+        public void GetBytes_str(int size)
+        {
+            Encoding enc = Encoding.UTF8;
+            string toEncode = CreateString(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    enc.GetBytes(toEncode);
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -8,8 +8,10 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Text.Encoding.Tests</AssemblyName>
     <RootNamespace>System.Text.Encoding.Tests</RootNamespace>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
-   <!-- Default configurations to help VS understand the configurations -->
+  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -68,6 +70,7 @@
     <Compile Include="Encoding\EncodingUnicode.cs" />
     <Compile Include="Encoding\EncodingUTF8.cs" />
     <Compile Include="Encoding\EncodingWebName.cs" />
+    <Compile Include="Performance\Perf.Encoding.cs" />
     <Compile Include="UnicodeEncoding\UnicodeEncodingCtor1.cs" />
     <Compile Include="UnicodeEncoding\UnicodeEncodingEquals.cs" />
     <Compile Include="UnicodeEncoding\UnicodeEncodingGetByteCount1.cs" />
@@ -116,6 +119,9 @@
     <Compile Include="UTF8Encoding\UTF8EncodingGetPreamble.cs" />
     <Compile Include="UTF8Encoding\UTF8EncodingGetString.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
+    <Compile Include="$(CommonTestPath)\Performance\PerfTestBase.cs">
+      <Link>Common\Performance\PerfTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Globalization": "4.0.10",
     "System.Collections": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
@@ -11,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Threading/tests/Performance/Perf.EventWaitHandle.cs
+++ b/src/System.Threading/tests/Performance/Perf.EventWaitHandle.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Xunit.Performance;
+
+namespace System.Threading.Tests
+{
+    public class Perf_EventWaitHandle
+    {
+        [Benchmark]
+        public void Set()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset))
+                using (iteration.StartMeasurement())
+                    are.Set();
+        }
+    }
+}

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -7,6 +7,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tests</AssemblyName>
     <ProjectGuid>{33F5A50E-B823-4FDD-8571-365C909ACEAE}</ProjectGuid>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -24,6 +26,7 @@
     <Compile Include="ManualResetEventSlimCancellationTests.cs" />
     <Compile Include="ManualResetEventSlimTests.cs" />
     <Compile Include="MutexTests.cs" />
+    <Compile Include="Performance\Perf.EventWaitHandle.cs" />
     <Compile Include="SemaphoreSlimCancellationTests.cs" />
     <Compile Include="SemaphoreSlimTests.cs" />
     <Compile Include="SemaphoreTests.cs" />

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-beta-*",
     "System.Diagnostics.Debug": "4.0.10",
@@ -15,6 +16,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }

--- a/src/System.Xml.XmlDocument/tests/Performance/Perf.XmlDocument.cs
+++ b/src/System.Xml.XmlDocument/tests/Performance/Perf.XmlDocument.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Xml;
+using Microsoft.Xunit.Performance;
+
+namespace XmlDocumentTests.XmlDocumentTests
+{
+    public class Perf_XmlDocument
+    {
+        [Benchmark]
+        public void Create()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    new XmlDocument();
+        }
+
+        [Benchmark]
+        public void LoadXml()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                var doc = new XmlDocument();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    doc.LoadXml("<elem1 child1='' child2='duu' child3='e1;e2;' child4='a1' child5='goody'> text node two e1; text node three </elem1>");
+            }
+        }
+
+        [Benchmark]
+        public void GetDocumentElement()
+        {
+            XmlNode element;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                var doc = new XmlDocument();
+                doc.LoadXml("<elem1 child1='' child2='duu' child3='e1;e2;' child4='a1' child5='goody'> text node two e1; text node three </elem1>");
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    element = doc.DocumentElement;
+            }
+        }
+    }
+}

--- a/src/System.Xml.XmlDocument/tests/Performance/Perf.XmlNode.cs
+++ b/src/System.Xml.XmlDocument/tests/Performance/Perf.XmlNode.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Xml;
+using Microsoft.Xunit.Performance;
+
+namespace XmlDocumentTests.XmlNodeTests
+{
+    public class Perf_XmlNode
+    {
+        [Benchmark]
+        public void GetAttributes()
+        {
+            XmlAttributeCollection attr;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml("<a attr1='test' attr2='test2' />");
+                XmlNode node = doc.DocumentElement;
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    attr = node.Attributes;
+            }
+        }
+
+        [Benchmark]
+        public void GetValue()
+        {
+            string value;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                var doc = new XmlDocument();
+                doc.LoadXml("<a attr1='test' attr2='test2' />");
+                XmlNode node = doc.DocumentElement;
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    value = node.Value;
+            }
+        }
+    }
+}

--- a/src/System.Xml.XmlDocument/tests/Performance/Perf.XmlNodeList.cs
+++ b/src/System.Xml.XmlDocument/tests/Performance/Perf.XmlNodeList.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Xml;
+using Microsoft.Xunit.Performance;
+
+namespace XmlDocumentTests.XmlNodeListTests
+{
+    public class Perf_XmlNodeList
+    {
+        [Benchmark]
+        public void GetEnumerator()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                var doc = new XmlDocument();
+                doc.LoadXml("<a><sub1/><sub2/></a>");
+                XmlNodeList list = doc.DocumentElement.ChildNodes;
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    list.GetEnumerator();
+            }
+        }
+
+        [Benchmark]
+        public void GetCount()
+        {
+            int count;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup
+                var doc = new XmlDocument();
+                doc.LoadXml("<a><sub1/><sub2/></a>");
+                XmlNodeList list = doc.DocumentElement.ChildNodes;
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    count = list.Count;
+            }
+        }
+    }
+}

--- a/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
@@ -9,6 +9,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XmlDocument.UnitTests</RootNamespace>
+	<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -99,6 +101,9 @@
     <Compile Include="XmlProcessingInstructionTests\DataTests.cs" />
     <Compile Include="XmlProcessingInstructionTests\TargetTests.cs" />
     <Compile Include="XmlTextTests\SplitTextTests.cs" />
+    <Compile Include="Performance\Perf.XmlDocument.cs" />
+    <Compile Include="Performance\Perf.XmlNode.cs" />
+    <Compile Include="Performance\Perf.XmlNodeList.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Xml.XmlDocument.csproj">

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
@@ -7,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win"
+    }
   }
 }


### PR DESCRIPTION
Summary of changes:
- Added "Performance" folders containing perf xunit tests to a number of highly-used libraries (determined by Usage data)
- Two sets of usage data from store apps; I added a test for every function used in more than 5% of the covered assemblies in both data sets.
- This is a first-round pass of the most highly used libraries and does not include: abstract classes, interfaces, or Attributes
- Created a shared parent abstract class for commonly used functions across perf tests, stored in src\Common\tests\Performance. I only added a reference to this parent if i actually ended up using it, so in the future it can be added as necessary.
- Most functions only have basic microbenchmarks with the exception of a few BigO tests that are made using InlineData or MemberData that scale

Next Steps:
- Modify applicable microbenchmarks to also test BigO by scaling the size of the input data through InlineData/MemberData. I've already done this in a few classes (System.Collections) to demonstrate the plan.
- <b>Add Warmup code before the iteration loops begin.</b>
- I did not include tests for abstract functions/classes or any interface methods. Later I can look into implementing these perf tests for those classes that implement them that are highly utilized. This would be easily reusable since they would share a common ancestor, so we could potentially test several children within the same code. For example, usage data has Object.Equals highly utilized but it's actually a child (or children) of Object that is contributing that high utilization.


Disclaimer: 
These tests won't pass the CI build or even a local build until CoreFX is using xunit beta4. I do not plan on merging this PR to CoreFX. However, before I move forward with adding more tests I'd like to get some feedback on the overall design of the perf tests (their location, structure, and style) that I've added thus far. Any questions, comments, or nitpicks are greatly appreciated :)

Ian