### PR TITLE
Fix incorrect codegen for self-application of recursive expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
@@ -496,14 +496,16 @@ namespace System.Linq.Expressions.Compiler
             get
             {
                 CompilerScope s = this;
-                while (true)
+                while (s != null)
                 {
                     var lambda = s.Node as LambdaExpression;
                     if (lambda != null)
                     {
                         return lambda.Name;
                     }
+                    s = s._parent;
                 }
+                throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -202,7 +202,7 @@ namespace System.Linq.Expressions.Compiler
             List<WriteBack> wb = EmitArguments(lambda.Type.GetMethod("Invoke"), invoke);
 
             // 2. Create the nested LambdaCompiler
-            var inner = new LambdaCompiler(this, lambda);
+            var inner = new LambdaCompiler(this, lambda, invoke);
 
             // 3. Emit the body
             // if the inlined lambda is the last expression of the whole lambda,

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -88,9 +88,11 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         private LambdaCompiler(AnalyzedTree tree, LambdaExpression lambda, MethodBuilder method)
         {
-            _hasClosureArgument = tree.Scopes[lambda].NeedsClosure;
+            var scope = tree.Scopes[lambda];
+            var hasClosureArgument = scope.NeedsClosure;
+
             Type[] paramTypes = GetParameterTypes(lambda);
-            if (_hasClosureArgument)
+            if (hasClosureArgument)
             {
                 paramTypes = paramTypes.AddFirst(typeof(Closure));
             }
@@ -99,7 +101,7 @@ namespace System.Linq.Expressions.Compiler
             method.SetParameters(paramTypes);
             var paramNames = lambda.Parameters.Map(p => p.Name);
             // parameters are index from 1, with closure argument we need to skip the first arg
-            int startIndex = _hasClosureArgument ? 2 : 1;
+            int startIndex = hasClosureArgument ? 2 : 1;
             for (int i = 0; i < paramNames.Length; i++)
             {
                 method.DefineParameter(i + startIndex, ParameterAttributes.None, paramNames[i]);
@@ -109,11 +111,12 @@ namespace System.Linq.Expressions.Compiler
             _lambda = lambda;
             _typeBuilder = (TypeBuilder)method.DeclaringType.GetTypeInfo();
             _method = method;
+            _hasClosureArgument = hasClosureArgument;
 
             _ilg = method.GetILGenerator();
 
             // These are populated by AnalyzeTree/VariableBinder
-            _scope = tree.Scopes[lambda];
+            _scope = scope;
             _boundConstants = tree.Constants[lambda];
 
             InitializeMethod();
@@ -122,7 +125,10 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// Creates a lambda compiler for an inlined lambda
         /// </summary>
-        private LambdaCompiler(LambdaCompiler parent, LambdaExpression lambda)
+        private LambdaCompiler(
+            LambdaCompiler parent, 
+            LambdaExpression lambda, 
+            InvocationExpression invocation)
         {
             _tree = parent._tree;
             _lambda = lambda;
@@ -130,7 +136,8 @@ namespace System.Linq.Expressions.Compiler
             _ilg = parent._ilg;
             _hasClosureArgument = parent._hasClosureArgument;
             _typeBuilder = parent._typeBuilder;
-            _scope = _tree.Scopes[lambda];
+            // inlined scopes are associated with invocation, not with the lambda
+            _scope = _tree.Scopes[invocation];
             _boundConstants = parent._boundConstants;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
@@ -82,8 +82,8 @@ namespace System.Linq.Expressions.Compiler
             // optimization: inline code for literal lambda's directly
             if (lambda != null)
             {
-                // visit the lambda, but treat it more like a scope
-                _scopes.Push(_tree.Scopes[lambda] = new CompilerScope(lambda, false));
+                // visit the lambda, but treat it like a scope associated with invocation
+                _scopes.Push(_tree.Scopes[node] = new CompilerScope(lambda, false));
                 Visit(MergeScopes(lambda));
                 _scopes.Pop();
                 // visit the invoke's arguments

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests
+{
+    public static class InvocationTests
+    {
+        public delegate void X(X a);
+
+        [Fact] // [Issue(3224, "https://github.com/dotnet/corefx/issues/3224")]
+        public static void SelfApplication()
+        {
+            // Expression<X> f = x => {};
+            Expression<X> f = Expression.Lambda<X>(Expression.Empty(), Expression.Parameter(typeof(X)));
+            var a = Expression.Lambda(Expression.Invoke(f, f));
+
+            a.Compile().DynamicInvoke();
+
+            var it = Expression.Parameter(f.Type);
+            var b = Expression.Lambda(Expression.Invoke(Expression.Lambda(Expression.Invoke(it, it), it), f));
+
+            b.Compile().DynamicInvoke();
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="HelperTypes.cs" />
+    <Compile Include="Invoke\InvocationTests.cs" />
     <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Lambda\LambdaAddNullableTests.cs" />
     <Compile Include="Lambda\LambdaAddTests.cs" />


### PR DESCRIPTION
ET binder associates scope information with corresponding lambda nodes, which is valid in most cases since variables that belong to lambda depend only on the lambda contents.
Except that when lambda is inlined and parameters become locals.

This change makes scopes for inlined lambdas to be associated with parent invocation nodes, which disambiguates them from scopes for lambdas in their regular non-inlined form.

Fixes: #3224