### PR TITLE
Implement HttpClientHandler.MaxRequestContentBufferSize on Unix

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -128,8 +128,9 @@ namespace System.Net.Http
 
         public long MaxRequestContentBufferSize
         {
-            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
-            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            // See comments in HttpClientHandler.Windows.cs.  This behavior matches.
+            get { return 0; }
+            set { throw new PlatformNotSupportedException(); }
         }
 
         #endregion Properties

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -127,7 +127,8 @@ namespace System.Net.Http
             // 'Transfer-Encoding: chunked'. The handler will never automatically buffer in the request content.
             get { return 0; }
             
-            // TODO: Add message/link to exception explaining the deprecation.
+            // TODO: Add message/link to exception explaining the deprecation. 
+            // Update corresponding exception in HttpClientHandler.Unix.cs if/when this is updated.
             set { throw new PlatformNotSupportedException(); }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -66,7 +66,25 @@ namespace System.Net.Http.Tests
         {
             _output = output;
         }
-        
+
+        [Fact]
+        public void MaxRequestContentBufferSize_Get_ReturnsZero()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Equal(0, handler.MaxRequestContentBufferSize);
+            }
+        }
+
+        [Fact]
+        public void MaxRequestContentBufferSize_Set_ThrowsPlatformNotSupportedException()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => handler.MaxRequestContentBufferSize = 1024);
+            }
+        }
+
         [Fact]
         public async void SendAsync_SimpleGet_Success()
         {


### PR DESCRIPTION
Changed to match behavior on Windows (get returns 0, set throws PlatformNotSupportedException).

Fixes #3321 

cc: @kapilash, @davidsh, @CIPop 