### PR TITLE
Disable SafeHandle leak checking in WinHttpHandler Unit Tests

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeSafeWinHttpHandle.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeSafeWinHttpHandle.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Net.Http;
+using System.Diagnostics;
 using System.Threading;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
@@ -10,13 +10,17 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
     internal class FakeSafeWinHttpHandle : Interop.WinHttp.SafeWinHttpHandle
     {
         private static int s_HandlesOpen = 0;
-        
+
         public FakeSafeWinHttpHandle(bool markAsValid)
         {
             if (markAsValid)
             {
                 SetHandle(Marshal.AllocHGlobal(1));
                 Interlocked.Increment(ref s_HandlesOpen);
+                Debug.WriteLine(
+                    "FakeSafeWinHttpHandle.cctor, handle=#{0}, s_HandlesOpen={1}",
+                    handle.GetHashCode(),
+                    s_HandlesOpen);
             }
             else
             {
@@ -32,19 +36,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             }
         }
 
-        public static void ForceGarbageCollection()
-        {
-            // Make several passes through the FReachable list.
-            for (int i = 0; i < 10; i++)
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-            }
-        }
-        
         protected override bool ReleaseHandle()
         {
             Interlocked.Decrement(ref s_HandlesOpen);
+            Debug.WriteLine(
+                "FakeSafeWinHttpHandle.ReleaseHandle, handle=#{0}, s_HandlesOpen={1}",
+                handle.GetHashCode(),
+                s_HandlesOpen);
             
             return base.ReleaseHandle();
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
@@ -8,19 +8,8 @@ using Xunit;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class SafeWinHttpHandleTest : IDisposable
+    public class SafeWinHttpHandleTest
     {
-        public SafeWinHttpHandleTest()
-        {
-        }
-
-        public void Dispose()
-        {
-            // This runs after every test and makes sure that we run any finalizers to free all eligible handles.
-            FakeSafeWinHttpHandle.ForceGarbageCollection();
-            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
-        }
-
         [Fact]
         public void CreateAddRefDispose_HandleIsNotClosed()
         {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -31,9 +31,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public void Dispose()
         {
             TestControl.ResponseDelayCompletedEvent.WaitOne();
-            
-            FakeSafeWinHttpHandle.ForceGarbageCollection();
-            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
         }
 
         [Fact]
@@ -859,7 +856,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
         
         [Fact]
-        public void SendAsync_MultipleCallsWithDispose_NoHandleLeaks()
+        public void SendAsync_MultipleCallsWithDispose_NoHandleLeaksManuallyVerifiedUsingLogging()
         {
             WinHttpHandler handler;
             HttpResponseMessage response;
@@ -870,14 +867,10 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                 response.Dispose();
                 handler.Dispose();
             }
-            
-            FakeSafeWinHttpHandle.ForceGarbageCollection();
-            
-            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
         }
         
         [Fact]
-        public void SendAsync_MultipleCallsWithoutDispose_NoHandleLeaks()
+        public void SendAsync_MultipleCallsWithoutDispose_NoHandleLeaksManuallyVerifiedUsingLogging()
         {
             WinHttpHandler handler;
             HttpResponseMessage response;
@@ -886,12 +879,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                 handler = new WinHttpHandler();
                 response = SendRequestHelper(handler, () => { });
             }
-
-            handler = null;
-            response = null;
-            FakeSafeWinHttpHandle.ForceGarbageCollection();
-            
-            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
         }
         
         private HttpResponseMessage SendRequestHelper(WinHttpHandler handler, Action setup)


### PR DESCRIPTION
Addresses issue #3312 

I've discovered that the FakeSafeWinHttpHandle leak detection isn't stable.  SafeHandles finalize via the CriticalFinalizer thread.  This thread doesn't seem to run deterministically, so using code like this to wait for SafeHandles to be finalized (and then testing for leaks) doesn't work reliably.

```c#
public static void ForceGarbageCollection()
{
    // Make several passes through the FReachable list.
   for (int i = 0; i < 10; i++)
   {
       GC.Collect();
       GC.WaitForPendingFinalizers();
   }
}
```

For now, logging will be used to verify no leaks.

