### PR TITLE
Adding optimized N-ary InvocationExpression nodes

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -504,7 +504,7 @@ namespace System.Linq.Expressions.Compiler
 
                 if (cr.Rewrite || spiller._lambdaRewrite != RewriteAction.None)
                 {
-                    node = new InvocationExpression(lambda, cr[0, -1], node.Type);
+                    node = node.Rewrite(lambda, cr[0, -1]);
                 }
 
                 Result result = cr.Finish(node);
@@ -524,7 +524,7 @@ namespace System.Linq.Expressions.Compiler
                 RequireNoRefArgs(Expression.GetInvokeMethod(node.Expression));
             }
 
-            return cr.Finish(cr.Rewrite ? new InvocationExpression(cr[0], cr[1, -1], node.Type) : expr);
+            return cr.Finish(cr.Rewrite ? node.Rewrite(cr[0], cr[1, -1]) : expr);
         }
 
         // NewExpression

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -120,6 +120,8 @@ namespace System.Linq.Expressions
         }
     }
 
+    #region Specialized Subclasses
+
     internal class InvocationExpressionN : InvocationExpression
     {
         private IList<Expression> _arguments;
@@ -157,8 +159,561 @@ namespace System.Linq.Expressions
         }
     }
 
+    internal class InvocationExpression0 : InvocationExpression
+    {
+        public InvocationExpression0(Expression lambda, Type returnType)
+            : base(lambda, returnType)
+        {
+        }
+
+        internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
+        {
+            return EmptyReadOnlyCollection<Expression>.Instance;
+        }
+
+        public override Expression GetArgument(int index)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override int ArgumentCount
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        internal override InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
+        {
+            Debug.Assert(lambda != null);
+            Debug.Assert(arguments == null || arguments.Length == 0);
+
+            return Expression.Invoke(lambda);
+        }
+    }
+
+    internal class InvocationExpression1 : InvocationExpression
+    {
+        private object _arg0;       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+
+        public InvocationExpression1(Expression lambda, Type returnType, Expression arg0)
+            : base(lambda, returnType)
+        {
+            _arg0 = arg0;
+        }
+
+        internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
+        {
+            return ReturnReadOnly(this, ref _arg0);
+        }
+
+        public override Expression GetArgument(int index)
+        {
+            switch (index)
+            {
+                case 0: return ReturnObject<Expression>(_arg0);
+                default: throw new InvalidOperationException();
+            }
+        }
+
+        public override int ArgumentCount
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        internal override InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
+        {
+            Debug.Assert(lambda != null);
+            Debug.Assert(arguments == null || arguments.Length == 1);
+
+            if (arguments != null)
+            {
+                return Expression.Invoke(lambda, arguments[0]);
+            }
+            return Expression.Invoke(lambda, ReturnObject<Expression>(_arg0));
+        }
+    }
+
+    internal class InvocationExpression2 : InvocationExpression
+    {
+        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd arg
+
+        public InvocationExpression2(Expression lambda, Type returnType, Expression arg0, Expression arg1)
+            : base(lambda, returnType)
+        {
+            _arg0 = arg0;
+            _arg1 = arg1;
+        }
+
+        internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
+        {
+            return ReturnReadOnly(this, ref _arg0);
+        }
+
+        public override Expression GetArgument(int index)
+        {
+            switch (index)
+            {
+                case 0: return ReturnObject<Expression>(_arg0);
+                case 1: return _arg1;
+                default: throw new InvalidOperationException();
+            }
+        }
+
+        public override int ArgumentCount
+        {
+            get
+            {
+                return 2;
+            }
+        }
+
+        internal override InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
+        {
+            Debug.Assert(lambda != null);
+            Debug.Assert(arguments == null || arguments.Length == 2);
+
+            if (arguments != null)
+            {
+                return Expression.Invoke(lambda, arguments[0], arguments[1]);
+            }
+            return Expression.Invoke(lambda, ReturnObject<Expression>(_arg0), _arg1);
+        }
+    }
+
+    internal class InvocationExpression3 : InvocationExpression
+    {
+        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd arg
+        private readonly Expression _arg2;  // storage for the 3rd arg
+
+        public InvocationExpression3(Expression lambda, Type returnType, Expression arg0, Expression arg1, Expression arg2)
+            : base(lambda, returnType)
+        {
+            _arg0 = arg0;
+            _arg1 = arg1;
+            _arg2 = arg2;
+        }
+
+        internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
+        {
+            return ReturnReadOnly(this, ref _arg0);
+        }
+
+        public override Expression GetArgument(int index)
+        {
+            switch (index)
+            {
+                case 0: return ReturnObject<Expression>(_arg0);
+                case 1: return _arg1;
+                case 2: return _arg2;
+                default: throw new InvalidOperationException();
+            }
+        }
+
+        public override int ArgumentCount
+        {
+            get
+            {
+                return 3;
+            }
+        }
+
+        internal override InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
+        {
+            Debug.Assert(lambda != null);
+            Debug.Assert(arguments == null || arguments.Length == 3);
+
+            if (arguments != null)
+            {
+                return Expression.Invoke(lambda, arguments[0], arguments[1], arguments[2]);
+            }
+            return Expression.Invoke(lambda, ReturnObject<Expression>(_arg0), _arg1, _arg2);
+        }
+    }
+
+    internal class InvocationExpression4 : InvocationExpression
+    {
+        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd arg
+        private readonly Expression _arg2;  // storage for the 3rd arg
+        private readonly Expression _arg3;  // storage for the 4th arg
+
+        public InvocationExpression4(Expression lambda, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
+            : base(lambda, returnType)
+        {
+            _arg0 = arg0;
+            _arg1 = arg1;
+            _arg2 = arg2;
+            _arg3 = arg3;
+        }
+
+        internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
+        {
+            return ReturnReadOnly(this, ref _arg0);
+        }
+
+        public override Expression GetArgument(int index)
+        {
+            switch (index)
+            {
+                case 0: return ReturnObject<Expression>(_arg0);
+                case 1: return _arg1;
+                case 2: return _arg2;
+                case 3: return _arg3;
+                default: throw new InvalidOperationException();
+            }
+        }
+
+        public override int ArgumentCount
+        {
+            get
+            {
+                return 4;
+            }
+        }
+
+        internal override InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
+        {
+            Debug.Assert(lambda != null);
+            Debug.Assert(arguments == null || arguments.Length == 4);
+
+            if (arguments != null)
+            {
+                return Expression.Invoke(lambda, arguments[0], arguments[1], arguments[2], arguments[3]);
+            }
+            return Expression.Invoke(lambda, ReturnObject<Expression>(_arg0), _arg1, _arg2, _arg3);
+        }
+    }
+
+    internal class InvocationExpression5 : InvocationExpression
+    {
+        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd arg
+        private readonly Expression _arg2;  // storage for the 3rd arg
+        private readonly Expression _arg3;  // storage for the 4th arg
+        private readonly Expression _arg4;  // storage for the 5th arg
+
+        public InvocationExpression5(Expression lambda, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
+            : base(lambda, returnType)
+        {
+            _arg0 = arg0;
+            _arg1 = arg1;
+            _arg2 = arg2;
+            _arg3 = arg3;
+            _arg4 = arg4;
+        }
+
+        internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
+        {
+            return ReturnReadOnly(this, ref _arg0);
+        }
+
+        public override Expression GetArgument(int index)
+        {
+            switch (index)
+            {
+                case 0: return ReturnObject<Expression>(_arg0);
+                case 1: return _arg1;
+                case 2: return _arg2;
+                case 3: return _arg3;
+                case 4: return _arg4;
+                default: throw new InvalidOperationException();
+            }
+        }
+
+        public override int ArgumentCount
+        {
+            get
+            {
+                return 5;
+            }
+        }
+
+        internal override InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
+        {
+            Debug.Assert(lambda != null);
+            Debug.Assert(arguments == null || arguments.Length == 5);
+
+            if (arguments != null)
+            {
+                return Expression.Invoke(lambda, arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+            }
+            return Expression.Invoke(lambda, ReturnObject<Expression>(_arg0), _arg1, _arg2, _arg3, _arg4);
+        }
+    }
+
+    #endregion
+
     public partial class Expression
     {
+        ///<summary>
+        ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies a delegate or lambda expression with no arguments.
+        ///</summary>
+        ///<returns>
+        ///An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies the specified delegate or lambda expression.
+        ///</returns>
+        ///<param name="expression">
+        ///An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate
+        ///or lambda expression to be applied.
+        ///</param>
+        ///<exception cref="T:System.ArgumentNullException">
+        ///<paramref name="expression" /> is null.</exception>
+        ///<exception cref="T:System.ArgumentException">
+        ///<paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.</exception>
+        ///<exception cref="T:System.InvalidOperationException">
+        ///The number of arguments does not contain match the number of parameters for the delegate represented by <paramref name="expression" />.</exception>
+        internal static InvocationExpression Invoke(Expression expression)
+        {
+            // COMPAT: This method is marked as non-public to avoid a gap between a 0-ary and 2-ary overload (see remark for the unary case below).
+
+            RequiresCanRead(expression, "expression");
+
+            var method = GetInvokeMethod(expression);
+
+            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+
+            ValidateArgumentCount(method, ExpressionType.Invoke, 0, pis);
+
+            return new InvocationExpression0(expression, method.ReturnType);
+        }
+
+        ///<summary>
+        ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies a delegate or lambda expression to one argument expression.
+        ///</summary>
+        ///<returns>
+        ///An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies the specified delegate or lambda expression to the provided arguments.
+        ///</returns>
+        ///<param name="expression">
+        ///An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate
+        ///or lambda expression to be applied.
+        ///</param>
+        ///<param name="arg0">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.
+        ///</param>
+        ///<exception cref="T:System.ArgumentNullException">
+        ///<paramref name="expression" /> is null.</exception>
+        ///<exception cref="T:System.ArgumentException">
+        ///<paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an arugment expression is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
+        ///<exception cref="T:System.InvalidOperationException">
+        ///The number of arguments does not contain match the number of parameters for the delegate represented by <paramref name="expression" />.</exception>
+        internal static InvocationExpression Invoke(Expression expression, Expression arg0)
+        {
+            // COMPAT: This method is marked as non-public to ensure compile-time compatibility for Expression.Invoke(e, null).
+
+            RequiresCanRead(expression, "expression");
+
+            var method = GetInvokeMethod(expression);
+
+            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+
+            ValidateArgumentCount(method, ExpressionType.Invoke, 1, pis);
+
+            arg0 = ValidateOneArgument(method, ExpressionType.Invoke, arg0, pis[0]);
+
+            return new InvocationExpression1(expression, method.ReturnType, arg0);
+        }
+
+        ///<summary>
+        ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies a delegate or lambda expression to two argument expressions.
+        ///</summary>
+        ///<returns>
+        ///An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies the specified delegate or lambda expression to the provided arguments.
+        ///</returns>
+        ///<param name="expression">
+        ///An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate
+        ///or lambda expression to be applied.
+        ///</param>
+        ///<param name="arg0">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.
+        ///</param>
+        ///<param name="arg1">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.
+        ///</param>
+        ///<exception cref="T:System.ArgumentNullException">
+        ///<paramref name="expression" /> is null.</exception>
+        ///<exception cref="T:System.ArgumentException">
+        ///<paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an arugment expression is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
+        ///<exception cref="T:System.InvalidOperationException">
+        ///The number of arguments does not contain match the number of parameters for the delegate represented by <paramref name="expression" />.</exception>
+        internal static InvocationExpression Invoke(Expression expression, Expression arg0, Expression arg1)
+        {
+            // NB: This method is marked as non-public to avoid public API additions at this point.
+            RequiresCanRead(expression, "expression");
+
+            var method = GetInvokeMethod(expression);
+
+            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+
+            ValidateArgumentCount(method, ExpressionType.Invoke, 2, pis);
+
+            arg0 = ValidateOneArgument(method, ExpressionType.Invoke, arg0, pis[0]);
+            arg1 = ValidateOneArgument(method, ExpressionType.Invoke, arg1, pis[1]);
+
+            return new InvocationExpression2(expression, method.ReturnType, arg0, arg1);
+        }
+
+        ///<summary>
+        ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies a delegate or lambda expression to three argument expressions.
+        ///</summary>
+        ///<returns>
+        ///An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies the specified delegate or lambda expression to the provided arguments.
+        ///</returns>
+        ///<param name="expression">
+        ///An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate
+        ///or lambda expression to be applied.
+        ///</param>
+        ///<param name="arg0">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.
+        ///</param>
+        ///<param name="arg1">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.
+        ///</param>
+        ///<param name="arg2">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the third argument.
+        ///</param>
+        ///<exception cref="T:System.ArgumentNullException">
+        ///<paramref name="expression" /> is null.</exception>
+        ///<exception cref="T:System.ArgumentException">
+        ///<paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an arugment expression is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
+        ///<exception cref="T:System.InvalidOperationException">
+        ///The number of arguments does not contain match the number of parameters for the delegate represented by <paramref name="expression" />.</exception>
+        internal static InvocationExpression Invoke(Expression expression, Expression arg0, Expression arg1, Expression arg2)
+        {
+            // NB: This method is marked as non-public to avoid public API additions at this point.
+
+            RequiresCanRead(expression, "expression");
+
+            var method = GetInvokeMethod(expression);
+
+            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+
+            ValidateArgumentCount(method, ExpressionType.Invoke, 3, pis);
+
+            arg0 = ValidateOneArgument(method, ExpressionType.Invoke, arg0, pis[0]);
+            arg1 = ValidateOneArgument(method, ExpressionType.Invoke, arg1, pis[1]);
+            arg2 = ValidateOneArgument(method, ExpressionType.Invoke, arg2, pis[2]);
+
+            return new InvocationExpression3(expression, method.ReturnType, arg0, arg1, arg2);
+        }
+
+        ///<summary>
+        ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies a delegate or lambda expression to four argument expressions.
+        ///</summary>
+        ///<returns>
+        ///An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies the specified delegate or lambda expression to the provided arguments.
+        ///</returns>
+        ///<param name="expression">
+        ///An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate
+        ///or lambda expression to be applied.
+        ///</param>
+        ///<param name="arg0">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.
+        ///</param>
+        ///<param name="arg1">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.
+        ///</param>
+        ///<param name="arg2">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the third argument.
+        ///</param>
+        ///<param name="arg3">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the fourth argument.
+        ///</param>
+        ///<exception cref="T:System.ArgumentNullException">
+        ///<paramref name="expression" /> is null.</exception>
+        ///<exception cref="T:System.ArgumentException">
+        ///<paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an arugment expression is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
+        ///<exception cref="T:System.InvalidOperationException">
+        ///The number of arguments does not contain match the number of parameters for the delegate represented by <paramref name="expression" />.</exception>
+        internal static InvocationExpression Invoke(Expression expression, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
+        {
+            // NB: This method is marked as non-public to avoid public API additions at this point.
+
+            RequiresCanRead(expression, "expression");
+
+            var method = GetInvokeMethod(expression);
+
+            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+
+            ValidateArgumentCount(method, ExpressionType.Invoke, 4, pis);
+
+            arg0 = ValidateOneArgument(method, ExpressionType.Invoke, arg0, pis[0]);
+            arg1 = ValidateOneArgument(method, ExpressionType.Invoke, arg1, pis[1]);
+            arg2 = ValidateOneArgument(method, ExpressionType.Invoke, arg2, pis[2]);
+            arg3 = ValidateOneArgument(method, ExpressionType.Invoke, arg3, pis[3]);
+
+            return new InvocationExpression4(expression, method.ReturnType, arg0, arg1, arg2, arg3);
+        }
+
+        ///<summary>
+        ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies a delegate or lambda expression to five argument expressions.
+        ///</summary>
+        ///<returns>
+        ///An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
+        ///applies the specified delegate or lambda expression to the provided arguments.
+        ///</returns>
+        ///<param name="expression">
+        ///An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate
+        ///or lambda expression to be applied.
+        ///</param>
+        ///<param name="arg0">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.
+        ///</param>
+        ///<param name="arg1">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.
+        ///</param>
+        ///<param name="arg2">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the third argument.
+        ///</param>
+        ///<param name="arg3">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the fourth argument.
+        ///</param>
+        ///<param name="arg4">
+        ///The <see cref="T:System.Linq.Expressions.Expression" /> that represents the fifth argument.
+        ///</param>
+        ///<exception cref="T:System.ArgumentNullException">
+        ///<paramref name="expression" /> is null.</exception>
+        ///<exception cref="T:System.ArgumentException">
+        ///<paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an arugment expression is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
+        ///<exception cref="T:System.InvalidOperationException">
+        ///The number of arguments does not contain match the number of parameters for the delegate represented by <paramref name="expression" />.</exception>
+        internal static InvocationExpression Invoke(Expression expression, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
+        {
+            // NB: This method is marked as non-public to avoid public API additions at this point.
+
+            RequiresCanRead(expression, "expression");
+
+            var method = GetInvokeMethod(expression);
+
+            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+
+            ValidateArgumentCount(method, ExpressionType.Invoke, 5, pis);
+
+            arg0 = ValidateOneArgument(method, ExpressionType.Invoke, arg0, pis[0]);
+            arg1 = ValidateOneArgument(method, ExpressionType.Invoke, arg1, pis[1]);
+            arg2 = ValidateOneArgument(method, ExpressionType.Invoke, arg2, pis[2]);
+            arg3 = ValidateOneArgument(method, ExpressionType.Invoke, arg3, pis[3]);
+            arg4 = ValidateOneArgument(method, ExpressionType.Invoke, arg4, pis[4]);
+
+            return new InvocationExpression5(expression, method.ReturnType, arg0, arg1, arg2, arg3, arg4);
+        }
+
         ///<summary>
         ///Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that 
         ///applies a delegate or lambda expression to a list of argument expressions.
@@ -210,6 +765,27 @@ namespace System.Linq.Expressions
         ///<paramref name="arguments" /> does not contain the same number of elements as the list of parameters for the delegate represented by <paramref name="expression" />.</exception>
         public static InvocationExpression Invoke(Expression expression, IEnumerable<Expression> arguments)
         {
+            var argumentList = arguments as IReadOnlyList<Expression>;
+
+            if (argumentList != null)
+            {
+                switch (argumentList.Count)
+                {
+                    case 0:
+                        return Invoke(expression);
+                    case 1:
+                        return Invoke(expression, argumentList[0]);
+                    case 2:
+                        return Invoke(expression, argumentList[0], argumentList[1]);
+                    case 3:
+                        return Invoke(expression, argumentList[0], argumentList[1], argumentList[2]);
+                    case 4:
+                        return Invoke(expression, argumentList[0], argumentList[1], argumentList[2], argumentList[3]);
+                    case 5:
+                        return Invoke(expression, argumentList[0], argumentList[1], argumentList[2], argumentList[3], argumentList[4]);
+                }
+            }
+
             RequiresCanRead(expression, "expression");
 
             var args = arguments.ToReadOnly();

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests
+{
+    public static class InvokeFactoryTests
+    {
+        [Fact]
+        public static void CheckInvokeFactoryOptimization0()
+        {
+            AssertInvokeIsOptimized(0);
+        }
+
+        [Fact]
+        public static void CheckInvokeFactoryOptimization1()
+        {
+            AssertInvokeIsOptimized(1);
+        }
+
+        [Fact]
+        public static void CheckInvokeFactoryOptimization2()
+        {
+            AssertInvokeIsOptimized(2);
+        }
+
+        [Fact]
+        public static void CheckInvokeFactoryOptimization3()
+        {
+            AssertInvokeIsOptimized(3);
+        }
+
+        [Fact]
+        public static void CheckInvokeFactoryOptimization4()
+        {
+            AssertInvokeIsOptimized(4);
+        }
+
+        [Fact]
+        public static void CheckInvokeFactoryOptimization5()
+        {
+            AssertInvokeIsOptimized(5);
+        }
+
+        private static void AssertInvokeIsOptimized(int n)
+        {
+            var genArgs = Enumerable.Repeat(typeof(int), n + 1).ToArray();
+            var delegateType = Expression.GetFuncType(genArgs);
+
+            var instance = Expression.Parameter(delegateType);
+
+            // Expression[] overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                var expr = Expression.Invoke(instance, args);
+
+                AssertInvokeIsOptimized(expr, instance, args);
+            }
+
+            // IEnumerable<Expression> overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                var expr = Expression.Invoke(instance, args);
+
+                AssertInvokeIsOptimized(expr, instance, args);
+            }
+        }
+
+        private static void AssertInvokeIsOptimized(InvocationExpression expr, Expression expression, IReadOnlyList<Expression> args)
+        {
+            var n = args.Count;
+
+            var updated = Update(expr);
+            var visited = Visit(expr);
+
+            foreach (var node in new[] { expr, updated, visited })
+            {
+                Assert.Same(expression, node.Expression);
+
+                AssertInvocation(n, node);
+
+                var argProvider = node as IArgumentProvider;
+                Assert.NotNull(argProvider);
+
+                Assert.Equal(n, argProvider.ArgumentCount);
+
+                if (node != visited) // our visitor clones argument nodes
+                {
+                    for (var i = 0; i < n; i++)
+                    {
+                        Assert.Same(args[i], argProvider.GetArgument(i));
+                        Assert.Same(args[i], node.Arguments[i]);
+                    }
+                }
+            }
+        }
+
+        private static void AssertInvocation(int n, object obj)
+        {
+            AssertTypeName("InvocationExpression" + n, obj);
+        }
+
+        private static void AssertTypeName(string expected, object obj)
+        {
+            Assert.Equal(expected, obj.GetType().Name);
+        }
+
+        private static InvocationExpression Update(InvocationExpression node)
+        {
+            // Tests the call of Update to Expression.Invoke factories.
+
+            var res = node.Update(node.Expression, node.Arguments.ToArray());
+
+            Assert.NotSame(node, res);
+
+            return res;
+        }
+
+        private static InvocationExpression Visit(InvocationExpression node)
+        {
+            // Tests dispatch of ExpressionVisitor into Rewrite method which calls Expression.Invoke factories.
+
+            return (InvocationExpression)new Visitor().Visit(node);
+        }
+
+        class Visitor : ExpressionVisitor
+        {
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                return Expression.Constant(node.Value, node.Type); // clones
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="HelperTypes.cs" />
+    <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Lambda\LambdaAddNullableTests.cs" />
     <Compile Include="Lambda\LambdaAddTests.cs" />
     <Compile Include="Lambda\LambdaDivideNullableTests.cs" />


### PR DESCRIPTION
This is a proposed improvement as described in issue #3245. It follows the strategy used in PR #3288.

Note that no public API additions were made even though some of the factory overloads would make sense to be exposed publicly. This conservative stance could be revisited separately if a decision is made to incorporate public API additions for the expression API.