### PR TITLE
Adding a clang-format file and a script to format every cpp and h file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,11 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
 # Xml project files
 [*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2

--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -1,7 +1,9 @@
 C# Coding Style
 ===============
 
-For non .cs files (c++, xml etc) our current best guidance is consistency. When editing files, keep new code and changes consistent with the style in the files. For new files, it should conform to the style for that component. Last, if there's a completely new component, anything that is reasonably broadly accepted is fine.
+For C++ files (*.cpp and *.h), we use clang-format (version 3.6+) to ensure code styling. After changing any Cpp or H file and before merging, be sure to run ./formatCode.sh from within the Native directory; this script will ensure that all native code files adhere to the coding style guidelines.
+
+For non code files (xml etc) our current best guidance is consistency. When editing files, keep new code and changes consistent with the style in the files. For new files, it should conform to the style for that component. Last, if there's a completely new component, anything that is reasonably broadly accepted is fine.
 
 The general rule we follow is "use Visual Studio defaults".
 

--- a/src/Native/.clang-format
+++ b/src/Native/.clang-format
@@ -1,0 +1,18 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AlignEscapedNewlinesLeft: false
+AlignAfterOpenBracket: true
+AllowShortFunctionsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+ColumnLimit:     120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+IndentCaseLabels: true
+IndentWidth: 4
+PointerAlignment: Left
+TabWidth:    4
+...
+

--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -16,7 +16,6 @@
 // provides the same 64-bit aware struct when targeting OS X > 10.5
 // and not passing _DARWIN_NO_64_BIT_INODE.
 #ifdef __APPLE__
-#    undef HAVE_STAT64
-#    define HAVE_STAT64 0
+#undef HAVE_STAT64
+#define HAVE_STAT64 0
 #endif
-

--- a/src/Native/Common/pal_types.h
+++ b/src/Native/Common/pal_types.h
@@ -3,4 +3,3 @@
 
 #pragma once
 #include <stdint.h> // int32_t, int64_t, etc.
-

--- a/src/Native/Common/pal_utilities.h
+++ b/src/Native/Common/pal_utilities.h
@@ -21,7 +21,7 @@
  * inadvertently defeat the compiler's narrowing conversion warnings
  * (which we treat as error).
  */
-template<typename T>
+template <typename T>
 inline typename std::make_unsigned<T>::type UnsignedCast(T value)
 {
     assert(value >= 0);

--- a/src/Native/System.Native/pal_errno.cpp
+++ b/src/Native/System.Native/pal_errno.cpp
@@ -9,183 +9,336 @@
 #include <string.h>
 #include <assert.h>
 
-extern "C"
-Error ConvertErrorPlatformToPal(int32_t platformErrno)
+extern "C" Error ConvertErrorPlatformToPal(int32_t platformErrno)
 {
     switch (platformErrno)
     {
-        case 0:                return PAL_SUCCESS;
-        case E2BIG:            return PAL_E2BIG;
-        case EACCES:           return PAL_EACCES;
-        case EADDRINUSE:       return PAL_EADDRINUSE;
-        case EADDRNOTAVAIL:    return PAL_EADDRNOTAVAIL;
-        case EAFNOSUPPORT:     return PAL_EAFNOSUPPORT;
-        case EAGAIN:           return PAL_EAGAIN;
-        case EALREADY:         return PAL_EALREADY;
-        case EBADF:            return PAL_EBADF;
-        case EBADMSG:          return PAL_EBADMSG;
-        case EBUSY:            return PAL_EBUSY;
-        case ECANCELED:        return PAL_ECANCELED;
-        case ECHILD:           return PAL_ECHILD;
-        case ECONNABORTED:     return PAL_ECONNABORTED;
-        case ECONNREFUSED:     return PAL_ECONNREFUSED;
-        case ECONNRESET:       return PAL_ECONNRESET;
-        case EDEADLK:          return PAL_EDEADLK;
-        case EDESTADDRREQ:     return PAL_EDESTADDRREQ;
-        case EDOM:             return PAL_EDOM;
-        case EDQUOT:           return PAL_EDQUOT;
-        case EEXIST:           return PAL_EEXIST;
-        case EFAULT:           return PAL_EFAULT;
-        case EFBIG:            return PAL_EFBIG;
-        case EHOSTUNREACH:     return PAL_EHOSTUNREACH;
-        case EIDRM:            return PAL_EIDRM;
-        case EILSEQ:           return PAL_EILSEQ;
-        case EINPROGRESS:      return PAL_EINPROGRESS;
-        case EINTR:            return PAL_EINTR;
-        case EINVAL:           return PAL_EINVAL;
-        case EIO:              return PAL_EIO;
-        case EISCONN:          return PAL_EISCONN;
-        case EISDIR:           return PAL_EISDIR;
-        case ELOOP:            return PAL_ELOOP;
-        case EMFILE:           return PAL_EMFILE;
-        case EMLINK:           return PAL_EMLINK;
-        case EMSGSIZE:         return PAL_EMSGSIZE;
-        case EMULTIHOP:        return PAL_EMULTIHOP;
-        case ENAMETOOLONG:     return PAL_ENAMETOOLONG;
-        case ENETDOWN:         return PAL_ENETDOWN;
-        case ENETRESET:        return PAL_ENETRESET;
-        case ENETUNREACH:      return PAL_ENETUNREACH;
-        case ENFILE:           return PAL_ENFILE;
-        case ENOBUFS:          return PAL_ENOBUFS;
-        case ENODEV:           return PAL_ENODEV;
-        case ENOENT:           return PAL_ENOENT;
-        case ENOEXEC:          return PAL_ENOEXEC;
-        case ENOLCK:           return PAL_ENOLCK;
-        case ENOLINK:          return PAL_ENOLINK;
-        case ENOMEM:           return PAL_ENOMEM;
-        case ENOMSG:           return PAL_ENOMSG;
-        case ENOPROTOOPT:      return PAL_ENOPROTOOPT;
-        case ENOSPC:           return PAL_ENOSPC;
-        case ENOSYS:           return PAL_ENOSYS;
-        case ENOTCONN:         return PAL_ENOTCONN;
-        case ENOTDIR:          return PAL_ENOTDIR;
-        case ENOTEMPTY:        return PAL_ENOTEMPTY;
-        case ENOTRECOVERABLE:  return PAL_ENOTRECOVERABLE;
-        case ENOTSOCK:         return PAL_ENOTSOCK;
-        case ENOTSUP:          return PAL_ENOTSUP;
-        case ENOTTY:           return PAL_ENOTTY;
-        case ENXIO:            return PAL_ENXIO;
-        case EOVERFLOW:        return PAL_EOVERFLOW;
-        case EOWNERDEAD:       return PAL_EOWNERDEAD;
-        case EPERM:            return PAL_EPERM;
-        case EPIPE:            return PAL_EPIPE;
-        case EPROTO:           return PAL_EPROTO;
-        case EPROTONOSUPPORT:  return PAL_EPROTONOSUPPORT;
-        case EPROTOTYPE:       return PAL_EPROTOTYPE;
-        case ERANGE:           return PAL_ERANGE;
-        case EROFS:            return PAL_EROFS;
-        case ESPIPE:           return PAL_ESPIPE;
-        case ESRCH:            return PAL_ESRCH;
-        case ESTALE:           return PAL_ESTALE;
-        case ETIMEDOUT:        return PAL_ETIMEDOUT;
-        case ETXTBSY:          return PAL_ETXTBSY;
-        case EXDEV:            return PAL_EXDEV;
+        case 0:
+            return PAL_SUCCESS;
+        case E2BIG:
+            return PAL_E2BIG;
+        case EACCES:
+            return PAL_EACCES;
+        case EADDRINUSE:
+            return PAL_EADDRINUSE;
+        case EADDRNOTAVAIL:
+            return PAL_EADDRNOTAVAIL;
+        case EAFNOSUPPORT:
+            return PAL_EAFNOSUPPORT;
+        case EAGAIN:
+            return PAL_EAGAIN;
+        case EALREADY:
+            return PAL_EALREADY;
+        case EBADF:
+            return PAL_EBADF;
+        case EBADMSG:
+            return PAL_EBADMSG;
+        case EBUSY:
+            return PAL_EBUSY;
+        case ECANCELED:
+            return PAL_ECANCELED;
+        case ECHILD:
+            return PAL_ECHILD;
+        case ECONNABORTED:
+            return PAL_ECONNABORTED;
+        case ECONNREFUSED:
+            return PAL_ECONNREFUSED;
+        case ECONNRESET:
+            return PAL_ECONNRESET;
+        case EDEADLK:
+            return PAL_EDEADLK;
+        case EDESTADDRREQ:
+            return PAL_EDESTADDRREQ;
+        case EDOM:
+            return PAL_EDOM;
+        case EDQUOT:
+            return PAL_EDQUOT;
+        case EEXIST:
+            return PAL_EEXIST;
+        case EFAULT:
+            return PAL_EFAULT;
+        case EFBIG:
+            return PAL_EFBIG;
+        case EHOSTUNREACH:
+            return PAL_EHOSTUNREACH;
+        case EIDRM:
+            return PAL_EIDRM;
+        case EILSEQ:
+            return PAL_EILSEQ;
+        case EINPROGRESS:
+            return PAL_EINPROGRESS;
+        case EINTR:
+            return PAL_EINTR;
+        case EINVAL:
+            return PAL_EINVAL;
+        case EIO:
+            return PAL_EIO;
+        case EISCONN:
+            return PAL_EISCONN;
+        case EISDIR:
+            return PAL_EISDIR;
+        case ELOOP:
+            return PAL_ELOOP;
+        case EMFILE:
+            return PAL_EMFILE;
+        case EMLINK:
+            return PAL_EMLINK;
+        case EMSGSIZE:
+            return PAL_EMSGSIZE;
+        case EMULTIHOP:
+            return PAL_EMULTIHOP;
+        case ENAMETOOLONG:
+            return PAL_ENAMETOOLONG;
+        case ENETDOWN:
+            return PAL_ENETDOWN;
+        case ENETRESET:
+            return PAL_ENETRESET;
+        case ENETUNREACH:
+            return PAL_ENETUNREACH;
+        case ENFILE:
+            return PAL_ENFILE;
+        case ENOBUFS:
+            return PAL_ENOBUFS;
+        case ENODEV:
+            return PAL_ENODEV;
+        case ENOENT:
+            return PAL_ENOENT;
+        case ENOEXEC:
+            return PAL_ENOEXEC;
+        case ENOLCK:
+            return PAL_ENOLCK;
+        case ENOLINK:
+            return PAL_ENOLINK;
+        case ENOMEM:
+            return PAL_ENOMEM;
+        case ENOMSG:
+            return PAL_ENOMSG;
+        case ENOPROTOOPT:
+            return PAL_ENOPROTOOPT;
+        case ENOSPC:
+            return PAL_ENOSPC;
+        case ENOSYS:
+            return PAL_ENOSYS;
+        case ENOTCONN:
+            return PAL_ENOTCONN;
+        case ENOTDIR:
+            return PAL_ENOTDIR;
+        case ENOTEMPTY:
+            return PAL_ENOTEMPTY;
+        case ENOTRECOVERABLE:
+            return PAL_ENOTRECOVERABLE;
+        case ENOTSOCK:
+            return PAL_ENOTSOCK;
+        case ENOTSUP:
+            return PAL_ENOTSUP;
+        case ENOTTY:
+            return PAL_ENOTTY;
+        case ENXIO:
+            return PAL_ENXIO;
+        case EOVERFLOW:
+            return PAL_EOVERFLOW;
+        case EOWNERDEAD:
+            return PAL_EOWNERDEAD;
+        case EPERM:
+            return PAL_EPERM;
+        case EPIPE:
+            return PAL_EPIPE;
+        case EPROTO:
+            return PAL_EPROTO;
+        case EPROTONOSUPPORT:
+            return PAL_EPROTONOSUPPORT;
+        case EPROTOTYPE:
+            return PAL_EPROTOTYPE;
+        case ERANGE:
+            return PAL_ERANGE;
+        case EROFS:
+            return PAL_EROFS;
+        case ESPIPE:
+            return PAL_ESPIPE;
+        case ESRCH:
+            return PAL_ESRCH;
+        case ESTALE:
+            return PAL_ESTALE;
+        case ETIMEDOUT:
+            return PAL_ETIMEDOUT;
+        case ETXTBSY:
+            return PAL_ETXTBSY;
+        case EXDEV:
+            return PAL_EXDEV;
 
 // #if because these will trigger duplicate case label warnings when
 // they have the same value, which is permitted by POSIX and common.
 #if EOPNOTSUPP != ENOTSUP
-        case EOPNOTSUPP:       return PAL_EOPNOTSUPP;
+        case EOPNOTSUPP:
+            return PAL_EOPNOTSUPP;
 #endif
 #if EWOULDBLOCK != EAGAIN
-        case EWOULDBLOCK:      return PAL_EWOULDBLOCK;
+        case EWOULDBLOCK:
+            return PAL_EWOULDBLOCK;
 #endif
     }
 
     return PAL_ENONSTANDARD;
 }
 
-extern "C"
-int32_t ConvertErrorPalToPlatform(Error error)
+extern "C" int32_t ConvertErrorPalToPlatform(Error error)
 {
     switch (error)
     {
-        case PAL_SUCCESS:          return 0;
-        case PAL_E2BIG:            return E2BIG;
-        case PAL_EACCES:           return EACCES;
-        case PAL_EADDRINUSE:       return EADDRINUSE;
-        case PAL_EADDRNOTAVAIL:    return EADDRNOTAVAIL;
-        case PAL_EAFNOSUPPORT:     return EAFNOSUPPORT;
-        case PAL_EAGAIN:           return EAGAIN;
-        case PAL_EALREADY:         return EALREADY;
-        case PAL_EBADF:            return EBADF;
-        case PAL_EBADMSG:          return EBADMSG;
-        case PAL_EBUSY:            return EBUSY;
-        case PAL_ECANCELED:        return ECANCELED;
-        case PAL_ECHILD:           return ECHILD;
-        case PAL_ECONNABORTED:     return ECONNABORTED;
-        case PAL_ECONNREFUSED:     return ECONNREFUSED;
-        case PAL_ECONNRESET:       return ECONNRESET;
-        case PAL_EDEADLK:          return EDEADLK;
-        case PAL_EDESTADDRREQ:     return EDESTADDRREQ;
-        case PAL_EDOM:             return EDOM;
-        case PAL_EDQUOT:           return EDQUOT;
-        case PAL_EEXIST:           return EEXIST;
-        case PAL_EFAULT:           return EFAULT;
-        case PAL_EFBIG:            return EFBIG;
-        case PAL_EHOSTUNREACH:     return EHOSTUNREACH;
-        case PAL_EIDRM:            return EIDRM;
-        case PAL_EILSEQ:           return EILSEQ;
-        case PAL_EINPROGRESS:      return EINPROGRESS;
-        case PAL_EINTR:            return EINTR;
-        case PAL_EINVAL:           return EINVAL;
-        case PAL_EIO:              return EIO;
-        case PAL_EISCONN:          return EISCONN;
-        case PAL_EISDIR:           return EISDIR;
-        case PAL_ELOOP:            return ELOOP;
-        case PAL_EMFILE:           return EMFILE;
-        case PAL_EMLINK:           return EMLINK;
-        case PAL_EMSGSIZE:         return EMSGSIZE;
-        case PAL_EMULTIHOP:        return EMULTIHOP;
-        case PAL_ENAMETOOLONG:     return ENAMETOOLONG;
-        case PAL_ENETDOWN:         return ENETDOWN;
-        case PAL_ENETRESET:        return ENETRESET;
-        case PAL_ENETUNREACH:      return ENETUNREACH;
-        case PAL_ENFILE:           return ENFILE;
-        case PAL_ENOBUFS:          return ENOBUFS;
-        case PAL_ENODEV:           return ENODEV;
-        case PAL_ENOENT:           return ENOENT;
-        case PAL_ENOEXEC:          return ENOEXEC;
-        case PAL_ENOLCK:           return ENOLCK;
-        case PAL_ENOLINK:          return ENOLINK;
-        case PAL_ENOMEM:           return ENOMEM;
-        case PAL_ENOMSG:           return ENOMSG;
-        case PAL_ENOPROTOOPT:      return ENOPROTOOPT;
-        case PAL_ENOSPC:           return ENOSPC;
-        case PAL_ENOSYS:           return ENOSYS;
-        case PAL_ENOTCONN:         return ENOTCONN;
-        case PAL_ENOTDIR:          return ENOTDIR;
-        case PAL_ENOTEMPTY:        return ENOTEMPTY;
-        case PAL_ENOTRECOVERABLE:  return ENOTRECOVERABLE;
-        case PAL_ENOTSOCK:         return ENOTSOCK;
-        case PAL_ENOTSUP:          return ENOTSUP;
-        case PAL_ENOTTY:           return ENOTTY;
-        case PAL_ENXIO:            return ENXIO;
-        case PAL_EOVERFLOW:        return EOVERFLOW;
-        case PAL_EOWNERDEAD:       return EOWNERDEAD;
-        case PAL_EPERM:            return EPERM;
-        case PAL_EPIPE:            return EPIPE;
-        case PAL_EPROTO:           return EPROTO;
-        case PAL_EPROTONOSUPPORT:  return EPROTONOSUPPORT;
-        case PAL_EPROTOTYPE:       return EPROTOTYPE;
-        case PAL_ERANGE:           return ERANGE;
-        case PAL_EROFS:            return EROFS;
-        case PAL_ESPIPE:           return ESPIPE;
-        case PAL_ESRCH:            return ESRCH;
-        case PAL_ESTALE:           return ESTALE;
-        case PAL_ETIMEDOUT:        return ETIMEDOUT;
-        case PAL_ETXTBSY:          return ETXTBSY;
-        case PAL_EXDEV:            return EXDEV;
-        case PAL_ENONSTANDARD:     break; // fall through to assert
+        case PAL_SUCCESS:
+            return 0;
+        case PAL_E2BIG:
+            return E2BIG;
+        case PAL_EACCES:
+            return EACCES;
+        case PAL_EADDRINUSE:
+            return EADDRINUSE;
+        case PAL_EADDRNOTAVAIL:
+            return EADDRNOTAVAIL;
+        case PAL_EAFNOSUPPORT:
+            return EAFNOSUPPORT;
+        case PAL_EAGAIN:
+            return EAGAIN;
+        case PAL_EALREADY:
+            return EALREADY;
+        case PAL_EBADF:
+            return EBADF;
+        case PAL_EBADMSG:
+            return EBADMSG;
+        case PAL_EBUSY:
+            return EBUSY;
+        case PAL_ECANCELED:
+            return ECANCELED;
+        case PAL_ECHILD:
+            return ECHILD;
+        case PAL_ECONNABORTED:
+            return ECONNABORTED;
+        case PAL_ECONNREFUSED:
+            return ECONNREFUSED;
+        case PAL_ECONNRESET:
+            return ECONNRESET;
+        case PAL_EDEADLK:
+            return EDEADLK;
+        case PAL_EDESTADDRREQ:
+            return EDESTADDRREQ;
+        case PAL_EDOM:
+            return EDOM;
+        case PAL_EDQUOT:
+            return EDQUOT;
+        case PAL_EEXIST:
+            return EEXIST;
+        case PAL_EFAULT:
+            return EFAULT;
+        case PAL_EFBIG:
+            return EFBIG;
+        case PAL_EHOSTUNREACH:
+            return EHOSTUNREACH;
+        case PAL_EIDRM:
+            return EIDRM;
+        case PAL_EILSEQ:
+            return EILSEQ;
+        case PAL_EINPROGRESS:
+            return EINPROGRESS;
+        case PAL_EINTR:
+            return EINTR;
+        case PAL_EINVAL:
+            return EINVAL;
+        case PAL_EIO:
+            return EIO;
+        case PAL_EISCONN:
+            return EISCONN;
+        case PAL_EISDIR:
+            return EISDIR;
+        case PAL_ELOOP:
+            return ELOOP;
+        case PAL_EMFILE:
+            return EMFILE;
+        case PAL_EMLINK:
+            return EMLINK;
+        case PAL_EMSGSIZE:
+            return EMSGSIZE;
+        case PAL_EMULTIHOP:
+            return EMULTIHOP;
+        case PAL_ENAMETOOLONG:
+            return ENAMETOOLONG;
+        case PAL_ENETDOWN:
+            return ENETDOWN;
+        case PAL_ENETRESET:
+            return ENETRESET;
+        case PAL_ENETUNREACH:
+            return ENETUNREACH;
+        case PAL_ENFILE:
+            return ENFILE;
+        case PAL_ENOBUFS:
+            return ENOBUFS;
+        case PAL_ENODEV:
+            return ENODEV;
+        case PAL_ENOENT:
+            return ENOENT;
+        case PAL_ENOEXEC:
+            return ENOEXEC;
+        case PAL_ENOLCK:
+            return ENOLCK;
+        case PAL_ENOLINK:
+            return ENOLINK;
+        case PAL_ENOMEM:
+            return ENOMEM;
+        case PAL_ENOMSG:
+            return ENOMSG;
+        case PAL_ENOPROTOOPT:
+            return ENOPROTOOPT;
+        case PAL_ENOSPC:
+            return ENOSPC;
+        case PAL_ENOSYS:
+            return ENOSYS;
+        case PAL_ENOTCONN:
+            return ENOTCONN;
+        case PAL_ENOTDIR:
+            return ENOTDIR;
+        case PAL_ENOTEMPTY:
+            return ENOTEMPTY;
+        case PAL_ENOTRECOVERABLE:
+            return ENOTRECOVERABLE;
+        case PAL_ENOTSOCK:
+            return ENOTSOCK;
+        case PAL_ENOTSUP:
+            return ENOTSUP;
+        case PAL_ENOTTY:
+            return ENOTTY;
+        case PAL_ENXIO:
+            return ENXIO;
+        case PAL_EOVERFLOW:
+            return EOVERFLOW;
+        case PAL_EOWNERDEAD:
+            return EOWNERDEAD;
+        case PAL_EPERM:
+            return EPERM;
+        case PAL_EPIPE:
+            return EPIPE;
+        case PAL_EPROTO:
+            return EPROTO;
+        case PAL_EPROTONOSUPPORT:
+            return EPROTONOSUPPORT;
+        case PAL_EPROTOTYPE:
+            return EPROTOTYPE;
+        case PAL_ERANGE:
+            return ERANGE;
+        case PAL_EROFS:
+            return EROFS;
+        case PAL_ESPIPE:
+            return ESPIPE;
+        case PAL_ESRCH:
+            return ESRCH;
+        case PAL_ESTALE:
+            return ESTALE;
+        case PAL_ETIMEDOUT:
+            return ETIMEDOUT;
+        case PAL_ETXTBSY:
+            return ETXTBSY;
+        case PAL_EXDEV:
+            return EXDEV;
+        case PAL_ENONSTANDARD:
+            break; // fall through to assert
     }
 
     // We should not use this function to round-trip platform -> pal
@@ -201,8 +354,7 @@ int32_t ConvertErrorPalToPlatform(Error error)
     return -1;
 }
 
-extern "C"
-const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
+extern "C" const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr);
     assert(bufferSize > 0);
@@ -210,16 +362,16 @@ const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
     if (bufferSize < 0)
         return nullptr;
 
-    // Note that we must use strerror_r because plain strerror is not
-    // thread-safe.
-    //
-    // However, there are two versions of strerror_r:
-    //    - GNU:   char* strerror_r(int, char*, size_t);
-    //    - POSIX: int   strerror_r(int, char*, size_t);
-    //
-    // The former may or may not use the supplied buffer, and returns
-    // the error message string. The latter stores the error message
-    // string into the supplied buffer and returns an error code.
+// Note that we must use strerror_r because plain strerror is not
+// thread-safe.
+//
+// However, there are two versions of strerror_r:
+//    - GNU:   char* strerror_r(int, char*, size_t);
+//    - POSIX: int   strerror_r(int, char*, size_t);
+//
+// The former may or may not use the supplied buffer, and returns
+// the error message string. The latter stores the error message
+// string into the supplied buffer and returns an error code.
 
 #if HAVE_GNU_STRERROR_R
     const char* message = strerror_r(platformErrno, buffer, UnsignedCast(bufferSize));
@@ -231,7 +383,7 @@ const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
     {
         // Buffer is too small to hold the entire message, but has
         // still been filled to the extent possible and null-terminated.
-        return nullptr; 
+        return nullptr;
     }
 
     // The only other valid error codes are 0 for success or EINVAL for

--- a/src/Native/System.Native/pal_errno.h
+++ b/src/Native/System.Native/pal_errno.h
@@ -26,94 +26,94 @@
  */
 enum Error : int32_t
 {
-    PAL_SUCCESS          = 0,
+    PAL_SUCCESS = 0,
 
-    PAL_E2BIG            = 0x10001,           // Argument list too long.
-    PAL_EACCES           = 0x10002,           // Permission denied.
-    PAL_EADDRINUSE       = 0x10003,           // Address in use.
-    PAL_EADDRNOTAVAIL    = 0x10004,           // Address not available.
-    PAL_EAFNOSUPPORT     = 0x10005,           // Address family not supported.
-    PAL_EAGAIN           = 0x10006,           // Resource unavailable, try again (same value as EWOULDBLOCK),
-    PAL_EALREADY         = 0x10007,           // Connection already in progress.
-    PAL_EBADF            = 0x10008,           // Bad file descriptor.
-    PAL_EBADMSG          = 0x10009,           // Bad message.
-    PAL_EBUSY            = 0x1000A,           // Device or resource busy.
-    PAL_ECANCELED        = 0x1000B,           // Operation canceled.
-    PAL_ECHILD           = 0x1000C,           // No child processes.
-    PAL_ECONNABORTED     = 0x1000D,           // Connection aborted.
-    PAL_ECONNREFUSED     = 0x1000E,           // Connection refused.
-    PAL_ECONNRESET       = 0x1000F,           // Connection reset.
-    PAL_EDEADLK          = 0x10010,           // Resource deadlock would occur.
-    PAL_EDESTADDRREQ     = 0x10011,           // Destination address required.
-    PAL_EDOM             = 0x10012,           // Mathematics argument out of domain of function.
-    PAL_EDQUOT           = 0x10013,           // Reserved.
-    PAL_EEXIST           = 0x10014,           // File exists.
-    PAL_EFAULT           = 0x10015,           // Bad address.
-    PAL_EFBIG            = 0x10016,           // File too large.
-    PAL_EHOSTUNREACH     = 0x10017,           // Host is unreachable.
-    PAL_EIDRM            = 0x10018,           // Identifier removed.
-    PAL_EILSEQ           = 0x10019,           // Illegal byte sequence.
-    PAL_EINPROGRESS      = 0x1001A,           // Operation in progress.
-    PAL_EINTR            = 0x1001B,           // Interrupted function.
-    PAL_EINVAL           = 0x1001C,           // Invalid argument.
-    PAL_EIO              = 0x1001D,           // I/O error.
-    PAL_EISCONN          = 0x1001E,           // Socket is connected.
-    PAL_EISDIR           = 0x1001F,           // Is a directory.
-    PAL_ELOOP            = 0x10020,           // Too many levels of symbolic links.
-    PAL_EMFILE           = 0x10021,           // File descriptor value too large.
-    PAL_EMLINK           = 0x10022,           // Too many links.
-    PAL_EMSGSIZE         = 0x10023,           // Message too large.
-    PAL_EMULTIHOP        = 0x10024,           // Reserved.
-    PAL_ENAMETOOLONG     = 0x10025,           // Filename too long.
-    PAL_ENETDOWN         = 0x10026,           // Network is down.
-    PAL_ENETRESET        = 0x10027,           // Connection aborted by network.
-    PAL_ENETUNREACH      = 0x10028,           // Network unreachable.
-    PAL_ENFILE           = 0x10029,           // Too many files open in system.
-    PAL_ENOBUFS          = 0x1002A,           // No buffer space available.
-    PAL_ENODEV           = 0x1002C,           // No such device.
-    PAL_ENOENT           = 0x1002D,           // No such file or directory.
-    PAL_ENOEXEC          = 0x1002E,           // Executable file format error.
-    PAL_ENOLCK           = 0x1002F,           // No locks available.
-    PAL_ENOLINK          = 0x10030,           // Reserved.
-    PAL_ENOMEM           = 0x10031,           // Not enough space.
-    PAL_ENOMSG           = 0x10032,           // No message of the desired type.
-    PAL_ENOPROTOOPT      = 0x10033,           // Protocol not available.
-    PAL_ENOSPC           = 0x10034,           // No space left on device.
-    PAL_ENOSYS           = 0x10037,           // Function not supported.
-    PAL_ENOTCONN         = 0x10038,           // The socket is not connected.
-    PAL_ENOTDIR          = 0x10039,           // Not a directory or a symbolic link to a directory.
-    PAL_ENOTEMPTY        = 0x1003A,           // Directory not empty.
-    PAL_ENOTRECOVERABLE  = 0x1003B,           // State not recoverable.
-    PAL_ENOTSOCK         = 0x1003C,           // Not a socket.
-    PAL_ENOTSUP          = 0x1003D,           // Not supported (same value as EOPNOTSUP).
-    PAL_ENOTTY           = 0x1003E,           // Inappropriate I/O control operation.
-    PAL_ENXIO            = 0x1003F,           // No such device or address.
-    PAL_EOVERFLOW        = 0x10040,           // Value too large to be stored in data type.
-    PAL_EOWNERDEAD       = 0x10041,           // Previous owner died.
-    PAL_EPERM            = 0x10042,           // Operation not permitted.
-    PAL_EPIPE            = 0x10043,           // Broken pipe.
-    PAL_EPROTO           = 0x10044,           // Protocol error.
-    PAL_EPROTONOSUPPORT  = 0x10045,           // Protocol not supported.
-    PAL_EPROTOTYPE       = 0x10046,           // Protocol wrong type for socket.
-    PAL_ERANGE           = 0x10047,           // Result too large.
-    PAL_EROFS            = 0x10048,           // Read-only file system.
-    PAL_ESPIPE           = 0x10049,           // Invalid seek.
-    PAL_ESRCH            = 0x1004A,           // No such process.
-    PAL_ESTALE           = 0x1004B,           // Reserved.
-    PAL_ETIMEDOUT        = 0x1004D,           // Connection timed out.
-    PAL_ETXTBSY          = 0x1004E,           // Text file busy.
-    PAL_EXDEV            = 0x1004F,           // Cross-device link.
+    PAL_E2BIG = 0x10001,           // Argument list too long.
+    PAL_EACCES = 0x10002,          // Permission denied.
+    PAL_EADDRINUSE = 0x10003,      // Address in use.
+    PAL_EADDRNOTAVAIL = 0x10004,   // Address not available.
+    PAL_EAFNOSUPPORT = 0x10005,    // Address family not supported.
+    PAL_EAGAIN = 0x10006,          // Resource unavailable, try again (same value as EWOULDBLOCK),
+    PAL_EALREADY = 0x10007,        // Connection already in progress.
+    PAL_EBADF = 0x10008,           // Bad file descriptor.
+    PAL_EBADMSG = 0x10009,         // Bad message.
+    PAL_EBUSY = 0x1000A,           // Device or resource busy.
+    PAL_ECANCELED = 0x1000B,       // Operation canceled.
+    PAL_ECHILD = 0x1000C,          // No child processes.
+    PAL_ECONNABORTED = 0x1000D,    // Connection aborted.
+    PAL_ECONNREFUSED = 0x1000E,    // Connection refused.
+    PAL_ECONNRESET = 0x1000F,      // Connection reset.
+    PAL_EDEADLK = 0x10010,         // Resource deadlock would occur.
+    PAL_EDESTADDRREQ = 0x10011,    // Destination address required.
+    PAL_EDOM = 0x10012,            // Mathematics argument out of domain of function.
+    PAL_EDQUOT = 0x10013,          // Reserved.
+    PAL_EEXIST = 0x10014,          // File exists.
+    PAL_EFAULT = 0x10015,          // Bad address.
+    PAL_EFBIG = 0x10016,           // File too large.
+    PAL_EHOSTUNREACH = 0x10017,    // Host is unreachable.
+    PAL_EIDRM = 0x10018,           // Identifier removed.
+    PAL_EILSEQ = 0x10019,          // Illegal byte sequence.
+    PAL_EINPROGRESS = 0x1001A,     // Operation in progress.
+    PAL_EINTR = 0x1001B,           // Interrupted function.
+    PAL_EINVAL = 0x1001C,          // Invalid argument.
+    PAL_EIO = 0x1001D,             // I/O error.
+    PAL_EISCONN = 0x1001E,         // Socket is connected.
+    PAL_EISDIR = 0x1001F,          // Is a directory.
+    PAL_ELOOP = 0x10020,           // Too many levels of symbolic links.
+    PAL_EMFILE = 0x10021,          // File descriptor value too large.
+    PAL_EMLINK = 0x10022,          // Too many links.
+    PAL_EMSGSIZE = 0x10023,        // Message too large.
+    PAL_EMULTIHOP = 0x10024,       // Reserved.
+    PAL_ENAMETOOLONG = 0x10025,    // Filename too long.
+    PAL_ENETDOWN = 0x10026,        // Network is down.
+    PAL_ENETRESET = 0x10027,       // Connection aborted by network.
+    PAL_ENETUNREACH = 0x10028,     // Network unreachable.
+    PAL_ENFILE = 0x10029,          // Too many files open in system.
+    PAL_ENOBUFS = 0x1002A,         // No buffer space available.
+    PAL_ENODEV = 0x1002C,          // No such device.
+    PAL_ENOENT = 0x1002D,          // No such file or directory.
+    PAL_ENOEXEC = 0x1002E,         // Executable file format error.
+    PAL_ENOLCK = 0x1002F,          // No locks available.
+    PAL_ENOLINK = 0x10030,         // Reserved.
+    PAL_ENOMEM = 0x10031,          // Not enough space.
+    PAL_ENOMSG = 0x10032,          // No message of the desired type.
+    PAL_ENOPROTOOPT = 0x10033,     // Protocol not available.
+    PAL_ENOSPC = 0x10034,          // No space left on device.
+    PAL_ENOSYS = 0x10037,          // Function not supported.
+    PAL_ENOTCONN = 0x10038,        // The socket is not connected.
+    PAL_ENOTDIR = 0x10039,         // Not a directory or a symbolic link to a directory.
+    PAL_ENOTEMPTY = 0x1003A,       // Directory not empty.
+    PAL_ENOTRECOVERABLE = 0x1003B, // State not recoverable.
+    PAL_ENOTSOCK = 0x1003C,        // Not a socket.
+    PAL_ENOTSUP = 0x1003D,         // Not supported (same value as EOPNOTSUP).
+    PAL_ENOTTY = 0x1003E,          // Inappropriate I/O control operation.
+    PAL_ENXIO = 0x1003F,           // No such device or address.
+    PAL_EOVERFLOW = 0x10040,       // Value too large to be stored in data type.
+    PAL_EOWNERDEAD = 0x10041,      // Previous owner died.
+    PAL_EPERM = 0x10042,           // Operation not permitted.
+    PAL_EPIPE = 0x10043,           // Broken pipe.
+    PAL_EPROTO = 0x10044,          // Protocol error.
+    PAL_EPROTONOSUPPORT = 0x10045, // Protocol not supported.
+    PAL_EPROTOTYPE = 0x10046,      // Protocol wrong type for socket.
+    PAL_ERANGE = 0x10047,          // Result too large.
+    PAL_EROFS = 0x10048,           // Read-only file system.
+    PAL_ESPIPE = 0x10049,          // Invalid seek.
+    PAL_ESRCH = 0x1004A,           // No such process.
+    PAL_ESTALE = 0x1004B,          // Reserved.
+    PAL_ETIMEDOUT = 0x1004D,       // Connection timed out.
+    PAL_ETXTBSY = 0x1004E,         // Text file busy.
+    PAL_EXDEV = 0x1004F,           // Cross-device link.
 
     // POSIX permits these to have the same value and we make them
     // always equal so that we cannot introduce a dependency on
     // distinguishing between them that would not work on all
     // platforms.
-    PAL_EOPNOTSUPP      = PAL_ENOTSUP,         // Operation not supported on socket
-    PAL_EWOULDBLOCK     = PAL_EAGAIN,          // Operation would block
+    PAL_EOPNOTSUPP = PAL_ENOTSUP, // Operation not supported on socket
+    PAL_EWOULDBLOCK = PAL_EAGAIN, // Operation would block
 
     // This one is not part of POSIX, but is a catch-all for the case
     // where we cannot convert the raw errno value to something above.
-    PAL_ENONSTANDARD    = 0x1FFFF,
+    PAL_ENONSTANDARD = 0x1FFFF,
 };
 
 /**
@@ -122,18 +122,14 @@ enum Error : int32_t
  * Error above. If the value is not recognized, returns
  * PAL_ENONSTANDARD.
  */
-extern "C"
-Error ConvertErrorPlatformToPal(
-    int32_t platformErrno);
+extern "C" Error ConvertErrorPlatformToPal(int32_t platformErrno);
 
 /**
  * Converts the given PAL Error value to a platform-specific errno
  * value. This is to be used when we want to synthesize a given error
  * and obtain the appropriate error message via StrErrorR.
  */
-extern "C"
-int32_t ConvertErrorPalToPlatform(
-    Error error);
+extern "C" int32_t ConvertErrorPalToPlatform(Error error);
 
 /**
  * Obtains the system error message for the given raw numeric value
@@ -148,16 +144,12 @@ int32_t ConvertErrorPalToPlatform(
  *
  *  2. We don't lose the ability to get the system error message for
  *     non-standard, platform-specific errors.
- * 
+ *
  * Note that buffer may or may not be used and the error message is
  * passed back via the return value.
  *
- * If the buffer was too small to fit the full message, null is 
+ * If the buffer was too small to fit the full message, null is
  * returned and the buffer is filled with as much of the message
  * as possible and null-terminated.
  */
-extern "C"
-const char* StrErrorR(
-    int32_t platformErrno,
-    char* buffer,
-    int32_t bufferSize);
+extern "C" const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize);

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -19,15 +19,14 @@
 #include <syslog.h>
 #include <unistd.h>
 
-
 #if HAVE_STAT64
-#    define stat_ stat64
-#    define fstat_ fstat64
-#    define lstat_ lstat64
+#define stat_ stat64
+#define fstat_ fstat64
+#define lstat_ lstat64
 #else
-#   define stat_ stat
-#   define fstat_ fstat
-#   define lstat_ lstat
+#define stat_ stat
+#define fstat_ fstat
+#define lstat_ lstat
 #endif
 
 // These numeric values are specified by POSIX.
@@ -51,14 +50,14 @@ static_assert(PAL_S_ISGID == S_ISGID, "");
 // are common to our current targets.  If these static asserts fail,
 // ConvertFileStatus needs to be updated to twiddle mode bits
 // accordingly.
-static_assert(PAL_S_IFMT  == S_IFMT,  "");
+static_assert(PAL_S_IFMT == S_IFMT, "");
 static_assert(PAL_S_IFIFO == S_IFIFO, "");
 static_assert(PAL_S_IFCHR == S_IFCHR, "");
 static_assert(PAL_S_IFDIR == S_IFDIR, "");
 static_assert(PAL_S_IFREG == S_IFREG, "");
 static_assert(PAL_S_IFLNK == S_IFLNK, "");
 
-// Validate that our enum for inode types is the same as what is 
+// Validate that our enum for inode types is the same as what is
 // declared by the dirent.h header on the local system.
 static_assert(PAL_DT_UNKNOWN == DT_UNKNOWN, "");
 static_assert(PAL_DT_FIFO == DT_FIFO, "");
@@ -88,33 +87,32 @@ static_assert(PAL_SEEK_CUR == SEEK_CUR, "");
 static_assert(PAL_SEEK_END == SEEK_END, "");
 
 // Validate our PollFlags enum values are correct for the platform
-static_assert(PAL_POLLIN   == POLLIN, "");
-static_assert(PAL_POLLOUT  == POLLOUT, "");
-static_assert(PAL_POLLERR  == POLLERR, "");
-static_assert(PAL_POLLHUP  == POLLHUP, "");
+static_assert(PAL_POLLIN == POLLIN, "");
+static_assert(PAL_POLLOUT == POLLOUT, "");
+static_assert(PAL_POLLERR == POLLERR, "");
+static_assert(PAL_POLLHUP == POLLHUP, "");
 static_assert(PAL_POLLNVAL == POLLNVAL, "");
 
 // Validate our FileAdvice enum values are correct for the platform
 #if HAVE_POSIX_ADVISE
-static_assert(PAL_POSIX_FADV_NORMAL       == POSIX_FADV_NORMAL, "");
-static_assert(PAL_POSIX_FADV_RANDOM       == POSIX_FADV_RANDOM, "");
-static_assert(PAL_POSIX_FADV_SEQUENTIAL   == POSIX_FADV_SEQUENTIAL, "");
-static_assert(PAL_POSIX_FADV_WILLNEED     == POSIX_FADV_WILLNEED, "");
-static_assert(PAL_POSIX_FADV_DONTNEED     == POSIX_FADV_DONTNEED, "");
-static_assert(PAL_POSIX_FADV_NOREUSE      == POSIX_FADV_NOREUSE, "");
-#endif 
+static_assert(PAL_POSIX_FADV_NORMAL == POSIX_FADV_NORMAL, "");
+static_assert(PAL_POSIX_FADV_RANDOM == POSIX_FADV_RANDOM, "");
+static_assert(PAL_POSIX_FADV_SEQUENTIAL == POSIX_FADV_SEQUENTIAL, "");
+static_assert(PAL_POSIX_FADV_WILLNEED == POSIX_FADV_WILLNEED, "");
+static_assert(PAL_POSIX_FADV_DONTNEED == POSIX_FADV_DONTNEED, "");
+static_assert(PAL_POSIX_FADV_NOREUSE == POSIX_FADV_NOREUSE, "");
+#endif
 
-static
-void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
+static void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
 {
-    dst->Flags  = FILESTATUS_FLAGS_NONE;
-    dst->Mode   = static_cast<int32_t>(src.st_mode);
-    dst->Uid    = src.st_uid;
-    dst->Gid    = src.st_gid;
-    dst->Size   = src.st_size;
-    dst->ATime  = src.st_atime;
-    dst->MTime  = src.st_mtime;
-    dst->CTime  = src.st_ctime;
+    dst->Flags = FILESTATUS_FLAGS_NONE;
+    dst->Mode = static_cast<int32_t>(src.st_mode);
+    dst->Uid = src.st_uid;
+    dst->Gid = src.st_gid;
+    dst->Size = src.st_size;
+    dst->ATime = src.st_atime;
+    dst->MTime = src.st_mtime;
+    dst->CTime = src.st_ctime;
 
 #if HAVE_STAT_BIRTHTIME
     dst->BirthTime = src.st_birthtime;
@@ -124,22 +122,20 @@ void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
 #endif
 }
 
-extern "C"
-int32_t Stat(const char* path, FileStatus* output)
+extern "C" int32_t Stat(const char* path, FileStatus* output)
 {
     struct stat_ result;
     int ret = stat_(path, &result);
 
-     if (ret == 0)
-     {
+    if (ret == 0)
+    {
         ConvertFileStatus(result, output);
-     }
+    }
 
     return ret;
 }
 
-extern "C"
-int32_t FStat(int32_t fd, FileStatus* output)
+extern "C" int32_t FStat(int32_t fd, FileStatus* output)
 {
     struct stat_ result;
     int ret = fstat_(fd, &result);
@@ -152,8 +148,7 @@ int32_t FStat(int32_t fd, FileStatus* output)
     return ret;
 }
 
-extern "C"
-int32_t LStat(const char* path, FileStatus* output)
+extern "C" int32_t LStat(const char* path, FileStatus* output)
 {
     struct stat_ result;
     int ret = lstat_(path, &result);
@@ -166,39 +161,31 @@ int32_t LStat(const char* path, FileStatus* output)
     return ret;
 }
 
-static 
-int32_t ConvertOpenFlags(int32_t flags)
+static int32_t ConvertOpenFlags(int32_t flags)
 {
     int32_t ret;
     switch (flags & PAL_O_ACCESS_MODE_MASK)
     {
-        case PAL_O_RDONLY: 
+        case PAL_O_RDONLY:
             ret = O_RDONLY;
             break;
         case PAL_O_RDWR:
             ret = O_RDWR;
             break;
-        case PAL_O_WRONLY: 
+        case PAL_O_WRONLY:
             ret = O_WRONLY;
             break;
         default:
             assert(false && "Unknown Open access mode.");
             return -1;
     }
-    
-    if (flags 
-        & ~(PAL_O_ACCESS_MODE_MASK
-          | PAL_O_CLOEXEC 
-          | PAL_O_CREAT 
-          | PAL_O_EXCL 
-          | PAL_O_TRUNC 
-          | PAL_O_SYNC
-          ))
+
+    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC))
     {
         assert(false && "Unknown Open flag.");
         return -1;
     }
- 
+
     if (flags & PAL_O_CLOEXEC)
         ret |= O_CLOEXEC;
     if (flags & PAL_O_CREAT)
@@ -209,13 +196,12 @@ int32_t ConvertOpenFlags(int32_t flags)
         ret |= O_TRUNC;
     if (flags & PAL_O_SYNC)
         ret |= O_SYNC;
- 
+
     assert(ret != -1);
     return ret;
 }
 
-extern "C"
-int32_t Open(const char* path, int32_t flags, int32_t mode)
+extern "C" int32_t Open(const char* path, int32_t flags, int32_t mode)
 {
     flags = ConvertOpenFlags(flags);
     if (flags == -1)
@@ -223,24 +209,21 @@ int32_t Open(const char* path, int32_t flags, int32_t mode)
         errno = EINVAL;
         return -1;
     }
-    
+
     return open(path, flags, static_cast<mode_t>(mode));
 }
 
-extern "C"
-int32_t Close(int32_t fd)
+extern "C" int32_t Close(int32_t fd)
 {
     return close(fd);
 }
 
-extern "C"
-int32_t Unlink(const char* path)
+extern "C" int32_t Unlink(const char* path)
 {
     return unlink(path);
 }
 
-extern "C"
-int32_t ShmOpen(const char* name, int32_t flags, int32_t mode)
+extern "C" int32_t ShmOpen(const char* name, int32_t flags, int32_t mode)
 {
 #if HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP
     flags = ConvertOpenFlags(flags);
@@ -249,7 +232,7 @@ int32_t ShmOpen(const char* name, int32_t flags, int32_t mode)
         errno = EINVAL;
         return -1;
     }
-    
+
     return shm_open(name, flags, static_cast<mode_t>(mode));
 #else
     (void)name, (void)flags, (void)mode;
@@ -258,17 +241,15 @@ int32_t ShmOpen(const char* name, int32_t flags, int32_t mode)
 #endif
 }
 
-extern "C"
-int32_t ShmUnlink(const char* name)
+extern "C" int32_t ShmUnlink(const char* name)
 {
     return shm_unlink(name);
 }
 
-static
-void ConvertDirent(const dirent& entry, DirectoryEntry* outputEntry)
+static void ConvertDirent(const dirent& entry, DirectoryEntry* outputEntry)
 {
     // We use Marshal.PtrToStringAnsi on the managed side, which takes a pointer to
-    // the start of the unmanaged string. Give the caller back a pointer to the 
+    // the start of the unmanaged string. Give the caller back a pointer to the
     // location of the start of the string that exists in their own byte buffer.
     outputEntry->Name = entry.d_name;
     outputEntry->InodeType = static_cast<NodeType>(entry.d_type);
@@ -280,8 +261,7 @@ void ConvertDirent(const dirent& entry, DirectoryEntry* outputEntry)
 #endif
 }
 
-extern "C" 
-int32_t GetDirentSize()
+extern "C" int32_t GetDirentSize()
 {
     // dirent should be under 2k in size
     static_assert(sizeof(dirent) < 2048, "");
@@ -289,18 +269,17 @@ int32_t GetDirentSize()
 }
 
 // To reduce the number of string copies, this function calling pattern works as follows:
-// 1) The managed code calls GetDirentSize() to get the platform-specific 
+// 1) The managed code calls GetDirentSize() to get the platform-specific
 //    size of the dirent struct.
 // 2) The managed code creates a byte[] buffer of the size of the native dirent
-//    and passes a pointer to this buffer to this function. 
+//    and passes a pointer to this buffer to this function.
 // 3) This function passes input byte[] buffer to the OS to fill with dirent data
 //    which makes the 1st strcpy.
 // 4) The ConvertDirent function will set a pointer to the start of the inode name
-//    in the byte[] buffer so the managed code and find it and copy it out of the 
+//    in the byte[] buffer so the managed code and find it and copy it out of the
 //    buffer into a managed string that the caller of the framework can use, making
-//    the 2nd and final strcpy. 
-extern "C" 
-int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
+//    the 2nd and final strcpy.
+extern "C" int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
 {
     assert(buffer != nullptr);
     assert(dir != nullptr);
@@ -320,15 +299,15 @@ int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* out
     if (error != 0)
     {
         assert(error > 0);
-        *outputEntry = { }; // managed out param must be initialized
+        *outputEntry = {}; // managed out param must be initialized
         return error;
     }
 
     // 0 returned with null result -> end-of-stream
     if (result == nullptr)
     {
-        *outputEntry = { }; // managed out param must be initialized
-        return -1;          // shim convention for end-of-stream
+        *outputEntry = {}; // managed out param must be initialized
+        return -1;         // shim convention for end-of-stream
     }
 
     // 0 returned with non-null result (guaranteed to be set to entry arg) -> success
@@ -337,43 +316,39 @@ int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* out
     return 0;
 }
 
-extern "C" 
-DIR* OpenDir(const char* path)
+extern "C" DIR* OpenDir(const char* path)
 {
     return opendir(path);
 }
 
-extern "C" 
-int32_t CloseDir(DIR* dir)
+extern "C" int32_t CloseDir(DIR* dir)
 {
     return closedir(dir);
 }
 
-extern "C"
-int32_t Pipe(int32_t pipeFds[2], int32_t flags)
+extern "C" int32_t Pipe(int32_t pipeFds[2], int32_t flags)
 {
     switch (flags)
     {
-    case 0:
-        break;
-    case PAL_O_CLOEXEC:
-        flags = O_CLOEXEC;
-        break;
-    default:
-        assert(false && "Unknown flag.");
-        errno = EINVAL;
-        return -1;
+        case 0:
+            break;
+        case PAL_O_CLOEXEC:
+            flags = O_CLOEXEC;
+            break;
+        default:
+            assert(false && "Unknown flag.");
+            errno = EINVAL;
+            return -1;
     }
 
 #if HAVE_PIPE2
     return pipe2(pipeFds, flags);
 #else
-    return pipe(pipeFds); // CLOEXEC intentionally ignored on platforms without pipe2.
+    return pipe(pipeFds);         // CLOEXEC intentionally ignored on platforms without pipe2.
 #endif
 }
 
-extern "C"
-int32_t FcntlCanGetSetPipeSz()
+extern "C" int32_t FcntlCanGetSetPipeSz()
 {
 #if defined(F_GETPIPE_SZ) && defined(F_SETPIPE_SZ)
     return true;
@@ -382,8 +357,7 @@ int32_t FcntlCanGetSetPipeSz()
 #endif
 }
 
-extern "C"
-int32_t FcntlGetPipeSz(int32_t fd)
+extern "C" int32_t FcntlGetPipeSz(int32_t fd)
 {
 #ifdef F_GETPIPE_SZ
     return fcntl(fd, F_GETPIPE_SZ);
@@ -394,8 +368,7 @@ int32_t FcntlGetPipeSz(int32_t fd)
 #endif
 }
 
-extern "C"
-int32_t FcntlSetPipeSz(int32_t fd, int32_t size)
+extern "C" int32_t FcntlSetPipeSz(int32_t fd, int32_t size)
 {
 #ifdef F_SETPIPE_SZ
     return fcntl(fd, F_SETPIPE_SZ, size);
@@ -406,74 +379,62 @@ int32_t FcntlSetPipeSz(int32_t fd, int32_t size)
 #endif
 }
 
-extern "C"
-int32_t MkDir(const char* path, int32_t mode)
+extern "C" int32_t MkDir(const char* path, int32_t mode)
 {
     return mkdir(path, static_cast<mode_t>(mode));
 }
 
-extern "C"
-int32_t ChMod(const char* path, int32_t mode)
+extern "C" int32_t ChMod(const char* path, int32_t mode)
 {
     return chmod(path, static_cast<mode_t>(mode));
 }
 
-extern "C"
-int32_t MkFifo(const char* path, int32_t mode)
+extern "C" int32_t MkFifo(const char* path, int32_t mode)
 {
     return mkfifo(path, static_cast<mode_t>(mode));
 }
 
-extern "C"
-int32_t FSync(int32_t fd)
+extern "C" int32_t FSync(int32_t fd)
 {
     return fsync(fd);
 }
 
-extern "C"
-int32_t FLock(int32_t fd, LockOperations operation)
+extern "C" int32_t FLock(int32_t fd, LockOperations operation)
 {
     return flock(fd, operation);
 }
 
-extern "C"
-int32_t ChDir(const char* path)
+extern "C" int32_t ChDir(const char* path)
 {
     return chdir(path);
 }
 
-extern "C"
-int32_t Access(const char* path, AccessMode mode)
+extern "C" int32_t Access(const char* path, AccessMode mode)
 {
     return access(path, mode);
 }
 
-extern "C"
-int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags)
+extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags)
 {
     return fnmatch(pattern, path, flags);
 }
 
-extern "C"
-int64_t LSeek(int32_t fd, int64_t offset, SeekWhence whence)
+extern "C" int64_t LSeek(int32_t fd, int64_t offset, SeekWhence whence)
 {
     return lseek(fd, offset, whence);
 }
 
-extern "C"
-int32_t Link(const char* source, const char* linkTarget)
+extern "C" int32_t Link(const char* source, const char* linkTarget)
 {
     return link(source, linkTarget);
 }
 
-extern "C"
-int32_t MksTemps(char* pathTemplate, int32_t suffixLength)
+extern "C" int32_t MksTemps(char* pathTemplate, int32_t suffixLength)
 {
     return mkstemps(pathTemplate, suffixLength);
 }
 
-static
-int32_t ConvertMMapProtection(int32_t protection)
+static int32_t ConvertMMapProtection(int32_t protection)
 {
     if (protection == PAL_PROT_NONE)
         return PROT_NONE;
@@ -483,79 +444,75 @@ int32_t ConvertMMapProtection(int32_t protection)
         assert(false && "Unknown protection.");
         return -1;
     }
-    
+
     int32_t ret = 0;
     if (protection & PAL_PROT_READ)
         ret |= PROT_READ;
     if (protection & PAL_PROT_WRITE)
         ret |= PROT_WRITE;
     if (protection & PAL_PROT_EXEC)
-        ret |= PROT_EXEC;   
-    
+        ret |= PROT_EXEC;
+
     assert(ret != -1);
     return ret;
 }
 
-static 
-int32_t ConvertMMapFlags(int32_t flags)
+static int32_t ConvertMMapFlags(int32_t flags)
 {
     if (flags & ~(PAL_MAP_SHARED | PAL_MAP_PRIVATE | PAL_MAP_ANONYMOUS))
     {
         assert(false && "Unknown MMap flag.");
         return -1;
     }
-    
+
     int32_t ret = 0;
     if (flags & PAL_MAP_PRIVATE)
-       ret |= MAP_PRIVATE;
+        ret |= MAP_PRIVATE;
     if (flags & PAL_MAP_SHARED)
-       ret |= MAP_SHARED;
+        ret |= MAP_SHARED;
     if (flags & PAL_MAP_ANONYMOUS)
-       ret |= MAP_ANON;
+        ret |= MAP_ANON;
 
     assert(ret != -1);
     return ret;
 }
 
-static 
-int32_t ConvertMSyncFlags(int32_t flags)
+static int32_t ConvertMSyncFlags(int32_t flags)
 {
     if (flags & ~(PAL_MS_SYNC | PAL_MS_ASYNC | PAL_MS_INVALIDATE))
     {
         assert(false && "Unknown MSync flag.");
         return -1;
     }
-    
+
     int32_t ret = 0;
     if (flags & PAL_MS_SYNC)
-       ret |= MS_SYNC;
+        ret |= MS_SYNC;
     if (flags & PAL_MS_ASYNC)
-       ret |= MS_ASYNC;
+        ret |= MS_ASYNC;
     if (flags & PAL_MS_INVALIDATE)
-       ret |= MS_INVALIDATE;
-    
+        ret |= MS_INVALIDATE;
+
     assert(ret != -1);
     return ret;
 }
 
-extern "C"
-void* MMap(
-   void* address,
-   uint64_t length,
-   int32_t protection,  // bitwise OR of PAL_PROT_*
-   int32_t flags,       // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
-   int32_t fd,
-   int64_t offset)
-{ 
+extern "C" void* MMap(void* address,
+                      uint64_t length,
+                      int32_t protection, // bitwise OR of PAL_PROT_*
+                      int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
+                      int32_t fd,
+                      int64_t offset)
+{
     if (length > SIZE_MAX)
     {
         errno = ERANGE;
         return nullptr;
     }
- 
+
     protection = ConvertMMapProtection(protection);
     flags = ConvertMMapFlags(flags);
-    
+
     if (flags == -1 || protection == -1)
     {
         errno = EINVAL;
@@ -568,24 +525,22 @@ void* MMap(
         return nullptr;
     }
 
-    assert(ret != nullptr); 
+    assert(ret != nullptr);
     return ret;
 }
-   
-extern "C"
-int32_t MUnmap(void *address, uint64_t length)
+
+extern "C" int32_t MUnmap(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
     {
         errno = ERANGE;
         return -1;
-    }  
+    }
 
     return munmap(address, static_cast<size_t>(length));
 }
 
-extern "C"
-int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice)
+extern "C" int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice)
 {
     if (length > SIZE_MAX)
     {
@@ -610,8 +565,7 @@ int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice)
     return -1;
 }
 
-extern "C"
-int32_t MLock(void* address, uint64_t length)
+extern "C" int32_t MLock(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
     {
@@ -621,9 +575,8 @@ int32_t MLock(void* address, uint64_t length)
 
     return mlock(address, static_cast<size_t>(length));
 }
-    
-extern "C"
-int32_t MUnlock(void* address, uint64_t length)
+
+extern "C" int32_t MUnlock(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
     {
@@ -633,9 +586,8 @@ int32_t MUnlock(void* address, uint64_t length)
 
     return munlock(address, static_cast<size_t>(length));
 }
-    
-extern "C"
-int32_t MProtect(void* address, uint64_t length, int32_t protection)
+
+extern "C" int32_t MProtect(void* address, uint64_t length, int32_t protection)
 {
     if (length > SIZE_MAX)
     {
@@ -653,8 +605,7 @@ int32_t MProtect(void* address, uint64_t length, int32_t protection)
     return mprotect(address, static_cast<size_t>(length), protection);
 }
 
-extern "C"
-int32_t MSync(void* address, uint64_t length, int32_t flags)
+extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags)
 {
     if (length > SIZE_MAX)
     {
@@ -668,12 +619,11 @@ int32_t MSync(void* address, uint64_t length, int32_t flags)
         errno = EINVAL;
         return -1;
     }
-    
+
     return msync(address, static_cast<size_t>(length), flags);
 }
-    
-extern "C"
-int64_t SysConf(SysConfName name)
+
+extern "C" int64_t SysConf(SysConfName name)
 {
     switch (name)
     {
@@ -681,15 +631,14 @@ int64_t SysConf(SysConfName name)
             return sysconf(_SC_CLK_TCK);
         case PAL_SC_PAGESIZE:
             return sysconf(_SC_PAGESIZE);
-    } 
+    }
 
     assert(false && "Unknown SysConfName");
     errno = EINVAL;
     return -1;
 }
-    
-extern "C"
-int32_t FTruncate(int32_t fd, int64_t length)
+
+extern "C" int32_t FTruncate(int32_t fd, int64_t length)
 {
     return ftruncate(fd, length);
 }
@@ -701,16 +650,14 @@ void ConvertPollFDPalToPlatform(const PollFD& pal, pollfd& native)
     native.revents = pal.REvents;
 }
 
-static
-void ConvertPollFDPlatformToPal(const pollfd& native, PollFD& pal)
+static void ConvertPollFDPlatformToPal(const pollfd& native, PollFD& pal)
 {
     pal.FD = native.fd;
     pal.Events = native.events;
     pal.REvents = native.revents;
 }
 
-extern "C"
-int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout)
+extern "C" int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout)
 {
     assert(numberOfPollFds <= 2);
 
@@ -737,8 +684,7 @@ int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout)
     return result;
 }
 
-extern "C"
-int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, FileAdvice advice)
+extern "C" int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, FileAdvice advice)
 {
 #if HAVE_POSIX_ADVISE
     return posix_fadvise(fd, offset, length, advice);
@@ -750,8 +696,7 @@ int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, FileAdvice advi
 #endif
 }
 
-extern "C"
-int32_t Read(int32_t fd, void* buffer, int32_t bufferSize)
+extern "C" int32_t Read(int32_t fd, void* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);
@@ -767,8 +712,7 @@ int32_t Read(int32_t fd, void* buffer, int32_t bufferSize)
     return static_cast<int32_t>(count);
 }
 
-extern "C"
-int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize)
+extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);
@@ -784,26 +728,22 @@ int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize)
     return static_cast<int32_t>(count);
 }
 
-extern "C"
-int32_t Rename(const char* oldPath, const char* newPath)
+extern "C" int32_t Rename(const char* oldPath, const char* newPath)
 {
     return rename(oldPath, newPath);
 }
 
-extern "C"
-int32_t RmDir(const char* path)
+extern "C" int32_t RmDir(const char* path)
 {
     return rmdir(path);
 }
 
-extern "C"
-void Sync()
+extern "C" void Sync()
 {
     sync();
 }
 
-extern "C"
-int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize)
+extern "C" int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -22,13 +22,11 @@ struct FileStatus
     int64_t BirthTime; // time the file was created
 };
 
-
 /************
- * The values below in the header are fixed and correct for managed callers to use forever. 
- * We must never change them. The implementation must either static_assert that they are equal 
+ * The values below in the header are fixed and correct for managed callers to use forever.
+ * We must never change them. The implementation must either static_assert that they are equal
  * to the native equivalent OR convert them appropriately.
  */
-
 
 /**
  * Constants for interpreting the permissions encoded in FileStatus.Mode.
@@ -59,7 +57,7 @@ enum
  */
 enum
 {
-    PAL_S_IFMT  = 0xF000, // Type of file (apply as mask to FileStatus.Mode and one of S_IF*)
+    PAL_S_IFMT = 0xF000,  // Type of file (apply as mask to FileStatus.Mode and one of S_IF*)
     PAL_S_IFIFO = 0x1000, // FIFO (named pipe)
     PAL_S_IFCHR = 0x2000, // Character special
     PAL_S_IFDIR = 0x4000, // Directory
@@ -77,9 +75,9 @@ enum
 enum
 {
     // Access modes (mutually exclusive).
-    PAL_O_RDONLY           = 0x0000, // Open for read-only
-    PAL_O_WRONLY           = 0x0001, // Open for write-only
-    PAL_O_RDWR             = 0x0002, // Open for read-write
+    PAL_O_RDONLY = 0x0000, // Open for read-only
+    PAL_O_WRONLY = 0x0001, // Open for write-only
+    PAL_O_RDWR = 0x0002,   // Open for read-write
 
     // Mask to get just the access mode. Some room is left for more.
     // POSIX also defines O_SEARCH and O_EXEC that are not available
@@ -88,11 +86,11 @@ enum
 
     // Flags (combineable)
     // These numeric values are not defined by POSIX and vary across targets.
-    PAL_O_CLOEXEC          = 0x0010, // Close-on-exec
-    PAL_O_CREAT            = 0x0020, // Create file if it doesn't already exist
-    PAL_O_EXCL             = 0x0040, // When combined with CREAT, fails if file already exists
-    PAL_O_TRUNC            = 0x0080, // Truncate file to length 0 if it already exists
-    PAL_O_SYNC             = 0x0100, // Block writes call will block until physically written
+    PAL_O_CLOEXEC = 0x0010, // Close-on-exec
+    PAL_O_CREAT = 0x0020,   // Create file if it doesn't already exist
+    PAL_O_EXCL = 0x0040,    // When combined with CREAT, fails if file already exists
+    PAL_O_TRUNC = 0x0080,   // Truncate file to length 0 if it already exists
+    PAL_O_SYNC = 0x0100,    // Block writes call will block until physically written
 };
 
 /**
@@ -100,7 +98,7 @@ enum
  */
 enum
 {
-    FILESTATUS_FLAGS_NONE          = 0,
+    FILESTATUS_FLAGS_NONE = 0,
     FILESTATUS_FLAGS_HAS_BIRTHTIME = 1,
 };
 
@@ -109,15 +107,15 @@ enum
  */
 enum NodeType : int32_t
 {
-    PAL_DT_UNKNOWN  =  0,   // Unknown file type
-    PAL_DT_FIFO     =  1,   // Named Pipe
-    PAL_DT_CHR      =  2,   // Character Device
-    PAL_DT_DIR      =  4,   // Directory
-    PAL_DT_BLK      =  6,   // Block Device
-    PAL_DT_REG      =  8,   // Regular file
-    PAL_DT_LNK      = 10,   // Symlink
-    PAL_DT_SOCK     = 12,   // Socket
-    PAL_DT_WHT      = 14    // BSD Whiteout
+    PAL_DT_UNKNOWN = 0, // Unknown file type
+    PAL_DT_FIFO = 1,    // Named Pipe
+    PAL_DT_CHR = 2,     // Character Device
+    PAL_DT_DIR = 4,     // Directory
+    PAL_DT_BLK = 6,     // Block Device
+    PAL_DT_REG = 8,     // Regular file
+    PAL_DT_LNK = 10,    // Symlink
+    PAL_DT_SOCK = 12,   // Socket
+    PAL_DT_WHT = 14     // BSD Whiteout
 };
 
 /**
@@ -125,21 +123,21 @@ enum NodeType : int32_t
  */
 enum LockOperations : int32_t
 {
-    PAL_LOCK_SH = 1,    /* shared lock */
-    PAL_LOCK_EX = 2,    /* exclusive lock */
-    PAL_LOCK_NB = 4,    /* don't block when locking*/
-    PAL_LOCK_UN = 8,    /* unlock */
+    PAL_LOCK_SH = 1, /* shared lock */
+    PAL_LOCK_EX = 2, /* exclusive lock */
+    PAL_LOCK_NB = 4, /* don't block when locking*/
+    PAL_LOCK_UN = 8, /* unlock */
 };
 
-/** 
+/**
  * Constants for changing the access permissions of a path
  */
 enum AccessMode : int32_t
 {
-    PAL_F_OK = 0,   /* Check for existence */
-    PAL_X_OK = 1,   /* Check for execute */
-    PAL_W_OK = 2,   /* Check for write */
-    PAL_R_OK = 4,   /* Check for read */
+    PAL_F_OK = 0, /* Check for existence */
+    PAL_X_OK = 1, /* Check for execute */
+    PAL_W_OK = 2, /* Check for write */
+    PAL_R_OK = 4, /* Check for read */
 };
 
 /**
@@ -155,9 +153,9 @@ enum FnMatchFlags : int32_t
  */
 enum SeekWhence : int32_t
 {
-    PAL_SEEK_SET = 0,   /* seek from the beginning of the stream */
-    PAL_SEEK_CUR = 1,   /* seek from the current position */
-    PAL_SEEK_END = 2,   /* seek from the end of the stream, wrapping if necessary */
+    PAL_SEEK_SET = 0, /* seek from the beginning of the stream */
+    PAL_SEEK_CUR = 1, /* seek from the current position */
+    PAL_SEEK_END = 2, /* seek from the end of the stream, wrapping if necessary */
 };
 
 /**
@@ -165,10 +163,10 @@ enum SeekWhence : int32_t
  */
 enum
 {
-    PAL_PROT_NONE  = 0, // pages may not be accessed (unless combined with one of below)
-    PAL_PROT_READ  = 1, // pages may be read
+    PAL_PROT_NONE = 0,  // pages may not be accessed (unless combined with one of below)
+    PAL_PROT_READ = 1,  // pages may be read
     PAL_PROT_WRITE = 2, // pages may be written
-    PAL_PROT_EXEC  = 4, // pages may be executed
+    PAL_PROT_EXEC = 4,  // pages may be executed
 };
 
 /**
@@ -177,10 +175,10 @@ enum
 enum
 {
     // shared/private are mutually exclusive
-    PAL_MAP_SHARED  = 0x01,    // shared mapping
-    PAL_MAP_PRIVATE = 0x02,    // private copy-on-write-mapping
-    
-    PAL_MAP_ANONYMOUS = 0x10,  // mapping is not backed by any file
+    PAL_MAP_SHARED = 0x01,  // shared mapping
+    PAL_MAP_PRIVATE = 0x02, // private copy-on-write-mapping
+
+    PAL_MAP_ANONYMOUS = 0x10, // mapping is not backed by any file
 };
 
 /**
@@ -189,10 +187,10 @@ enum
 enum
 {
     // sync/async are mutually exclusive
-    PAL_MS_ASYNC = 0x01,       // request sync, but don't block on completion
-    PAL_MS_SYNC  = 0x02,       // block until sync completes
-        
-    PAL_MS_INVALIDATE = 0x10,  // cause other mappings of the same file to be updated
+    PAL_MS_ASYNC = 0x01, // request sync, but don't block on completion
+    PAL_MS_SYNC = 0x02,  // block until sync completes
+
+    PAL_MS_INVALIDATE = 0x10, // cause other mappings of the same file to be updated
 };
 
 /**
@@ -208,21 +206,21 @@ enum MemoryAdvice : int32_t
  */
 enum SysConfName : int32_t
 {
-    PAL_SC_CLK_TCK  = 1,  // Number of clock ticks per second
-    PAL_SC_PAGESIZE = 2,  // Size of a page in bytes
+    PAL_SC_CLK_TCK = 1,  // Number of clock ticks per second
+    PAL_SC_PAGESIZE = 2, // Size of a page in bytes
 };
 
 /**
- * Constants passed to and from poll describing what to poll for and what 
+ * Constants passed to and from poll describing what to poll for and what
  * kind of data was received from poll.
  */
 enum PollFlags : int16_t
 {
-    PAL_POLLIN   = 0x0001,  /* any readable data available */
-    PAL_POLLOUT  = 0x0004,  /* data can be written without blocked */
-    PAL_POLLERR  = 0x0008,  /* an error occurred */
-    PAL_POLLHUP  = 0x0010,  /* the file descriptor hung up */
-    PAL_POLLNVAL = 0x0020,  /* the requested events were invalid */
+    PAL_POLLIN = 0x0001,   /* any readable data available */
+    PAL_POLLOUT = 0x0004,  /* data can be written without blocked */
+    PAL_POLLERR = 0x0008,  /* an error occurred */
+    PAL_POLLHUP = 0x0010,  /* the file descriptor hung up */
+    PAL_POLLNVAL = 0x0020, /* the requested events were invalid */
 };
 
 /**
@@ -231,12 +229,12 @@ enum PollFlags : int16_t
  */
 enum FileAdvice : int32_t
 {
-    PAL_POSIX_FADV_NORMAL       = 0,    /* no special advice, the default value */
-    PAL_POSIX_FADV_RANDOM       = 1,    /* random I/O access */
-    PAL_POSIX_FADV_SEQUENTIAL   = 2,    /* sequential I/O access */
-    PAL_POSIX_FADV_WILLNEED     = 3,    /* will need specified pages */
-    PAL_POSIX_FADV_DONTNEED     = 4,    /* dont need the specified pages */
-    PAL_POSIX_FADV_NOREUSE      = 5,    /* data will only be acessed once */
+    PAL_POSIX_FADV_NORMAL = 0,     /* no special advice, the default value */
+    PAL_POSIX_FADV_RANDOM = 1,     /* random I/O access */
+    PAL_POSIX_FADV_SEQUENTIAL = 2, /* sequential I/O access */
+    PAL_POSIX_FADV_WILLNEED = 3,   /* will need specified pages */
+    PAL_POSIX_FADV_DONTNEED = 4,   /* dont need the specified pages */
+    PAL_POSIX_FADV_NOREUSE = 5,    /* data will only be acessed once */
 };
 
 /**
@@ -244,9 +242,9 @@ enum FileAdvice : int32_t
  */
 struct DirectoryEntry
 {
-    const char* Name;               // Address of the name of the inode
-    int32_t     NameLength;         // Length (in chars) of the inode name
-    NodeType    InodeType;          // The inode type as described in the NodeType enum
+    const char* Name;   // Address of the name of the inode
+    int32_t NameLength; // Length (in chars) of the inode name
+    NodeType InodeType; // The inode type as described in the NodeType enum
 };
 
 /**
@@ -254,9 +252,9 @@ struct DirectoryEntry
  */
 struct PollFD
 {
-    int32_t FD;         // The file descriptor to poll
-    int16_t Events;     // The events to poll for
-    int16_t REvents;    // The events that occurred which triggered the poll
+    int32_t FD;      // The file descriptor to poll
+    int16_t Events;  // The events to poll for
+    int16_t REvents; // The events that occurred which triggered the poll
 };
 
 /**
@@ -264,111 +262,78 @@ struct PollFD
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t FStat(
-    int32_t fd,
-    FileStatus* output);
+extern "C" int32_t FStat(int32_t fd, FileStatus* output);
 
 /**
  * Get file status from a full path. Implemented as shim to stat(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" 
-int32_t Stat(
-    const char* path,
-    FileStatus* output);
+extern "C" int32_t Stat(const char* path, FileStatus* output);
 
 /**
  * Get file stats from a full path. Implemented as shim to lstat(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t LStat(
-    const char* path, 
-    FileStatus* output);
+extern "C" int32_t LStat(const char* path, FileStatus* output);
 
 /**
  * Open or create a file or device. Implemented as shim to open(2).
  *
  * Returns file descriptor or -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t Open(
-    const char* path,
-    int32_t flags,
-    int32_t mode);
+extern "C" int32_t Open(const char* path, int32_t flags, int32_t mode);
 
 /**
  * Close a file descriptor. Implemented as shim to open(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t Close(
-    int32_t fd);
+extern "C" int32_t Close(int32_t fd);
 
 /**
  * Delete an entry from the file system. Implemented as shim to unlink(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t Unlink(
-    const char* path);
+extern "C" int32_t Unlink(const char* path);
 
 /**
  * Open or create a shared memory object. Implemented as shim to shm_open(3).
  *
  * Returns file descriptor or -1 on fiailure. Sets errno on failure.
  */
-extern "C"
-int32_t ShmOpen(
-    const char* name,
-    int32_t flags,
-    int32_t mode);
-     
+extern "C" int32_t ShmOpen(const char* name, int32_t flags, int32_t mode);
+
 /**
  * Unlink a shared memory object. Implemented as shim to shm_unlink(3).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t ShmUnlink(
-     const char* name);
+extern "C" int32_t ShmUnlink(const char* name);
 
 /**
  * Returns the size of the dirent struct on the current architecture
  */
-extern "C"
-int32_t GetDirentSize();
+extern "C" int32_t GetDirentSize();
 
 /**
  * Re-entrant readdir that will retrieve the next dirent from the directory stream pointed to by dir.
- * 
+ *
  * Returns 0 when data is retrieved; returns -1 when end-of-stream is reached; returns an error code on failure
  */
-extern "C"
-int32_t ReadDirR(
-    DIR*                dir, 
-    void*               buffer, 
-    int32_t             bufferSize, 
-    DirectoryEntry*     outputEntry);
+extern "C" int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry);
 
 /**
  * Returns a DIR struct containing info about the current path or NULL on failure; sets errno on fail.
  */
-extern "C"
-DIR* OpenDir(
-    const char* path);
+extern "C" DIR* OpenDir(const char* path);
 
 /**
  * Closes the directory stream opened by opendir and returns 0 on success. On fail, -1 is returned and errno is set
  */
-extern "C"
-int32_t CloseDir(
-    DIR* dir);
+extern "C" int32_t CloseDir(DIR* dir);
 
 /**
  * Creates a pipe. Implemented as shim to pipe(2) or pipe2(2) if available.
@@ -376,13 +341,10 @@ int32_t CloseDir(
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t Pipe(
-    int32_t pipefd[2], // [out] pipefds[0] gets read end, pipefd[1] gets write end.
-    int32_t flags);    // 0 for defaults or PAL_O_CLOEXEC for close-on-exec
+extern "C" int32_t Pipe(int32_t pipefd[2], // [out] pipefds[0] gets read end, pipefd[1] gets write end.
+                        int32_t flags);    // 0 for defaults or PAL_O_CLOEXEC for close-on-exec
 
-
-// NOTE: Rather than a general fcntl shim, we opt to export separate functions 
+// NOTE: Rather than a general fcntl shim, we opt to export separate functions
 // for each command. This allows use to have strongly typed arguments and saves
 // complexity around converting command codes.
 
@@ -391,8 +353,7 @@ int32_t Pipe(
  *
  * Returns true (non-zero) if supported, false (zero) if not.
  */
-extern "C"
-int32_t FcntlCanGetSetPipeSz();
+extern "C" int32_t FcntlCanGetSetPipeSz();
 
 /**
  * Gets the capacity of a pipe.
@@ -401,9 +362,7 @@ int32_t FcntlCanGetSetPipeSz();
  *
  * NOTE: Some platforms do not support this operation and will always fail with errno = ENOTSUP.
  */
-extern "C"
-int32_t FcntlGetPipeSz(
-    int32_t fd);
+extern "C" int32_t FcntlGetPipeSz(int32_t fd);
 
 /**
  * Sets the capacity of a pipe.
@@ -412,107 +371,88 @@ int32_t FcntlGetPipeSz(
  *
  * NOTE: Some platforms do not support this operation and will always fail with errno = ENOTSUP.
  */
-extern "C"
-int32_t FcntlSetPipeSz(
-    int32_t fd,
-    int32_t size);
+extern "C" int32_t FcntlSetPipeSz(int32_t fd, int32_t size);
 
 /**
  * Create a directory. Implemented as a shim to mkdir(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
- */    
-extern "C"
-int32_t MkDir(
-    const char* path,
-    int32_t mode);
+ */
+extern "C" int32_t MkDir(const char* path, int32_t mode);
 
 /**
  * Change permissions of a file. Implemented as a shim to chmod(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
  */
-extern "C"
-int32_t ChMod(
-    const char* path,
-    int32_t mode);
+extern "C" int32_t ChMod(const char* path, int32_t mode);
 
 /**
  * Create a FIFO (named pipe). Implemented as a shim to mkfifo(3).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
- */    
-extern "C"
-int32_t MkFifo(
-    const char* path,
-    int32_t mode);
+ */
+extern "C" int32_t MkFifo(const char* path, int32_t mode);
 
 /**
  * Flushes all modified data and attribtues of the specified File Descriptor to the storage medium.
- * 
+ *
  * Returns 0 for success; on fail, -1 is returned and errno is set.
  */
-extern "C"
-int32_t FSync(int32_t fd);
+extern "C" int32_t FSync(int32_t fd);
 
 /**
  * Changes the advisory lock status on a given File Descriptor
- * 
+ *
  * Returns 0 on success; otherwise, -1 is returned and errno is set
  */
-extern "C"
-int32_t FLock(int32_t fd, LockOperations operation);
+extern "C" int32_t FLock(int32_t fd, LockOperations operation);
 
-/** 
+/**
  * Changes the current working directory to be the specified path.
- * 
+ *
  * Returns 0 on success; otherwise, returns -1 and errno is set
  */
-extern "C"
-int32_t ChDir(const char* path);
+extern "C" int32_t ChDir(const char* path);
 
 /**
  * Checks the access permissions of the current calling user on the specified path for the specified mode.
- * 
- * Returns -1 if the path cannot be found or the if desired access is not granted and errno is set; otherwise, returns 0.
+ *
+ * Returns -1 if the path cannot be found or the if desired access is not granted and errno is set; otherwise, returns
+ * 0.
  */
-extern "C"
-int32_t Access(const char* path, AccessMode mode);
+extern "C" int32_t Access(const char* path, AccessMode mode);
 
 /**
  * Tests whether a pathname matches a specified pattern.
- * 
+ *
  * Returns 0 if the string matches; returns FNM_NOMATCH if the call succeeded but the
  * string does not match; otherwise, returns a non-zero error code.
  */
-extern "C"
-int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags);
+extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags);
 
 /**
  * Seek to a specified location within a seekable stream
- * 
+ *
  * On success, the resulting offet, in bytes, from the begining of the stream; otherwise,
  * returns -1 and errno is set.
  */
-extern "C"
-int64_t LSeek(int32_t fd, int64_t offset, SeekWhence whence);
+extern "C" int64_t LSeek(int32_t fd, int64_t offset, SeekWhence whence);
 
 /**
  * Creates a hard-link at link pointing to source.
- * 
+ *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C"
-int32_t Link(const char* source, const char* linkTarget);
+extern "C" int32_t Link(const char* source, const char* linkTarget);
 
 /**
  * Creates a file name that adheres to the specified template, creates the file on disk with
- * 0600 permissions, and returns an open r/w File Descriptor on the file. 
- * 
+ * 0600 permissions, and returns an open r/w File Descriptor on the file.
+ *
  * Returns a valid File Descriptor on success; otherwise, returns -1 and errno is set.
  */
-extern "C"
-int32_t MksTemps(char* pathTemplate, int32_t suffixLength);
+extern "C" int32_t MksTemps(char* pathTemplate, int32_t suffixLength);
 
 /**
  * Map file or device into memory. Implemented as shim to mmap(2).
@@ -522,78 +462,55 @@ int32_t MksTemps(char* pathTemplate, int32_t suffixLength);
  * Note that null failure result is a departure from underlying
  * mmap(2) using non-null sentinel.
  */
-extern "C"
-void* MMap(
-    void* address, 
-    uint64_t length, 
-    int32_t protection,  // bitwise OR of PAL_PROT_*
-    int32_t flags,       // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
-    int32_t fd, 
-    int64_t offset);
+extern "C" void* MMap(void* address,
+                      uint64_t length,
+                      int32_t protection, // bitwise OR of PAL_PROT_*
+                      int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
+                      int32_t fd,
+                      int64_t offset);
 
 /**
  * Unmap file or device from memory. Implemented as shim to mmap(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t MUnmap(
-    void *address,
-    uint64_t length);
+extern "C" int32_t MUnmap(void* address, uint64_t length);
 
 /**
  * Give advice about use of memory. Implemented as shim to madvise(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t MAdvise(
-    void* address,
-    uint64_t length,
-    MemoryAdvice advice);
+extern "C" int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice);
 
 /**
  * Lock memory from being swapped out. Implemented as shim to mlock(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t MLock(
-    void* address,
-    uint64_t length);
-    
+extern "C" int32_t MLock(void* address, uint64_t length);
+
 /**
  * Unlock memory, allowing it to be swapped out. Implemented as shim to munlock(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t MUnlock(
-    void* address,
-    uint64_t length);
+extern "C" int32_t MUnlock(void* address, uint64_t length);
 
 /**
  * Set protection on a region of memory. Implemented as shim to mprotect(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t MProtect(
-    void* address,
-    uint64_t length,
-    int32_t protection);
+extern "C" int32_t MProtect(void* address, uint64_t length, int32_t protection);
 
 /**
  * Sycnhronize a file with a memory map. Implemented as shim to mmap(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
- extern "C"
- int32_t MSync(
-     void* address,
-     uint64_t length,
-     int32_t flags);
- 
+extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags);
+
 /**
  * Get system configuration value. Implemented as shim to sysconf(3).
  *
@@ -603,27 +520,23 @@ int32_t MProtect(
  * note that -1 can also be a meaningful successful return value, in
  * which case errno is unchanged.
  */
-extern "C"
-int64_t SysConf(
-    SysConfName name);
-    
+extern "C" int64_t SysConf(SysConfName name);
+
 /**
  * Truncate a file to given length. Implemented as shim to ftruncate(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C"
-int32_t FTruncate(
-    int32_t fd,
-    int64_t length);
+extern "C" int32_t FTruncate(int32_t fd, int64_t length);
 
 /**
- * Examines one or more file descriptors for the specified state(s) and blocks until the state(s) occur or the timeout ellapses. 
+ * Examines one or more file descriptors for the specified state(s) and blocks until the state(s) occur or the timeout
+ * ellapses.
  *
- * Returns the number of descriptors ready, if any; if the timeout ellapses, returns 0; otherwise, returns -1 and errno is set.
+ * Returns the number of descriptors ready, if any; if the timeout ellapses, returns 0; otherwise, returns -1 and errno
+ * is set.
  */
-extern "C"
-int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout);
+extern "C" int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout);
 
 /**
  * Notifies the OS kernel that the specified file will be accessed in a particular way soon; this allows the kernel to
@@ -631,54 +544,48 @@ int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout);
  *
  * Returns 0 on success; otherwise, the error code is returned and errno is NOT set.
  */
-extern "C"
-int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, FileAdvice advice);
+extern "C" int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, FileAdvice advice);
 
 /**
  * Reads the number of bytes specified into the provided buffer from the specified, opened file descriptor.
  *
  * Returns the number of bytes read on success; otherwise, -1 is returned an errno is set.
- * 
+ *
  * Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
  */
-extern "C"
-int32_t Read(int32_t fd, void* buffer, int32_t bufferSize);
+extern "C" int32_t Read(int32_t fd, void* buffer, int32_t bufferSize);
 
 /**
  * Takes a path to a symbolic link and attempts to place the link target path into the buffer. If the buffer is too
- * small, the path will be truncated. No matter what, the buffer will not be null terminated. 
+ * small, the path will be truncated. No matter what, the buffer will not be null terminated.
  *
  * Returns the number of bytes placed into the buffer on success; otherwise, -1 is returned and errno is set.
  */
-extern "C"
-int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize);
+extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize);
 
 /**
- * Renames a file, moving to the correct destination if necessary. There are many edge cases to this call, check man 2 rename for more info
+ * Renames a file, moving to the correct destination if necessary. There are many edge cases to this call, check man 2
+ * rename for more info
  *
  * Returns 0 on succes; otherwise, returns -1 and errno is set.
  */
-extern "C"
-int32_t Rename(const char* oldPath, const char* newPath);
+extern "C" int32_t Rename(const char* oldPath, const char* newPath);
 
 /**
  * Deletes the specified empty directory.
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C"
-int32_t RmDir(const char* path);
+extern "C" int32_t RmDir(const char* path);
 
 /**
  * Forces a write of all modified I/O buffers to their storage mediums.
  */
-extern "C"
-void Sync();
+extern "C" void Sync();
 
 /**
  * Writes the specified buffer to the provided open file descriptor
  *
  * Returns the number of bytes written on success; otherwise, returns -1 and sets errno
  */
-extern "C"
-int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize);
+extern "C" int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize);

--- a/src/Native/System.Native/pal_mount.cpp
+++ b/src/Native/System.Native/pal_mount.cpp
@@ -17,9 +17,7 @@
 #define STRING_BUFFER_SIZE 8192
 #endif
 
-
-static
-int32_t GetMountInfo(MountPointFound onFound)
+static int32_t GetMountInfo(MountPointFound onFound)
 {
 #if HAVE_MNTINFO
     // getmntinfo returns pointers to OS-internal structs, so we don't need to worry about free'ing the object
@@ -41,7 +39,7 @@ int32_t GetMountInfo(MountPointFound onFound)
     {
         // The _r version of getmntent needs all buffers to be passed in; however, we don't know how big of a string
         // buffer we will need, so pick something that seems like it will be big enough.
-        char buffer[STRING_BUFFER_SIZE] = { };
+        char buffer[STRING_BUFFER_SIZE] = {};
         mntent entry;
         while (getmntent_r(fp, &entry, buffer, STRING_BUFFER_SIZE) != nullptr)
         {
@@ -50,7 +48,8 @@ int32_t GetMountInfo(MountPointFound onFound)
 
         result = endmntent(fp);
         assert(result == 1); // documented to always return 1
-        result = 0; // We need to standardize a success return code between our implementations, so settle on 0 for success
+        result =
+            0; // We need to standardize a success return code between our implementations, so settle on 0 for success
     }
 
     return result;
@@ -58,26 +57,22 @@ int32_t GetMountInfo(MountPointFound onFound)
 
 #endif
 
-extern "C"
-int32_t GetAllMountPoints(MountPointFound onFound)
+extern "C" int32_t GetAllMountPoints(MountPointFound onFound)
 {
     return GetMountInfo(onFound);
 }
 
-extern "C"
-int32_t GetSpaceInfoForMountPoint(
-    const char*             name,
-    MountPointInformation*  mpi)
+extern "C" int32_t GetSpaceInfoForMountPoint(const char* name, MountPointInformation* mpi)
 {
     assert(name != nullptr);
     assert(mpi != nullptr);
 
-    struct statfs stats = { };
+    struct statfs stats = {};
     int result = statfs(name, &stats);
     if (result == 0)
     {
         // Note that f_bsize has a signed integer type on some platforms but musn't be negative.
-        // Also, upcast here (some platforms have smaller types) to 64-bit before multiplying to 
+        // Also, upcast here (some platforms have smaller types) to 64-bit before multiplying to
         // avoid overflow.
         uint64_t bsize = UnsignedCast(stats.f_bsize);
 
@@ -87,18 +82,14 @@ int32_t GetSpaceInfoForMountPoint(
     }
     else
     {
-        *mpi = { };
+        *mpi = {};
     }
 
     return result;
 }
 
-extern "C"
-int32_t GetFormatInfoForMountPoint(
-    const char* name, 
-    char*       formatNameBuffer, 
-    int32_t     bufferLength, 
-    int64_t*    formatType)
+extern "C" int32_t
+GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer, int32_t bufferLength, int64_t* formatType)
 {
     assert((formatNameBuffer != nullptr) && (formatType != nullptr));
     assert(bufferLength > 0);
@@ -124,7 +115,6 @@ int32_t GetFormatInfoForMountPoint(
         *formatType = stats.f_type;
         SafeStringCopy(formatNameBuffer, bufferLength, "");
 #endif
-
     }
     else
     {

--- a/src/Native/System.Native/pal_mount.h
+++ b/src/Native/System.Native/pal_mount.h
@@ -16,8 +16,8 @@ struct MountPointInformation
 };
 
 /**
- * Function pointer to call back into C# when we find a mount point via GetAllMountPoints. 
- * Using the callback pattern allows us to limit the number of allocs we do and makes it 
+ * Function pointer to call back into C# when we find a mount point via GetAllMountPoints.
+ * Using the callback pattern allows us to limit the number of allocs we do and makes it
  * cleaner on the managed side since we don't have to worry about cleaning up any unmanaged memory.
  */
 typedef void (*MountPointFound)(const char* name);
@@ -25,31 +25,23 @@ typedef void (*MountPointFound)(const char* name);
 /**
  * Gets the space information for the given mount point and populates the input struct with the data.
  */
-extern "C"
-int32_t GetSpaceInfoForMountPoint(
-    const char*             name, 
-    MountPointInformation*  mpi);
+extern "C" int32_t GetSpaceInfoForMountPoint(const char* name, MountPointInformation* mpi);
 
 /**
- * Gets the format information about the given mount point. 
+ * Gets the format information about the given mount point.
  * We separate format info from space info because format information is given back differently per-platform
- * so keep the space information simple (above) and do all the platform logic here. 
+ * so keep the space information simple (above) and do all the platform logic here.
  * Ubuntu (and most Linux systems) will provide the mount point format as a long int in statfs while
- * OS X and BSD-like systems will provide the information in a char buffer. 
+ * OS X and BSD-like systems will provide the information in a char buffer.
  * Since C# is much better at enum and string handling, pass either the char buffer or the long type
  * back, depending on what the platform gives us, and let C# reason on it in an easy way.
  */
-extern "C"
-int32_t GetFormatInfoForMountPoint(
-    const char* name,
-    char*       formatNameBuffer,
-    int32_t     bufferLength,
-    int64_t*    formatType);
+extern "C" int32_t
+GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer, int32_t bufferLength, int64_t* formatType);
 
 /**
  * Enumerate all mount points on the system and call the input
  * function pointer once-per-mount-point to prevent heap allocs
  * as much as possible.
  */
-extern "C"
-int32_t GetAllMountPoints(MountPointFound onFound);
+extern "C" int32_t GetAllMountPoints(MountPointFound onFound);

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -18,45 +18,45 @@
 static_assert(PAL_SIGKILL == SIGKILL, "");
 
 // Validate that our WaitPidOptions enum values are correct for the platform
-static_assert(PAL_WNOHANG     == WNOHANG, "");
-static_assert(PAL_WUNTRACED   == WUNTRACED, "");
+static_assert(PAL_WNOHANG == WNOHANG, "");
+static_assert(PAL_WUNTRACED == WUNTRACED, "");
 
 // Validate that our SysLogPriority values are correct for the platform
-static_assert(PAL_LOG_EMERG        == LOG_EMERG, "");
-static_assert(PAL_LOG_ALERT        == LOG_ALERT, "");
-static_assert(PAL_LOG_CRIT         == LOG_CRIT, "");
-static_assert(PAL_LOG_ERR          == LOG_ERR, "");
-static_assert(PAL_LOG_WARNING      == LOG_WARNING, "");
-static_assert(PAL_LOG_NOTICE       == LOG_NOTICE, "");
-static_assert(PAL_LOG_INFO         == LOG_INFO, "");
-static_assert(PAL_LOG_DEBUG        == LOG_DEBUG, "");
-static_assert(PAL_LOG_KERN         == LOG_KERN, "");
-static_assert(PAL_LOG_USER         == LOG_USER, "");
-static_assert(PAL_LOG_MAIL         == LOG_MAIL, "");
-static_assert(PAL_LOG_DAEMON       == LOG_DAEMON, "");
-static_assert(PAL_LOG_AUTH         == LOG_AUTH, "");
-static_assert(PAL_LOG_SYSLOG       == LOG_SYSLOG, "");
-static_assert(PAL_LOG_LPR          == LOG_LPR, "");
-static_assert(PAL_LOG_NEWS         == LOG_NEWS, "");
-static_assert(PAL_LOG_UUCP         == LOG_UUCP, "");
-static_assert(PAL_LOG_CRON         == LOG_CRON, "");
-static_assert(PAL_LOG_AUTHPRIV     == LOG_AUTHPRIV, "");
-static_assert(PAL_LOG_FTP          == LOG_FTP, "");
-static_assert(PAL_LOG_LOCAL0       == LOG_LOCAL0, "");
-static_assert(PAL_LOG_LOCAL1       == LOG_LOCAL1, "");
-static_assert(PAL_LOG_LOCAL2       == LOG_LOCAL2, "");
-static_assert(PAL_LOG_LOCAL3       == LOG_LOCAL3, "");
-static_assert(PAL_LOG_LOCAL4       == LOG_LOCAL4, "");
-static_assert(PAL_LOG_LOCAL5       == LOG_LOCAL5, "");
-static_assert(PAL_LOG_LOCAL6       == LOG_LOCAL6, "");
-static_assert(PAL_LOG_LOCAL7       == LOG_LOCAL7, "");
+static_assert(PAL_LOG_EMERG == LOG_EMERG, "");
+static_assert(PAL_LOG_ALERT == LOG_ALERT, "");
+static_assert(PAL_LOG_CRIT == LOG_CRIT, "");
+static_assert(PAL_LOG_ERR == LOG_ERR, "");
+static_assert(PAL_LOG_WARNING == LOG_WARNING, "");
+static_assert(PAL_LOG_NOTICE == LOG_NOTICE, "");
+static_assert(PAL_LOG_INFO == LOG_INFO, "");
+static_assert(PAL_LOG_DEBUG == LOG_DEBUG, "");
+static_assert(PAL_LOG_KERN == LOG_KERN, "");
+static_assert(PAL_LOG_USER == LOG_USER, "");
+static_assert(PAL_LOG_MAIL == LOG_MAIL, "");
+static_assert(PAL_LOG_DAEMON == LOG_DAEMON, "");
+static_assert(PAL_LOG_AUTH == LOG_AUTH, "");
+static_assert(PAL_LOG_SYSLOG == LOG_SYSLOG, "");
+static_assert(PAL_LOG_LPR == LOG_LPR, "");
+static_assert(PAL_LOG_NEWS == LOG_NEWS, "");
+static_assert(PAL_LOG_UUCP == LOG_UUCP, "");
+static_assert(PAL_LOG_CRON == LOG_CRON, "");
+static_assert(PAL_LOG_AUTHPRIV == LOG_AUTHPRIV, "");
+static_assert(PAL_LOG_FTP == LOG_FTP, "");
+static_assert(PAL_LOG_LOCAL0 == LOG_LOCAL0, "");
+static_assert(PAL_LOG_LOCAL1 == LOG_LOCAL1, "");
+static_assert(PAL_LOG_LOCAL2 == LOG_LOCAL2, "");
+static_assert(PAL_LOG_LOCAL3 == LOG_LOCAL3, "");
+static_assert(PAL_LOG_LOCAL4 == LOG_LOCAL4, "");
+static_assert(PAL_LOG_LOCAL5 == LOG_LOCAL5, "");
+static_assert(PAL_LOG_LOCAL6 == LOG_LOCAL6, "");
+static_assert(PAL_LOG_LOCAL7 == LOG_LOCAL7, "");
 
 enum
 {
     READ_END_OF_PIPE = 0,
     WRITE_END_OF_PIPE = 1,
 };
-    
+
 static void CloseIfOpen(int fd)
 {
     // Ignoring errors from close is a deliberate choice and we musn't
@@ -69,28 +69,25 @@ static void CloseIfOpen(int fd)
     }
 }
 
-extern "C"
-int32_t ForkAndExecProcess(
-    const char* filename,
-    char* const argv[],
-    char* const envp[],
-    const char* cwd,
-    int32_t redirectStdin,
-    int32_t redirectStdout,
-    int32_t redirectStderr,
-    int32_t* childPid,
-    int32_t* stdinFd,
-    int32_t* stdoutFd,
-    int32_t* stderrFd)
+extern "C" int32_t ForkAndExecProcess(const char* filename,
+                                      char* const argv[],
+                                      char* const envp[],
+                                      const char* cwd,
+                                      int32_t redirectStdin,
+                                      int32_t redirectStdout,
+                                      int32_t redirectStderr,
+                                      int32_t* childPid,
+                                      int32_t* stdinFd,
+                                      int32_t* stdoutFd,
+                                      int32_t* stderrFd)
 {
     int success = true;
-    int stdinFds[2] = { -1, -1 }, stdoutFds[2] = { -1, -1 }, stderrFds[2] = { -1, -1 };
+    int stdinFds[2] = {-1, -1}, stdoutFds[2] = {-1, -1}, stderrFds[2] = {-1, -1};
     int processId = -1;
 
     // Validate arguments
-    if (nullptr == filename || nullptr == argv || nullptr == envp ||
-        nullptr == stdinFd || nullptr == stdoutFd || nullptr == stderrFd ||
-        nullptr == childPid)
+    if (nullptr == filename || nullptr == argv || nullptr == envp || nullptr == stdinFd || nullptr == stdoutFd ||
+        nullptr == stderrFd || nullptr == childPid)
     {
         assert(false && "null argument.");
         errno = EINVAL;
@@ -98,9 +95,7 @@ int32_t ForkAndExecProcess(
         goto done;
     }
 
-    if ((redirectStdin  & ~1) != 0 ||
-        (redirectStdout & ~1) != 0 ||
-        (redirectStderr & ~1) != 0)
+    if ((redirectStdin & ~1) != 0 || (redirectStdout & ~1) != 0 || (redirectStderr & ~1) != 0)
     {
         assert(false && "Boolean redirect* inputs must be 0 or 1.");
         errno = EINVAL;
@@ -109,8 +104,7 @@ int32_t ForkAndExecProcess(
     }
 
     // Open pipes for any requests to redirect stdin/stdout/stderr
-    if ((redirectStdin  && pipe(stdinFds)  != 0) ||
-        (redirectStdout && pipe(stdoutFds) != 0) ||
+    if ((redirectStdin && pipe(stdinFds) != 0) || (redirectStdout && pipe(stdoutFds) != 0) ||
         (redirectStderr && pipe(stderrFds) != 0))
     {
         assert(false && "pipe() failed.");
@@ -135,7 +129,7 @@ int32_t ForkAndExecProcess(
 
         // For any redirections that should happen, dup the pipe descriptors onto stdin/out/err.
         // Then close out the old pipe descriptrs, which we no longer need.
-        if ((redirectStdin  && dup2(stdinFds[READ_END_OF_PIPE],   STDIN_FILENO)  == -1) ||
+        if ((redirectStdin && dup2(stdinFds[READ_END_OF_PIPE], STDIN_FILENO) == -1) ||
             (redirectStdout && dup2(stdoutFds[WRITE_END_OF_PIPE], STDOUT_FILENO) == -1) ||
             (redirectStderr && dup2(stderrFds[WRITE_END_OF_PIPE], STDERR_FILENO) == -1))
         {
@@ -176,19 +170,18 @@ done:
         CloseIfOpen(stdoutFds[READ_END_OF_PIPE]);
         CloseIfOpen(stderrFds[READ_END_OF_PIPE]);
 
-        *stdinFd  = -1;
+        *stdinFd = -1;
         *stdoutFd = -1;
         *stderrFd = -1;
         *childPid = -1;
     }
-    
+
     return success ? 0 : -1;
 }
 
 // Each platform type has it's own RLIMIT values but the same name, so we need
 // to convert our standard types into the platform specific ones.
-static
-int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
+static int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
 {
     switch (value)
     {
@@ -219,9 +212,9 @@ int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
 }
 
 // Because RLIM_INFINITY is different per-platform, use the max value of a uint64 (which is RLIM_INFINITY on Ubuntu)
-// to signify RLIM_INIFINITY; on OS X, where RLIM_INFINITY is slightly lower, we'll translate it to the correct value here.
-static
-uint64_t ConvertFromManagedRLimitInfinityToPalIfNecessary(uint64_t value)
+// to signify RLIM_INIFINITY; on OS X, where RLIM_INFINITY is slightly lower, we'll translate it to the correct value
+// here.
+static uint64_t ConvertFromManagedRLimitInfinityToPalIfNecessary(uint64_t value)
 {
     if (value == UINT64_MAX)
         return RLIM_INFINITY;
@@ -230,9 +223,9 @@ uint64_t ConvertFromManagedRLimitInfinityToPalIfNecessary(uint64_t value)
 }
 
 // Because RLIM_INFINITY is different per-platform, use the max value of a uint64 (which is RLIM_INFINITY on Ubuntu)
-// to signify RLIM_INIFINITY; on OS X, where RLIM_INFINITY is slightly lower, we'll translate it to the correct value here.
-static
-uint64_t ConvertFromNativeRLimitInfinityToManagedIfNecessary(uint64_t value)
+// to signify RLIM_INIFINITY; on OS X, where RLIM_INFINITY is slightly lower, we'll translate it to the correct value
+// here.
+static uint64_t ConvertFromNativeRLimitInfinityToManagedIfNecessary(uint64_t value)
 {
     if (value == RLIM_INFINITY)
         return UINT64_MAX;
@@ -240,24 +233,19 @@ uint64_t ConvertFromNativeRLimitInfinityToManagedIfNecessary(uint64_t value)
         return value;
 }
 
-static
-void ConvertFromRLimitManagedToPal(const RLimit& pal, rlimit& native)
+static void ConvertFromRLimitManagedToPal(const RLimit& pal, rlimit& native)
 {
     native.rlim_cur = ConvertFromManagedRLimitInfinityToPalIfNecessary(pal.CurrentLimit);
     native.rlim_max = ConvertFromManagedRLimitInfinityToPalIfNecessary(pal.MaximumLimit);
 }
 
-static
-void ConvertFromPalRLimitToManaged(const rlimit& native, RLimit& pal)
+static void ConvertFromPalRLimitToManaged(const rlimit& native, RLimit& pal)
 {
     pal.CurrentLimit = ConvertFromNativeRLimitInfinityToManagedIfNecessary(native.rlim_cur);
     pal.MaximumLimit = ConvertFromNativeRLimitInfinityToManagedIfNecessary(native.rlim_max);
 }
 
-extern "C"
-int32_t GetRLimit(
-    RLimitResources     resourceType,
-    RLimit*             limits)
+extern "C" int32_t GetRLimit(RLimitResources resourceType, RLimit* limits)
 {
     assert(limits != nullptr);
 
@@ -270,16 +258,13 @@ int32_t GetRLimit(
     }
     else
     {
-        *limits = { };
+        *limits = {};
     }
-    
+
     return result;
 }
 
-extern "C"
-int32_t SetRLimit(
-    RLimitResources     resourceType,
-    const RLimit* limits)
+extern "C" int32_t SetRLimit(RLimitResources resourceType, const RLimit* limits)
 {
     assert(limits != nullptr);
 
@@ -289,58 +274,49 @@ int32_t SetRLimit(
     return setrlimit(platformLimit, &internalLimit);
 }
 
-extern "C"
-int32_t Kill(int32_t pid, int32_t signal)
+extern "C" int32_t Kill(int32_t pid, int32_t signal)
 {
     return kill(pid, signal);
 }
 
-extern "C"
-int32_t GetPid()
+extern "C" int32_t GetPid()
 {
     return getpid();
 }
 
-extern "C"
-int32_t GetSid(int32_t pid)
+extern "C" int32_t GetSid(int32_t pid)
 {
     return getsid(pid);
 }
 
-extern "C"
-void SysLog(SysLogPriority priority, const char* message, const char* arg1)
+extern "C" void SysLog(SysLogPriority priority, const char* message, const char* arg1)
 {
     syslog(static_cast<int>(priority), message, arg1);
 }
 
-extern "C"
-int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
+extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
 {
     assert(status != nullptr);
-    
+
     return waitpid(pid, status, static_cast<int>(options));
 }
 
-extern "C"
-int32_t WExitStatus(int32_t status)
+extern "C" int32_t WExitStatus(int32_t status)
 {
     return WEXITSTATUS(status);
 }
 
-extern "C"
-int32_t WIfExited(int32_t status)
+extern "C" int32_t WIfExited(int32_t status)
 {
     return WIFEXITED(status);
 }
 
-extern "C"
-int32_t WIfSignaled(int32_t status)
+extern "C" int32_t WIfSignaled(int32_t status)
 {
     return WIFSIGNALED(status);
 }
 
-extern "C"
-int32_t WTermSig(int32_t status)
+extern "C" int32_t WTermSig(int32_t status)
 {
     return WTERMSIG(status);
 }

--- a/src/Native/System.Native/pal_process.h
+++ b/src/Native/System.Native/pal_process.h
@@ -16,27 +16,24 @@
  * As would have been the case with fork/execve, a return value of 0 is success and -1
  * is failure; if failure, error information is provided in errno.
  */
-extern "C"
-int32_t ForkAndExecProcess(
-    const char* filename,    // filename argument to execve
-    char* const argv[],      // argv argument to execve
-    char* const envp[],      // envp argument to execve
-    const char* cwd,         // path passed to chdir in child process
-    int32_t redirectStdin,    // whether to redirect standard input from the parent
-    int32_t redirectStdout,   // whether to redirect standard output to the parent
-    int32_t redirectStderr,   // whether to redirect standard error to the parent
-    int32_t* childPid,        // [out] the child process' id
-    int32_t* stdinFd,         // [out] if redirectStdin, the parent's fd for the child's stdin
-    int32_t* stdoutFd,        // [out] if redirectStdout, the parent's fd for the child's stdout
-    int32_t* stderrFd);       // [out] if redirectStderr, the parent's fd for the child's stderr
-
+extern "C" int32_t
+ForkAndExecProcess(const char* filename,   // filename argument to execve
+                   char* const argv[],     // argv argument to execve
+                   char* const envp[],     // envp argument to execve
+                   const char* cwd,        // path passed to chdir in child process
+                   int32_t redirectStdin,  // whether to redirect standard input from the parent
+                   int32_t redirectStdout, // whether to redirect standard output to the parent
+                   int32_t redirectStderr, // whether to redirect standard error to the parent
+                   int32_t* childPid,      // [out] the child process' id
+                   int32_t* stdinFd,       // [out] if redirectStdin, the parent's fd for the child's stdin
+                   int32_t* stdoutFd,      // [out] if redirectStdout, the parent's fd for the child's stdout
+                   int32_t* stderrFd);     // [out] if redirectStderr, the parent's fd for the child's stderr
 
 /************
- * The values below in the header are fixed and correct for managed callers to use forever. 
- * We must never change them. The implementation must either static_assert that they are equal 
+ * The values below in the header are fixed and correct for managed callers to use forever.
+ * We must never change them. The implementation must either static_assert that they are equal
  * to the native equivalent OR convert them appropriately.
  */
-
 
 /**
  * These values differ from OS to OS, so make a constant contract.
@@ -44,21 +41,21 @@ int32_t ForkAndExecProcess(
  */
 enum RLimitResources : int32_t
 {
-    PAL_RLIMIT_CPU          = 0,        // CPU limit in seconds
-    PAL_RLIMIT_FSIZE        = 1,        // Largest file that can be created, in bytes
-    PAL_RLIMIT_DATA         = 2,        // Maximum size of data segment, in bytes
-    PAL_RLIMIT_STACK        = 3,        // Maximum size of stack segment, in bytes
-    PAL_RLIMIT_CORE         = 4,        // Largest core file that can be created, in bytes
-    PAL_RLIMIT_AS           = 5,        // Address space limit
-    PAL_RLIMIT_RSS          = 6,        // Largest resident set size, in bytes
-    PAL_RLIMIT_MEMLOCK      = 7,        // Locked-in-memory address space
-    PAL_RLIMIT_NPROC        = 8,        // Number of processes
-    PAL_RLIMIT_NOFILE       = 9,        // Number of open files
+    PAL_RLIMIT_CPU = 0,     // CPU limit in seconds
+    PAL_RLIMIT_FSIZE = 1,   // Largest file that can be created, in bytes
+    PAL_RLIMIT_DATA = 2,    // Maximum size of data segment, in bytes
+    PAL_RLIMIT_STACK = 3,   // Maximum size of stack segment, in bytes
+    PAL_RLIMIT_CORE = 4,    // Largest core file that can be created, in bytes
+    PAL_RLIMIT_AS = 5,      // Address space limit
+    PAL_RLIMIT_RSS = 6,     // Largest resident set size, in bytes
+    PAL_RLIMIT_MEMLOCK = 7, // Locked-in-memory address space
+    PAL_RLIMIT_NPROC = 8,   // Number of processes
+    PAL_RLIMIT_NOFILE = 9,  // Number of open files
 };
 
 enum Signals : int32_t
 {
-    PAL_SIGKILL = 9,    /* kill the specified process */
+    PAL_SIGKILL = 9, /* kill the specified process */
 };
 
 /**
@@ -66,8 +63,8 @@ enum Signals : int32_t
  */
 enum WaitPidOptions : int32_t
 {
-    PAL_WNOHANG     = 1,    /* don't block waiting */
-    PAL_WUNTRACED   = 2,    /* report status of stopped children */
+    PAL_WNOHANG = 1,   /* don't block waiting */
+    PAL_WUNTRACED = 2, /* report status of stopped children */
 };
 
 /**
@@ -81,36 +78,36 @@ enum WaitPidOptions : int32_t
 enum SysLogPriority : int32_t
 {
     // Priorities
-    PAL_LOG_EMERG       = 0,        /* system is unusable */
-    PAL_LOG_ALERT       = 1,        /* action must be taken immediately */
-    PAL_LOG_CRIT        = 2,        /* critical conditions */
-    PAL_LOG_ERR         = 3,        /* error conditions */
-    PAL_LOG_WARNING     = 4,        /* warning conditions */
-    PAL_LOG_NOTICE      = 5,        /* normal but significant condition */
-    PAL_LOG_INFO        = 6,        /* informational */
-    PAL_LOG_DEBUG       = 7,        /* debug-level messages */
+    PAL_LOG_EMERG = 0,   /* system is unusable */
+    PAL_LOG_ALERT = 1,   /* action must be taken immediately */
+    PAL_LOG_CRIT = 2,    /* critical conditions */
+    PAL_LOG_ERR = 3,     /* error conditions */
+    PAL_LOG_WARNING = 4, /* warning conditions */
+    PAL_LOG_NOTICE = 5,  /* normal but significant condition */
+    PAL_LOG_INFO = 6,    /* informational */
+    PAL_LOG_DEBUG = 7,   /* debug-level messages */
     // Facilities
-    PAL_LOG_KERN        = (0<<3),   /* kernel messages */
-    PAL_LOG_USER        = (1<<3),   /* random user-level messages */
-    PAL_LOG_MAIL        = (2<<3),   /* mail system */
-    PAL_LOG_DAEMON      = (3<<3),   /* system daemons */
-    PAL_LOG_AUTH        = (4<<3),   /* authorization messages */
-    PAL_LOG_SYSLOG      = (5<<3),   /* messages generated internally by syslogd */
-    PAL_LOG_LPR         = (6<<3),   /* line printer subsystem */
-    PAL_LOG_NEWS        = (7<<3),   /* network news subsystem */
-    PAL_LOG_UUCP        = (8<<3),   /* UUCP subsystem */
-    PAL_LOG_CRON        = (9<<3),   /* clock daemon */
-    PAL_LOG_AUTHPRIV    = (10<<3),  /* authorization messages (private) */
-    PAL_LOG_FTP         = (11<<3),  /* ftp daemon */
+    PAL_LOG_KERN = (0 << 3),      /* kernel messages */
+    PAL_LOG_USER = (1 << 3),      /* random user-level messages */
+    PAL_LOG_MAIL = (2 << 3),      /* mail system */
+    PAL_LOG_DAEMON = (3 << 3),    /* system daemons */
+    PAL_LOG_AUTH = (4 << 3),      /* authorization messages */
+    PAL_LOG_SYSLOG = (5 << 3),    /* messages generated internally by syslogd */
+    PAL_LOG_LPR = (6 << 3),       /* line printer subsystem */
+    PAL_LOG_NEWS = (7 << 3),      /* network news subsystem */
+    PAL_LOG_UUCP = (8 << 3),      /* UUCP subsystem */
+    PAL_LOG_CRON = (9 << 3),      /* clock daemon */
+    PAL_LOG_AUTHPRIV = (10 << 3), /* authorization messages (private) */
+    PAL_LOG_FTP = (11 << 3),      /* ftp daemon */
     // Between FTP and Local is reserved for system use
-    PAL_LOG_LOCAL0      = (16<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL1      = (17<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL2      = (18<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL3      = (19<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL4      = (20<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL5      = (21<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL6      = (22<<3),  /* reserved for local use */
-    PAL_LOG_LOCAL7      = (23<<3),  /* reserved for local use */
+    PAL_LOG_LOCAL0 = (16 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL1 = (17 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL2 = (18 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL3 = (19 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL4 = (20 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL5 = (21 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL6 = (22 << 3), /* reserved for local use */
+    PAL_LOG_LOCAL7 = (23 << 3), /* reserved for local use */
 };
 
 /**
@@ -123,79 +120,63 @@ struct RLimit
     uint64_t MaximumLimit;
 };
 
-
 /**
  * Get the current limit for the specified resource of the current process.
  * Returns 0 on success; returns -1 on failure and errno is set to the error reason.
  */
-extern "C"
-int32_t GetRLimit(
-    RLimitResources     resourceType, 
-    RLimit*             limits);
+extern "C" int32_t GetRLimit(RLimitResources resourceType, RLimit* limits);
 
 /**
- * Set the soft and hard limits for the specified resource. 
+ * Set the soft and hard limits for the specified resource.
  * Only a super-user can increase hard limits for the current process.
  * Returns 0 on success; returns -1 on failure and errno is set to the error reason.
  */
-extern "C"
-int32_t SetRLimit(
-    RLimitResources resourceType,
-    const RLimit*   limits);
+extern "C" int32_t SetRLimit(RLimitResources resourceType, const RLimit* limits);
 
 /**
- * Kill the specified process (or process group) identified by the supplied pid; the 
+ * Kill the specified process (or process group) identified by the supplied pid; the
  * process or process group will be killed by the specified signal.
  * Returns 0 on success; on failure, -1 is returned and errno is set
  */
-extern "C"
-int32_t Kill(int32_t pid, int32_t signal);
+extern "C" int32_t Kill(int32_t pid, int32_t signal);
 
 /**
- * Returns the Process ID of the current executing process. 
+ * Returns the Process ID of the current executing process.
  * This call should never fail
  */
-extern "C"
-int32_t GetPid();
+extern "C" int32_t GetPid();
 
 /**
- * Returns the sessions ID of the specified process; if 0 is passed in, returns the 
+ * Returns the sessions ID of the specified process; if 0 is passed in, returns the
  * session ID of the current process.
  * Returns a session ID on success; otherwise, returns -1 and sets errno.
  */
-extern "C"
-int32_t GetSid(int32_t pid);
+extern "C" int32_t GetSid(int32_t pid);
 
 /**
- * Write a message to the system logger, which in turn writes the message to the system console, log files, etc. 
+ * Write a message to the system logger, which in turn writes the message to the system console, log files, etc.
  * See man 3 syslog for more info
  */
- extern "C"
- void SysLog(SysLogPriority priority, const char* message, const char* arg1);
+extern "C" void SysLog(SysLogPriority priority, const char* message, const char* arg1);
 
 /**
  * Waits for child process(s) or gathers resource utilization information about child processes
  *
- * The return value from WaitPid can very greatly. 
+ * The return value from WaitPid can very greatly.
  * 1) returns the process id of a terminating or stopped child process
  * 2) if no children are waiting, -1 is returned and errno is set to ECHILD
  * 3) if WNOHANG is specified and there are no stopped or exited children, 0 is returned
  * 4) on error, -1 is returned and errno is set
  */
-extern "C"
-int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options);
+extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options);
 
 /**
  * The four functions below are wrappers around the platform-specific macros of the same name.
  */
-extern "C"
-int32_t WExitStatus(int32_t status);
+extern "C" int32_t WExitStatus(int32_t status);
 
-extern "C"
-int32_t WIfExited(int32_t status);
+extern "C" int32_t WIfExited(int32_t status);
 
-extern "C"
-int32_t WIfSignaled(int32_t status);
+extern "C" int32_t WIfSignaled(int32_t status);
 
-extern "C"
-int32_t WTermSig(int32_t status);
+extern "C" int32_t WTermSig(int32_t status);

--- a/src/Native/System.Native/pal_string.cpp
+++ b/src/Native/System.Native/pal_string.cpp
@@ -10,8 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
-extern "C"
-int32_t SNPrintF(char* string, int32_t size, const char* format, ...)
+extern "C" int32_t SNPrintF(char* string, int32_t size, const char* format, ...)
 {
     assert(string != nullptr || size == 0);
     assert(size >= 0);

--- a/src/Native/System.Native/pal_string.h
+++ b/src/Native/System.Native/pal_string.h
@@ -7,11 +7,10 @@
 
 /**
  * snprintf is difficult to represent in C# due to the argument list, so the C# PInvoke
- * layer will have multiple overloads pointing to this function 
+ * layer will have multiple overloads pointing to this function
  *
- * Returns the number of characters (excluding null terminator) written to the buffer on 
- * success; if the return value is equal to the size then the result may have been truncated. 
+ * Returns the number of characters (excluding null terminator) written to the buffer on
+ * success; if the return value is equal to the size then the result may have been truncated.
  * On failure, returns a negative value.
  */
-extern "C"
-int32_t SNPrintF(char* string, int32_t size, const char* format, ...);
+extern "C" int32_t SNPrintF(char* string, int32_t size, const char* format, ...);

--- a/src/Native/System.Native/pal_time.cpp
+++ b/src/Native/System.Native/pal_time.cpp
@@ -7,16 +7,13 @@
 #include <assert.h>
 #include <utime.h>
 
-
-static
-void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
+static void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
 {
     native.actime = pal.AcTime;
     native.modtime = pal.ModTime;
 }
 
-extern "C"
-int32_t UTime(const char* path, UTimBuf* times)
+extern "C" int32_t UTime(const char* path, UTimBuf* times)
 {
     assert(times != nullptr);
 

--- a/src/Native/System.Native/pal_time.h
+++ b/src/Native/System.Native/pal_time.h
@@ -12,9 +12,8 @@ struct UTimBuf
 };
 
 /**
- * Sets the last access and last modified time of a file 
+ * Sets the last access and last modified time of a file
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C"
-int32_t UTime(const char* path, UTimBuf* time);
+extern "C" int32_t UTime(const char* path, UTimBuf* time);

--- a/src/Native/System.Native/pal_uid.cpp
+++ b/src/Native/System.Native/pal_uid.cpp
@@ -12,59 +12,52 @@
 #include <sys/types.h>
 #include <pwd.h>
 
-extern "C"
-int32_t GetPwUidR(
-	uint32_t  uid,
-	Passwd*   pwd,
-	char*     buf,
-	int32_t   buflen)
+extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
 {
-	assert(pwd != nullptr);
-	assert(buf != nullptr);
-	assert(buflen >= 0);
+    assert(pwd != nullptr);
+    assert(buf != nullptr);
+    assert(buflen >= 0);
 
-	if (buflen < 0)
-		return EINVAL;
+    if (buflen < 0)
+        return EINVAL;
 
-	struct passwd nativePwd;
-	struct passwd* result;
-	int error = getpwuid_r(uid, &nativePwd, buf, UnsignedCast(buflen), &result);
+    struct passwd nativePwd;
+    struct passwd* result;
+    int error = getpwuid_r(uid, &nativePwd, buf, UnsignedCast(buflen), &result);
 
-	// positive error number returned -> failure other than entry-not-found
-	if (error != 0)
-	{
-		assert(error > 0);
-		*pwd = { }; // managed out param must be initialized
-		return error;
-	}
+    // positive error number returned -> failure other than entry-not-found
+    if (error != 0)
+    {
+        assert(error > 0);
+        *pwd = {}; // managed out param must be initialized
+        return error;
+    }
 
-	// 0 returned with null result -> entry-not-found
-	if (result == nullptr)
-	{
-		*pwd = { }; // managed out param must be initialized
-		return -1;  // shim convention for entry-not-found
-	}
+    // 0 returned with null result -> entry-not-found
+    if (result == nullptr)
+    {
+        *pwd = {}; // managed out param must be initialized
+        return -1; // shim convention for entry-not-found
+    }
 
-	// 0 returned with non-null result (guaranteed to be set to pwd arg) -> success
-	assert(result == &nativePwd);
-	pwd->Name = nativePwd.pw_name;
-	pwd->Password = nativePwd.pw_passwd;
-	pwd->UserId = nativePwd.pw_uid;
-	pwd->GroupId = nativePwd.pw_gid;
-	pwd->UserInfo = nativePwd.pw_gecos;
-	pwd->HomeDirectory = nativePwd.pw_dir;
-	pwd->Shell = nativePwd.pw_shell;
-	return 0;
+    // 0 returned with non-null result (guaranteed to be set to pwd arg) -> success
+    assert(result == &nativePwd);
+    pwd->Name = nativePwd.pw_name;
+    pwd->Password = nativePwd.pw_passwd;
+    pwd->UserId = nativePwd.pw_uid;
+    pwd->GroupId = nativePwd.pw_gid;
+    pwd->UserInfo = nativePwd.pw_gecos;
+    pwd->HomeDirectory = nativePwd.pw_dir;
+    pwd->Shell = nativePwd.pw_shell;
+    return 0;
 }
 
-extern "C"
-uint32_t GetEUid()
+extern "C" uint32_t GetEUid()
 {
-	return geteuid();
+    return geteuid();
 }
 
-extern "C"
-uint32_t GetEGid()
+extern "C" uint32_t GetEGid()
 {
-	return getegid();
+    return getegid();
 }

--- a/src/Native/System.Native/pal_uid.h
+++ b/src/Native/System.Native/pal_uid.h
@@ -6,32 +6,28 @@
 #include "pal_types.h"
 
 /**
-* Passwd struct 
+* Passwd struct
 */
-struct Passwd {
-	char*    Name;
-	char*    Password; 
-	uint32_t UserId;
-	uint32_t GroupId;
-	char*    UserInfo;
-	char*    HomeDirectory;
-	char*    Shell;
+struct Passwd
+{
+    char* Name;
+    char* Password;
+    uint32_t UserId;
+    uint32_t GroupId;
+    char* UserInfo;
+    char* HomeDirectory;
+    char* Shell;
 };
 
 /**
-* Gets a password structure for the given uid. 
+* Gets a password structure for the given uid.
 * Implemented as shim to getpwuid_r(3).
 *
-* Returns 0 for success, -1 if no entry found, positive error 
+* Returns 0 for success, -1 if no entry found, positive error
 * number for any other failure.
 *
 */
-extern "C"
-int32_t GetPwUidR(
-	uint32_t uid,
-	Passwd*  pwd,
-	char*    buf,
-	int32_t  buflen);
+extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen);
 
 /**
 * Gets and returns the effective user's identity.
@@ -39,8 +35,7 @@ int32_t GetPwUidR(
 *
 * Always succeeds.
 */
-extern "C"
-uint32_t GetEUid();
+extern "C" uint32_t GetEUid();
 
 /**
 * Gets and returns the effective group's identity.
@@ -48,5 +43,4 @@ uint32_t GetEUid();
 *
 * Always succeeds.
 */
-extern "C"
-uint32_t GetEGid();
+extern "C" uint32_t GetEGid();

--- a/src/Native/System.Net.Http.Native/pal_curlinit.cpp
+++ b/src/Native/System.Net.Http.Native/pal_curlinit.cpp
@@ -7,10 +7,9 @@
 #include <pthread.h>
 #include <curl/curl.h>
 
-extern "C"
-int32_t EnsureCurlIsInitialized()
+extern "C" int32_t EnsureCurlIsInitialized()
 {
-    static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;    
+    static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
     static bool initializationAttempted = false;
     static int32_t errorCode = -1;
 
@@ -23,6 +22,6 @@ int32_t EnsureCurlIsInitialized()
         }
     }
     pthread_mutex_unlock(&lock);
- 
+
     return errorCode;
 }

--- a/src/Native/System.Net.Http.Native/pal_curlinit.h
+++ b/src/Native/System.Net.Http.Native/pal_curlinit.h
@@ -6,7 +6,7 @@
 #include "pal_types.h"
 
 /**
- * Initializes curl. 
+ * Initializes curl.
  *
  * Thread-safe and idempotent. Must be called before using any other curl function.
  * EnsureOpenSSLIsInitialized from System.Security.Cryptography.Native must already
@@ -14,5 +14,4 @@
  *
  * Returns 0 on success and non-zero on failure.
  */
-extern "C"
-int32_t EnsureCurlIsInitialized();
+extern "C" int32_t EnsureCurlIsInitialized();

--- a/src/Native/formatCode.sh
+++ b/src/Native/formatCode.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# OS X names clang-format as clang-format; Ubuntu uses
+# clang-format-version so check for the right one
+if which "clang-format-3.6" > /dev/null 2>&1 ; then
+   export CF="$(which clang-format-3.6)"
+elif which "clang-format" > /dev/null 2>&1 ; then
+   export CF="$(which clang-format)"
+else
+   echo "Unable to find clang-format"
+   exit 1
+fi
+
+for D in */; do
+    for file in "${D}"*.cpp; do
+        if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+        fi
+    done
+   
+    for file in "${D}"*.h ; do
+        if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+        fi
+    done
+
+   for file in "${D}"*.in ; do
+       if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+       fi
+   done
+done


### PR DESCRIPTION
Adding a clang-format file and a script to format every cpp and h file. This style is based on the LLVM style with some minor tweaks. This commit also ran the script against the current code to bring us into compliance. This fixes #3051

/cc @nguerrera @stephentoub 