### PR TITLE
Add exclusion for ToolRuntime directory in the linux test script

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -137,7 +137,7 @@ create_test_overlay()
 	echo "Corefx binaries not found at $CoreFxBins"
 	exit 1
   fi
-  find $CoreFxBins -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
+  find $CoreFxBins -path "*ToolRuntime*" -prune -o -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
 
   # Then the native CoreFX binaries
   if [ ! -d $CoreFxNativeBins ]


### PR DESCRIPTION
This should take care of the current linux tests running failing. The reason they were failing is because the run-test script was finding the windows versions of some of the libraries in the new ToolRuntime directory and it was overlaying those over top the linux overlay.