### PR TITLE
Make OpenSsl-originated CryptographicExceptions set HResult and Message

### DIFF
--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ERR.cs
@@ -71,7 +71,7 @@ internal static partial class Interop
 
             // If there was an error code, and it wasn't something handled specially,
             // use the OpenSSL error string as the message to a CryptographicException.
-            return new CryptographicException(ERR_error_string_n(error));
+            return new OpenSslCryptographicException(unchecked((int)error), ERR_error_string_n(error));
         }
 
         internal static void CheckValidOpenSslHandle(SafeHandle handle)
@@ -87,6 +87,15 @@ internal static partial class Interop
             if (handle == IntPtr.Zero)
             {
                 throw CreateOpenSslCryptographicException();
+            }
+        }
+
+        private sealed class OpenSslCryptographicException : CryptographicException
+        {
+            internal OpenSslCryptographicException(int errorCode, string message)
+                : base(message)
+            {
+                HResult = errorCode;
             }
         }
     }


### PR DESCRIPTION
Since CryptographicException has no constructor that takes both an HResult and a Message this is being achieved by a private derived type which can set both properties. (Fixes #3232.)