### PR TITLE
Issue #3233 - More useful messages for Crypto exceptions.

### DIFF
--- a/src/Common/src/Internal/Cryptography/Windows/CryptoThrowHelper.cs
+++ b/src/Common/src/Internal/Cryptography/Windows/CryptoThrowHelper.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal static class CryptoThrowHelper
+    {
+        public static CryptographicException ToCryptographicException(this int hr)
+        {
+            string message = Interop.mincore.GetMessage(hr);
+            return new WindowsCryptographicException(hr, message);
+        }
+
+        private sealed class WindowsCryptographicException : CryptographicException
+        {
+            public WindowsCryptographicException(int hr, string message)
+                : base(message)
+            {
+                HResult = hr;
+            }
+        }        
+    }
+}

--- a/src/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Runtime.InteropServices;
 
+using Internal.Cryptography;
+
 namespace Internal.NativeCrypto
 {
     internal static partial class BCryptNative
@@ -210,7 +212,7 @@ namespace Internal.NativeCrypto
         private static Exception CreateCryptographicException(NTSTATUS ntStatus)
         {
             int hr = ((int)ntStatus) | 0x01000000;
-            return new CryptographicException(hr);
+            return hr.ToCryptographicException();
         }
     }
 

--- a/src/Common/tests/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -192,7 +192,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             using (RSA rsa = RSAFactory.Create())
             {
                 rsa.ImportParameters(imported);
-                Assert.Throws<CryptographicException>(() => rsa.ExportParameters(true));
+                Assert.ThrowsAny<CryptographicException>(() => rsa.ExportParameters(true));
             }
         }
 
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
             using (RSA rsa = RSAFactory.Create())
             {
-                Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
+                Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
             using (RSA rsa = RSAFactory.Create())
             {
-                Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
+                Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 
@@ -234,7 +234,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
             using (RSA rsa = RSAFactory.Create())
             {
-                Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
+                Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -118,6 +118,12 @@
     <Compile Include="$(CommonPath)\Internal\Cryptography\HashProviderCng.cs">
       <Link>Internal\Cryptography\HashProviderCng.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+      <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
+      <Link>Internal\Windows\mincore\Interop.FormatMessage.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Unix.cs" />

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -43,7 +43,7 @@ namespace Internal.Cryptography
 
         public static CryptographicException ToCryptographicException(this ErrorCode errorCode)
         {
-            return new CryptographicException((int)errorCode);
+            return ((int)errorCode).ToCryptographicException();
         }
 
         public static SafeNCryptProviderHandle OpenStorageProvider(this CngProvider provider)

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -110,6 +110,9 @@
      <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
        <Link>Internal\Windows\BCrypt\BCryptAlgorithmCache.cs</Link>
      </Compile>
+     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
+       <Link>Internal\Windows\mincore\Interop.FormatMessage.cs</Link>
+     </Compile>
      <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
        <Link>Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs</Link>
      </Compile>
@@ -118,6 +121,9 @@
      </Compile>
      <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs">
        <Link>Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
      </Compile>
      <Compile Include="$(CommonPath)\Internal\Cryptography\HashProvider.cs">
        <Link>Internal\Cryptography\HashProvider.cs</Link>

--- a/src/System.Security.Cryptography.Cng/tests/PropertyTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/PropertyTests.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography.Cng.Tests
         {
             using (CngKey key = CngKey.Import(TestData.Key_ECDiffieHellmanP256, CngKeyBlobFormat.GenericPublicBlob))
             {
-                Assert.Throws<CryptographicException>(() => key.GetProperty("DOES NOT EXIST", CngPropertyOptions.CustomProperty));
+                Assert.ThrowsAny<CryptographicException>(() => key.GetProperty("DOES NOT EXIST", CngPropertyOptions.CustomProperty));
             }
         }
 
@@ -42,7 +42,7 @@ namespace System.Security.Cryptography.Cng.Tests
             {
                 const string propertyName = "CustomNullProperty";
                 CngProperty p = new CngProperty(propertyName, null, CngPropertyOptions.CustomProperty);
-                Assert.Throws<CryptographicException>(() => key.SetProperty(p));
+                Assert.ThrowsAny<CryptographicException>(() => key.SetProperty(p));
             }
         }
 

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -41,6 +41,15 @@
     <Compile Include="System\Security\Cryptography\SafeCryptoHandles.cs" />
     <Compile Include="System\Security\Cryptography\Utils.cs" />
     <Compile Include="Internal\Cryptography\Helpers.cs" />
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+      <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
+      <Link>Internal\Windows\mincore\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -885,7 +885,7 @@ namespace Internal.NativeCrypto
             if (!Interop.CryptImportKey(saveProvHandle, keyBlob, keyBlob.Length, SafeKeyHandle.InvalidHandle, dwCapiFlags, out hKey))
             {
                 int hr = Marshal.GetHRForLastWin32Error();
-                throw new CryptographicException(hr);
+                throw hr.ToCryptographicException();
             }
 
             safeKeyHandle = hKey;
@@ -933,10 +933,10 @@ namespace Internal.NativeCrypto
 
             // Validate the RSA structure first.
             if (rsaParameters.Modulus == null)
-                throw new CryptographicException(NTE_BAD_DATA);
+                throw NTE_BAD_DATA.ToCryptographicException();
 
             if (rsaParameters.Exponent == null || rsaParameters.Exponent.Length > 4)
-                throw new CryptographicException(NTE_BAD_DATA);
+                throw NTE_BAD_DATA.ToCryptographicException();
 
             int modulusLength = rsaParameters.Modulus.Length;
             int halfModulusLength = (modulusLength + 1) / 2;
@@ -945,22 +945,22 @@ namespace Internal.NativeCrypto
             if (rsaParameters.P != null)
             {
                 if (rsaParameters.P.Length != halfModulusLength)
-                    throw new CryptographicException(NTE_BAD_DATA);
+                    throw NTE_BAD_DATA.ToCryptographicException();
 
                 if (rsaParameters.Q == null || rsaParameters.Q.Length != halfModulusLength)
-                    throw new CryptographicException(NTE_BAD_DATA);
+                    throw NTE_BAD_DATA.ToCryptographicException();
 
                 if (rsaParameters.DP == null || rsaParameters.DP.Length != halfModulusLength)
-                    throw new CryptographicException(NTE_BAD_DATA);
+                    throw NTE_BAD_DATA.ToCryptographicException();
 
                 if (rsaParameters.DQ == null || rsaParameters.DQ.Length != halfModulusLength)
-                    throw new CryptographicException(NTE_BAD_DATA);
+                    throw NTE_BAD_DATA.ToCryptographicException();
 
                 if (rsaParameters.InverseQ == null || rsaParameters.InverseQ.Length != halfModulusLength)
-                    throw new CryptographicException(NTE_BAD_DATA);
+                    throw NTE_BAD_DATA.ToCryptographicException();
 
                 if (rsaParameters.D == null || rsaParameters.D.Length != modulusLength)
-                    throw new CryptographicException(NTE_BAD_DATA);
+                    throw NTE_BAD_DATA.ToCryptographicException();
             }
 
             bool isPrivate = (rsaParameters.P != null && rsaParameters.P.Length != 0);
@@ -1057,7 +1057,7 @@ namespace Internal.NativeCrypto
             {
                 // For compat reasons, we throw an E_FAIL CrytoException if CAPI returns a smaller blob than expected.
                 // For compat reasons, we ignore the extra bits if the CAPI returns a larger blob than expected.
-                throw new CryptographicException(E_FAIL);
+                throw E_FAIL.ToCryptographicException();
             }
         }
 
@@ -1248,14 +1248,14 @@ namespace Internal.NativeCrypto
                 if (!Interop.CryptSignHash(hHash, (KeySpec)keyNumber, null, CryptSignAndVerifyHashFlags.None, null, ref cbSignature))
                 {
                     int hr = Marshal.GetHRForLastWin32Error();
-                    throw new CryptographicException(hr);
+                    throw hr.ToCryptographicException();
                 }
 
                 byte[] signature = new byte[cbSignature];
                 if (!Interop.CryptSignHash(hHash, (KeySpec)keyNumber, null, CryptSignAndVerifyHashFlags.None, signature, ref cbSignature))
                 {
                     int hr = Marshal.GetHRForLastWin32Error();
-                    throw new CryptographicException(hr);
+                    throw hr.ToCryptographicException();
                 }
 
                 switch (calgKey)
@@ -1309,7 +1309,7 @@ namespace Internal.NativeCrypto
             if (!Interop.CryptCreateHash(hProv, calgHash, SafeKeyHandle.InvalidHandle, CryptCreateHashFlags.None, out hHash))
             {
                 int hr = Marshal.GetHRForLastWin32Error();
-                throw new CryptographicException(hr);
+                throw hr.ToCryptographicException();
             }
 
             try
@@ -1319,15 +1319,15 @@ namespace Internal.NativeCrypto
                 if (!Interop.CryptGetHashParam(hHash, CryptHashProperty.HP_HASHSIZE, out dwHashSize, ref cbHashSize, 0))
                 {
                     int hr = Marshal.GetHRForLastWin32Error();
-                    throw new CryptographicException(hr);
+                    throw hr.ToCryptographicException();
                 }
                 if (dwHashSize != hash.Length)
-                    throw new CryptographicException(unchecked((int)CryptKeyError.NTE_BAD_HASH));
+                    throw unchecked((int)CryptKeyError.NTE_BAD_HASH).ToCryptographicException();
 
                 if (!Interop.CryptSetHashParam(hHash, CryptHashProperty.HP_HASHVAL, hash, 0))
                 {
                     int hr = Marshal.GetHRForLastWin32Error();
-                    throw new CryptographicException(hr);
+                    throw hr.ToCryptographicException();
                 }
 
                 SafeHashHandle hHashPermanent = hHash;

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -48,6 +48,15 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\OidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\OidInfo.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+      <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
+      <Link>Internal\Windows\mincore\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="Internal\Cryptography\AsnFormatter.Unix.cs" />


### PR DESCRIPTION
Windows version of #3062.

Note that SSC.X509Certificate is another candidate recipient but doing that separately as it requires changing dozens of callsites and I want to get synced up to the K changes first to avoid a merge mess.
