### PR TITLE
Expression interpretation support for UnaryPlus, IsTrue, and IsFalse

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1238,29 +1238,17 @@ namespace System.Linq.Expressions.Interpreter
             Compile(node.Operand);
             if (node.IsLifted)
             {
-                LocalDefinition temp = _locals.DefineLocal(
-                    Expression.Parameter(node.Operand.Type),
-                    _instructions.Count
-                );
                 var notNull = _instructions.MakeLabel();
                 var computed = _instructions.MakeLabel();
 
-                _instructions.EmitStoreLocal(temp.Index);
-                _instructions.EmitLoadLocal(temp.Index);
-                _instructions.EmitLoad(null, typeof(object));
-                _instructions.EmitEqual(typeof(object));
-                _instructions.EmitBranchFalse(notNull);
-
-                _instructions.EmitLoad(null, typeof(object));
+                _instructions.EmitCoalescingBranch(notNull);
                 _instructions.EmitBranch(computed);
 
                 _instructions.MarkLabel(notNull);
-                _instructions.EmitLoadLocal(temp.Index);
                 _instructions.EmitLoad(node.NodeType == ExpressionType.IsTrue);
                 _instructions.EmitEqual(typeof(bool));
 
                 _instructions.MarkLabel(computed);
-                _locals.UndefineLocal(temp, _instructions.Count);
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1187,6 +1187,19 @@ namespace System.Linq.Expressions.Interpreter
                         Compile(node.Operand);
                         _instructions.EmitDecrement(node.Type);
                         break;
+                    case ExpressionType.UnaryPlus:
+                        Compile(node.Operand);
+                        break;
+                    case ExpressionType.IsTrue:
+                        Compile(node.Operand);
+                        _instructions.EmitLoad(true);
+                        _instructions.EmitEqual(typeof(bool));
+                        break;
+                    case ExpressionType.IsFalse:
+                        Compile(node.Operand);
+                        _instructions.EmitLoad(false);
+                        _instructions.EmitEqual(typeof(bool));
+                        break;
                     default:
                         throw new PlatformNotSupportedException(SR.Format(SR.UnsupportedExpressionType, node.NodeType));
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1191,14 +1191,8 @@ namespace System.Linq.Expressions.Interpreter
                         Compile(node.Operand);
                         break;
                     case ExpressionType.IsTrue:
-                        Compile(node.Operand);
-                        _instructions.EmitLoad(true);
-                        _instructions.EmitEqual(typeof(bool));
-                        break;
                     case ExpressionType.IsFalse:
-                        Compile(node.Operand);
-                        _instructions.EmitLoad(false);
-                        _instructions.EmitEqual(typeof(bool));
+                        EmitUnaryBoolCheck(node);
                         break;
                     default:
                         throw new PlatformNotSupportedException(SR.Format(SR.UnsupportedExpressionType, node.NodeType));
@@ -1236,6 +1230,42 @@ namespace System.Linq.Expressions.Interpreter
             else
             {
                 _instructions.EmitCall(node.Method);
+            }
+        }
+
+        private void EmitUnaryBoolCheck(UnaryExpression node)
+        {
+            Compile(node.Operand);
+            if (node.IsLifted)
+            {
+                LocalDefinition temp = _locals.DefineLocal(
+                    Expression.Parameter(node.Operand.Type),
+                    _instructions.Count
+                );
+                var notNull = _instructions.MakeLabel();
+                var computed = _instructions.MakeLabel();
+
+                _instructions.EmitStoreLocal(temp.Index);
+                _instructions.EmitLoadLocal(temp.Index);
+                _instructions.EmitLoad(null, typeof(object));
+                _instructions.EmitEqual(typeof(object));
+                _instructions.EmitBranchFalse(notNull);
+
+                _instructions.EmitLoad(null, typeof(object));
+                _instructions.EmitBranch(computed);
+
+                _instructions.MarkLabel(notNull);
+                _instructions.EmitLoadLocal(temp.Index);
+                _instructions.EmitLoad(node.NodeType == ExpressionType.IsTrue);
+                _instructions.EmitEqual(typeof(bool));
+
+                _instructions.MarkLabel(computed);
+                _locals.UndefineLocal(temp, _instructions.Count);
+            }
+            else
+            {
+                _instructions.EmitLoad(node.NodeType == ExpressionType.IsTrue);
+                _instructions.EmitEqual(typeof(bool));
             }
         }
 

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -128,8 +128,13 @@
     <Compile Include="Unary\UnaryArithmeticNegateTests.cs" />
     <Compile Include="Unary\UnaryBitwiseNotNullableTests.cs" />
     <Compile Include="Unary\UnaryBitwiseNotTests.cs" />
+    <Compile Include="Unary\UnaryIsFalseNullableTests.cs" />
+    <Compile Include="Unary\UnaryIsFalseTests.cs" />
+    <Compile Include="Unary\UnaryIsTrueNullableTests.cs" />
+    <Compile Include="Unary\UnaryIsTrueTests.cs" />
+    <Compile Include="Unary\UnaryUnaryPlusNullableTests.cs" />
+    <Compile Include="Unary\UnaryUnaryPlusTests.cs" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">
       <Project>{aef718e9-d4fc-418f-a7ae-ed6b2c7b3787}</Project>

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryIsFalseNullableTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryIsFalseNullableBoolTest()
+        {
+            bool?[] values = new bool?[] { null, false, true };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyIsFalseNullableBool(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyIsFalseNullableBool(bool? value)
+        {
+            Expression<Func<bool?>> e =
+                Expression.Lambda<Func<bool?>>(
+                    Expression.IsFalse(Expression.Constant(value, typeof(bool?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<bool?> f = e.Compile();
+            Assert.Equal((bool?)(value == default(bool?) ? default(bool?) : value == false), f());
+        }
+
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryIsFalseTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryIsFalseBoolTest()
+        {
+            bool[] values = new bool[] { false, true };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyIsFalseBool(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyIsFalseBool(bool value)
+        {
+            Expression<Func<bool>> e =
+                Expression.Lambda<Func<bool>>(
+                    Expression.IsFalse(Expression.Constant(value, typeof(bool))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<bool> f = e.Compile();
+            Assert.Equal((bool)(value == false), f());
+        }
+
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryIsTrueNullableTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryIsTrueNullableBoolTest()
+        {
+            bool?[] values = new bool?[] { null, false, true };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyIsTrueNullableBool(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyIsTrueNullableBool(bool? value)
+        {
+            Expression<Func<bool?>> e =
+                Expression.Lambda<Func<bool?>>(
+                    Expression.IsTrue(Expression.Constant(value, typeof(bool?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<bool?> f = e.Compile();
+            Assert.Equal((bool?)(value == default(bool?) ? default(bool?) : value == true), f());
+        }
+
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryIsTrueTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryIsTrueBoolTest()
+        {
+            bool[] values = new bool[] { false, true };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyIsTrueBool(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyIsTrueBool(bool value)
+        {
+            Expression<Func<bool>> e =
+                Expression.Lambda<Func<bool>>(
+                    Expression.IsTrue(Expression.Constant(value, typeof(bool))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<bool> f = e.Compile();
+            Assert.Equal((bool)(value == true), f());
+        }
+
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryPlusNullableTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableShortTest()
+        {
+            short?[] values = new short?[] { null, 0, 1, -1, short.MinValue, short.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableUShortTest()
+        {
+            ushort?[] values = new ushort?[] { null, 0, 1, ushort.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableUShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableIntTest()
+        {
+            int?[] values = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableUIntTest()
+        {
+            uint?[] values = new uint?[] { null, 0, 1, uint.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableUInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableLongTest()
+        {
+            long?[] values = new long?[] { null, 0, 1, -1, long.MinValue, long.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableLong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableULongTest()
+        {
+            ulong?[] values = new ulong?[] { null, 0, 1, ulong.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableULong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableFloatTest()
+        {
+            float?[] values = new float?[] { null, 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableFloat(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableDoubleTest()
+        {
+            double?[] values = new double?[] { null, 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableDouble(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusNullableDecimalTest()
+        {
+            decimal?[] values = new decimal?[] { null, decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusNullableDecimal(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyArithmeticUnaryPlusNullableShort(short? value)
+        {
+            Expression<Func<short?>> e =
+                Expression.Lambda<Func<short?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(short?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short?> f = e.Compile();
+            Assert.Equal((short?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableUShort(ushort? value)
+        {
+            Expression<Func<ushort?>> e =
+                Expression.Lambda<Func<ushort?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(ushort?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort?> f = e.Compile();
+            Assert.Equal((ushort?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableInt(int? value)
+        {
+            Expression<Func<int?>> e =
+                Expression.Lambda<Func<int?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(int?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int?> f = e.Compile();
+            Assert.Equal((int?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableUInt(uint? value)
+        {
+            Expression<Func<uint?>> e =
+                Expression.Lambda<Func<uint?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(uint?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint?> f = e.Compile();
+            Assert.Equal((uint?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableLong(long? value)
+        {
+            Expression<Func<long?>> e =
+                Expression.Lambda<Func<long?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(long?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long?> f = e.Compile();
+            Assert.Equal((long?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableULong(ulong? value)
+        {
+            Expression<Func<ulong?>> e =
+                Expression.Lambda<Func<ulong?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(ulong?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong?> f = e.Compile();
+            Assert.Equal((ulong?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableFloat(float? value)
+        {
+            Expression<Func<float?>> e =
+                Expression.Lambda<Func<float?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(float?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<float?> f = e.Compile();
+            Assert.Equal((float?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableDouble(double? value)
+        {
+            Expression<Func<double?>> e =
+                Expression.Lambda<Func<double?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(double?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<double?> f = e.Compile();
+            Assert.Equal((double?)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusNullableDecimal(decimal? value)
+        {
+            Expression<Func<decimal?>> e =
+                Expression.Lambda<Func<decimal?>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(decimal?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<decimal?> f = e.Compile();
+            Assert.Equal((decimal?)(+value), f());
+        }
+
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryPlusTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusShortTest()
+        {
+            short[] values = new short[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusUShortTest()
+        {
+            ushort[] values = new ushort[] { 0, 1, ushort.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusUShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusIntTest()
+        {
+            int[] values = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusUIntTest()
+        {
+            uint[] values = new uint[] { 0, 1, uint.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusUInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusLongTest()
+        {
+            long[] values = new long[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusLong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusULongTest()
+        {
+            ulong[] values = new ulong[] { 0, 1, ulong.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusULong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusFloatTest()
+        {
+            float[] values = new float[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusFloat(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusDoubleTest()
+        {
+            double[] values = new double[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusDouble(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3196, "https://github.com/dotnet/corefx/issues/3196")]
+        public static void CheckUnaryArithmeticUnaryPlusDecimalTest()
+        {
+            decimal[] values = new decimal[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticUnaryPlusDecimal(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyArithmeticUnaryPlusShort(short value)
+        {
+            Expression<Func<short>> e =
+                Expression.Lambda<Func<short>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(short))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short> f = e.Compile();
+            Assert.Equal((short)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusUShort(ushort value)
+        {
+            Expression<Func<ushort>> e =
+                Expression.Lambda<Func<ushort>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(ushort))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort> f = e.Compile();
+            Assert.Equal((ushort)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusInt(int value)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(int))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+            Assert.Equal((int)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusUInt(uint value)
+        {
+            Expression<Func<uint>> e =
+                Expression.Lambda<Func<uint>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(uint))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint> f = e.Compile();
+            Assert.Equal((uint)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusLong(long value)
+        {
+            Expression<Func<long>> e =
+                Expression.Lambda<Func<long>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(long))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long> f = e.Compile();
+            Assert.Equal((long)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusULong(ulong value)
+        {
+            Expression<Func<ulong>> e =
+                Expression.Lambda<Func<ulong>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(ulong))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong> f = e.Compile();
+            Assert.Equal((ulong)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusFloat(float value)
+        {
+            Expression<Func<float>> e =
+                Expression.Lambda<Func<float>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(float))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<float> f = e.Compile();
+            Assert.Equal((float)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusDouble(double value)
+        {
+            Expression<Func<double>> e =
+                Expression.Lambda<Func<double>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(double))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<double> f = e.Compile();
+            Assert.Equal((double)(+value), f());
+        }
+
+        private static void VerifyArithmeticUnaryPlusDecimal(decimal value)
+        {
+            Expression<Func<decimal>> e =
+                Expression.Lambda<Func<decimal>>(
+                    Expression.UnaryPlus(Expression.Constant(value, typeof(decimal))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<decimal> f = e.Compile();
+            Assert.Equal((decimal)(+value), f());
+        }
+
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Those node types were not supported by the expression interpreter for primitive types, while the factory methods allow them. The expression compiler works fine for those.

This fixes issue #3196.