### PR TITLE
Restore Tool Runtime as part of root src traversal

### DIFF
--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -33,4 +33,13 @@
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets')" />
 
+  <!-- When doing a traversal build restore the tools runtime before the traversal starts to avoid races --> 
+  <Import Project="$(ToolsDir)toolruntime.targets" Condition="Exists('$(ToolsDir)toolruntime.targets')" />
+  <PropertyGroup Condition="Exists('$(ToolsDir)toolruntime.targets')">
+    <TraversalBuildDependsOn>
+      EnsureBuildToolsRuntime;
+      $(TraversalBuildDependsOn)
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
There are cases where multiple projects building in parallel try
to restore the tools runtime at the same time which cause some
copying over and potential failed writes. This add the restoring
of the tool runtime as part of the root traversal project so
the other projects will not have any work to do.