### PR TITLE
Fix for ConditionalExpression.Update undesired cloning behavior

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -115,6 +115,7 @@
     <Compile Include="System\Linq\Expressions\TryExpression.cs" />
     <Compile Include="System\Linq\Expressions\TypeBinaryExpression.cs" />
     <Compile Include="System\Linq\Expressions\UnaryExpression.cs" />
+    <Compile Include="System\Linq\Expressions\Utils.cs" />
     <Compile Include="System\Linq\IQueryable.cs" />
     <Compile Include="System\Runtime\CompilerServices\IRuntimeVariables.cs" />
     <None Include="project.json" />

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -5,6 +5,8 @@ using System;
 using System.Dynamic.Utils;
 using System.Diagnostics;
 
+using AstUtils = System.Linq.Expressions.Utils;
+
 namespace System.Linq.Expressions
 {
     /// <summary>
@@ -81,7 +83,8 @@ namespace System.Linq.Expressions
 
         internal virtual Expression GetFalse()
         {
-            return Expression.Empty();
+            // Using a singleton here to ensure a stable object identity for IfFalse, which Update relies on.
+            return AstUtils.Empty();
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -11,7 +11,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-using AstUtils = System.Linq.Expressions.Interpreter.Utils;
+using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Linq.Expressions.Interpreter
 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -10,9 +11,8 @@ using System.Runtime.CompilerServices;
 using System.Security;
 using System.Text;
 using System.Threading;
-using System.Dynamic.Utils;
 
-using AstUtils = System.Linq.Expressions.Interpreter.Utils;
+using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Linq.Expressions.Interpreter
 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Dynamic.Utils;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
-using System.Dynamic.Utils;
-using AstUtils = System.Linq.Expressions.Interpreter.Utils;
 using System.Runtime.CompilerServices;
+using System.Threading;
+
+using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -516,16 +517,6 @@ namespace System.Linq.Expressions.Interpreter
         Read = 1,
         Write = 2,
         ReadWrite = Read | Write,
-    }
-
-    internal static class Utils
-    {
-        private static readonly DefaultExpression s_voidInstance = Expression.Empty();
-
-        public static DefaultExpression Empty()
-        {
-            return s_voidInstance;
-        }
     }
 
     internal sealed class ListEqualityComparer<T> : EqualityComparer<ICollection<T>>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Linq.Expressions
+{
+    internal static class Utils
+    {
+        private static readonly DefaultExpression s_voidInstance = Expression.Empty();
+
+        public static DefaultExpression Empty()
+        {
+            return s_voidInstance;
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalOneOffTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.Expressions.Conditional
+{
+    public static unsafe class ConditionalOneOffTests
+    {
+        [Fact] // [Issue(3223, "https://github.com/dotnet/corefx/issues/3223")]
+        public static void VisitIfThenDoesNotCloneTree()
+        {
+            var ifTrue = ((Expression<Action>)(() => Nop())).Body;
+
+            var e = Expression.IfThen(Expression.Constant(true), ifTrue);
+
+            var r = new Visitor().Visit(e);
+
+            Assert.Same(e, r);
+        }
+
+        private static void Nop()
+        {
+        }
+
+        class Visitor : ExpressionVisitor
+        {
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Cast\CastTests.cs" />
     <Compile Include="Cast\IsNullableTests.cs" />
     <Compile Include="Cast\IsTests.cs" />
+    <Compile Include="Conditional\ConditionalOneOffTests.cs" />
     <Compile Include="Constant\ConstantArrayTests.cs" />
     <Compile Include="Constant\ConstantNullableTests.cs" />
     <Compile Include="Constant\ConstantTests.cs" />
@@ -129,7 +130,6 @@
     <Compile Include="Unary\UnaryBitwiseNotNullableTests.cs" />
     <Compile Include="Unary\UnaryBitwiseNotTests.cs" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">
       <Project>{aef718e9-d4fc-418f-a7ae-ed6b2c7b3787}</Project>


### PR DESCRIPTION
This fixes issue #3223 at the expense of a more compact object layout for the "IfThen" case without an Else branch. Note that this change does not attempt to reduce the number of copies of Expression.Empty created for IfFalse properties (this is done by the factory method). It solely avoids the cloning behavior of the entire ConditionalExpression upon the visitor's invocation of the Update method.

An alternative would be to virtualize the Update method and do a type check for the ifFalse expression that's provided, checking whether it's a DefaultExpression of type void. That'd enable us to keep the compact layout for IfThen cases but it'd suppress cloning of the tree even if another "copy" of the Empty expression is provided, effectively treating those copies as singletons. That's likely to be considered a breaking change (although a similar type check was present in the Make method to begin with, but IfFalse would return a different instance of Empty each time it's called).

Note: Should we add a RegressionTests.cs file with the name of test methods referring to the issues here in GitHub, or should we add the tests to the proper file (most of which seem machine-generated, so that may cause issues).

Fixes #3223