### PR TITLE
Fix failing FileSystem tests on OS X

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -12,9 +12,9 @@ namespace System.IO.FileSystem.Tests
         public delegate void SetTime(string path, DateTime time);
         public delegate DateTime GetTime(string path);
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions()
+        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
         {
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
                 yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
                     ((path, time) => Directory.SetCreationTime(path, time)),
@@ -68,7 +68,7 @@ namespace System.IO.FileSystem.Tests
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            Assert.All(TimeFunctions(), (tuple) =>
+            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testDir.FullName, dt);
@@ -107,7 +107,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Equal(DateTime.FromFileTime(0).Ticks, new DirectoryInfo(path).LastAccessTime.Ticks);
             Assert.Equal(DateTime.FromFileTime(0).Ticks, Directory.GetLastWriteTime(path).Ticks);
             Assert.Equal(DateTime.FromFileTime(0).Ticks, new DirectoryInfo(path).LastWriteTime.Ticks);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Equal(DateTime.FromFileTime(0).Ticks, Directory.GetCreationTime(path).Ticks);
                 Assert.Equal(DateTime.FromFileTime(0).Ticks, new DirectoryInfo(path).CreationTime.Ticks);
@@ -118,7 +118,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new DirectoryInfo(path).LastAccessTimeUtc.Ticks);
             Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, Directory.GetLastWriteTimeUtc(path).Ticks);
             Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new DirectoryInfo(path).LastWriteTimeUtc.Ticks);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, Directory.GetCreationTimeUtc(path).Ticks);
                 Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new DirectoryInfo(path).CreationTimeUtc.Ticks);
@@ -136,7 +136,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Throws<FileNotFoundException>(() => new DirectoryInfo(path).LastAccessTime);
             Assert.Throws<FileNotFoundException>(() => Directory.GetLastWriteTime(path));
             Assert.Throws<FileNotFoundException>(() => new DirectoryInfo(path).LastWriteTime);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Throws<FileNotFoundException>(() => Directory.GetCreationTime(path));
                 Assert.Throws<FileNotFoundException>(() => new DirectoryInfo(path).CreationTime);
@@ -147,7 +147,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Throws<FileNotFoundException>(() => new DirectoryInfo(path).LastAccessTimeUtc);
             Assert.Throws<FileNotFoundException>(() => Directory.GetLastWriteTimeUtc(path));
             Assert.Throws<FileNotFoundException>(() => new DirectoryInfo(path).LastWriteTimeUtc);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Throws<FileNotFoundException>(() => Directory.GetCreationTimeUtc(path));
                 Assert.Throws<FileNotFoundException>(() => new DirectoryInfo(path).CreationTimeUtc);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -12,9 +12,9 @@ namespace System.IO.FileSystem.Tests
         public delegate void SetTime(DirectoryInfo testDir, DateTime time);
         public delegate DateTime GetTime(DirectoryInfo testDir);
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions()
+        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
         {
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
                 yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
                     ((testDir, time) => {testDir.CreationTime = time; }), 
@@ -48,7 +48,7 @@ namespace System.IO.FileSystem.Tests
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            Assert.All(TimeFunctions(), (tuple) =>
+            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testDir, dt);

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -12,9 +12,9 @@ namespace System.IO.FileSystem.Tests
         public delegate void SetTime(string path, DateTime time);
         public delegate DateTime GetTime(string path);
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions()
+        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
         {
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
                 yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
                     ((path, time) => File.SetCreationTime(path, time)),
@@ -69,7 +69,7 @@ namespace System.IO.FileSystem.Tests
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
 
-            Assert.All(TimeFunctions(), (tuple) =>
+            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testFile.FullName, dt);
@@ -108,7 +108,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Equal(DateTime.FromFileTime(0).Ticks, new FileInfo(path).LastAccessTime.Ticks);
             Assert.Equal(DateTime.FromFileTime(0).Ticks, File.GetLastWriteTime(path).Ticks);
             Assert.Equal(DateTime.FromFileTime(0).Ticks, new FileInfo(path).LastWriteTime.Ticks);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Equal(DateTime.FromFileTime(0).Ticks, File.GetCreationTime(path).Ticks);
                 Assert.Equal(DateTime.FromFileTime(0).Ticks, new FileInfo(path).CreationTime.Ticks);
@@ -119,7 +119,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new FileInfo(path).LastAccessTimeUtc.Ticks);
             Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, File.GetLastWriteTimeUtc(path).Ticks);
             Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new FileInfo(path).LastWriteTimeUtc.Ticks);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, File.GetCreationTimeUtc(path).Ticks);
                 Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new FileInfo(path).CreationTimeUtc.Ticks);
@@ -137,7 +137,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Throws<FileNotFoundException>(() => new FileInfo(path).LastAccessTime);
             Assert.Throws<FileNotFoundException>(() => File.GetLastWriteTime(path));
             Assert.Throws<FileNotFoundException>(() => new FileInfo(path).LastWriteTime);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Throws<FileNotFoundException>(() => File.GetCreationTime(path));
                 Assert.Throws<FileNotFoundException>(() => new FileInfo(path).CreationTime);
@@ -148,7 +148,7 @@ namespace System.IO.FileSystem.Tests
             Assert.Throws<FileNotFoundException>(() => new FileInfo(path).LastAccessTimeUtc);
             Assert.Throws<FileNotFoundException>(() => File.GetLastWriteTimeUtc(path));
             Assert.Throws<FileNotFoundException>(() => new FileInfo(path).LastWriteTimeUtc);
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime)
             {
                 Assert.Throws<FileNotFoundException>(() => File.GetCreationTimeUtc(path));
                 Assert.Throws<FileNotFoundException>(() => new FileInfo(path).CreationTimeUtc);

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -12,9 +12,9 @@ namespace System.IO.FileSystem.Tests
         public delegate void SetTime(FileInfo testFile, DateTime time);
         public delegate DateTime GetTime(FileInfo testFile);
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions()
+        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
         {
-            if (IOInputs.SupportsCreationTime)
+            if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
                 yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
                     ((testFile, time) => { testFile.CreationTime = time; }),
@@ -49,7 +49,7 @@ namespace System.IO.FileSystem.Tests
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
 
-            Assert.All(TimeFunctions(), (tuple) =>
+            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
                 tuple.Item1(testFile, dt);

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -14,7 +14,8 @@ internal static class IOInputs
         new char[] { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31, ':', '*', '?' } :
         new char[] { '\0' };
 
-    public static bool SupportsCreationTime { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) | RuntimeInformation.IsOSPlatform(OSPlatform.OSX); } }
+    public static bool SupportsSettingCreationTime { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); } }
+    public static bool SupportsGettingCreationTime { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) | RuntimeInformation.IsOSPlatform(OSPlatform.OSX); } }
     public static bool CaseSensitive { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) | RuntimeInformation.IsOSPlatform(OSPlatform.OSX); } }
     public static bool CaseInsensitive { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) | RuntimeInformation.IsOSPlatform(OSPlatform.OSX); } }
 


### PR DESCRIPTION
Several FileSystem tests are failing on OS X because the tests are expecting that file/directory creation time can be changed on Unix.  Fixing the tests.

Fixes #2895 
cc: @ianhays, @sokket 