### PR TITLE
Fix two failing System.IO.Pipes.Tests on OS X

### DIFF
--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
@@ -108,11 +108,24 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~PlatformID.Linux)]
-        public static void BufferSizeRoundtripping()
+        [PlatformSpecific(PlatformID.OSX)]
+        public static void OSX_BufferSizeNotSupported()
         {
-            // On systems other than Linux, setting the buffer size of the server will only set
-            // set the buffer size of the client if the flow of the pipe is towards the client i.e.
+            int desiredBufferSize = 10;
+            using (var server = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None, desiredBufferSize))
+            using (var client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => server.OutBufferSize);
+                Assert.Throws<PlatformNotSupportedException>(() => client.InBufferSize);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void Windows_BufferSizeRoundtripping()
+        {
+            // On Windows, setting the buffer size of the server will only set
+            // the buffer size of the client if the flow of the pipe is towards the client i.e.
             // the client is defined with PipeDirection.In
 
             int desiredBufferSize = 10;

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -262,8 +262,26 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~PlatformID.Linux)]
-        public static void BufferSizeRoundtripping()
+        [PlatformSpecific(PlatformID.OSX)]
+        public static void OSX_BufferSizeNotSupported()
+        {
+            int desiredBufferSize = 10;
+            string pipeName = GetUniquePipeName();
+            using (var server = new NamedPipeServerStream(pipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, desiredBufferSize, desiredBufferSize))
+            using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.Out))
+            {
+                Task clientConnect = client.ConnectAsync();
+                server.WaitForConnection();
+                clientConnect.Wait();
+
+                Assert.Throws<PlatformNotSupportedException>(() => server.InBufferSize);
+                Assert.Throws<PlatformNotSupportedException>(() => client.OutBufferSize);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void Windows_BufferSizeRoundtripping()
         {
             int desiredBufferSize = 10;
             string pipeName = GetUniquePipeName();


### PR DESCRIPTION
The tests were using PipeStream's BufferSize, which throws PlatformNotSupported on OS X.

cc: @ianhays 