### PR TITLE
OverflowException for interpretation of NewArrayBounds

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -87,7 +87,15 @@ namespace System.Linq.Expressions.Interpreter
             var lengths = new int[_rank];
             for (int i = _rank - 1; i >= 0; i--)
             {
-                lengths[i] = ConvertHelper.ToInt32NoNull(frame.Pop());
+                var length = ConvertHelper.ToInt32NoNull(frame.Pop());
+
+                if (length < 0)
+                {
+                    // to make behavior aligned with array creation emitted by C# compiler
+                    throw new OverflowException();
+                }
+
+                lengths[i] = length;
             }
             var array = Array.CreateInstance(_elementType, lengths);
             frame.Push(array);

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
@@ -25,5 +25,24 @@ namespace Tests.ExpressionCompiler.Array
             object y = x.Compile()(2);
             Assert.Equal("System.Double[,]", y.ToString());
         }
+
+        [Fact]
+        public static void ArrayBoundsVectorNegativeThrowsOverflowException()
+        {
+            Expression<Func<int, int[]>> e = a => new int[a];
+            Func<int, int[]> f = e.Compile();
+
+            Assert.Throws<OverflowException>(() => f(-1));
+        }
+
+        [Fact]
+        public static void ArrayBoundsMultiDimensionalNegativeThrowsOverflowException()
+        {
+            Expression<Func<int, int, int[,]>> e = (a, b) => new int[a, b];
+            Func<int, int, int[,]> f = e.Compile();
+
+            Assert.Throws<OverflowException>(() => f(-1, 1));
+            Assert.Throws<OverflowException>(() => f(1, -1));
+        }
     }
 }


### PR DESCRIPTION
Unlike the vector array type creation logic, the multi-dimensional case didn't throw OverflowException in the interpreter while the expression compiler does.

This fixes #3147.