### PR TITLE
Add missing IsInvalid check to ECDsaOpenSsl's GenerateKey

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography
                 {
                     int nid = s_supportedAlgorithms[i].Nid;
                     SafeEcKeyHandle key = Interop.libcrypto.EC_KEY_new_by_curve_name(nid);
-                    if (key == null)
+                    if (key == null || key.IsInvalid)
                         throw Interop.libcrypto.CreateOpenSslCryptographicException();
 
                     if (!Interop.libcrypto.EC_KEY_generate_key(key))


### PR DESCRIPTION
After calling EC_KEY_new_by_curve_name, we're currently checking whether the returned SafeHandle is null, but not whether it's Invalid, and if EC_KEY_new_by_curve_name fails, it'll return a null pointer, which will be stored into a non-null SafeHandle instance.  This means that if EC_KEY_new_by_curve_name fails, we then get a "passed a null parameter" error from the subsequent call to EC_KEY_generate_key, rather than an exception for the original error from EC_KEY_new_by_curve_name.

This commit just adds the appropriate check.

cc: @bartonjs, @AtsushiKan 