### PR TITLE
Remove faulty assert from CurlHandler.CurlResponseStream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -446,8 +446,6 @@ namespace System.Net.Http
                 Debug.Assert(!((_remainingDataCount > 0) && (_pendingReadRequest != null)), "We can't have both remaining data and a pending request.");
                 Debug.Assert(!((_completed != null) && (_pendingReadRequest != null)), "We can't both be completed and have a pending request.");
                 Debug.Assert(_pendingReadRequest == null || !_pendingReadRequest.Task.IsCompleted, "A pending read request must not have been completed yet.");
-
-                Debug.Assert(!_disposed || _completed != null, "If disposed, the stream must also be completed.");
             }
 
             /// <summary>State associated with a pending read request.</summary>


### PR DESCRIPTION
CurlResponseStream.VerifyInvariants has an assert that assumes that if the stream has been disposed, it must have also completed.  But since this stream is exposed publically, it's possible for consuming code to Dispose of the stream before the request has finished, violating the assert.  In such a situation, a subsequent attempt to transfer data to the response stream will fail and cause the request to be aborted as desired, cleaning up resources (there are probably some opportunities here for some optimizations to handle this case, but that can be explored later.)

This commit just removes the bad assert.

Fixes #3319 
cc: @kapilash, @roncain 