### PR TITLE
Port additional System.Net.Http tests to CoreFx

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/SendAsyncWinHttpMockHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/SendAsyncWinHttpMockHandler.cs
@@ -4,7 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.Net.Http.WinHttpHandlerTests
+namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
     public class SendAsyncWinHttpMockHandler : WinHttpHandler
     {

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -6,8 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>System.Net.Http.WinHttpHandler.Tests</RootNamespace>
-    <AssemblyName>System.Net.Http.WinHttpHandler.Tests</AssemblyName>
+    <AssemblyName>System.Net.Http.WinHttpHandler.Functional.Tests</AssemblyName>
     <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -11,7 +11,9 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace System.Net.Http.WinHttpHandlerTests
+// Can't use "WinHttpHandler.Functional.Tests" in namespace as it won't compile.
+// WinHttpHandler is a class and not a namespace and can't be part of namespace paths.
+namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
     public class WinHttpHandlerTest
     {

--- a/src/System.Net.Http/tests/FunctionalTests/ByteArrayContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ByteArrayContentTest.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class ByteArrayContentTest
+    {
+        [Fact]
+        public void Ctor_NullSourceArray_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ByteArrayContent(null));
+        }
+
+        [Fact]
+        public void Ctor_NullSourceArrayWithRange_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ByteArrayContent(null, 0, 1));
+        }
+
+        [Fact]
+        public void Ctor_EmptySourceArrayWithRange_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteArrayContent(new byte[0], 0, 1));
+        }
+
+        [Fact]
+        public void Ctor_StartIndexTooBig_ThrowsArgumentOufOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteArrayContent(new byte[5], 5, 1));
+        }
+
+        [Fact]
+        public void Ctor_StartIndexNegative_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteArrayContent(new byte[5], -1, 1));
+        }
+
+        [Fact]
+        public void Ctor_LengthTooBig_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteArrayContent(new byte[5], 1, 5));
+        }
+
+        [Fact]
+        public void Ctor_LengthPlusOffsetCauseIntOverflow_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteArrayContent(new byte[5], 1, int.MaxValue));
+        }
+
+        [Fact]
+        public void Ctor_LengthNegative_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteArrayContent(new byte[5], 0, -1));
+        }
+
+        [Fact]
+        public void ContentLength_UseWholeSourceArray_LengthMatchesArrayLength()
+        {
+            var contentData = new byte[10];
+            var content = new ByteArrayContent(contentData);
+
+            Assert.Equal(contentData.Length, content.Headers.ContentLength);
+        }
+
+        [Fact]
+        public void ContentLength_UsePartialSourceArray_LengthMatchesArrayLength()
+        {
+            var contentData = new byte[10];
+            var content = new ByteArrayContent(contentData, 5, 3);
+
+            Assert.Equal(3, content.Headers.ContentLength);
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_EmptySourceArray_Succeed()
+        {
+            var content = new ByteArrayContent(new byte[0]);
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_Call_MemoryStreamWrappingByteArrayReturned()
+        {
+            var contentData = new byte[10];
+            var content = new MockByteArrayContent(contentData, 5, 3);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+            Assert.Equal(3, stream.Length);
+            Assert.Equal(0, content.CopyToCount);
+        }
+
+        [Fact]
+        public void CopyToAsync_NullDestination_ThrowsArgumentNullException()
+        {
+            byte[] contentData = CreateSourceArray();
+            var content = new ByteArrayContent(contentData);
+
+            Assert.Throws<ArgumentNullException>(() => { Task t = content.CopyToAsync(null); });
+        }
+
+        [Fact]
+        public async Task CopyToAsync_UseWholeSourceArray_WholeContentCopied()
+        {
+            byte[] contentData = CreateSourceArray();
+            var content = new ByteArrayContent(contentData);
+
+            var destination = new MemoryStream();
+            await content.CopyToAsync(destination);
+
+            Assert.Equal(contentData.Length, destination.Length);
+            CheckResult(destination, 0);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_UsePartialSourceArray_PartialContentCopied()
+        {
+            byte[] contentData = CreateSourceArray();
+            var content = new ByteArrayContent(contentData, 3, 5);
+
+            var destination = new MemoryStream();
+            await content.CopyToAsync(destination);
+
+            Assert.Equal(5, destination.Length);
+            CheckResult(destination, 3);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_UseEmptySourceArray_NothingCopied()
+        {
+            var contentData = new byte[0];
+            var content = new ByteArrayContent(contentData, 0, 0);
+
+            var destination = new MemoryStream();
+            await content.CopyToAsync(destination);
+
+            Assert.Equal(0, destination.Length);
+        }
+
+        #region Helper methods
+
+        private static byte[] CreateSourceArray()
+        {
+            var contentData = new byte[10];
+            for (int i = 0; i < contentData.Length; i++)
+            {
+                contentData[i] = (byte)(i % 256);
+            }
+            return contentData;
+        }
+
+        private static void CheckResult(Stream destination, byte firstValue)
+        {
+            destination.Position = 0;
+            var destinationData = new byte[destination.Length];
+            int read = destination.Read(destinationData, 0, destinationData.Length);
+
+            Assert.Equal(destinationData.Length, read);
+            Assert.Equal(firstValue, destinationData[0]);
+
+            for (int i = 1; i < read; i++)
+            {
+                Assert.True((destinationData[i] == (destinationData[i - 1] + 1)) ||
+                    ((destinationData[i] == 0) && (destinationData[i - 1] != 0)));
+            }
+        }
+
+        private class MockByteArrayContent : ByteArrayContent
+        {
+            public int CopyToCount { get; private set; }
+
+            public MockByteArrayContent(byte[] content, int offset, int count)
+                : base(content, offset, count)
+            {
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                CopyToCount++;
+                return base.CopyToAsync(stream, context);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/DelegatingHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DelegatingHandlerTest.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class DelegatingHandlerTest
+    {
+        [Fact]
+        public void Ctor_CreateDispose_Success()
+        {
+            MockHandler handler = new MockHandler();
+            Assert.Null(handler.InnerHandler);
+            handler.Dispose();
+        }
+
+        [Fact]
+        public void Ctor_CreateDisposeAssign_ThrowsObjectDisposedException()
+        {
+            MockHandler handler = new MockHandler();
+            Assert.Null(handler.InnerHandler);
+            handler.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => handler.InnerHandler = new MockTransportHandler());
+        }
+
+        [Fact]
+        public void Ctor_NullInnerHandler_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MockHandler(null));
+        }
+
+        [Fact]
+        public void Ctor_SetNullInnerHandler_ThrowsArgumentNullException()
+        {
+            MockHandler handler = new MockHandler();
+            Assert.Throws<ArgumentNullException>(() => handler.InnerHandler = null);
+        }
+
+        [Fact]
+        public void SendAsync_WithoutSettingInnerHandlerCallMethod_ThrowsInvalidOperationException()
+        {
+            MockHandler handler = new MockHandler();
+
+            Assert.Throws<InvalidOperationException>(() => 
+                { Task t = handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None); });
+        }
+
+        [Fact]
+        public async Task SendAsync_SetInnerHandlerCallMethod_InnerHandlerSendIsCalled()
+        {
+            var handler = new MockHandler();
+            var transport = new MockTransportHandler();
+            handler.InnerHandler = transport;
+
+            HttpResponseMessage response = await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            Assert.NotNull(response);
+            Assert.Equal(1, handler.SendAsyncCount);
+            Assert.Equal(1, transport.SendAsyncCount);
+
+            Assert.Throws<InvalidOperationException>(() => handler.InnerHandler = transport);
+            Assert.Equal(transport, handler.InnerHandler);
+        }
+
+        [Fact]
+        public async Task SendAsync_SetInnerHandlerTwiceCallMethod_SecondInnerHandlerSendIsCalled()
+        {
+            var handler = new MockHandler();
+            var transport1 = new MockTransportHandler();
+            var transport2 = new MockTransportHandler();
+            handler.InnerHandler = transport1;
+            handler.InnerHandler = transport2;
+
+            HttpResponseMessage response = await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            Assert.NotNull(response);
+            Assert.Equal(1, handler.SendAsyncCount);
+            Assert.Equal(0, transport1.SendAsyncCount);
+            Assert.Equal(1, transport2.SendAsyncCount);
+        }
+
+        [Fact]
+        public void SendAsync_NullRequest_ThrowsArgumentNullException()
+        {
+            var transport = new MockTransportHandler();
+            var handler = new MockHandler(transport);
+
+            Assert.Throws<ArgumentNullException>(() => 
+                { Task t = handler.TestSendAsync(null, CancellationToken.None); });
+        }
+
+        [Fact]
+        public void SendAsync_Disposed_Throws()
+        {
+            var transport = new MockTransportHandler();
+            var handler = new MockHandler(transport);
+            handler.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                { Task t = handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None); });
+            Assert.Throws<ObjectDisposedException>(() => handler.InnerHandler = new MockHandler());
+            Assert.Equal(transport, handler.InnerHandler);
+        }
+
+        [Fact]
+        public async Task SendAsync_CallMethod_InnerHandlerSendAsyncIsCalled()
+        {
+            var transport = new MockTransportHandler();
+            var handler = new MockHandler(transport);
+
+            await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            Assert.Equal(1, handler.SendAsyncCount);
+            Assert.Equal(1, transport.SendAsyncCount);
+        }
+
+        [Fact]
+        public void SendAsync_CallMethodWithoutSettingInnerHandler_ThrowsInvalidOperationException()
+        {
+            var handler = new MockHandler();
+
+            Assert.Throws<InvalidOperationException>(() => 
+                { Task t = handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None); });
+        }
+
+        [Fact]
+        public async Task SendAsync_SetInnerHandlerAfterCallMethod_ThrowsInvalidOperationException()
+        {
+            var transport = new MockTransportHandler();
+            var handler = new MockHandler(transport);
+
+            await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            Assert.Equal(1, handler.SendAsyncCount);
+            Assert.Equal(1, transport.SendAsyncCount);
+
+            Assert.Throws<InvalidOperationException>(() => handler.InnerHandler = transport);
+        }
+
+        [Fact]
+        public void Dispose_CallDispose_OverriddenDisposeMethodCalled()
+        {
+            var innerHandler = new MockTransportHandler();
+            var handler = new MockHandler(innerHandler);
+            handler.Dispose();
+
+            Assert.Equal(1, handler.DisposeCount);
+            Assert.Equal(1, innerHandler.DisposeCount);
+        }
+
+        [Fact]
+        public void Dispose_CallDisposeMultipleTimes_OverriddenDisposeMethodCalled()
+        {
+            var innerHandler = new MockTransportHandler();
+            var handler = new MockHandler(innerHandler);
+            handler.Dispose();
+            handler.Dispose();
+            handler.Dispose();
+
+            Assert.Equal(3, handler.DisposeCount);
+            Assert.Equal(1, innerHandler.DisposeCount);
+        }
+
+        #region Helper methods
+        private class MockHandler : DelegatingHandler
+        {
+            public int SendAsyncCount { get; private set; }
+            public int DisposeCount { get; private set; }
+
+            public MockHandler() : base()
+            {
+            }
+
+            public MockHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+            {
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                SendAsyncCount++;
+                return base.SendAsync(request, cancellationToken);
+            }
+
+            public Task<HttpResponseMessage> TestSendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return SendAsync(request, cancellationToken);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+        }
+
+        private class MockTransportHandler : HttpMessageHandler
+        {
+            public int SendAsyncCount { get; private set; }
+            public int DisposeCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                SendAsyncCount++;
+                return Task.FromResult(new HttpResponseMessage());
+            }
+
+            public Task<HttpResponseMessage> TestSendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return SendAsync(request, cancellationToken);
+            }
+            
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class FormUrlEncodedContentTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public FormUrlEncodedContentTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Ctor_NullSource_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormUrlEncodedContent(null));
+        }
+
+        [Fact]
+        public async Task Ctor_EmptySource_Succeed()
+        {
+            var content = new FormUrlEncodedContent(new Dictionary<string, string>());
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
+        public async Task Ctor_OneEntry_SeparatedByEquals()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key", "value");
+            var content = new FormUrlEncodedContent(data);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(9, stream.Length);
+            string result = new StreamReader(stream).ReadToEnd();
+            Assert.Equal("key=value", result);
+        }
+
+        [Fact]
+        public async Task Ctor_OneUnicodeEntry_Encoded()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key", "valueク");
+            var content = new FormUrlEncodedContent(data);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(18, stream.Length);
+            string result = new StreamReader(stream).ReadToEnd();
+            Assert.Equal("key=value%E3%82%AF", result);
+        }
+
+        [Fact]
+        public async Task Ctor_TwoEntries_SeparatedByAnd()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key1", "value1");
+            data.Add("key2", "value2");
+            var content = new FormUrlEncodedContent(data);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(23, stream.Length);
+            string result = new StreamReader(stream).ReadToEnd();
+            Assert.Equal("key1=value1&key2=value2", result);
+        }
+
+        [Fact]
+        public async Task Ctor_WithSpaces_EncodedAsPlus()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key 1", "val%20ue 1"); // %20 is a percent-encoded space, make sure it survives.
+            data.Add("key 2", "val%ue 2");
+            var content = new FormUrlEncodedContent(data);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(35, stream.Length);
+            string result = new StreamReader(stream).ReadToEnd();
+            Assert.Equal("key+1=val%2520ue+1&key+2=val%25ue+2", result);
+        }
+
+        [Fact]
+        public async Task Ctor_AllAsciiChars_EncodingMatchesHttpUtilty()
+        {
+            var builder = new StringBuilder();
+            for (int ch = 0; ch < 128; ch++)
+            {
+                builder.Append((char)ch);
+            }
+            string testString = builder.ToString();
+
+            var data = new Dictionary<string, string>();
+            data.Add("key", testString);
+            var content = new FormUrlEncodedContent(data);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            string result = new StreamReader(stream).ReadToEnd().ToLowerInvariant();
+
+            // Result of UrlEncode invoked in .Net 4.6
+            // string expectedResult = "key=" + HttpUtility.UrlEncode(testString).ToLowerInvariant();
+            // HttpUtility is not part of ProjectK.
+
+            string expectedResult = "key=%00%01%02%03%04%05%06%07%08%09%0a%0b%0c%0d%0e%0f%10%11%12%13%14%15%16%17%18" +
+                "%19%1a%1b%1c%1d%1e%1f+!%22%23%24%25%26%27()*%2b%2c-.%2f0123456789%3a%3b%3c%3d%3e%3f%40abcdefghijklm" +
+                "nopqrstuvwxyz%5b%5c%5d%5e_%60abcdefghijklmnopqrstuvwxyz%7b%7c%7d%7e%7f";
+
+            string knownDiscrepancies = "~!*()";
+
+            _output.WriteLine("Expecting result: '{0}'", expectedResult);
+            _output.WriteLine("Actual result   : '{0}'", result);
+
+            int discrepancies = 0;
+            for (int i = 0; i < result.Length && i < expectedResult.Length; i++)
+            {
+                if (result[i] != expectedResult[i])
+                {
+                    Assert.True((result[i] == '%' || expectedResult[i] == '%'),
+                        "Non-Escaping mis-match at position: " + i);
+
+                    if (result[i] == '%')
+                    {
+                        Assert.True(knownDiscrepancies.Contains(expectedResult[i]),
+                            "Escaped when it shouldn't be: " + expectedResult[i] + " at position " + i);
+                        result = result.Substring(i + 3);
+                        expectedResult = expectedResult.Substring(i + 1);
+                    }
+                    else
+                    {
+                        Assert.True(knownDiscrepancies.Contains(result[i]),
+                            "Not escaped when it should be : " + result[i] + " at position " + i);
+                        result = result.Substring(i + 1);
+                        expectedResult = expectedResult.Substring(i + 3);
+                    }
+                    i = -1;
+                    discrepancies++;
+                }
+            }
+            Assert.Equal(5, discrepancies);
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace System.Net.Http.Tests
+namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientHandlerTest
     {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace System.Net.Http.Tests
+namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientTest
     {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -1,0 +1,631 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpContentTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public HttpContentTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task CopyToAsync_CallWithMockContent_MockContentMethodCalled()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+            var m = new MemoryStream();
+
+            await content.CopyToAsync(m);
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Assert.Equal(content.GetMockData(), m.ToArray());
+        }
+
+        [Fact]
+        public async Task CopyToAsync_ThrowCustomExceptionInOverriddenMethod_ThrowsMockException()
+        {
+            var content = new MockContent(new MockException(), MockOptions.ThrowInSerializeMethods);
+
+            var m = new MemoryStream();
+            await Assert.ThrowsAsync<MockException>(() => content.CopyToAsync(m));
+        }
+
+        [Fact]
+        public async Task CopyToAsync_ThrowObjectDisposedExceptionInOverriddenMethod_ThrowsWrappedHttpRequestException()
+        {
+            var content = new MockContent(new ObjectDisposedException(""), MockOptions.ThrowInSerializeMethods);
+
+            var m = new MemoryStream();
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.CopyToAsync(m));
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_ThrowIOExceptionInOverriddenMethod_ThrowsWrappedHttpRequestException()
+        {
+            var content = new MockContent(new IOException(), MockOptions.ThrowInSerializeMethods);
+
+            var m = new MemoryStream();
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.CopyToAsync(m));
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void CopyToAsync_ThrowCustomExceptionInOverriddenAsyncMethod_ExceptionBubblesUp()
+        {
+            var content = new MockContent(new MockException(), MockOptions.ThrowInAsyncSerializeMethods);
+
+            var m = new MemoryStream();
+            Assert.Throws<MockException>(() => { Task t = content.CopyToAsync(m); });
+        }
+
+        [Fact]
+        public async Task CopyToAsync_ThrowObjectDisposedExceptionInOverriddenAsyncMethod_ThrowsWrappedHttpRequestException()
+        {
+            var content = new MockContent(new ObjectDisposedException(""), MockOptions.ThrowInAsyncSerializeMethods);
+
+            var m = new MemoryStream();
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.CopyToAsync(m));
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_ThrowIOExceptionInOverriddenAsyncMethod_ThrowsWrappedHttpRequestException()
+        {
+            var content = new MockContent(new IOException(), MockOptions.ThrowInAsyncSerializeMethods);
+
+            var m = new MemoryStream();
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.CopyToAsync(m));
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void CopyToAsync_MockContentReturnsNull_ThrowsInvalidOperationException()
+        {
+            // return 'null' when CopyToAsync() is called.
+            var content = new MockContent(MockOptions.ReturnNullInCopyToAsync); 
+            var m = new MemoryStream();
+            
+            // The HttpContent derived class (MockContent in our case) must return a Task object when WriteToAsync()
+            // is called. If not, HttpContent will throw.
+            Assert.Throws<InvalidOperationException>(() => { Task t = content.CopyToAsync(m); });
+        }
+
+        [Fact]
+        public async Task CopyToAsync_BufferContentFirst_UseBufferedStreamAsSource()
+        {
+            var data = new byte[10];
+            var content = new MockContent(data);
+            content.LoadIntoBufferAsync().Wait();
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            var destination = new MemoryStream();
+            await content.CopyToAsync(destination);
+
+            // Our MockContent should not be called for the CopyTo() operation since the buffered stream should be 
+            // used.
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Assert.Equal(data.Length, destination.Length);
+        }
+
+        [Fact]
+        public void TryComputeLength_RetrieveContentLength_ComputeLengthShouldBeCalled()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+
+            Assert.Equal(content.GetMockData().Length, content.Headers.ContentLength);
+            Assert.Equal(1, content.TryComputeLengthCount);
+        }
+
+        [Fact]
+        public async Task TryComputeLength_RetrieveContentLengthFromBufferedContent_ComputeLengthIsNotCalled()
+        {
+            var content = new MockContent();
+            await content.LoadIntoBufferAsync();
+
+            Assert.Equal(content.GetMockData().Length, content.Headers.ContentLength);
+            
+            // Called once to determine the size of the buffer.
+            Assert.Equal(1, content.TryComputeLengthCount); 
+        }
+
+        [Fact]
+        public void TryComputeLength_ThrowCustomExceptionInOverriddenMethod_ExceptionBubblesUpToCaller()
+        {
+            var content = new MockContent(MockOptions.ThrowInTryComputeLength); 
+
+            var m = new MemoryStream();
+            Assert.Throws<MockException>(() => content.Headers.ContentLength);
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_GetFromUnbufferedContent_CreateContentReadStreamCalledOnce()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+
+            // Call multiple times: CreateContentReadStreamAsync() should be called only once.
+            Stream stream = await content.ReadAsStreamAsync();
+            stream = await content.ReadAsStreamAsync();
+            stream = await content.ReadAsStreamAsync();
+
+            Assert.Equal(1, content.CreateContentReadStreamCount);
+            Assert.Equal(content.GetMockData().Length, stream.Length);
+            Stream stream2 = await content.ReadAsStreamAsync();
+            Assert.Same(stream, stream2);
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_GetFromBufferedContent_CreateContentReadStreamCalled()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+            await content.LoadIntoBufferAsync();
+
+            Stream stream = await content.ReadAsStreamAsync();
+
+            Assert.Equal(0, content.CreateContentReadStreamCount);
+            Assert.Equal(content.GetMockData().Length, stream.Length);
+            Stream stream2 = await content.ReadAsStreamAsync();
+            Assert.Same(stream, stream2);
+            Assert.Equal(0, stream.Position);
+            Assert.Equal((byte)'d', stream.ReadByte());
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_FirstGetFromUnbufferedContentThenGetFromBufferedContent_SameStream()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+
+            Stream before = await content.ReadAsStreamAsync();
+            Assert.Equal(1, content.CreateContentReadStreamCount);
+
+            await content.LoadIntoBufferAsync();
+
+            Stream after = await content.ReadAsStreamAsync();
+            Assert.Equal(1, content.CreateContentReadStreamCount);
+
+            // Note that ContentReadStream returns always the same stream. If the user gets the stream, buffers content,
+            // and gets the stream again, the same instance is returned. Returning a different instance could be 
+            // confusing, even though there shouldn't be any real world scenario for retrieving the read stream both
+            // before and after buffering content.
+            Assert.Equal(before, after);
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_UseBaseImplementation_ContentGetsBufferedThenMemoryStreamReturned()
+        {
+            var content = new MockContent(MockOptions.DontOverrideCreateContentReadStream);
+            Stream stream = await content.ReadAsStreamAsync();
+
+            Assert.NotNull(stream);
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Stream stream2 = await content.ReadAsStreamAsync();
+            Assert.Same(stream, stream2);
+            Assert.Equal(0, stream.Position);
+            Assert.Equal((byte)'d', stream.ReadByte());
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_BufferSizeSmallerThanContentSizeWithCalculatedContentLength_ThrowsHttpRequestException()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+            await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync(content.GetMockData().Length - 1));
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_BufferSizeSmallerThanContentSizeWithNullContentLength_ThrowsHttpRequestException()
+        {
+            var content = new MockContent();
+            await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync(content.GetMockData().Length - 1));
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_CallOnMockContentWithCalculatedContentLength_CopyToAsyncMemoryStreamCalled()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+            Assert.NotNull(content.Headers.ContentLength);
+            await content.LoadIntoBufferAsync();
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_CallOnMockContentWithNullContentLength_CopyToAsyncMemoryStreamCalled()
+        {
+            var content = new MockContent();
+            Assert.Null(content.Headers.ContentLength);
+            await content.LoadIntoBufferAsync();
+            Assert.NotNull(content.Headers.ContentLength);
+            Assert.Equal(content.MockData.Length, content.Headers.ContentLength);
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_CallOnMockContentWithLessLengthThanContentLengthHeader_BufferedStreamLengthMatchesActualLengthNotContentLengthHeaderValue()
+        {
+            byte[] data = Encoding.UTF8.GetBytes("16 bytes of data");
+            var content = new MockContent(data);
+            content.Headers.ContentLength = 32; // Set the Content-Length header to a value > actual data length.
+            Assert.Equal(32, content.Headers.ContentLength);
+
+            await content.LoadIntoBufferAsync();
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Assert.NotNull(content.Headers.ContentLength);
+            Assert.Equal(32, content.Headers.ContentLength);
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.Equal(data.Length, stream.Length);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_CallMultipleTimesWithCalculatedContentLength_CopyToAsyncMemoryStreamCalledOnce()
+        {
+            var content = new MockContent(MockOptions.CanCalculateLength);
+            await content.LoadIntoBufferAsync();
+            await content.LoadIntoBufferAsync();
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_CallMultipleTimesWithNullContentLength_CopyToAsyncMemoryStreamCalledOnce()
+        {
+            var content = new MockContent();
+            await content.LoadIntoBufferAsync();
+            await content.LoadIntoBufferAsync();
+
+            Assert.Equal(1, content.SerializeToStreamAsyncCount);
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_ThrowCustomExceptionInOverriddenMethod_ThrowsMockException()
+        {
+            var content = new MockContent(new MockException(), MockOptions.ThrowInSerializeMethods);
+
+            await Assert.ThrowsAsync<MockException>(() => content.LoadIntoBufferAsync());
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_ThrowObjectDisposedExceptionInOverriddenMethod_ThrowsWrappedHttpRequestException()
+        {
+            var content = new MockContent(new ObjectDisposedException(""), MockOptions.ThrowInSerializeMethods);
+
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync());
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_ThrowIOExceptionInOverriddenMethod_ThrowsWrappedHttpRequestException()
+        {
+            MockContent content = new MockContent(new IOException(), MockOptions.ThrowInSerializeMethods);
+
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync());
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_ThrowCustomExceptionInOverriddenAsyncMethod_ExceptionBubblesUpToCaller()
+        {
+            var content = new MockContent(new MockException(), MockOptions.ThrowInAsyncSerializeMethods);
+
+            await Assert.ThrowsAsync<MockException>(() => content.LoadIntoBufferAsync());
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_ThrowObjectDisposedExceptionInOverriddenAsyncMethod_ThrowsHttpRequestException()
+        {
+            var content = new MockContent(new ObjectDisposedException(""), MockOptions.ThrowInAsyncSerializeMethods);
+
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync());
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task LoadIntoBufferAsync_ThrowIOExceptionInOverriddenAsyncMethod_ThrowsHttpRequestException()
+        {
+            var content = new MockContent(new IOException(), MockOptions.ThrowInAsyncSerializeMethods);
+
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync());
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task Dispose_GetReadStreamThenDispose_ReadStreamGetsDisposed()
+        {
+            var content = new MockContent();
+            MockMemoryStream s = (MockMemoryStream) await content.ReadAsStreamAsync();
+            Assert.Equal(1, content.CreateContentReadStreamCount);
+
+            Assert.Equal(0, s.DisposeCount);
+            content.Dispose();
+            Assert.Equal(1, s.DisposeCount);
+        }
+
+        [Fact]
+        public void Dispose_DisposeContentThenAccessContentLength_Throw()
+        {
+            var content = new MockContent();
+
+            // This is not really typical usage of the type, but let's make sure we consider also this case: The user
+            // keeps a reference to the Headers property before disposing the content. Then after disposing, the user
+            // accesses the ContentLength property.
+            var headers = content.Headers;
+            content.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => headers.ContentLength.ToString());
+        }
+
+        [Fact]
+        public async Task CopyToAsync_UseStreamWriteByteWithBufferSizeSmallerThanContentSize_ThrowsHttpRequestException()
+        {
+            // MockContent uses stream.WriteByte() rather than stream.Write(): Verify that the max. buffer size
+            // is also checked when using WriteByte().
+            var content = new MockContent(MockOptions.UseWriteByteInCopyTo);
+            await Assert.ThrowsAsync<HttpRequestException>(() => content.LoadIntoBufferAsync(content.GetMockData().Length - 1));
+        }
+        
+        [Fact]
+        public async Task ReadAsStringAsync_EmptyContent_EmptyString()
+        {
+            var content = new MockContent(new byte[0]);
+            string actualContent = await content.ReadAsStringAsync();
+            Assert.Equal(string.Empty, actualContent);
+        }
+
+        [Fact]
+        [ActiveIssue(3343, PlatformID.AnyUnix)]
+        public async Task ReadAsStringAsync_SetInvalidCharset_ThrowsInvalidOperationException()
+        {
+            string sourceString = "some string";
+            byte[] contentBytes = Encoding.UTF8.GetBytes(sourceString);
+
+            var content = new MockContent(contentBytes);
+            content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+            content.Headers.ContentType.CharSet = "invalid";
+
+            // This will throw because we have an invalid charset.
+            await Assert.ThrowsAsync<InvalidOperationException>(() => content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task ReadAsStringAsync_SetNoCharset_DefaultCharsetUsed()
+        {
+            // Use content with umlaut characters.
+            string sourceString = "ÄäüÜ"; // c4 e4 fc dc
+            Encoding defaultEncoding = Encoding.GetEncoding("utf-8");
+            byte[] contentBytes = defaultEncoding.GetBytes(sourceString);
+
+            var content = new MockContent(contentBytes);
+
+            // Reading the string should consider the charset of the 'Content-Type' header.
+            string result = await content.ReadAsStringAsync();
+
+            Assert.Equal(sourceString, result);
+        }
+
+        [Fact]
+        public async Task ReadAsByteArrayAsync_EmptyContent_EmptyArray()
+        {
+            var content = new MockContent(new byte[0]);
+            byte[] bytes = await content.ReadAsByteArrayAsync();
+            Assert.Equal(0, bytes.Length);
+        }
+
+        [Fact]
+        public async Task Dispose_DisposedObjectThenAccessMembers_ThrowsObjectDisposedException()
+        {
+            var content = new MockContent();
+            content.Dispose();
+
+            var m = new MemoryStream();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => content.CopyToAsync(m));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => content.ReadAsByteArrayAsync());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => content.ReadAsStringAsync());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => content.ReadAsStreamAsync());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => content.LoadIntoBufferAsync());
+
+            // Note that we don't throw when users access the Headers property. This is useful e.g. to be able to 
+            // read the headers of a content, even though the content is already disposed. Note that the .NET guidelines
+            // only require members to throw ObjectDisposedExcpetion for members "that cannot be used after the object 
+            // has been disposed of".
+            _output.WriteLine(content.Headers.ToString());
+        }
+
+        #region Helper methods
+
+        private byte[] EncodeStringWithBOM(Encoding encoding, string str)
+        {
+            byte[] rawBytes = encoding.GetBytes(str);
+            byte[] preamble = encoding.GetPreamble(); // Get the correct BOM characters
+            byte[] contentBytes = new byte[preamble.Length + rawBytes.Length];
+            Array.Copy(preamble, contentBytes, preamble.Length);
+            Array.Copy(rawBytes, 0, contentBytes, preamble.Length, rawBytes.Length);
+            return contentBytes;
+        }
+
+        public class MockException : Exception
+        {
+            public MockException() { }
+            public MockException(string message) : base(message) { }
+            public MockException(string message, Exception inner) : base(message, inner) { }
+        }
+
+        [Flags]
+        private enum MockOptions
+        {
+            None = 0x0,
+            ThrowInSerializeMethods = 0x1,
+            ReturnNullInCopyToAsync = 0x2,
+            UseWriteByteInCopyTo = 0x4,
+            DontOverrideCreateContentReadStream = 0x8,
+            CanCalculateLength = 0x10,
+            ThrowInTryComputeLength = 0x20,
+            ThrowInAsyncSerializeMethods = 0x40
+        }
+
+        private class MockContent : HttpContent
+        {
+            private byte[] _mockData;
+            private MockOptions _options;
+            private Exception _customException;
+            
+            public int TryComputeLengthCount { get; private set; }
+            public int SerializeToStreamAsyncCount { get; private set; }
+            public int CreateContentReadStreamCount { get; private set; }
+            public int DisposeCount { get; private set; }
+
+            public byte[] MockData
+            {
+                get { return _mockData; }
+            }
+
+            public MockContent()
+                : this((byte[])null, MockOptions.None)
+            { 
+            }
+
+            public MockContent(byte[] mockData)
+                : this(mockData, MockOptions.None)
+            {
+            }
+
+            public MockContent(MockOptions options)
+                : this((byte[])null, options)
+            { 
+            }
+
+            public MockContent(Exception customException, MockOptions options)
+                : this((byte[])null, options)
+            {
+                _customException = customException;
+            }
+
+            public MockContent(byte[] mockData, MockOptions options)
+            {
+                _options = options;
+
+                if (mockData == null)
+                {
+                    _mockData = Encoding.UTF8.GetBytes("data");
+                }
+                else
+                {
+                    _mockData = mockData;
+                }
+            }
+
+            public byte[] GetMockData()
+            {
+                return _mockData;
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                TryComputeLengthCount++;
+
+                if ((_options & MockOptions.ThrowInTryComputeLength) != 0)
+                {
+                    throw new MockException();
+                }
+
+                if ((_options & MockOptions.CanCalculateLength) != 0)
+                {
+                    length = _mockData.Length;
+                    return true;
+                }
+                else
+                {
+                    length = 0;
+                    return false;
+                }
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                SerializeToStreamAsyncCount++;
+
+                if ((_options & MockOptions.ReturnNullInCopyToAsync) != 0)
+                {
+                    return null;
+                }
+
+                if ((_options & MockOptions.ThrowInAsyncSerializeMethods) != 0)
+                {
+                    throw _customException;
+                }
+
+                return Task.Factory.StartNew(() =>
+                {
+                    CheckThrow();
+                    return stream.WriteAsync(_mockData, 0, _mockData.Length);
+                });
+            }
+
+            protected override Task<Stream> CreateContentReadStreamAsync()
+            {
+                CreateContentReadStreamCount++;
+
+                if ((_options & MockOptions.DontOverrideCreateContentReadStream) != 0)
+                {
+                    return base.CreateContentReadStreamAsync();
+                }
+                else
+                {
+                    return Task.FromResult<Stream>(new MockMemoryStream(_mockData, 0, _mockData.Length, false));
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+
+            private void CheckThrow()
+            {
+                if ((_options & MockOptions.ThrowInSerializeMethods) != 0)
+                {
+                    throw _customException;
+                }
+            }
+        }
+
+        private class MockMemoryStream : MemoryStream
+        {
+            public int DisposeCount { get; private set; }
+
+            public MockMemoryStream(byte[] buffer, int index, int count, bool writable)
+                : base(buffer, index, count, writable)
+            {
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+        }
+        
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMessageInvokerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMessageInvokerTest.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpMessageInvokerTest
+    {
+        [Fact]
+        public void Constructor_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HttpMessageInvoker(null));
+            Assert.Throws<ArgumentNullException>(() => new HttpMessageInvoker(null, false));
+        }
+
+        [Fact]
+        public void SendAsync_Null_ThrowsArgumentNullException()
+        {
+            var invoker = new HttpMessageInvoker(new MockHandler());
+            Assert.Throws<ArgumentNullException>(() => { Task t = invoker.SendAsync(null, CancellationToken.None); });
+        }
+
+        [Fact]
+        public async Task SendAsync_Request_HandlerInvoked()
+        {
+            var handler = new MockHandler();
+            var invoker = new HttpMessageInvoker(handler);
+            HttpResponseMessage response = await invoker.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+            Assert.NotNull(response);
+            Assert.Equal(1, handler.SendAsyncCount);
+        }
+        
+        [Fact]
+        public void Dispose_DisposeHandler_HandlerDisposed()
+        {
+            var handler = new MockHandler();
+            var invoker = new HttpMessageInvoker(handler);
+
+            invoker.Dispose();
+            Assert.Equal(1, handler.DisposeCount);
+
+            Assert.Throws<ObjectDisposedException>(() => { Task t = invoker.SendAsync(new HttpRequestMessage(), CancellationToken.None); });
+            Assert.Equal(0, handler.SendAsyncCount);
+
+
+            handler = new MockHandler();
+            invoker = new HttpMessageInvoker(handler, true);
+
+            invoker.Dispose();
+            Assert.Equal(1, handler.DisposeCount);
+
+            Assert.Throws<ObjectDisposedException>(() => { Task t = invoker.SendAsync(new HttpRequestMessage(), CancellationToken.None); });
+            Assert.Equal(0, handler.SendAsyncCount);
+        }
+
+        [Fact]
+        public void Dispose_DontDisposeHandler_HandlerNotDisposed()
+        {
+            var handler = new MockHandler();
+            var invoker = new HttpMessageInvoker(handler, false);
+
+            invoker.Dispose();
+            Assert.Equal(0, handler.DisposeCount);
+
+            Assert.Throws<ObjectDisposedException>(() => { Task t = invoker.SendAsync(new HttpRequestMessage(), CancellationToken.None); });
+            Assert.Equal(0, handler.SendAsyncCount);
+        }
+
+        #region Helpers
+
+        private class MockHandler : HttpMessageHandler
+        {
+            public int DisposeCount { get; private set; }
+            public int SendAsyncCount { get; private set; }
+
+            public MockHandler()
+            {
+            }
+                        
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                SendAsyncCount++;
+
+                return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+        }
+
+        #endregion Helepers
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 
 using Xunit;
 
-namespace System.Net.Http.Tests
+namespace System.Net.Http.Functional.Tests
 {
     public class HttpMethodTest
     {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -1,0 +1,242 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpRequestMessageTest
+    {
+        Version _expectedRequestMessageVersion = new Version(1, 1);
+
+        [Fact]
+        public void Ctor_Default_CorrectDefaults()
+        {
+            var rm = new HttpRequestMessage();
+
+            Assert.Equal(HttpMethod.Get, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(null, rm.RequestUri);
+        }
+
+        [Fact]
+        public void Ctor_RelativeStringUri_CorrectValues()
+        {
+            var rm = new HttpRequestMessage(HttpMethod.Post, "/relative");
+
+            Assert.Equal(HttpMethod.Post, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(new Uri("/relative", UriKind.Relative), rm.RequestUri);
+        }
+
+        [Fact]
+        public void Ctor_AbsoluteStringUri_CorrectValues()
+        {
+            var rm = new HttpRequestMessage(HttpMethod.Post, "http://host/absolute/");
+
+            Assert.Equal(HttpMethod.Post, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(new Uri("http://host/absolute/"), rm.RequestUri);
+        }
+
+        [Fact]
+        public void Ctor_NullStringUri_Accepted()
+        {
+            var rm = new HttpRequestMessage(HttpMethod.Put, (string)null);
+
+            Assert.Equal(null, rm.RequestUri);
+            Assert.Equal(HttpMethod.Put, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+        }
+
+        [Fact]
+        public void Ctor_RelativeUri_CorrectValues()
+        {
+            var uri = new Uri("/relative", UriKind.Relative);
+            var rm = new HttpRequestMessage(HttpMethod.Post, uri);
+
+            Assert.Equal(HttpMethod.Post, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(uri, rm.RequestUri);
+        }
+
+        [Fact]
+        public void Ctor_AbsoluteUri_CorrectValues()
+        {
+            var uri = new Uri("http://host/absolute/");
+            var rm = new HttpRequestMessage(HttpMethod.Post, uri);
+
+            Assert.Equal(HttpMethod.Post, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(uri, rm.RequestUri);
+        }
+
+        [Fact]
+        public void Ctor_NullUri_Accepted()
+        {
+            var rm = new HttpRequestMessage(HttpMethod.Put, (Uri)null);
+
+            Assert.Equal(null, rm.RequestUri);
+            Assert.Equal(HttpMethod.Put, rm.Method);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(null, rm.Content);
+        }
+
+        [Fact]
+        public void Ctor_NullMethod_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HttpRequestMessage(null, "http://example.com"));
+        }
+
+        [Fact]
+        public void Ctor_NonHttpUri_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new HttpRequestMessage(HttpMethod.Put, "ftp://example.com"));
+        }
+
+        [Fact]
+        public void Dispose_DisposeObject_ContentGetsDisposedAndSettersWillThrowButGettersStillWork()
+        {
+            var rm = new HttpRequestMessage(HttpMethod.Get, "http://example.com");
+            var content = new MockContent();
+            rm.Content = content;
+            Assert.False(content.IsDisposed);
+
+            rm.Dispose();
+            rm.Dispose(); // Multiple calls don't throw.
+            
+            Assert.True(content.IsDisposed);
+            Assert.Throws<ObjectDisposedException>(() => { rm.Method = HttpMethod.Put; });
+            Assert.Throws<ObjectDisposedException>(() => { rm.RequestUri = null; });
+            Assert.Throws<ObjectDisposedException>(() => { rm.Version = new Version(1, 0); });
+            Assert.Throws<ObjectDisposedException>(() => { rm.Content = null; });
+
+            // Property getters should still work after disposing.
+            Assert.Equal(HttpMethod.Get, rm.Method);
+            Assert.Equal(new Uri("http://example.com"), rm.RequestUri);
+            Assert.Equal(_expectedRequestMessageVersion, rm.Version);
+            Assert.Equal(content, rm.Content);
+        }
+
+        [Fact]
+        public void Properties_SetPropertiesAndGetTheirValue_MatchingValues()
+        {
+            var rm = new HttpRequestMessage();
+
+            var content = new MockContent();
+            var uri = new Uri("https://example.com");
+            var version = new Version(1, 0);
+            var method = new HttpMethod("custom");
+
+            rm.Content = content;
+            rm.Method = method;
+            rm.RequestUri = uri;
+            rm.Version = version;
+
+            Assert.Equal(content, rm.Content);
+            Assert.Equal(uri, rm.RequestUri);
+            Assert.Equal(method, rm.Method);
+            Assert.Equal(version, rm.Version);
+
+            Assert.NotNull(rm.Headers);
+            Assert.NotNull(rm.Properties);
+        }
+
+        [Fact]
+        public void RequestUri_SetNonHttpUri_ThrowsArgumentException()
+        {
+            var rm = new HttpRequestMessage();
+            Assert.Throws<ArgumentException>(() => { rm.RequestUri = new Uri("ftp://example.com"); });
+        }
+
+        [Fact]
+        public void Version_SetToNull_ThrowsArgumentNullException()
+        {
+            var rm = new HttpRequestMessage();
+            Assert.Throws<ArgumentNullException>(() => { rm.Version = null; });
+        }
+
+        [Fact]
+        public void Method_SetToNull_ThrowsArgumentNullException()
+        {
+            var rm = new HttpRequestMessage();
+            Assert.Throws<ArgumentNullException>(() => { rm.Method = null; });
+        }
+
+        [Fact]
+        public void ToString_DefaultAndNonDefaultInstance_DumpAllFields()
+        {
+            var rm = new HttpRequestMessage();
+            string expected = 
+                    "Method: GET, RequestUri: '<null>', Version: " + 
+                    _expectedRequestMessageVersion.ToString(2) + 
+                    ", Content: <null>, Headers:\r\n{\r\n}";
+            Assert.Equal(expected, rm.ToString());
+
+            rm.Method = HttpMethod.Put;
+            rm.RequestUri = new Uri("http://a.com/");
+            rm.Version = new Version(1, 0);
+            rm.Content = new StringContent("content");
+
+            // Note that there is no Content-Length header: The reason is that the value for Content-Length header
+            // doesn't get set by StringContent..ctor, but ony if someone actually accesses the ContentLength property.
+            Assert.Equal(
+                "Method: PUT, RequestUri: 'http://a.com/', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                "{\r\n" +
+                "  Content-Type: text/plain; charset=utf-8\r\n" +
+                "}", rm.ToString());
+
+            rm.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain", 0.2));
+            rm.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/xml", 0.1));
+            rm.Headers.Add("Custom-Request-Header", "value1");            
+            rm.Content.Headers.Add("Custom-Content-Header", "value2");
+
+            Assert.Equal(
+                "Method: PUT, RequestUri: 'http://a.com/', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                "{\r\n" +
+                "  Accept: text/plain; q=0.2\r\n" +
+                "  Accept: text/xml; q=0.1\r\n" +
+                "  Custom-Request-Header: value1\r\n" +
+                "  Content-Type: text/plain; charset=utf-8\r\n" +
+                "  Custom-Content-Header: value2\r\n" +
+                "}", rm.ToString());
+        }
+
+        #region Helper methods
+
+        private class MockContent : HttpContent
+        {
+            public bool IsDisposed { get; private set; }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpResponseMessageTest
+    {
+        [Fact]
+        public void Ctor_Default_CorrectDefaults()
+        {
+            var rm = new HttpResponseMessage();
+            
+            Assert.Equal(HttpStatusCode.OK, rm.StatusCode);
+            Assert.Equal("OK", rm.ReasonPhrase);
+            Assert.Equal(new Version(1, 1), rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(null, rm.RequestMessage);
+        }
+
+        [Fact]
+        public void Ctor_SpecifiedValues_CorrectValues()
+        {
+            var rm = new HttpResponseMessage(HttpStatusCode.Accepted);
+
+            Assert.Equal(HttpStatusCode.Accepted, rm.StatusCode);
+            Assert.Equal("Accepted", rm.ReasonPhrase);
+            Assert.Equal(new Version(1, 1), rm.Version);
+            Assert.Equal(null, rm.Content);
+            Assert.Equal(null, rm.RequestMessage);
+        }
+
+        [Fact]
+        public void Ctor_InvalidStatusCodeRange_Throw()
+        {
+            int x = -1;
+            Assert.Throws<ArgumentOutOfRangeException>(() => new HttpResponseMessage((HttpStatusCode)x));
+            x = 1000;
+            Assert.Throws<ArgumentOutOfRangeException>(() => new HttpResponseMessage((HttpStatusCode)x));
+        }
+
+        [Fact]
+        public void Dispose_DisposeObject_ContentGetsDisposedAndSettersWillThrowButGettersStillWork()
+        {
+            var rm = new HttpResponseMessage(HttpStatusCode.OK);
+            var content = new MockContent();
+            rm.Content = content;
+            Assert.False(content.IsDisposed);
+
+            rm.Dispose();
+            rm.Dispose(); // Multiple calls don't throw.
+
+            Assert.True(content.IsDisposed);
+            Assert.Throws<ObjectDisposedException>(() => { rm.StatusCode = HttpStatusCode.BadRequest; });
+            Assert.Throws<ObjectDisposedException>(() => { rm.ReasonPhrase = "Bad Request"; });
+            Assert.Throws<ObjectDisposedException>(() => { rm.Version = new Version(1, 0); });
+            Assert.Throws<ObjectDisposedException>(() => { rm.Content = null; });
+
+            // Property getters should still work after disposing.
+            Assert.Equal(HttpStatusCode.OK, rm.StatusCode);
+            Assert.Equal("OK", rm.ReasonPhrase);
+            Assert.Equal(new Version(1, 1), rm.Version);
+            Assert.Equal(content, rm.Content);
+        }
+
+        [Fact]
+        public void Headers_ReadProperty_HeaderCollectionInitialized()
+        {
+            var rm = new HttpResponseMessage();
+            Assert.NotNull(rm.Headers);
+        }
+
+        [Fact]
+        public void IsSuccessStatusCode_VariousStatusCodes_ReturnTrueFor2xxFalseOtherwise()
+        {
+            Assert.True((new HttpResponseMessage()).IsSuccessStatusCode);
+            Assert.True((new HttpResponseMessage(HttpStatusCode.OK)).IsSuccessStatusCode);
+            Assert.True((new HttpResponseMessage(HttpStatusCode.PartialContent)).IsSuccessStatusCode);
+
+            Assert.False((new HttpResponseMessage(HttpStatusCode.MultipleChoices)).IsSuccessStatusCode);
+            Assert.False((new HttpResponseMessage(HttpStatusCode.Continue)).IsSuccessStatusCode);
+            Assert.False((new HttpResponseMessage(HttpStatusCode.BadRequest)).IsSuccessStatusCode);
+            Assert.False((new HttpResponseMessage(HttpStatusCode.BadGateway)).IsSuccessStatusCode);
+        }
+
+        [Fact]
+        public void EnsureSuccessStatusCode_VariousStatusCodes_ThrowIfNot2xx()
+        {
+            Assert.Throws<HttpRequestException>(() =>
+                (new HttpResponseMessage(HttpStatusCode.MultipleChoices)).EnsureSuccessStatusCode());
+            Assert.Throws<HttpRequestException>(() =>
+                (new HttpResponseMessage(HttpStatusCode.BadGateway)).EnsureSuccessStatusCode());
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            Assert.Same(response, response.EnsureSuccessStatusCode());
+        }
+
+        [Fact]
+        public void EnsureSuccessStatusCode_AddContentToMessage_ContentIsDisposed()
+        {
+            var response404 = new HttpResponseMessage(HttpStatusCode.NotFound);
+            response404.Content = new MockContent();
+            Assert.Throws<HttpRequestException>(() => response404.EnsureSuccessStatusCode());
+            Assert.True((response404.Content as MockContent).IsDisposed);
+
+            var response200 = new HttpResponseMessage(HttpStatusCode.OK);
+            response200.Content = new MockContent();
+            response200.EnsureSuccessStatusCode(); // No exception.
+            Assert.False((response200.Content as MockContent).IsDisposed);
+        }
+
+        [Fact]
+        public void Properties_SetPropertiesAndGetTheirValue_MatchingValues()
+        {
+            var rm = new HttpResponseMessage();
+
+            var content = new MockContent();
+            HttpStatusCode statusCode = HttpStatusCode.LengthRequired;
+            string reasonPhrase = "Length Required";
+            var version = new Version(1, 0);
+            var requestMessage = new HttpRequestMessage();
+            
+            rm.Content = content;
+            rm.ReasonPhrase = reasonPhrase;
+            rm.RequestMessage = requestMessage;
+            rm.StatusCode = statusCode;
+            rm.Version = version;
+
+            Assert.Equal(content, rm.Content);
+            Assert.Equal(reasonPhrase, rm.ReasonPhrase);
+            Assert.Equal(requestMessage, rm.RequestMessage);
+            Assert.Equal(statusCode, rm.StatusCode);
+            Assert.Equal(version, rm.Version);
+            
+            Assert.NotNull(rm.Headers);
+        }
+
+        [Fact]
+        public void Version_SetToNull_ThrowsArgumentNullException()
+        {
+            var rm = new HttpResponseMessage();
+            Assert.Throws<ArgumentNullException>(() => { rm.Version = null; });
+        }
+
+        [Fact]
+        public void ReasonPhrase_ContainsCRChar_ThrowsFormatException()
+        {
+            var rm = new HttpResponseMessage();
+            Assert.Throws<FormatException>(() => { rm.ReasonPhrase = "text\rtext"; });
+        }
+
+        [Fact]
+        public void ReasonPhrase_ContainsLFChar_ThrowsFormatException()
+        {
+            var rm = new HttpResponseMessage();
+            Assert.Throws<FormatException>(() => { rm.ReasonPhrase = "text\ntext"; });
+        }
+
+        [Fact]
+        public void ReasonPhrase_SetToNull_Accepted()
+        {
+            var rm = new HttpResponseMessage();
+            rm.ReasonPhrase = null;
+            Assert.Equal("OK", rm.ReasonPhrase); // Default provided.
+        }
+
+        [Fact]
+        public void ReasonPhrase_UnknownStatusCode_Null()
+        {
+            var rm = new HttpResponseMessage();
+            rm.StatusCode = (HttpStatusCode)150; // Default reason unknown.
+            Assert.Null(rm.ReasonPhrase); // No default provided.
+        }
+
+        [Fact]
+        public void ReasonPhrase_SetToEmpty_Accepted()
+        {
+            var rm = new HttpResponseMessage();
+            rm.ReasonPhrase = String.Empty;
+            Assert.Equal(String.Empty, rm.ReasonPhrase);
+        }
+
+        [Fact]
+        public void Content_SetToNull_Accepted()
+        {
+            var rm = new HttpResponseMessage();
+            rm.Content = null;
+            Assert.Null(rm.Content);
+        }
+
+        [Fact]
+        public void StatusCode_InvalidStatusCodeRange_ThrowsArgumentOutOfRangeException()
+        {
+            var rm = new HttpResponseMessage();
+
+            int x = -1;
+            Assert.Throws<ArgumentOutOfRangeException>(() => { rm.StatusCode = (HttpStatusCode)x; });
+            x = 1000;
+            Assert.Throws<ArgumentOutOfRangeException>(() => { rm.StatusCode = (HttpStatusCode)x; });
+        }
+
+        [Fact]
+        public void ToString_DefaultAndNonDefaultInstance_DumpAllFields()
+        {
+            var rm = new HttpResponseMessage();
+            Assert.Equal("StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:\r\n{\r\n}",
+                rm.ToString());
+
+            rm.StatusCode = HttpStatusCode.BadRequest;
+            rm.ReasonPhrase = null;
+            rm.Version = new Version(1, 0);
+            rm.Content = new StringContent("content");
+
+            // Note that there is no Content-Length header: The reason is that the value for Content-Length header
+            // doesn't get set by StringContent..ctor, but only if someone actually accesses the ContentLength property.
+            Assert.Equal(
+                "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                "{\r\n" +
+                "  Content-Type: text/plain; charset=utf-8\r\n" +
+                "}", rm.ToString());
+
+            rm.Headers.AcceptRanges.Add("bytes");
+            rm.Headers.AcceptRanges.Add("pages");
+            rm.Headers.Add("Custom-Response-Header", "value1");
+            rm.Content.Headers.Add("Custom-Content-Header", "value2");
+
+            Assert.Equal(
+                "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                "{\r\n" +
+                "  Accept-Ranges: bytes\r\n" +
+                "  Accept-Ranges: pages\r\n" +
+                "  Custom-Response-Header: value1\r\n" +
+                "  Content-Type: text/plain; charset=utf-8\r\n" +
+                "  Custom-Content-Header: value2\r\n" +
+                "}", rm.ToString());
+        }
+
+        #region Helper methods
+
+        private class MockContent : HttpContent
+        {
+            public bool IsDisposed { get; private set; }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
+
+        #endregion   
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/MessageProcessingHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MessageProcessingHandlerTest.cs
@@ -1,0 +1,353 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class MessageProcessingHandlerTest
+    {
+        [Fact]
+        public void Ctor_CreateDispose_Success()
+        {
+            using (var handler = new MockHandler())
+            {
+                Assert.Null(handler.InnerHandler);
+            }
+        }
+
+        [Fact]
+        public void Ctor_CreateWithHandlerDispose_Success()
+        {
+            using (var handler = new MockHandler(new MockTransportHandler()))
+            {
+                Assert.NotNull(handler.InnerHandler);
+            }
+        }
+
+        [Fact]
+        public void Ctor_CreateWithNullHandler_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MockHandler(null));
+        }
+
+        [Fact]
+        public void SendAsync_NullRequest_ThrowsArgumentNullException()
+        {
+            var transport = new MockTransportHandler();
+            var handler = new MockHandler(transport);
+
+            Assert.Throws<ArgumentNullException>(() => { Task t = handler.TestSendAsync(null, CancellationToken.None); });
+        }
+
+        [Fact]
+        public async Task SendAsync_CallMethod_ProcessRequestAndProcessResponseCalled()
+        {
+            var transport = new MockTransportHandler();
+            var handler = new MockHandler(transport);
+
+            await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            Assert.Equal(1, handler.ProcessRequestCount);
+            Assert.Equal(1, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_InnerHandlerThrows_ThrowWithoutCallingProcessRequest()
+        {
+            var transport = new MockTransportHandler(true); // Throw if Send/SendAsync() is called.
+            var handler = new MockHandler(transport);
+
+            await Assert.ThrowsAsync<MockException>(() => handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None));
+
+            Assert.Equal(1, handler.ProcessRequestCount);
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_InnerHandlerReturnsNullResponse_ThrowInvalidOperationExceptionWithoutCallingProcessRequest()
+        {
+            var transport = new MockTransportHandler(() => { return null; });
+            var handler = new MockHandler(transport);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None));
+
+            Assert.Equal(1, handler.ProcessRequestCount);
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_ProcessRequestThrows_ThrowWithoutCallingProcessRequestNorInnerHandler()
+        {
+            var transport = new MockTransportHandler();
+            // ProcessRequest() throws exception.
+            var handler = new MockHandler(transport, true, () => { throw new MockException(); }); 
+
+            // Note that ProcessRequest() is called by SendAsync(). However, the exception is not thrown
+            // by SendAsync(). Instead, the returned Task is marked as faulted and contains the exception. 
+            await Assert.ThrowsAsync<MockException>(() => handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None));
+
+            Assert.Equal(0, transport.SendAsyncCount);
+            Assert.Equal(1, handler.ProcessRequestCount);
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_ProcessResponseThrows_TaskIsFaulted()
+        {
+            var transport = new MockTransportHandler();
+            // ProcessResponse() throws exception.
+            var handler = new MockHandler(transport, false, () => { throw new MockException(); }); 
+
+            // Throwing an exception in ProcessResponse() will cause the Task to complete as 'faulted'.
+            await Assert.ThrowsAsync<MockException>(() => handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None));
+
+            Assert.Equal(1, transport.SendAsyncCount);
+            Assert.Equal(1, handler.ProcessRequestCount);
+            Assert.Equal(1, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_OperationCanceledWhileInnerHandlerIsWorking_TaskSetToIsCanceled()
+        {
+            var cts = new CancellationTokenSource();
+            // We simulate a cancellation happening while the inner handler was processing the request, by letting
+            // the inner mock handler call Cancel() and behave like if another thread called cancel while it was
+            // processing.
+            var transport = new MockTransportHandler(cts); // inner handler will cancel.
+            var handler = new MockHandler(transport);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_OperationCanceledWhileProcessRequestIsExecuted_TaskSetToIsCanceled()
+        {
+            var cts = new CancellationTokenSource();
+            var transport = new MockTransportHandler();
+            // ProcessRequest will cancel.
+            var handler = new MockHandler(transport, true,
+                () => { cts.Cancel(); cts.Token.ThrowIfCancellationRequested(); });
+
+            // Note that even ProcessMessage() is called on the same thread, we don't expect SendAsync() to throw.
+            // SendAsync() must complete successfully, but the Task will be canceled. 
+            await Assert.ThrowsAsync<TaskCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_OperationCanceledWhileProcessResponseIsExecuted_TaskSetToIsCanceled()
+        {
+            var cts = new CancellationTokenSource();
+            var transport = new MockTransportHandler();
+            // ProcessResponse will cancel.
+            var handler = new MockHandler(transport, false,
+                () => { cts.Cancel(); cts.Token.ThrowIfCancellationRequested(); });
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+        }
+
+        [Fact]
+        public async Task SendAsync_ProcessRequestThrowsOperationCanceledExceptionNotBoundToCts_TaskSetToIsFaulted()
+        {
+            var cts = new CancellationTokenSource();
+            var transport = new MockTransportHandler();
+            // ProcessRequest will throw a random OperationCanceledException() not related to cts. We also cancel
+            // the cts to make sure the code behaves correctly even if cts is canceled & an OperationCanceledException
+            // was thrown.
+            var handler = new MockHandler(transport, true,
+                () => { cts.Cancel(); throw new OperationCanceledException("custom"); });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_ProcessResponseThrowsOperationCanceledExceptionNotBoundToCts_TaskSetToIsFaulted()
+        {
+            var cts = new CancellationTokenSource();
+            var transport = new MockTransportHandler();
+            // ProcessResponse will throw a random OperationCanceledException() not related to cts. We also cancel
+            // the cts to make sure the code behaves correctly even if cts is canceled & an OperationCanceledException
+            // was thrown.
+            var handler = new MockHandler(transport, false,
+                () => { cts.Cancel(); throw new OperationCanceledException("custom"); });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+
+            Assert.Equal(1, handler.ProcessResponseCount);
+        }
+        
+        [Fact]
+        public async Task SendAsync_ProcessRequestThrowsOperationCanceledExceptionUsingOtherCts_TaskSetToIsFaulted()
+        {
+            var cts = new CancellationTokenSource();
+            var otherCts = new CancellationTokenSource();
+            var transport = new MockTransportHandler();
+            // ProcessRequest will throw a random OperationCanceledException() not related to cts. We also cancel
+            // the cts to make sure the code behaves correctly even if cts is canceled & an OperationCanceledException
+            // was thrown.
+            var handler = new MockHandler(transport, true,
+                () => { cts.Cancel(); throw new OperationCanceledException("custom", otherCts.Token); });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+
+            Assert.Equal(0, handler.ProcessResponseCount);
+        }
+
+        [Fact]
+        public async Task SendAsync_ProcessResponseThrowsOperationCanceledExceptionUsingOtherCts_TaskSetToIsFaulted()
+        {
+            var cts = new CancellationTokenSource();
+            var otherCts = new CancellationTokenSource();
+            var transport = new MockTransportHandler();
+            // ProcessResponse will throw a random OperationCanceledException() not related to cts. We also cancel
+            // the cts to make sure the code behaves correctly even if cts is canceled & an OperationCanceledException
+            // was thrown.
+            var handler = new MockHandler(transport, false,
+                () => { cts.Cancel(); throw new OperationCanceledException("custom", otherCts.Token); });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => handler.TestSendAsync(new HttpRequestMessage(), cts.Token));
+
+            Assert.Equal(1, handler.ProcessResponseCount);
+        }
+
+        #region Helper methods
+
+        public class MockException : Exception
+        {
+            public MockException() { }
+            public MockException(string message) : base(message) { }
+            public MockException(string message, Exception inner) : base(message, inner) { }
+        }
+
+        private class MockHandler : MessageProcessingHandler
+        {
+            private bool _callInProcessRequest;
+            private Action _customAction;
+
+            public int ProcessRequestCount { get; private set; }
+            public int ProcessResponseCount { get; private set; }
+
+            public MockHandler()
+                : base()
+            {
+            }
+
+            public MockHandler(HttpMessageHandler innerHandler)
+                : this(innerHandler, true, null)
+            {
+            }
+
+            public MockHandler(HttpMessageHandler innerHandler, bool callInProcessRequest, Action customAction)
+                : base(innerHandler)
+            {
+                _customAction = customAction;
+                _callInProcessRequest = callInProcessRequest;
+            }
+
+            public Task<HttpResponseMessage> TestSendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return SendAsync(request, cancellationToken);
+            }
+            
+            protected override HttpRequestMessage ProcessRequest(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                ProcessRequestCount++;
+                Assert.NotNull(request);
+
+                if (_callInProcessRequest && (_customAction != null))
+                {
+                    _customAction();
+                }
+
+                return request;
+            }
+
+            protected override HttpResponseMessage ProcessResponse(HttpResponseMessage response,
+                CancellationToken cancellationToken)
+            {
+                ProcessResponseCount++;
+                Assert.NotNull(response);
+
+                if (!_callInProcessRequest && (_customAction != null))
+                {
+                    _customAction();
+                }
+
+                return response;
+            }
+        }
+
+        private class MockTransportHandler : HttpMessageHandler
+        {
+            private bool _alwaysThrow;
+            private CancellationTokenSource _cts;
+            private Func<HttpResponseMessage> _mockResultDelegate;
+
+            public int SendAsyncCount { get; private set; }
+
+            public MockTransportHandler(Func<HttpResponseMessage> mockResultDelegate)
+            {
+                _mockResultDelegate = mockResultDelegate;
+            }
+
+            public MockTransportHandler()
+            {
+            }
+
+            public MockTransportHandler(bool alwaysThrow)
+            {
+                _alwaysThrow = alwaysThrow;
+            }
+
+            public MockTransportHandler(CancellationTokenSource cts)
+            {
+                _cts = cts;
+            }
+                        
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                SendAsyncCount++;
+
+                TaskCompletionSource<HttpResponseMessage> tcs = new TaskCompletionSource<HttpResponseMessage>();
+
+                if (_cts != null)
+                {
+                    _cts.Cancel();
+                    tcs.TrySetCanceled();
+                }
+
+                if (_alwaysThrow)
+                {
+                    tcs.TrySetException(new MockException());
+                }
+                else
+                {
+                    if (_mockResultDelegate == null)
+                    {
+                        tcs.TrySetResult(new HttpResponseMessage());
+                    }
+                    else
+                    {
+                        tcs.TrySetResult(_mockResultDelegate());
+                    }
+                }
+
+                return tcs.Task;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class MultipartContentTest
+    {
+        [Fact]
+        public void Ctor_NullOrEmptySubType_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MultipartContent(null));
+            Assert.Throws<ArgumentException>(() => new MultipartContent(""));
+            Assert.Throws<ArgumentException>(() => new MultipartContent(" "));
+        }
+
+        [Fact]
+        public void Ctor_NullOrEmptyBoundary_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", null));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", ""));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", " "));
+        }
+
+        [Fact]
+        public void Ctor_TooLongBoundary_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new MultipartContent("Some",
+                "LongerThan70CharactersLongerThan70CharactersLongerThan70CharactersLongerThan70CharactersLongerThan70Characters"));
+        }
+        
+        [Fact]
+        public void Ctor_BadBoundary_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "EndsInSpace "));
+            
+            // Invalid chars CTLs HT < > @ ; \ " [ ] { } ! # $ % & ^ ~ `
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "a\t"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "<"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "@"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "["));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "{"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "!"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "#"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "$"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "%"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "&"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "^"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "~"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "`"));
+            Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "\"quoted\""));
+        }
+
+        [Fact]
+        public void Ctor_GoodBoundary_Success()
+        {
+            // RFC 2046 Section 5.1.1
+            // boundary := 0*69<bchars> bcharsnospace
+            // bchars := bcharsnospace / " "
+            // bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
+            new MultipartContent("some", "09");
+            new MultipartContent("some", "az");
+            new MultipartContent("some", "AZ");
+            new MultipartContent("some", "'");
+            new MultipartContent("some", "(");
+            new MultipartContent("some", "+");
+            new MultipartContent("some", "_");
+            new MultipartContent("some", ",");
+            new MultipartContent("some", "-");
+            new MultipartContent("some", ".");
+            new MultipartContent("some", "/");
+            new MultipartContent("some", ":");
+            new MultipartContent("some", "=");
+            new MultipartContent("some", "?");
+            new MultipartContent("some", "Contains Space");
+            new MultipartContent("some", " StartsWithSpace");
+            new MultipartContent("some", Guid.NewGuid().ToString());
+        }
+
+        [Fact]
+        public void Ctor_Headers_AutomaticallyCreated()
+        {
+            var content = new MultipartContent("test_subtype", "test_boundary");
+            Assert.Equal("multipart/test_subtype", content.Headers.ContentType.MediaType);
+            Assert.Equal(1, content.Headers.ContentType.Parameters.Count);
+        }
+
+        [Fact]
+        public void Dispose_Empty_Sucess()
+        {
+            var content = new MultipartContent();
+            content.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_InnerContent_InnerContentDisposed()
+        {
+            var content = new MultipartContent();
+            var innerContent = new MockContent();
+            content.Add(innerContent);
+            content.Dispose();
+            Assert.Equal(1, innerContent.DisposeCount);
+            content.Dispose();
+            // Inner content is discarded after first dispose.
+            Assert.Equal(1, innerContent.DisposeCount);
+        }
+
+        [Fact]
+        public void Dispose_NestedContent_NestedContentDisposed()
+        {
+            var outer = new MultipartContent();
+            var inner = new MultipartContent();
+            outer.Add(inner);
+            var mock = new MockContent();
+            inner.Add(mock);
+            outer.Dispose();
+            Assert.Equal(1, mock.DisposeCount);
+            outer.Dispose();
+            // Inner content is discarded after first dispose.
+            Assert.Equal(1, mock.DisposeCount);
+        }
+
+        #region Helpers
+
+        private class MockContent : HttpContent
+        {
+            public int DisposeCount { get; private set; }
+
+            public MockContent() { }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion Helpers
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartFormDataContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartFormDataContentTest.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class MultipartFormDataContentTest
+    {
+        [Fact]
+        public void Ctor_NoParams_CorrectMediaType()
+        {
+            var content = new MultipartFormDataContent();
+            Assert.Equal("multipart/form-data", content.Headers.ContentType.MediaType);
+            Assert.Equal(1, content.Headers.ContentType.Parameters.Count);
+        }
+
+        [Fact]
+        public void Ctor_NullBoundary_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MultipartFormDataContent(null));
+        }
+
+        [Fact]
+        public void Ctor_EmptyBoundary_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MultipartFormDataContent(String.Empty));
+        }
+
+        [Fact]
+        public void Add_NullContent_ThrowsArgumentNullException()
+        {
+            var content = new MultipartFormDataContent();
+            Assert.Throws<ArgumentNullException>(() => content.Add(null));
+        }
+
+        [Fact]
+        public void Add_NullName_ThrowsArgumentException()
+        {
+            var content = new MultipartFormDataContent();
+            Assert.Throws<ArgumentException>(() => content.Add(new StringContent("Hello world"), null));
+        }
+
+        [Fact]
+        public void Add_EmptyName_ThrowsArgumentException()
+        {
+            var content = new MultipartFormDataContent();
+            Assert.Throws<ArgumentException>(() => content.Add(new StringContent("Hello world"), String.Empty));
+        }
+
+        [Fact]
+        public void Add_NullFileName_ThrowsArgumentException()
+        {
+            var content = new MultipartFormDataContent();
+            Assert.Throws<ArgumentException>(() => content.Add(new StringContent("Hello world"), "name", null));
+        }
+
+        [Fact]
+        public void Add_EmptyFileName_ThrowsArgumentException()
+        {
+            var content = new MultipartFormDataContent();
+            Assert.Throws<ArgumentException>(() => content.Add(new StringContent("Hello world"), "name", String.Empty));
+        }
+
+        [Fact]
+        public async Task Serialize_EmptyList_Success()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            var output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal("--test_boundary\r\n\r\n--test_boundary--\r\n", result);
+        }
+
+        [Fact]
+        public async Task Serialize_StringContent_Success()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"));
+
+            var output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data\r\n\r\nHello World\r\n--test_boundary--\r\n",
+                result);
+        }
+
+        [Fact]
+        public async Task Serialize_NamedStringContent_Success()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"), "test_name");
+
+            var output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data; name=test_name\r\n\r\nHello World\r\n--test_boundary--\r\n",
+                result);
+        }
+
+        [Fact]
+        public async Task Serialize_FileNameStringContent_Success()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"), "test_name", "test_file_name");
+
+            var output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data; name=test_name; " 
+                + "filename=test_file_name; filename*=utf-8\'\'test_file_name\r\n\r\n"
+                + "Hello World\r\n--test_boundary--\r\n",
+                result);
+        }
+
+        [Fact]
+        public async Task Serialize_QuotedName_Success()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"), "\"test name\"");
+
+            var output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data; name=\"test name\"\r\n\r\nHello World\r\n--test_boundary--\r\n",
+                result);
+        }
+
+        [Fact]
+        public async Task Serialize_InvalidName_Encoded()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"), "testク\r\n namé");
+
+            MemoryStream output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data; name=\"=?utf-8?B?dGVzdOOCrw0KIG5hbcOp?=\""
+                + "\r\n\r\nHello World\r\n--test_boundary--\r\n",
+                result);
+        }
+
+        [Fact]
+        public async Task Serialize_InvalidQuotedName_Encoded()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"), "\"testク\r\n namé\"");
+
+            var output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data; name=\"=?utf-8?B?dGVzdOOCrw0KIG5hbcOp?=\""
+                + "\r\n\r\nHello World\r\n--test_boundary--\r\n",
+                result);
+        }
+
+        [Fact]
+        public async Task Serialize_InvalidNamedFileName_Encoded()
+        {
+            var content = new MultipartFormDataContent("test_boundary");
+            content.Add(new StringContent("Hello World"), "testク\r\n namé", "fileク\r\n namé");
+
+            MemoryStream output = new MemoryStream();
+            await content.CopyToAsync(output);
+
+            output.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(output).ReadToEnd();
+
+            Assert.Equal(
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                + "Content-Disposition: form-data; name=\"=?utf-8?B?dGVzdOOCrw0KIG5hbcOp?=\";"
+                + " filename=\"=?utf-8?B?ZmlsZeOCrw0KIG5hbcOp?=\"; filename*=utf-8\'\'file%E3%82%AF%0D%0A%20nam%C3%A9" 
+                + "\r\n\r\nHello World\r\n--test_boundary--\r\n",
+                result);
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Tests;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class ResponseStreamTest
+    {
+        private readonly ITestOutputHelper _output;
+        
+        public ResponseStreamTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task GetStreamAsync_ReadToEnd_Success()
+        {
+            HttpClient client = GetHttpClient();
+            
+            Stream stream = await client.GetStreamAsync(HttpTestServers.RemoteGetServer);
+            using (var reader = new StreamReader(stream))
+            {
+                string responseBody = reader.ReadToEnd();
+                _output.WriteLine(responseBody);
+                Assert.True(IsValidResponseBody(responseBody));
+            }
+        }
+
+        [Fact]
+        public async Task GetAsync_UseResponseHeadersReadAndCallLoadIntoBuffer_Success()
+        {
+            HttpClient client = GetHttpClient();
+            
+            HttpResponseMessage response =
+                await client.GetAsync(HttpTestServers.RemoteGetServer, HttpCompletionOption.ResponseHeadersRead);
+            await response.Content.LoadIntoBufferAsync();
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            _output.WriteLine(responseBody);
+            Assert.True(IsValidResponseBody(responseBody));
+        }
+
+        [Fact]
+        public async Task GetAsync_UseResponseHeadersReadAndCopyToMemoryStream_Success()
+        {
+            HttpClient client = GetHttpClient();
+            
+            HttpResponseMessage response =
+                await client.GetAsync(HttpTestServers.RemoteGetServer, HttpCompletionOption.ResponseHeadersRead);
+
+            var memoryStream = new MemoryStream();
+            await response.Content.CopyToAsync(memoryStream);
+            memoryStream.Position = 0;
+            
+            using (var reader = new StreamReader(memoryStream))
+            {
+                string responseBody = reader.ReadToEnd();
+                _output.WriteLine(responseBody);
+                Assert.True(IsValidResponseBody(responseBody));
+            }
+        }
+
+        // These methods help to validate the response body since the endpoint will echo
+        // all request headers.
+        //
+        // TODO: This validation will be improved in the future once the test server endpoint
+        // is able to provide a custom response header with a SHA1 hash of the expected response body.
+        private readonly string[] CustomHeaderValues = new string[] {"abcdefg", "12345678", "A1B2C3D4"};
+        private HttpClient GetHttpClient()
+        {
+            var client = new HttpClient();
+            int ndx = 1;
+            foreach (string headerValue in CustomHeaderValues)
+            {
+                client.DefaultRequestHeaders.Add("X-Custom" + ndx.ToString(), headerValue);
+                ndx++;
+            }
+
+            return client;
+        }
+
+        private bool IsValidResponseBody(string responseBody)
+        {
+            foreach (string headerValue in CustomHeaderValues)
+            {
+                if (!responseBody.Contains(headerValue))
+                {
+                    return false;
+                }
+            }            
+
+            return true;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
@@ -1,0 +1,351 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class StreamContentTest
+    {
+        private readonly ITestOutputHelper _output;
+        
+        public StreamContentTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+        
+        [Fact]
+        public void Ctor_NullStream_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StreamContent(null));
+        }
+
+        [Fact]
+        public void Ctor_ZeroBufferSize_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamContent(new MemoryStream(), 0));
+        }
+
+        [Fact]
+        public void ContentLength_SetStreamSupportingSeeking_StreamLengthMatchesHeaderValue()
+        {
+            var source = new MockStream(new byte[10], true, true); // Supports seeking.
+            var content = new StreamContent(source);
+
+            Assert.Equal(source.Length, content.Headers.ContentLength);;
+        }
+
+        [Fact]
+        public void ContentLength_SetStreamSupportingSeekingPartiallyConsumed_StreamLengthMatchesHeaderValueMinusConsumed()
+        {
+            int consumed = 4;
+            var source = new MockStream(new byte[10], true, true); // Supports seeking.
+            source.Read(new byte[consumed], 0, consumed);
+            var content = new StreamContent(source);
+
+            Assert.Equal(source.Length - consumed, content.Headers.ContentLength);
+        }
+
+        [Fact]
+        public void ContentLength_SetStreamNotSupportingSeeking_NullReturned()
+        {
+            var source = new MockStream(new byte[10], false, true); // Doesn't support seeking.
+            var content = new StreamContent(source);
+
+            Assert.Null(content.Headers.ContentLength);
+        }
+
+        [Fact]
+        public void Dispose_UseMockStreamSourceAndDisposeContent_MockStreamGotDisposed()
+        {
+            var source = new MockStream(new byte[10]);
+            var content = new StreamContent(source);
+            content.Dispose();
+
+            Assert.Equal(1, source.DisposeCount);
+        }
+
+        [Fact]
+        public void CopyToAsync_NullDestination_ThrowsArgumentnullException()
+        {
+            var source = new MockStream(new byte[10]);
+            var content = new StreamContent(source);
+            Assert.Throws<ArgumentNullException>(() => { Task t = content.CopyToAsync(null); });
+        }
+
+        [Fact]
+        public async Task CopyToAsync_CallMultipleTimesWithStreamSupportingSeeking_ContentIsSerializedMultipleTimes()
+        {
+            var source = new MockStream(new byte[10], true, true); // Supports seeking.
+            var content = new StreamContent(source);
+
+            var destination1 = new MemoryStream();
+            await content.CopyToAsync(destination1);
+            Assert.Equal(source.Length, destination1.Length);
+
+            var destination2 = new MemoryStream();
+            await content.CopyToAsync(destination2);
+            Assert.Equal(source.Length, destination2.Length);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_CallMultipleTimesWithStreamSupportingSeekingPartiallyConsumed_ContentIsSerializedMultipleTimesFromInitialPoint()
+        {
+            int consumed = 4;
+            var source = new MockStream(new byte[10], true, true); // supports seeking.
+            source.Read(new byte[consumed], 0, consumed);
+            var content = new StreamContent(source);
+
+            var destination1 = new MemoryStream();
+            await content.CopyToAsync(destination1);
+            Assert.Equal(source.Length - consumed, destination1.Length);
+
+            var destination2 = new MemoryStream();
+            await content.CopyToAsync(destination2);
+            Assert.Equal(source.Length - consumed, destination2.Length);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_CallMultipleTimesWithStreamNotSupportingSeeking_ThrowsInvalidOperationException()
+        {
+            var source = new MockStream(new byte[10], false, true); // doesn't support seeking.
+            var content = new StreamContent(source);
+
+            var destination1 = new MemoryStream();
+            await content.CopyToAsync(destination1);
+            // Use hardcoded expected length, since source.Length would throw (source stream gets disposed if non-seekable).
+            Assert.Equal(10, destination1.Length);
+
+            // Note that the InvalidOperationException is thrown in CopyToAsync(). It is not thrown inside the task.
+            var destination2 = new MemoryStream();
+            Assert.Throws<InvalidOperationException>(() => { Task t = content.CopyToAsync(destination2); });
+        }
+
+        [Fact]
+        public async Task CopyToAsync_CallMultipleTimesWithStreamNotSupportingSeekingButBufferedStream_ContentSerializedOnceToBuffer()
+        {
+            var source = new MockStream(new byte[10], false, true); // doesn't support seeking.
+            var content = new StreamContent(source);
+
+            // After loading the content into a buffer, we should be able to copy the content to a destination stream
+            // multiple times, even though the stream doesn't support seeking.
+            await content.LoadIntoBufferAsync();
+
+            var destination1 = new MemoryStream();
+            await content.CopyToAsync(destination1);
+            // Use hardcoded expected length, since source.Length would throw (source stream gets disposed if non-seekable)
+            Assert.Equal(10, destination1.Length);
+
+            var destination2 = new MemoryStream();
+            await content.CopyToAsync(destination2);
+            Assert.Equal(10, destination2.Length);
+        }
+
+        [Fact]
+        public async Task CopyToAsync_CallMultipleTimesWithStreamNotSupportingSeekingButBufferedStreamPartiallyConsumed_ContentSerializedOnceToBuffer()
+        {
+            int consumed = 4;
+            var source = new MockStream(new byte[10], false, true); // doesn't support seeking.
+            source.Read(new byte[consumed], 0, consumed);
+            var content = new StreamContent(source);
+
+            // After loading the content into a buffer, we should be able to copy the content to a destination stream
+            // multiple times, even though the stream doesn't support seeking.
+            await content.LoadIntoBufferAsync();
+
+            var destination1 = new MemoryStream();
+            await content.CopyToAsync(destination1);
+            // Use hardcoded expected length, since source.Length would throw (source stream gets disposed if non-seekable).
+            Assert.Equal(10 - consumed, destination1.Length);
+
+            var destination2 = new MemoryStream();
+            await content.CopyToAsync(destination2);
+            Assert.Equal(10 - consumed, destination2.Length);
+        }
+
+        [Fact]
+        public async Task ContentReadStream_GetProperty_ReturnOriginalStream()
+        {
+            var source = new MockStream(new byte[10]);
+            var content = new StreamContent(source);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+            Assert.Equal(source.Length, stream.Length);
+            Assert.Equal(0, source.ReadCount);
+            Assert.NotSame(source, stream);
+        }
+
+        [Fact]
+        public async Task ContentReadStream_GetPropertyPartiallyConsumed_ReturnOriginalStream()
+        {
+            int consumed = 4;
+            var source = new MockStream(new byte[10]);
+            source.Read(new byte[consumed], 0, consumed);
+            var content = new StreamContent(source);
+
+            Stream stream = await content.ReadAsStreamAsync();
+            Assert.False(stream.CanWrite);
+            Assert.Equal(source.Length, stream.Length);
+            Assert.Equal(1, source.ReadCount);
+            Assert.Equal(consumed, stream.Position);
+            Assert.NotSame(source, stream);
+        }
+
+        [Fact]
+        public async Task ContentReadStream_CheckResultProperties_ValuesRepresentReadOnlyStream()
+        {
+            byte[] data = new byte[10];
+            for (int i = 0; i < data.Length; i++)
+            {
+                data[i] = (byte)i;
+            }
+
+            var source = new MockStream(data);
+
+            var content = new StreamContent(source);
+            Stream contentReadStream = await content.ReadAsStreamAsync();
+
+            // The following checks verify that the stream returned passes all read-related properties to the 
+            // underlying MockStream and throws when using write-related members.
+
+            Assert.False(contentReadStream.CanWrite);
+            Assert.True(contentReadStream.CanRead);
+            Assert.Equal(source.Length, contentReadStream.Length);
+
+            Assert.Equal(1, source.CanSeekCount);
+            _output.WriteLine(contentReadStream.CanSeek.ToString());
+            Assert.Equal(2, source.CanSeekCount);
+
+            contentReadStream.Position = 3; // No exception.
+            Assert.Equal(3, contentReadStream.Position);
+          
+            byte byteOnIndex3 = (byte)contentReadStream.ReadByte();
+            Assert.Equal(data[3], byteOnIndex3);
+
+            byte[] byteOnIndex4 = new byte[1];
+            int result = await contentReadStream.ReadAsync(byteOnIndex4, 0, 1);
+            Assert.Equal(1, result);
+                        
+            Assert.Equal(data[4], byteOnIndex4[0]);
+
+            byte[] byteOnIndex5 = new byte[1];
+            Assert.Equal(1, contentReadStream.Read(byteOnIndex5, 0, 1));
+            Assert.Equal(data[5], byteOnIndex5[0]);
+
+            contentReadStream.ReadTimeout = 123;
+            Assert.Equal(123, source.ReadTimeout);
+            Assert.Equal(123, contentReadStream.ReadTimeout);
+
+            Assert.Equal(0, source.CanTimeoutCount);
+            _output.WriteLine(contentReadStream.CanTimeout.ToString());
+            Assert.Equal(1, source.CanTimeoutCount);
+
+            Assert.Equal(0, source.SeekCount);
+            contentReadStream.Seek(0, SeekOrigin.Begin);
+            Assert.Equal(1, source.SeekCount);
+
+            Assert.Throws<NotSupportedException>(() => { contentReadStream.WriteTimeout = 5; });
+            Assert.Throws<NotSupportedException>(() => contentReadStream.WriteTimeout.ToString());
+            Assert.Throws<NotSupportedException>(() => contentReadStream.Flush());
+            Assert.Throws<NotSupportedException>(() => contentReadStream.SetLength(1));
+            Assert.Throws<NotSupportedException>(() => contentReadStream.Write(null, 0, 0));
+            Assert.Throws<NotSupportedException>(() => contentReadStream.WriteByte(1));
+
+            Assert.Equal(0, source.DisposeCount);
+            contentReadStream.Dispose();
+            Assert.Equal(1, source.DisposeCount);
+        }
+
+        #region Helper methods
+
+        private class MockStream : MemoryStream
+        {
+            private bool _canSeek;
+            private bool _canRead;
+            private int _readTimeout;
+
+            public int DisposeCount { get; private set; }
+            public int BufferSize { get; private set; }
+            public int ReadCount { get; private set; }
+            public int CanSeekCount { get; private set; }
+            public int CanTimeoutCount { get; private set; }
+            public int SeekCount { get; private set; }
+
+            public override bool CanSeek
+            {
+                get
+                {
+                    CanSeekCount++;
+                    return _canSeek;
+                }
+            }
+
+            public override bool CanRead
+            {
+                get { return _canRead; }
+            }
+
+            public override int ReadTimeout
+            {
+                get { return _readTimeout; }
+                set { _readTimeout = value; }
+            }
+
+            public override bool CanTimeout
+            {
+                get
+                {
+                    CanTimeoutCount++;
+                    return base.CanTimeout;
+                }
+            }
+
+            public MockStream(byte[] data)
+                : this(data, true, true)
+            {
+            }
+
+            public MockStream(byte[] data, bool canSeek, bool canRead)
+                : base(data)
+            {
+                _canSeek = canSeek;
+                _canRead = canRead;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                ReadCount++;
+                SetBufferSize(count);
+                return base.Read(buffer, offset, count);
+            }
+
+            public override long Seek(long offset, SeekOrigin loc)
+            {
+                SeekCount++;
+                return base.Seek(offset, loc);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+
+            private void SetBufferSize(int count)
+            {
+                if (BufferSize == 0)
+                {
+                    BufferSize = count;
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class StringContentTest
+    {
+        [Fact]
+        public void Ctor_NullString_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StringContent(null));
+        }
+
+        [Fact]
+        public async Task Ctor_EmptyString_Accept()
+        {
+            // Consider empty strings like null strings (null and empty strings should be treated equally).
+            var content = new StringContent(string.Empty);
+            Stream result = await content.ReadAsStreamAsync();
+            Assert.Equal(0, result.Length);
+        }
+
+        [Fact]
+        public async Task Ctor_UseCustomEncodingAndMediaType_EncodingUsedAndContentTypeHeaderUpdated()
+        {
+            // Use UTF-8 encoding to serialize a chinese string.
+            string sourceString = "\u4f1a\u5458\u670d\u52a1";
+
+            var content = new StringContent(sourceString, Encoding.UTF8, "application/custom");
+
+            Assert.Equal("application/custom", content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", content.Headers.ContentType.CharSet);
+
+            var destination = new MemoryStream(12);
+            await content.CopyToAsync(destination);
+
+            string destinationString = Encoding.UTF8.GetString(destination.ToArray(), 0, (int)destination.Length);
+
+            Assert.Equal(sourceString, destinationString);
+        }
+
+        [Fact]
+        public async Task Ctor_DefineNoEncoding_DefaultEncodingUsed()
+        {
+            string sourceString = "\u00C4\u00E4\u00FC\u00DC";
+            var content = new StringContent(sourceString);
+            Encoding defaultStringEncoding = Encoding.GetEncoding("utf-8");
+
+            // If no encoding is defined, the default encoding is used: utf-8
+            Assert.Equal("text/plain", content.Headers.ContentType.MediaType);
+            Assert.Equal(defaultStringEncoding.WebName, content.Headers.ContentType.CharSet);
+
+            // Make sure the default encoding is also used when serializing the content.
+            var destination = new MemoryStream();
+            await content.CopyToAsync(destination);
+
+            Assert.Equal(8, destination.Length);
+
+            destination.Seek(0, SeekOrigin.Begin);
+            string roundTrip = new StreamReader(destination, defaultStringEncoding).ReadToEnd();
+            Assert.Equal(sourceString, roundTrip);
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -6,8 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>System.Net.Http.Tests</RootNamespace>
-    <AssemblyName>System.Net.Http.Tests</AssemblyName>
+    <AssemblyName>System.Net.Http.Functional.Tests</AssemblyName>
     <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />
@@ -25,9 +24,22 @@
     <Compile Include="$(CommonTestPath)\Streams\DelegateStream.cs">
       <Link>Common\Streams\DelegateStream.cs</Link>
     </Compile>
+    <Compile Include="ByteArrayContentTest.cs" />
+    <Compile Include="DelegatingHandlerTest.cs" />
+    <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />
     <Compile Include="HttpClientTest.cs" />
+    <Compile Include="HttpContentTest.cs" />
+    <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
+    <Compile Include="HttpRequestMessageTest.cs" />
+    <Compile Include="HttpResponseMessageTest.cs" />
+    <Compile Include="MessageProcessingHandlerTest.cs" />
+    <Compile Include="MultipartContentTest.cs" />
+    <Compile Include="MultipartFormDataContentTest.cs" />
+    <Compile Include="ResponseStreamTest.cs" />
+    <Compile Include="StreamContentTest.cs" />
+    <Compile Include="StringContentTest.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Added more http tests to open source from the original internal ToF tests. Some of the tests should be refactored in the future to avoid Assert'ing multiple logical things.

Fixed up test namespaces for System.Net.Http and System.Net.Http.WinHttpHandler.