### PR TITLE
Reduce FileSystem inner loop test time from 90 to 5 seconds

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -242,6 +242,7 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
+        [OuterLoop] // takes more than a minute
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -328,8 +328,23 @@ namespace System.IO.FileSystem.Tests
             }
         }
 
+        [Fact]
+        public Task ManyConcurrentWriteAsyncs()
+        {
+            // For inner loop, just test one case
+            return ManyConcurrentWriteAsyncs(
+                useAsync: RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                presize: false,
+                exposeHandle: false,
+                cancelable: true,
+                bufferSize: 4096,
+                writeSize: 1024,
+                numWrites: 10);
+        }
+
         [Theory]
         [MemberData("MemberData_FileStreamAsyncWriting")]
+        [OuterLoop] // many combinations: we test just one in inner loop and the rest outer
         public async Task ManyConcurrentWriteAsyncs(
             bool useAsync, bool presize, bool exposeHandle, bool cancelable, int bufferSize, int writeSize, int numWrites)
         {
@@ -369,8 +384,23 @@ namespace System.IO.FileSystem.Tests
             Assert.Equal<byte>(expectedData, actualData);
         }
 
+        [Fact]
+        public Task CopyToAsyncBetweenFileStreams()
+        {
+            // For inner loop, just test one case
+            return CopyToAsyncBetweenFileStreams(
+                useAsync: RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                preSize: false,
+                exposeHandle: false,
+                cancelable: true,
+                bufferSize: 4096,
+                writeSize: 1024,
+                numWrites: 10);
+        }
+
         [Theory]
         [MemberData("MemberData_FileStreamAsyncWriting")]
+        [OuterLoop] // many combinations: we test just one in inner loop and the rest outer
         public async Task CopyToAsyncBetweenFileStreams(
             bool useAsync, bool preSize, bool exposeHandle, bool cancelable, int bufferSize, int writeSize, int numWrites)
         {
@@ -396,7 +426,7 @@ namespace System.IO.FileSystem.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task BufferCorrectlyMaintaindWhenReadAndWrite(bool useAsync)
+        public async Task BufferCorrectlyMaintainedWhenReadAndWrite(bool useAsync)
         {
             string path = GetTestFilePath();
             File.WriteAllBytes(path, TestBuffer);


### PR DESCRIPTION
Three tests were consuming the vast majority of the time:
- DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException. It was taking 70 seconds on my machine.  I moved it to outer loop. (Separately, @JeremyKuhne, it'd be good to look at improving the perf of the test itself.)
- ManyConcurrentWriteAsyncs.  It uses a MemberData that results in it executing ~40 times, for a combined time of around 7 seconds on my machine.  I made one combination run in inner loop and moved the rest to outer.
- CopyToAsyncBetweenFileStreams.  Same MemberData, same solution.

Fixes #3192 
cc: @nguerrera