### PR TITLE
Fix Path.GetTempPath() test on OS X

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -277,6 +277,7 @@ public static class PathTests
     [InlineData("./tmp/", "./tmp")]
     [InlineData("/home/someuser/sometempdir/", "/home/someuser/sometempdir/")]
     [InlineData("/home/someuser/some tempdir/", "/home/someuser/some tempdir/")]
+    [InlineData("/tmp/", null)]
     public static void GetTempPath_SetEnvVar_Unix(string expected, string newTempPath)
     {
         GetTempPath_SetEnvVar("TMPDIR", expected, newTempPath);
@@ -295,7 +296,7 @@ public static class PathTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable(envVar, null);
+            Environment.SetEnvironmentVariable(envVar, original);
             Assert.Equal(original, Path.GetTempPath());
         }
     }


### PR DESCRIPTION
A Path test is assuming that the original temp path will match the temp path created by removing the TMPDIR environment variable.  That's typically the case on Linux, where TMPDIR is usually "/tmp", but on OS X TMPDIR is often initialized to something like "/var/folders/51/kchrq4qs1cd5...", such that after setting TMPDIR to null, the resulting "/tmp/" path no longer matches.

This commit just fixes the test to reset the TMPDIR environment variable back to what it was at the beginning of the test, rather than to null, and then adds a specific test case to validate that deleting TMPDIR results in "/tmp" as the new temp path.

cc: @Sridhar-MS 