### PR TITLE
Fix System.Console test failing on OS X

### DIFF
--- a/src/System.Console/tests/TermInfo.cs
+++ b/src/System.Console/tests/TermInfo.cs
@@ -159,7 +159,7 @@ public class TermInfo
     {
         // This file (available by default on OS X) is called out specifically since it contains a format where it has %i
         // but only one variable instead of two. Make sure we don't break in this case
-        TermInfoVerification("emu", "\u001Br1", "\u001Bs1", 0);
+        TermInfoVerification("emu", "\u001Br1;", "\u001Bs1;", 0);
     }
 
     [Fact]


### PR DESCRIPTION
The strings used in the EmuTermInfoDoesntBreakParser test are missing semicolons at the end, so they fail when compared against the strings in the emu file, which has semicolons at the end.

cc: @sokket