### PR TITLE
Fixed OSX file creation time format

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -170,7 +170,7 @@ namespace System.IO
             {
                 EnsureStatInitialized();
                 return (_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0 ?
-                    DateTimeOffset.FromUnixTimeSeconds(_fileStatus.BirthTime) :
+                    DateTimeOffset.FromUnixTimeSeconds(_fileStatus.BirthTime).ToLocalTime() :
                     default(DateTimeOffset);
             }
             set

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -64,16 +64,18 @@ namespace System.IO.FileSystem.Tests
         public void CreationSetsAllTimes()
         {
             string path = GetTestFilePath();
-            long beforeTime = DateTime.UtcNow.AddSeconds(-3).Ticks;
+            DateTime beforeTime = DateTime.UtcNow.AddSeconds(-3);
 
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
 
-            long afterTime = DateTime.UtcNow.AddSeconds(3).Ticks;
+            DateTime afterTime = DateTime.UtcNow.AddSeconds(3);
 
             Assert.All(TimeFunctions(), (tuple) =>
             {
-                Assert.InRange(tuple.Item2(testFile).ToUniversalTime().Ticks, beforeTime, afterTime);
+                Assert.InRange(tuple.Item2(testFile).Ticks, beforeTime.Ticks, afterTime.Ticks);
+                Assert.InRange(tuple.Item2(testFile).ToLocalTime().Ticks, beforeTime.ToLocalTime().Ticks, afterTime.ToLocalTime().Ticks);
+                Assert.InRange(tuple.Item2(testFile).ToUniversalTime().Ticks, beforeTime.ToUniversalTime().Ticks, afterTime.ToUniversalTime().Ticks);
             });
         }
     }


### PR DESCRIPTION
FileInfo.CreationTime on OSX was returning a correctly timed but incorrectly formatted DateTime. This commit fixes this issue and adds coverage to a existing test to fill the test gap that let the issue through.