### PR TITLE
Drop src/Native/build.sh completely.

### DIFF
--- a/src/Native/build.sh
+++ b/src/Native/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-__ScriptDir="$( dirname "${BASH_SOURCE[0]}" )"
-__ScriptDir="$( cd $__ScriptDir && pwd )"
-__ProjectRoot="$( cd $__ScriptDir && cd ../.. && pwd )"
-
-"$__ProjectRoot/build.sh" native "$@"


### PR DESCRIPTION
PR #3175 merged the separate build.sh files for managed and native
builds into one file on the top level of the repository.
src/Native/build.sh was left until the CI is updated to use the new
location. After the CI is now updated, drop the old file completely.