### PR TITLE
Fix System.Diagnostics.Process.Tests

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -33,6 +33,8 @@ namespace System.Diagnostics.ProcessTests
                 }
                 catch (InvalidOperationException) { } // in case it was never started
             }
+
+            base.Dispose(disposing);
         }
 
         protected Process CreateProcess(Func<int> method = null)


### PR DESCRIPTION
System.Diagnostics.Process.Tests leaves behind temp directories in %TMP%

/cc: @stephentoub 