### PR TITLE
Update to BuildTools version 87

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00085</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00087</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-12101</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00085" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00087" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-12101" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00085" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00087" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>


### PR DESCRIPTION
This update fixes the test-runtime\project.json so that it correctly
restores System.Console and also switches GenFacades to be running
on .NET Core isntead of the full framework.