### PR TITLE
Avoid calling Array.Clear on the entire _array when Queue is already empty.

### DIFF
--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -121,17 +121,21 @@ namespace System.Collections
         // Removes all Objects from the queue.
         public virtual void Clear()
         {
-            if (_head < _tail)
-                Array.Clear(_array, _head, _size);
-            else
+            if (_size != 0)
             {
-                Array.Clear(_array, _head, _array.Length - _head);
-                Array.Clear(_array, 0, _tail);
+                if (_head < _tail)
+                    Array.Clear(_array, _head, _size);
+                else
+                {
+                    Array.Clear(_array, _head, _array.Length - _head);
+                    Array.Clear(_array, 0, _tail);
+                }
+
+                _size = 0;
             }
 
             _head = 0;
             _tail = 0;
-            _size = 0;
             _version++;
         }
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Clear.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Clear.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class Queue_Clear
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Clear_Empty(int capacity)
+    {
+        var q = new Queue(capacity);
+        Assert.Equal(0, q.Count);
+        q.Clear();
+        Assert.Equal(0, q.Count);
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Hashtable\PropertyValuesTests.cs" />
     <Compile Include="Hashtable\RemoveTests.cs" />
     <Compile Include="Hashtable\SynchronizedTests.cs" />
+    <Compile Include="Queue\Queue_Clear.cs" />
     <Compile Include="Queue\Queue_Clone.cs" />
     <Compile Include="Queue\Queue_Contains.cs" />
     <Compile Include="Queue\Queue_ctor.cs" />


### PR DESCRIPTION
Now for non-generic Queue.