### PR TITLE
System.Linq ToDictionary performance improvement

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1032,14 +1032,39 @@ namespace System.Linq
             if (keySelector == null) throw Error.ArgumentNull("keySelector");
 
             int capacity = 0;
+            ICollection<TSource> collection = source as ICollection<TSource>;
+            if (collection != null)
+            {
+                capacity = collection.Count;
+                if (capacity == 0)
+                    return new Dictionary<TKey, TSource>(comparer);
 
-            if (source is TSource[]) capacity = (source as TSource[]).Length; // Cast to Array is much faster than cast to ICollection
-            else if (source is ICollection<TSource>) capacity = (source as ICollection<TSource>).Count;
+                TSource[] array = collection as TSource[];
+                if (array != null)
+                    return ToDictionary(array, keySelector, comparer);
+                List<TSource> list = collection as List<TSource>;
+                if (list != null)
+                    return ToDictionary(list, keySelector, comparer);
+            }
 
             Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(capacity, comparer);
             foreach (TSource element in source) d.Add(keySelector(element), element);
             return d;
         }
+
+        private static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(source.Length, comparer);
+            for (int i = 0; i < source.Length; i++) d.Add(keySelector(source[i]), source[i]);
+            return d;
+        }
+        private static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(List<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(source.Count, comparer);
+            foreach (TSource element in source) d.Add(keySelector(element), element);
+            return d;
+        }
+
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
         {
@@ -1053,14 +1078,39 @@ namespace System.Linq
             if (elementSelector == null) throw Error.ArgumentNull("elementSelector");
 
             int capacity = 0;
+            ICollection<TSource> collection = source as ICollection<TSource>;
+            if (collection != null)
+            {
+                capacity = collection.Count;
+                if (capacity == 0)
+                    return new Dictionary<TKey, TElement>(comparer);
 
-            if (source is TSource[]) capacity = (source as TSource[]).Length; // Cast to Array is much faster than cast to ICollection
-            else if (source is ICollection<TSource>) capacity = (source as ICollection<TSource>).Count;
+                TSource[] array = collection as TSource[];
+                if (array != null)
+                    return ToDictionary(array, keySelector, elementSelector, comparer);
+                List<TSource> list = collection as List<TSource>;
+                if (list != null)
+                    return ToDictionary(list, keySelector, elementSelector, comparer);
+            }
 
             Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(capacity, comparer);
             foreach (TSource element in source) d.Add(keySelector(element), elementSelector(element));
             return d;
         }
+
+        private static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(source.Length, comparer);
+            for (int i = 0; i < source.Length; i++) d.Add(keySelector(source[i]), elementSelector(source[i]));
+            return d;
+        }
+        private static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(List<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(source.Count, comparer);
+            foreach (TSource element in source) d.Add(keySelector(element), elementSelector(element));
+            return d;
+        }
+
 
         public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1023,12 +1023,22 @@ namespace System.Linq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            return ToDictionary<TSource, TKey, TSource>(source, keySelector, IdentityFunction<TSource>.Instance, null);
+            return ToDictionary<TSource, TKey>(source, keySelector, null);
         }
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            return ToDictionary<TSource, TKey, TSource>(source, keySelector, IdentityFunction<TSource>.Instance, comparer);
+            if (source == null) throw Error.ArgumentNull("source");
+            if (keySelector == null) throw Error.ArgumentNull("keySelector");
+
+            int capacity = 0;
+
+            if (source is TSource[]) capacity = (source as TSource[]).Length; // Cast to Array is much faster than cast to ICollection
+            else if (source is ICollection<TSource>) capacity = (source as ICollection<TSource>).Count;
+
+            Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(capacity, comparer);
+            foreach (TSource element in source) d.Add(keySelector(element), element);
+            return d;
         }
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
@@ -1041,7 +1051,13 @@ namespace System.Linq
             if (source == null) throw Error.ArgumentNull("source");
             if (keySelector == null) throw Error.ArgumentNull("keySelector");
             if (elementSelector == null) throw Error.ArgumentNull("elementSelector");
-            Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(comparer);
+
+            int capacity = 0;
+
+            if (source is TSource[]) capacity = (source as TSource[]).Length; // Cast to Array is much faster than cast to ICollection
+            else if (source is ICollection<TSource>) capacity = (source as ICollection<TSource>).Count;
+
+            Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(capacity, comparer);
             foreach (TSource element in source) d.Add(keySelector(element), elementSelector(element));
             return d;
         }


### PR DESCRIPTION
This PR is for the issue #3337.

Performance tests (_ToDictionary_Performance_ from _System.Linq.Tests_).
- Original - time of execution of the original code;
- Capacity est. - time of execution after capacity estimation for Array and ICollection was added;
- No IdentityFunction (ms) - time of execution after special implementation of the overload without _elementSelector_ was introduced (includes capacity estimation tweak).

__1000000 elements in source collection (100 iterations)__

Source collection | Original (ms) | Capacity est. (ms) | Boost (%) | No IdentityFunction (ms) | Boost (%)
----------------------|------------------|-------------------------|--------------|-------------------|-------
Array | 3604,5024ms | 2276,9344ms | -37% | 2088,8203ms | -42%
IEnumerable | 3598,2668ms | 3595,5406ms | 0% | 3424,7356ms | -5%
ICollection | 3591,0245ms | 2288,1238ms | -36% | 2118,0754ms | -41%


__100 elements (1000000 iterations)__

Source collection | Original (ms) | Capacity est. (ms) | Boost (%) | No IdentityFunction (ms) | Boost (%)
----------------------|------------------|------------------------|---------------|-------------------------------|--------
Array | 3289,5846ms | 2011,3236ms | -39% | 1774,5912ms | -46%
IEnumerable | 3321,1946ms | 3361,5469ms | +1% | 3104,9243ms | -6%
ICollection | 3323,8798ms | 2049,7582ms | -38% | 1808,4537ms | -46%


__4 elements (10000000 iterations)__

Source collection | Original (ms) | Capacity est. (ms) | Boost (%) | No IdentityFunction (ms) | Boost (%)
----------------------|------------------|------------------------|---------------|-------------------------------|--------
Array | 1993,3899ms | 1480,8956ms | -26% | 1336,9621ms | -33%
IEnumerable | 2322,84ms | 2404,4192ms | +3% | 2281,7706ms | -2%
ICollection | 2327,5683ms | 1776,3507ms | -24% | 1663,1914ms | -29%


__1 element (100000000 iterations)__ /absolute time of a single iteration is very small/

Source collection | Original (ms) | Capacity est. (ms) | Boost (%) | No IdentityFunction (ms) | Boost (%)
----------------------|------------------|------------------------|---------------|-------------------------------|--------
Array | 8167,0357ms | 8858,9957ms | +8% | 8287,586ms | +1%
IEnumerable | 11219,7955ms | 12047,7075ms | +7% | 11446,0032ms | +2%
ICollection | 11228,2195ms | 12036,7601ms | +7% | 11382,9351ms | +1%


__0 elements (100000000 iterations)__ /absolute time of a single iteration is very small/

Source collection | Original (ms) | Capacity est. (ms) | Boost (%) | No IdentityFunction (ms) | Boost (%)
----------------------|------------------|------------------------|---------------|-------------------------------|--------
Array | 4042,6531ms | 4419,2022ms | +9% | 4192,6036ms | +3%
IEnumerable | 6801,501ms | 7312,8057ms | +7% | 7154,1184ms | +5%
ICollection | 6782,3701ms | 7396,2199ms | +9% | 7164,335ms | +5%
