### PR TITLE
Make PFX import tests be order-independent for now

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -235,7 +235,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(3, count);
         }
 
-        [ActiveIssue(2893, PlatformID.OSX)]
         [Fact]
         public static void ImportPkcs12File_Chain_VerifyContents()
         {
@@ -244,33 +243,41 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             int count = certs.Count;
             Assert.Equal(3, count);
 
-            // Verify that the read ordering is consistent across the platforms
+            const string leafCertSubject = "test.local";
+
+            // TODO (#3207): Make this test be order-required once ordering is guaranteed on all platforms.
             string[] expectedSubjects =
             {
                 "MS Passport Test Sub CA",
                 "MS Passport Test Root CA",
-                "test.local",
+                leafCertSubject,
             };
 
-            string[] actualSubjects = certs.OfType<X509Certificate2>().
-                Select(cert => cert.GetNameInfo(X509NameType.SimpleName, false)).
-                ToArray();
+            string[] actualSubjects = new string[certs.Count];
 
-            Assert.Equal(expectedSubjects, actualSubjects);
-
-            // And verify that we have private keys when we expect them
-            bool[] expectedHasPrivateKeys =
+            for (int i = 0; i < certs.Count; i++)
             {
-                false,
-                false,
-                true,
-            };
+                X509Certificate2 cert = certs[i];
+                string subject = cert.GetNameInfo(X509NameType.SimpleName, false);
+                actualSubjects[i] = subject;
 
-            bool[] actualHasPrivateKeys = certs.OfType<X509Certificate2>().
-                Select(cert => cert.HasPrivateKey).
-                ToArray();
+                bool shouldHavePrivateKey = StringComparer.Ordinal.Equals(leafCertSubject, subject);
 
-            Assert.Equal(expectedHasPrivateKeys, actualHasPrivateKeys);
+                if (shouldHavePrivateKey)
+                {
+                    Assert.True(cert.HasPrivateKey, "Certificate '" + subject + "' HasPrivateKey");
+                }
+                else
+                {
+                    Assert.False(cert.HasPrivateKey, "Certificate '" + subject + "' HasPrivateKey");
+                }
+            }
+
+            // Confirm we saw each cert we expected.
+            foreach (string expectedSubject in expectedSubjects)
+            {
+                Assert.Contains(expectedSubject, actualSubjects);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -678,28 +678,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 var importedCollection = new X509Certificate2Collection();
                 importedCollection.Import(exported);
 
-                // Verify that the two collections contain the same certificates,
-                // but the order isn't really a factor.
-                Assert.Equal(collection.Count, importedCollection.Count);
-
-                // Compare just the subject names first, because it's the easiest thing to read out of the failure message.
-                string[] subjects = new string[collection.Count];
-                string[] importedSubjects = new string[collection.Count];
-
-                for (int i = 0; i < collection.Count; i++)
-                {
-                    subjects[i] = collection[i].GetNameInfo(X509NameType.SimpleName, false);
-                    importedSubjects[i] = importedCollection[i].GetNameInfo(X509NameType.SimpleName, false);
-                }
-
-                Assert.Equal(subjects, importedSubjects);
-
-                // But, really, the collections should be equivalent
-                // (after being coerced to IEnumerable<X509Certificate2>)
-                Assert.Equal(collection.OfType<X509Certificate2>(), importedCollection.OfType<X509Certificate2>());
+                // TODO (#3207): Make this test be order-required once ordering is guaranteed on all platforms.
+                AssertEqualUnordered(collection, importedCollection);
             }
         }
-
+       
         [Fact]
         public static void MultipleImport()
         {
@@ -1186,6 +1169,39 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.NotSame(pfxCer, second);
                     Assert.Equal(pfxCer, second);
                 }
+            }
+        }
+
+        private static void AssertEqualUnordered(
+           X509Certificate2Collection collection,
+           X509Certificate2Collection importedCollection)
+        {
+            // Verify that the two collections contain the same certificates,
+            // but the order isn't really a factor.
+            Assert.Equal(collection.Count, importedCollection.Count);
+
+            // Compare just the subject names first, because it's the easiest thing to read out of the failure message.
+            string[] subjects = new string[collection.Count];
+            string[] importedSubjects = new string[collection.Count];
+            X509Certificate2[] importedCertificates = new X509Certificate2[collection.Count];
+
+            for (int i = 0; i < collection.Count; i++)
+            {
+                subjects[i] = collection[i].GetNameInfo(X509NameType.SimpleName, false);
+                importedSubjects[i] = importedCollection[i].GetNameInfo(X509NameType.SimpleName, false);
+                importedCertificates[i] = importedCollection[i];
+            }
+
+            // The best error message would come from a mis-matched subject
+            foreach (string subject in subjects)
+            {
+                Assert.Contains(subject, importedSubjects);
+            }
+
+            // But, really, the collections should be equivalent
+            foreach (X509Certificate2 expectedCert in collection)
+            {
+                Assert.Contains(expectedCert, importedCertificates);
             }
         }
 


### PR DESCRIPTION
There seems to be a stack vs queue problem for the PKCS12 helper functions on OSX's version (0.9.8 family) and the Ubuntu version (1.0.1 family), so some of the ordering is not the same between them.

Issue #3207 tracks the ordering problem, mainly that we need to take over the heavy lifting from the OpenSSL PKCS12 helper functions (which was already known, as it is limited to a single private key).

Fixes #2893.