### PR TITLE
Expression interpretation of unary operators with lifted methods

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1215,6 +1215,7 @@ namespace System.Linq.Expressions.Interpreter
                 _instructions.EmitBranch(computed);
 
                 _instructions.MarkLabel(notNull);
+                _instructions.EmitLoadLocal(temp.Index);
                 _instructions.EmitCall(node.Method);
 
                 _instructions.MarkLabel(computed);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1198,28 +1198,16 @@ namespace System.Linq.Expressions.Interpreter
             Compile(node.Operand);
             if (node.IsLifted)
             {
-                LocalDefinition temp = _locals.DefineLocal(
-                    Expression.Parameter(node.Operand.Type),
-                    _instructions.Count
-                );
                 var notNull = _instructions.MakeLabel();
                 var computed = _instructions.MakeLabel();
 
-                _instructions.EmitStoreLocal(temp.Index);
-                _instructions.EmitLoadLocal(temp.Index);
-                _instructions.EmitLoad(null, typeof(object));
-                _instructions.EmitEqual(typeof(object));
-                _instructions.EmitBranchFalse(notNull);
-
-                _instructions.EmitLoad(null, typeof(object));
+                _instructions.EmitCoalescingBranch(notNull);
                 _instructions.EmitBranch(computed);
 
                 _instructions.MarkLabel(notNull);
-                _instructions.EmitLoadLocal(temp.Index);
                 _instructions.EmitCall(node.Method);
 
                 _instructions.MarkLabel(computed);
-                _locals.UndefineLocal(temp, _instructions.Count);
             }
             else
             {

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -124,12 +124,12 @@
     <Compile Include="Ternary\TernaryArrayTests.cs" />
     <Compile Include="Ternary\TernaryNullableTests.cs" />
     <Compile Include="Ternary\TernaryTests.cs" />
+    <Compile Include="Unary\UnaryArithmeticNegateNullableOneOffTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateNullableTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateTests.cs" />
     <Compile Include="Unary\UnaryBitwiseNotNullableTests.cs" />
     <Compile Include="Unary\UnaryBitwiseNotTests.cs" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">
       <Project>{aef718e9-d4fc-418f-a7ae-ed6b2c7b3787}</Project>

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static unsafe class UnaryArithmeticNegateNullableOneOffTests
+    {
+        [Fact] //[WorkItem(3197, "https://github.com/dotnet/corefx/issues/3197")]
+        public static void UnaryArithmeticNegateNullableStackBalance()
+        {
+            var e = Expression.Lambda<Func<decimal?>>(
+                Expression.Negate(
+                    Expression.Negate(
+                        Expression.Constant(1.0m, typeof(decimal?))
+                    )
+                )
+            );
+
+            var f = e.Compile();
+
+            Assert.True(f() == 1.0m);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<decimal?> f = e.Compile();
-            Assert.Equal((decimal?)(0 - value), f());
+            Assert.Equal((decimal?)(-value), f());
         }
 
         private static void VerifyArithmeticNegateNullableDouble(double? value)
@@ -133,7 +133,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<double?> f = e.Compile();
-            Assert.Equal((double?)(0 - value), f());
+            Assert.Equal((double?)(-value), f());
         }
 
         private static void VerifyArithmeticNegateNullableFloat(float? value)
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<float?> f = e.Compile();
-            Assert.Equal((float?)(0 - value), f());
+            Assert.Equal((float?)(-value), f());
         }
 
         private static void VerifyArithmeticNegateNullableInt(int? value)
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile();
-            Assert.Equal((int?)(0 - value), f());
+            Assert.Equal((int?)(-value), f());
         }
 
         private static void VerifyArithmeticNegateNullableLong(long? value)
@@ -163,7 +163,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile();
-            Assert.Equal((long?)(0 - value), f());
+            Assert.Equal((long?)(-value), f());
         }
 
         private static void VerifyArithmeticNegateNullableSByte(sbyte? value)
@@ -178,7 +178,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile();
-            Assert.Equal((short?)(0 - value), f());
+            Assert.Equal((short?)(-value), f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
             Func<decimal> f = e.Compile();
-            Assert.Equal((decimal)(0 - value), f());
+            Assert.Equal((decimal)(-value), f());
         }
 
         private static void VerifyArithmeticNegateDouble(double value)
@@ -133,7 +133,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
             Func<double> f = e.Compile();
-            Assert.Equal((double)(0 - value), f());
+            Assert.Equal((double)(-value), f());
         }
 
         private static void VerifyArithmeticNegateFloat(float value)
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
             Func<float> f = e.Compile();
-            Assert.Equal((float)(0 - value), f());
+            Assert.Equal((float)(-value), f());
         }
 
         private static void VerifyArithmeticNegateInt(int value)
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
-            Assert.Equal((int)(0 - value), f());
+            Assert.Equal((int)(-value), f());
         }
 
         private static void VerifyArithmeticNegateLong(long value)
@@ -163,7 +163,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile();
-            Assert.Equal((long)(0 - value), f());
+            Assert.Equal((long)(-value), f());
         }
 
         private static void VerifyArithmeticNegateSByte(sbyte value)
@@ -178,7 +178,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.Negate(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile();
-            Assert.Equal((short)(0 - value), f());
+            Assert.Equal((short)(-value), f());
         }
 
         #endregion


### PR DESCRIPTION
This fixes issue #3197 but stumbles upon the problem described in #3197 with regards to calculating the stack depth in the InstructionList class, causing an assert to fail. If that is indeed the case (@VSadov, please chime in), we likely have to open another issue to track the stack depth calculation logic and get that in prior to committing this. Either way, I'm staging the suggested fix for this issue which gets post the reported repro (modulo the debug assert check).

Note: I'm experiencing issues running tests reliably when specifying "/p:IsInterpreting=true" for the build of System.Linq.Expressions. Also, should we add a RegressionTests.cs file with the name of test methods referring to the issues here in GitHub, or should we add the tests to the proper file (most of which seem machine-generated, so that may cause issues).