### PR TITLE
Remove delegate allocation from WinHttpHandler.SendAsync

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -612,7 +612,7 @@ namespace System.Net.Http
             try
             {
                 Task.Factory.StartNew(
-                    StartRequest,
+                    s => ((RequestState)s).Handler.StartRequest(s),
                     state,
                     CancellationToken.None,
                     TaskCreationOptions.DenyChildAttach,


### PR DESCRIPTION
Each SendAsync call was allocating a new delegate for StartRequest.

cc: @davidsh, @CIPop 