### PR TITLE
Fix several Process shim function to return int32_t instead of bool

### DIFF
--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -330,13 +330,13 @@ int32_t WExitStatus(int32_t status)
 }
 
 extern "C"
-bool WIfExited(int32_t status)
+int32_t WIfExited(int32_t status)
 {
     return WIFEXITED(status);
 }
 
 extern "C"
-bool WIfSignaled(int32_t status)
+int32_t WIfSignaled(int32_t status)
 {
     return WIFSIGNALED(status);
 }

--- a/src/Native/System.Native/pal_process.h
+++ b/src/Native/System.Native/pal_process.h
@@ -194,10 +194,10 @@ extern "C"
 int32_t WExitStatus(int32_t status);
 
 extern "C"
-bool WIfExited(int32_t status);
+int32_t WIfExited(int32_t status);
 
 extern "C"
-bool WIfSignaled(int32_t status);
+int32_t WIfSignaled(int32_t status);
 
 extern "C"
 int32_t WTermSig(int32_t status);


### PR DESCRIPTION
Several of the process shim functions are returning the C++ bool type instead of int32_t.  This is causing values to be marshaled incorrectly to the consuming managed code and causing some tests to fail on OS X.

cc: @sokket, @nguerrera