### PR TITLE
Fix inverted return value for user entry not found

### DIFF
--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -162,7 +162,7 @@ namespace System.IO
                 if (error == -1)
                 {
                     path = null;
-                    return false;
+                    return true;
                 }
 
                 // If the call failed because it was interrupted, try again.


### PR DESCRIPTION
This was an error in a recent refactoring. The comment above
explains exactly why this should be return true, but the wrong
value was used in the actual code below.

Oops.

cc @stephentoub