### PR TITLE
Add a debug assert to SafeFileHandle.ReleaseHandle

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -73,8 +73,17 @@ namespace Microsoft.Win32.SafeHandles
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
             int fd = (int)handle;
-            Debug.Assert(fd >= 0);
-            return Interop.Sys.Close(fd) == 0;
+            Debug.Assert(fd >= 0, "Negative file descriptor");
+            int result = Interop.Sys.Close(fd);
+#if DEBUG
+            if (result != 0)
+            {
+                Debug.Fail(string.Format(
+                    "Close failed with result {0} and errno {1}", 
+                    result, Interop.Sys.GetLastErrorInfo().RawErrno));
+            }
+#endif
+            return result == 0;
         }
 
         public override bool IsInvalid


### PR DESCRIPTION
I'm trying to debug a sporadic failure that occurs now and again in the lab and that I believe may be due to a file descriptor getting left open.  Adding an assert to help flag cases where close fails, e.g. due to EINTR.

cc; @nguerrera, @sokket 