### PR TITLE
Ensure getting random bytes/numbers produces an unpredicatable sequence.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
@@ -5,9 +5,10 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static partial class libcrypto
+    internal static partial class Crypto
     {
-        [DllImport(Libraries.LibCrypto)]
-        internal static extern unsafe int RAND_pseudo_bytes(byte* buf, int num);
+        [DllImport(Libraries.CryptoNative)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetRandomBytes(byte[] buf, int num);
     }
 }

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -124,8 +124,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.RAND.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.RAND.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -183,15 +183,12 @@ namespace System.IO
             return path.Length > 0 && path[0] == DirectorySeparatorChar;
         }
 
-        private static unsafe byte[] CreateCryptoRandomByteArray(int byteLength)
+        private static byte[] CreateCryptoRandomByteArray(int byteLength)
         {
             var arr = new byte[byteLength];
-            fixed (byte* buf = arr)
+            if (!Interop.Crypto.GetRandomBytes(arr, arr.Length))
             {
-                if (Interop.libcrypto.RAND_pseudo_bytes(buf, arr.Length) == -1)
-                {
-                    throw new InvalidOperationException(SR.InvalidOperation_Cryptography);
-                }
+                throw new InvalidOperationException(SR.InvalidOperation_Cryptography);
             }
             return arr;
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -150,8 +150,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.RAND.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.RAND.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs</Link>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RNGCryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RNGCryptoServiceProvider.Unix.cs
@@ -5,17 +5,14 @@ namespace System.Security.Cryptography
 {
     internal sealed class RNGCryptoServiceProvider : RandomNumberGenerator
     {
-        public sealed override unsafe void GetBytes(byte[] data)
+        public sealed override void GetBytes(byte[] data)
         {
             ValidateGetBytesArgs(data);
             if (data.Length > 0)
             {
-                fixed (byte* buf = data)
+                if (!Interop.Crypto.GetRandomBytes(data, data.Length))
                 {
-                    if (Interop.libcrypto.RAND_pseudo_bytes(buf, data.Length) == -1)
-                    {
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
-                    }
+                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
                 }
             }
         }


### PR DESCRIPTION
To ensure we are getting truly random values, we now call RAND_poll()
during OpenSSL initialization.  Also, calling RAND_bytes instead of the
deprecated RAND_psuedo_bytes.

While I was fixing the code, I also added a shim for the native call
instead of invoking libcrypto directly from managed code.

Also, fixed a small bug in the tests to assert that the byte elements are different
in the arrays, and not the arrays themselves.

@bartonjs 