### PR TITLE
Test for exception on cast of null to non-nullable type.

### DIFF
--- a/src/System.Linq/tests/CastTests.cs
+++ b/src/System.Linq/tests/CastTests.cs
@@ -196,5 +196,13 @@ namespace System.Linq.Tests
             IEnumerable<long?> cast = source.Cast<long?>();
             Assert.Throws<InvalidCastException>(() => cast.ToList());
         }
+
+        [Fact]
+        public void CastingNullToNonnullableIsNullReferenceException()
+        {
+            int?[] source = new int?[] { -4, 1, null, 3 };
+            IEnumerable<int> cast = source.Cast<int>();
+            Assert.Throws<NullReferenceException>(() => cast.ToList());
+        }
     }
 }


### PR DESCRIPTION
Since it was decided in #2947 that the current behaviour is desired, and should
be documented as the correct behaviour, there should be a test that checks this
behaviour continues, to avoid regression changes to it.