### PR TITLE
Fix incorrect error handling when calling getpwuid_r shim

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
             internal byte* Shell;
         };
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern unsafe int GetPwUid(int uid, out Passwd pwd, byte* buf, long bufLen, out IntPtr result);
+        [DllImport(Libraries.SystemNative, SetLastError = false)]
+        internal static extern unsafe int GetPwUidR(int uid, out Passwd pwd, byte* buf, long bufLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -44,7 +44,7 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, SetLastError = false)]
         internal static extern int GetDirentSize();
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, SetLastError = false)]
         private static unsafe extern int ReadDirR(SafeDirectoryHandle dir, byte* buffer, int bufferSize, out InternalDirectoryEntry outputEntry);
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]

--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -146,28 +146,27 @@ namespace System.IO
             {
                 // Call getpwuid_r to get the passwd struct
                 Interop.Sys.Passwd passwd;
-                IntPtr result;
-                int rv = Interop.Sys.GetPwUid(Interop.Sys.GetEUid(), out passwd, buf, bufLen, out result);
+                int error = Interop.Sys.GetPwUidR(Interop.Sys.GetEUid(), out passwd, buf, bufLen);
 
                 // If the call succeeds, give back the home directory path retrieved
-                if (rv == 0)
+                if (error == 0)
                 {
-                    if (result == IntPtr.Zero)
-                    {
-                        // Current user's entry could not be found
-                        path = null; // we'll still return true, as false indicates the buffer was too small
-                    }
-                    else
-                    {
-                        Debug.Assert(result == (IntPtr)(&passwd));
-                        Debug.Assert(passwd.HomeDirectory != null);
-                        path = Marshal.PtrToStringAnsi((IntPtr)passwd.HomeDirectory);
-                    }
+                    Debug.Assert(passwd.HomeDirectory != null);
+                    path = Marshal.PtrToStringAnsi((IntPtr)passwd.HomeDirectory);
                     return true;
                 }
 
+                // If the current user's entry could not be found, give back null
+                // path, but still return true as false indicates the buffer was
+                // too small.
+                if (error == -1)
+                {
+                    path = null;
+                    return false;
+                }
+
                 // If the call failed because it was interrupted, try again.
-                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                var errorInfo = new Interop.ErrorInfo(error);
                 if (errorInfo.Error == Interop.Error.EINTR)
                     continue;
 
@@ -183,6 +182,5 @@ namespace System.IO
                 throw new IOException(errorInfo.GetErrorMessage(), errorInfo.RawErrno);
             }
         }
-
     }
 }

--- a/src/Native/System.Native/pal_uid.cpp
+++ b/src/Native/System.Native/pal_uid.cpp
@@ -17,48 +17,45 @@
 * Returns 0 for success, -1 for failure. Sets errno on failure.
 */
 extern "C"
-int32_t GetPwUid(
+int32_t GetPwUidR(
 	int32_t  uid,
 	Passwd*  pwd,
 	char*    buf,
-	int64_t  buflen,
-	Passwd** result)
+	int64_t  buflen)
 {
 	assert(pwd != nullptr);
 	assert(buf != nullptr);
 	assert(buflen >= 0);
-	assert(result != nullptr);
 
 	struct passwd nativePwd;
-	struct passwd* nativePwdResultPtr;
-	int rv = getpwuid_r(uid, &nativePwd, buf, buflen, &nativePwdResultPtr);
+	struct passwd* result;
+	int error = getpwuid_r(uid, &nativePwd, buf, buflen, &result);
 
-	// If successful, the result will be null if the user couldn't be found,
-	// or it'll contain the address of the provided pwd structure, into
-	// which the results are stored.
-	if (rv == 0 && nativePwdResultPtr != nullptr)
+	// positive error number returned -> failure other than entry-not-found
+	if (error != 0)
 	{
-		assert(nativePwdResultPtr == &nativePwd);
-		
-		pwd->Name = nativePwd.pw_name;
-		pwd->Password = nativePwd.pw_passwd;
-		pwd->UserId = nativePwd.pw_uid;
-		pwd->GroupId = nativePwd.pw_gid;
-		pwd->UserInfo = nativePwd.pw_gecos;
-		pwd->HomeDirectory = nativePwd.pw_dir;
-		pwd->Shell = nativePwd.pw_shell;
-		*result = pwd;
-	}
-	else
-	{
-		// Make sure we zero out the results fields, as the managed
-		// caller could be using out variables and expect them to be initialized
-		// after the call.
-		*pwd = { };
-		*result = nullptr;
+		assert(error > 0);
+		*pwd = { }; // managed out param must be initialized
+		return error;
 	}
 
-	return rv;
+	// 0 returned with null result -> entry-not-found
+	if (result == nullptr)
+	{
+		*pwd = { }; // managed out param must be initialized
+		return -1;  // shim convention for entry-not-found
+	}
+
+	// 0 returned with non-null result (guaranteed to be set to pwd arg) -> success
+	assert(result == &nativePwd);
+	pwd->Name = nativePwd.pw_name;
+	pwd->Password = nativePwd.pw_passwd;
+	pwd->UserId = nativePwd.pw_uid;
+	pwd->GroupId = nativePwd.pw_gid;
+	pwd->UserInfo = nativePwd.pw_gecos;
+	pwd->HomeDirectory = nativePwd.pw_dir;
+	pwd->Shell = nativePwd.pw_shell;
+	return 0;
 }
 
 extern "C"


### PR DESCRIPTION
getpwuid_r as well as its shim return errors rather than set them via
errno. Fix the single managed caller to interpret the value correctly.

Also, converge on the pattern established by readdir_r shim to map the
extra out **param (which can only be null or equal to input *param) to
a negative return value instead.

Finally, adopt a coding pattern in both of these shims that should
make it easier to see the 3 cases (success, not-found/end-of-stream,
and failure) and more obvious that the return value is an error code
and not the typical syscall 0/-1 + errno.

cc @stephentoub 