### PR TITLE
Update UnixFileStream to read more from OS after using buffer

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -618,6 +618,7 @@ namespace System.IO
             // we can just go directly into the user's buffer, if they asked
             // for more data than we'd otherwise buffer.
             int numBytesAvailable = _readLength - _readPos;
+            bool readFromOS = false;
             if (numBytesAvailable == 0)
             {
                 // If we're not able to seek, then we're not able to rewind the stream (i.e. flushing
@@ -626,9 +627,8 @@ namespace System.IO
                 if (!_parent.CanSeek || (count >= _bufferLength))
                 {
                     // Read directly into the user's buffer
-                    int bytesRead = ReadCore(array, offset, count);
-                    _readPos = _readLength = 0; // reset after the read just in case read experiences an exception
-                    return bytesRead;
+                    _readPos = _readLength = 0;
+                    return ReadCore(array, offset, count);
                 }
                 else
                 {
@@ -639,16 +639,36 @@ namespace System.IO
                     {
                         return 0;
                     }
+
+                    // Note that we did an OS read as part of this Read, so that later
+                    // we don't try to do one again if what's in the buffer doesn't
+                    // meet the user's request.
+                    readFromOS = true;
                 }
             }
 
-            // Now that we know there's data in the buffer, read from it into
-            // the user's buffer.
-            int bytesToRead = Math.Min(numBytesAvailable, count);
-            Buffer.BlockCopy(GetBuffer(), _readPos, array, offset, bytesToRead);
-            _readPos += bytesToRead;
+            // Now that we know there's data in the buffer, read from it into the user's buffer.
+            Debug.Assert(numBytesAvailable > 0, "Data must be in the buffer to be here");
+            int bytesRead = Math.Min(numBytesAvailable, count);
+            Buffer.BlockCopy(GetBuffer(), _readPos, array, offset, bytesRead);
+            _readPos += bytesRead;
 
-            return bytesToRead;
+            // We may not have had enough data in the buffer to completely satisfy the user's request.
+            // While Read doesn't require that we return as much data as the user requested (any amount
+            // up to the requested count is fine), FileStream on Windows tries to do so by doing a 
+            // subsequent read from the file if we tried to satisfy the request with what was in the 
+            // buffer but the buffer contained less than the requested count. To be consistent with that 
+            // behavior, we do the same thing here on Unix.  Note that we may still get less the requested 
+            // amount, as the OS may give us back fewer than we request, either due to reaching the end of 
+            // file, or due to its own whims.
+            if (!readFromOS && bytesRead < count)
+            {
+                Debug.Assert(_readPos == _readLength, "bytesToRead should only be < count if numBytesAvailable < count");
+                _readPos = _readLength = 0; // no data left in the read buffer
+                bytesRead += ReadCore(array, offset + bytesRead, count - bytesRead);
+            }
+
+            return bytesRead;
         }
 
         /// <summary>Unbuffered, reads a block of bytes from the stream and writes the data in a given buffer.</summary>


### PR DESCRIPTION
Stream.Read is not required to hand back as many bytes as the caller requested; a conforming implementation can hand back any number > 0 and <= count when there's still data left in the stream, and many streams do frequently return < count.  UnixFileStream currently frequently does this, returning what's left in the internal buffer when there's any data left in the buffer.

Win32FileStream, however, in this case does a subsequent read from the underlying file handle to try to give back as much data as the user requested.  This request still may not return the requested count, either because we reached the end of the file or because Windows decided not to return as much data as was requested, but it frequently will.  As such, some code has been written to expect this behavior, and while that code is flawed and should be fixed even on Windows, it frequently works.

To maintain the consistency with Windows, this change updates UnixFileStream to do such a subsequent read if we tried to satisfy a Read request purely from the buffer but didn't have as much data as the user requested.  I've not added a test for the behavior, because a) it's not guaranteed by Stream.Read, but more importantly b) the test could fail because the OS may not give us back what we requested.

cc: @ianhays, @sokket 