### PR TITLE
Throw NullReferenceException for field dereferences in expression interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -52,7 +52,14 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            frame.Push(_field.GetValue(frame.Pop()));
+            object self = frame.Pop();
+
+            if (self == null)
+            {
+                throw new NullReferenceException();
+            }
+
+            frame.Push(_field.GetValue(self));
             return +1;
         }
     }
@@ -77,6 +84,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             object value = frame.Pop();
             object self = frame.Pop();
+
+            if (self == null)
+            {
+                throw new NullReferenceException();
+            }
+
             _field.SetValue(self, value);
             return +1;
         }

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -200,4 +200,32 @@ namespace Tests.ExpressionCompiler
     public class BaseClass
     {
     }
+
+    public class FC
+    {
+        public int II;
+        public static int SI;
+        public const int CI = 42;
+        public static readonly int RI = 42;
+    }
+
+    public struct FS
+    {
+        public int II;
+        public static int SI;
+        public const int CI = 42;
+        public static readonly int RI = 42;
+    }
+
+    public class PC
+    {
+        public int II { get; set; }
+        public static int SI { get; set; }
+    }
+
+    public struct PS
+    {
+        public int II { get; set; }
+        public static int SI { get; set; }
+    }
 }

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -218,7 +218,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
             }
         }
 
-        [Fact]
+        [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
         public static void CheckMemberAccessClassInstanceFieldNullReferenceTest()
         {
             Expression<Func<int>> e =
@@ -242,7 +242,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
             Assert.NotNull(err);
         }
 
-        [Fact]
+        [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
         public static void CheckMemberAccessClassInstancePropertyNullReferenceTest()
         {
             Expression<Func<int>> e =

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.MemberAccess
+{
+    public static unsafe class MemberAccessTests
+    {
+        [Fact]
+        public static void CheckMemberAccessStructInstanceFieldTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        Expression.Constant(new FS() { II = 42 }),
+                        "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessStructStaticFieldTest()
+        {
+            FS.SI = 42;
+            try
+            {
+                Expression<Func<int>> e =
+                    Expression.Lambda<Func<int>>(
+                        Expression.Field(
+                            null,
+                            typeof(FS),
+                            "SI"),
+                        Enumerable.Empty<ParameterExpression>());
+                Func<int> f = e.Compile();
+
+                Assert.Equal(42, f());
+            }
+            finally
+            {
+                FS.SI = 0;
+            }
+        }
+
+        [Fact]
+        public static void CheckMemberAccessStructConstFieldTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        null,
+                        typeof(FS),
+                        "CI"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessStructStaticReadOnlyFieldTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        null,
+                        typeof(FS),
+                        "RI"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessStructInstancePropertyTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Property(
+                        Expression.Constant(new PS() { II = 42 }),
+                        "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessStructStaticPropertyTest()
+        {
+            PS.SI = 42;
+            try
+            {
+                Expression<Func<int>> e =
+                    Expression.Lambda<Func<int>>(
+                        Expression.Property(
+                            null,
+                            typeof(PS),
+                            "SI"),
+                        Enumerable.Empty<ParameterExpression>());
+                Func<int> f = e.Compile();
+
+                Assert.Equal(42, f());
+            }
+            finally
+            {
+                PS.SI = 0;
+            }
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassInstanceFieldTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        Expression.Constant(new FC() { II = 42 }),
+                        "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassStaticFieldTest()
+        {
+            FC.SI = 42;
+            try
+            {
+                Expression<Func<int>> e =
+                    Expression.Lambda<Func<int>>(
+                        Expression.Field(
+                            null,
+                            typeof(FC),
+                            "SI"),
+                        Enumerable.Empty<ParameterExpression>());
+                Func<int> f = e.Compile();
+
+                Assert.Equal(42, f());
+            }
+            finally
+            {
+                FC.SI = 0;
+            }
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassConstFieldTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        null,
+                        typeof(FC),
+                        "CI"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassStaticReadOnlyFieldTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        null,
+                        typeof(FC),
+                        "RI"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassInstancePropertyTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Property(
+                        Expression.Constant(new PC() { II = 42 }),
+                        "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            Assert.Equal(42, f());
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassStaticPropertyTest()
+        {
+            PC.SI = 42;
+            try
+            {
+                Expression<Func<int>> e =
+                    Expression.Lambda<Func<int>>(
+                        Expression.Property(
+                            null,
+                            typeof(PC),
+                            "SI"),
+                        Enumerable.Empty<ParameterExpression>());
+                Func<int> f = e.Compile();
+
+                Assert.Equal(42, f());
+            }
+            finally
+            {
+                PC.SI = 0;
+            }
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassInstanceFieldNullReferenceTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Field(
+                        Expression.Constant(null, typeof(FC)),
+                        "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            var err = default(Exception);
+            try
+            {
+                f();
+            }
+            catch (NullReferenceException ex)
+            {
+                err = ex;
+            }
+
+            Assert.NotNull(err);
+        }
+
+        [Fact]
+        public static void CheckMemberAccessClassInstancePropertyNullReferenceTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Property(
+                        Expression.Constant(null, typeof(PC)),
+                        "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            var err = default(Exception);
+            try
+            {
+                f();
+            }
+            catch (NullReferenceException ex)
+            {
+                err = ex;
+            }
+
+            Assert.NotNull(err);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Lifted\NonLiftedComparisonLessThanNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonLessThanOrEqualNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonNotEqualNullableTests.cs" />
+    <Compile Include="Member\MemberAccessTests.cs" />
     <Compile Include="New\NewTests.cs" />
     <Compile Include="New\NewWithParameterTests.cs" />
     <Compile Include="New\NewWithTwoParametersTests.cs" />
@@ -129,7 +130,6 @@
     <Compile Include="Unary\UnaryBitwiseNotNullableTests.cs" />
     <Compile Include="Unary\UnaryBitwiseNotTests.cs" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">
       <Project>{aef718e9-d4fc-418f-a7ae-ed6b2c7b3787}</Project>


### PR DESCRIPTION
This fixes issue #3217.

Note: I'm experiencing issues running tests reliably when specifying "/p:IsInterpreting=true" for the build of System.Linq.Expressions. Also, should we add a RegressionTests.cs file with the name of test methods referring to the issues here in GitHub, or should we add the tests to the proper file (most of which seem machine-generated, so that may cause issues).