### PR TITLE
Use optimized N-ary MethodCallExpression nodes from all Call factories

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -149,7 +149,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpressionN : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpressionN : MethodCallExpression, IArgumentProvider
     {
         private IList<Expression> _arguments;
 
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpressionN : InstanceMethodCallExpression, IArgumentProvider
+    internal sealed class InstanceMethodCallExpressionN : InstanceMethodCallExpression, IArgumentProvider
     {
         private IList<Expression> _arguments;
 
@@ -223,7 +223,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpression0 : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpression0 : MethodCallExpression, IArgumentProvider
     {
         public MethodCallExpression0(MethodInfo method)
             : base(method)
@@ -257,7 +257,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpression1 : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpression1 : MethodCallExpression, IArgumentProvider
     {
         private object _arg0;       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
 
@@ -303,7 +303,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpression2 : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpression2 : MethodCallExpression, IArgumentProvider
     {
         private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;  // storage for the 2nd arg
@@ -351,7 +351,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpression3 : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpression3 : MethodCallExpression, IArgumentProvider
     {
         private object _arg0;           // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2; // storage for the 2nd - 3rd args.
@@ -401,7 +401,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpression4 : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpression4 : MethodCallExpression, IArgumentProvider
     {
         private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2, _arg3;  // storage for the 2nd - 4th args.
@@ -453,7 +453,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class MethodCallExpression5 : MethodCallExpression, IArgumentProvider
+    internal sealed class MethodCallExpression5 : MethodCallExpression, IArgumentProvider
     {
         private object _arg0;           // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2, _arg3, _arg4;   // storage for the 2nd - 5th args.
@@ -508,7 +508,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression0 : InstanceMethodCallExpression, IArgumentProvider
+    internal sealed class InstanceMethodCallExpression0 : InstanceMethodCallExpression, IArgumentProvider
     {
         public InstanceMethodCallExpression0(MethodInfo method, Expression instance)
             : base(method, instance)
@@ -542,7 +542,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression1 : InstanceMethodCallExpression, IArgumentProvider
+    internal sealed class InstanceMethodCallExpression1 : InstanceMethodCallExpression, IArgumentProvider
     {
         private object _arg0;                // storage for the 1st argument or a readonly collection.  See IArgumentProvider
 
@@ -587,7 +587,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression2 : InstanceMethodCallExpression, IArgumentProvider
+    internal sealed class InstanceMethodCallExpression2 : InstanceMethodCallExpression, IArgumentProvider
     {
         private object _arg0;                // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;   // storage for the 2nd argument
@@ -635,7 +635,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression3 : InstanceMethodCallExpression, IArgumentProvider
+    internal sealed class InstanceMethodCallExpression3 : InstanceMethodCallExpression, IArgumentProvider
     {
         private object _arg0;                       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2;   // storage for the 2nd - 3rd argument
@@ -1046,7 +1046,9 @@ namespace System.Linq.Expressions
 
             if (argumentList != null)
             {
-                switch (argumentList.Count)
+                int argCount = argumentList.Count;
+
+                switch (argCount)
                 {
                     case 0:
                         return Call(instance, method);
@@ -1060,7 +1062,7 @@ namespace System.Linq.Expressions
 
                 if (instance == null)
                 {
-                    switch (argumentList.Count)
+                    switch (argCount)
                     {
                         case 4:
                             return Call(method, argumentList[0], argumentList[1], argumentList[2], argumentList[3]);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -131,6 +131,24 @@ namespace System.Linq.Expressions
 
     #region Specialized Subclasses
 
+    internal class InstanceMethodCallExpression : MethodCallExpression, IArgumentProvider
+    {
+        private readonly Expression _instance;
+
+        public InstanceMethodCallExpression(MethodInfo method, Expression instance)
+            : base(method)
+        {
+            Debug.Assert(instance != null);
+
+            _instance = instance;
+        }
+
+        internal override Expression GetInstance()
+        {
+            return _instance;
+        }
+    }
+
     internal class MethodCallExpressionN : MethodCallExpression, IArgumentProvider
     {
         private IList<Expression> _arguments;
@@ -168,15 +186,13 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpressionN : MethodCallExpression, IArgumentProvider
+    internal class InstanceMethodCallExpressionN : InstanceMethodCallExpression, IArgumentProvider
     {
         private IList<Expression> _arguments;
-        private readonly Expression _instance;
 
         public InstanceMethodCallExpressionN(MethodInfo method, Expression instance, IList<Expression> args)
-            : base(method)
+            : base(method, instance)
         {
-            _instance = instance;
             _arguments = args;
         }
 
@@ -191,11 +207,6 @@ namespace System.Linq.Expressions
             {
                 return _arguments.Count;
             }
-        }
-
-        internal override Expression GetInstance()
-        {
-            return _instance;
         }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
@@ -497,16 +508,11 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression0 : MethodCallExpression, IArgumentProvider
+    internal class InstanceMethodCallExpression0 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private readonly Expression _instance;
-
         public InstanceMethodCallExpression0(MethodInfo method, Expression instance)
-            : base(method)
+            : base(method, instance)
         {
-            Debug.Assert(instance != null);
-
-            _instance = instance;
         }
 
         public override Expression GetArgument(int index)
@@ -520,11 +526,6 @@ namespace System.Linq.Expressions
             {
                 return 0;
             }
-        }
-
-        internal override Expression GetInstance()
-        {
-            return _instance;
         }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
@@ -541,17 +542,13 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression1 : MethodCallExpression, IArgumentProvider
+    internal class InstanceMethodCallExpression1 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private readonly Expression _instance;
         private object _arg0;                // storage for the 1st argument or a readonly collection.  See IArgumentProvider
 
         public InstanceMethodCallExpression1(MethodInfo method, Expression instance, Expression arg0)
-            : base(method)
+            : base(method, instance)
         {
-            Debug.Assert(instance != null);
-
-            _instance = instance;
             _arg0 = arg0;
         }
 
@@ -572,11 +569,6 @@ namespace System.Linq.Expressions
             }
         }
 
-        internal override Expression GetInstance()
-        {
-            return _instance;
-        }
-
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             return ReturnReadOnly(this, ref _arg0);
@@ -595,18 +587,14 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression2 : MethodCallExpression, IArgumentProvider
+    internal class InstanceMethodCallExpression2 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private readonly Expression _instance;
         private object _arg0;                // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;   // storage for the 2nd argument
 
         public InstanceMethodCallExpression2(MethodInfo method, Expression instance, Expression arg0, Expression arg1)
-            : base(method)
+            : base(method, instance)
         {
-            Debug.Assert(instance != null);
-
-            _instance = instance;
             _arg0 = arg0;
             _arg1 = arg1;
         }
@@ -629,11 +617,6 @@ namespace System.Linq.Expressions
             }
         }
 
-        internal override Expression GetInstance()
-        {
-            return _instance;
-        }
-
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             return ReturnReadOnly(this, ref _arg0);
@@ -652,18 +635,14 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InstanceMethodCallExpression3 : MethodCallExpression, IArgumentProvider
+    internal class InstanceMethodCallExpression3 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private readonly Expression _instance;
         private object _arg0;                       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2;   // storage for the 2nd - 3rd argument
 
         public InstanceMethodCallExpression3(MethodInfo method, Expression instance, Expression arg0, Expression arg1, Expression arg2)
-            : base(method)
+            : base(method, instance)
         {
-            Debug.Assert(instance != null);
-
-            _instance = instance;
             _arg0 = arg0;
             _arg1 = arg1;
             _arg2 = arg2;
@@ -686,11 +665,6 @@ namespace System.Linq.Expressions
             {
                 return 3;
             }
-        }
-
-        internal override Expression GetInstance()
-        {
-            return _instance;
         }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -1,0 +1,249 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests
+{
+    public static class CallFactoryTests
+    {
+        [Fact]
+        public static void CheckCallFactoryOptimizationInstance1()
+        {
+            AssertCallIsOptimizedInstance(1);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationInstance2()
+        {
+            var expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I2"), Expression.Constant(0), Expression.Constant(1));
+
+            AssertInstanceMethodCall(2, expr);
+
+            AssertCallIsOptimizedInstance(2);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationInstance3()
+        {
+            var expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
+
+            AssertInstanceMethodCall(3, expr);
+
+            AssertCallIsOptimizedInstance(3);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationStatic1()
+        {
+            var expr = Expression.Call(typeof(MS).GetMethod("S1"), Expression.Constant(0));
+
+            AssertStaticMethodCall(1, expr);
+
+            AssertCallIsOptimizedStatic(1);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationStatic2()
+        {
+            var expr1 = Expression.Call(typeof(MS).GetMethod("S2"), Expression.Constant(0), Expression.Constant(1));
+            var expr2 = Expression.Call(null, typeof(MS).GetMethod("S2"), Expression.Constant(0), Expression.Constant(1));
+
+            AssertStaticMethodCall(2, expr1);
+            AssertStaticMethodCall(2, expr2);
+
+            AssertCallIsOptimizedStatic(2);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationStatic3()
+        {
+            var expr1 = Expression.Call(typeof(MS).GetMethod("S3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
+            var expr2 = Expression.Call(null, typeof(MS).GetMethod("S3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
+
+            AssertStaticMethodCall(3, expr1);
+            AssertStaticMethodCall(3, expr2);
+
+            AssertCallIsOptimizedStatic(3);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationStatic4()
+        {
+            var expr = Expression.Call(typeof(MS).GetMethod("S4"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3));
+
+            AssertStaticMethodCall(4, expr);
+
+            AssertCallIsOptimizedStatic(4);
+        }
+
+        [Fact]
+        public static void CheckCallFactoryOptimizationStatic5()
+        {
+            var expr = Expression.Call(typeof(MS).GetMethod("S5"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3), Expression.Constant(4));
+
+            AssertStaticMethodCall(5, expr);
+
+            AssertCallIsOptimizedStatic(5);
+        }
+
+        [Fact]
+        public static void CheckArrayIndexOptimization1()
+        {
+            var instance = Expression.Parameter(typeof(int[]));
+            var args = new[] { Expression.Constant(0) };
+            var expr = Expression.ArrayIndex(instance, args);
+            var method = typeof(int[]).GetMethod("Get", BindingFlags.Public | BindingFlags.Instance);
+
+            AssertCallIsOptimized(expr, instance, method, args);
+        }
+
+        [Fact]
+        public static void CheckArrayIndexOptimization2()
+        {
+            var instance = Expression.Parameter(typeof(int[,]));
+            var args = new[] { Expression.Constant(0), Expression.Constant(0) };
+            var expr = Expression.ArrayIndex(instance, args);
+            var method = typeof(int[,]).GetMethod("Get", BindingFlags.Public | BindingFlags.Instance);
+
+            AssertCallIsOptimized(expr, instance, method, args);
+        }
+
+        private static void AssertCallIsOptimizedInstance(int n)
+        {
+            var method = typeof(MS).GetMethod("I" + n);
+
+            AssertCallIsOptimized(method);
+        }
+
+        private static void AssertCallIsOptimizedStatic(int n)
+        {
+            var method = typeof(MS).GetMethod("S" + n);
+
+            AssertCallIsOptimized(method);
+        }
+
+        private static void AssertCallIsOptimized(MethodInfo method)
+        {
+            var instance = method.IsStatic ? null : Expression.Parameter(method.DeclaringType);
+
+            var n = method.GetParameters().Length;
+
+            // Expression[] overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                var expr = Expression.Call(instance, method, args);
+
+                AssertCallIsOptimized(expr, instance, method, args);
+            }
+
+            // IEnumerable<Expression> overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                var expr = Expression.Call(instance, method, args);
+
+                AssertCallIsOptimized(expr, instance, method, args);
+            }
+        }
+
+        private static void AssertCallIsOptimized(MethodCallExpression expr, Expression instance, MethodInfo method, IReadOnlyList<Expression> args)
+        {
+            var n = method.GetParameters().Length;
+
+            var updated = Update(expr);
+            var visited = Visit(expr);
+
+            foreach (var node in new[] { expr, updated, visited })
+            {
+                Assert.Same(instance, node.Object);
+                Assert.Same(method, node.Method);
+
+                if (method.IsStatic)
+                {
+                    AssertStaticMethodCall(n, node);
+                }
+                else
+                {
+                    AssertInstanceMethodCall(n, node);
+                }
+
+                var argProvider = node as IArgumentProvider;
+                Assert.NotNull(argProvider);
+
+                Assert.Equal(n, argProvider.ArgumentCount);
+
+                if (node != visited) // our visitor clones argument nodes
+                {
+                    for (var i = 0; i < n; i++)
+                    {
+                        Assert.Same(args[i], argProvider.GetArgument(i));
+                        Assert.Same(args[i], node.Arguments[i]);
+                    }
+                }
+            }
+        }
+
+        private static void AssertStaticMethodCall(int n, object obj)
+        {
+            AssertTypeName("MethodCallExpression" + n, obj);
+        }
+
+        private static void AssertInstanceMethodCall(int n, object obj)
+        {
+            AssertTypeName("InstanceMethodCallExpression" + n, obj);
+        }
+
+        private static void AssertTypeName(string expected, object obj)
+        {
+            Assert.Equal(expected, obj.GetType().Name);
+        }
+
+        private static MethodCallExpression Update(MethodCallExpression node)
+        {
+            // Tests the call of Update to Expression.Call factories.
+
+            var res = node.Update(node.Object, node.Arguments.ToArray());
+
+            Assert.NotSame(node, res);
+
+            return res;
+        }
+
+        private static MethodCallExpression Visit(MethodCallExpression node)
+        {
+            // Tests dispatch of ExpressionVisitor into Rewrite method which calls Expression.Call factories.
+
+            return (MethodCallExpression)new Visitor().Visit(node);
+        }
+
+        class Visitor : ExpressionVisitor
+        {
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                return Expression.Constant(node.Value, node.Type); // clones
+            }
+        }
+    }
+
+    public class MS
+    {
+        public void I0() { }
+        public void I1(int a) { }
+        public void I2(int a, int b) { }
+        public void I3(int a, int b, int c) { }
+        public void I4(int a, int b, int c, int d) { }
+        public void I5(int a, int b, int c, int d, int e) { }
+
+        public static void S0() { }
+        public static void S1(int a) { }
+        public static void S2(int a, int b) { }
+        public static void S3(int a, int b, int c) { }
+        public static void S4(int a, int b, int c, int d) { }
+        public static void S5(int a, int b, int c, int d, int e) { }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BinaryOperators\Comparison\BinaryNullableNotEqualTests.cs" />
     <Compile Include="BinaryOperators\Logical\BinaryLogicalTests.cs" />
     <Compile Include="BinaryOperators\Logical\BinaryNullableLogicalTests.cs" />
+    <Compile Include="Call\CallFactoryTests.cs" />
     <Compile Include="Cast\AsNullable.cs" />
     <Compile Include="Cast\AsTests.cs" />
     <Compile Include="Cast\CastNullableTests.cs" />


### PR DESCRIPTION
This PR contains a proposed change for issue #3266 to optimize N-ary MethodCallExpression nodes, even when constructed through the overloads that take Expression[] or IEnumerable<Expression> (e.g. as emitted by the compilers). This is similar to the approach taken by BlockExpression.

It's worth noting that those Call factory methods are invoked from a few other places than the public API, e.g. from the Update and Rewrite methods used by visitors, and from ArrayIndex factories. As such, those benefit as well.

The change also includes the addition of a 0-ary and 1-ary optimized nodes that were missing, despite there being a lot of methods that match this signature. To reduce code size a bit, I've factored the common pieces of instance method call expression nodes into an internal base class.

Note that this change does not introduce public API changes (see comments in the PR). Those would cause compile-time ambiguities or overload selection changes for calls with null:

Expression.Call(null) would change from (MethodInfo, params Expression[]) to (MethodInfo)
Expression.Call(e, m, null) would change frrom (Expression, MethodInfo, Expression[]) to (Expression, MethodInfo, Expression)

I'm not sure whether compile-time compat for method invocations with null literals is worth pursuing if it prevents the addition of useful overloads. In this case, we can get away without adding those public overloads. Note that while I was doing similar work for InvocationExpression optimizations (see #3245), I ran into a test where a null literal was passed and the addition of a public overload caused a compile-time failure, so it's not far-fetched. The use-site fix would be easy using default(T), but it's still a break.