### PR TITLE
ScriptingRuntimeHelpers.True and False should not be private.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -113,8 +113,8 @@ namespace System.Linq.Expressions.Interpreter
             return b ? True : False;
         }
 
-        private static readonly object True = true;
-        private static readonly object False = false;
+        internal static readonly object True = true;
+        internal static readonly object False = false;
 
         internal static object GetPrimitiveDefaultValue(Type type)
         {


### PR DESCRIPTION
There are many places where they are used internally and that breaks the build