### PR TITLE
Fail the build when native dependencies are missing, fix `build.sh native clean`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 usage()
 {
     echo "Usage: $0 [managed] [native] [BuildArch] [BuildType] [clean] [verbose] [clangx.y]"
-    echo "manged - optional argument to build the managed code"
+    echo "managed - optional argument to build the managed code"
     echo "native - optional argument to build the native code"
     echo "The following arguments affect native builds only:"
     echo "BuildArch can be: x64, arm"
@@ -30,6 +30,7 @@ clean()
     echo "Cleaning previous output for the selected configuration"
     rm -rf "$__BinDir"
     rm -rf "$__IntermediatesDir"
+    setup_dirs
 }
 
 # Check the system to ensure the right pre-reqs are in place

--- a/src/Native/System.Net.Http.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Http.Native/CMakeLists.txt
@@ -2,7 +2,7 @@ project(System.Net.Http.Native)
 
 find_library(CURL NAMES curl)
 if(CURL STREQUAL CURL-NOTFOUND)
-    message(WARNING "Cannot find libcurl, skipping build for System.Net.Http.Native. .NET HttpClient is not expected to function. Try installing libcurl4-dev (or the appropriate package for your platform)")
+    message(SEND_ERROR "!!! Cannot find libcurl and System.Net.Http.Native cannot build without it. Try installing libcurl4-openssl-dev (or the appropriate package for your platform) !!!")
     return()
 endif()
 

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -13,7 +13,7 @@ add_definitions(-DPIC=1)
 
 find_library(CRYPTO NAMES crypto)
 if(CRYPTO STREQUAL CRYPTO-NOTFOUND)
-    message(WARNING "Cannot find libcrypto, skipping build for System.Security.Cryptography.Native. .NET cryptography is not expected to function. Try installing libssl-dev (or the appropriate package for your platform)")
+    message(SEND_ERROR "!!! Cannot find libcrypto and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!")
     return()
 endif()
 


### PR DESCRIPTION
Two small, unrelated build fixes in two separate commits:

(1) **Fail the build when native dependencies are missing**  

Previously, we just warned.

(2) **Fix for `build.sh native clean` not working as expected**

We were failing to cd to the bin directory and CMake would spew files all over the the working directory and then put things in a bad state where builds would fail until a git clean was performed.

This was broken by the recent merge of managed and native builds into one script.

There's a lot of room to tighten up this script's error handling, but in the meantime this is the minimal fix, which makes clean() recreate dirs as the comment above it says that it should.

Also fixed a typo: s/manged/managed/

cc @stephentoub @sokket 