### PR TITLE
Fix performance issue when deserializing base64 content with linebreaks

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -1385,9 +1385,17 @@ namespace System.Xml
                 {
                     int actualCharCount;
                     if (readContent)
+                    {
                         actualCharCount = ReadContentAsChars(chars, charCount, maxCharCount - charCount);
+                        // When deserializing base64 content which contains new line chars (CR, LF) chars from ReadObject, the reader reads in chunks of base64 content, LF char, base64 content, LF char and so on
+                        // Relying on encoding.GetBytes' exception to handle LF char would result in performance degradation so skipping LF char here
+                        if (actualCharCount == 1 && chars[charCount] == '\n')
+                            continue;
+                    }
                     else
+                    {
                         actualCharCount = ReadValueChunk(chars, charCount, maxCharCount - charCount);
+                    }
                     if (actualCharCount == 0)
                         break;
                     charCount += actualCharCount;


### PR DESCRIPTION
Porting Desktop fix to NetCore for performance issue when deserializing base64 content with linebreak characters.
This changes improves the throughput to 50x for 1KB input and more than 130x for 10KB to 1MB inputs.
Fix #3316 