### PR TITLE
Expose DuplicateKeyHandle on OpenSSL-specific asymmetric algorithms.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-
+using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -96,9 +96,6 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
         internal static extern string GetX509RootStorePath();
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern int UpRefEvpPkey(SafeEvpPkeyHandle handle);
 
         [DllImport(Libraries.CryptoNative)]
         private static extern int GetPkcs7Certificates(SafePkcs7Handle p7, out SafeSharedX509StackHandle certs);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 internal static partial class Interop
 {
-    internal static partial class libcrypto
+    internal static partial class Crypto
     {
-        [DllImport(Libraries.LibCrypto)]
-        internal static extern SafeEvpPKeyHandle EVP_PKEY_new();
-
-        [DllImport(Libraries.LibCrypto)]
-        internal static extern void EVP_PKEY_free(IntPtr pkey);
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int UpRefEvpPkey(SafeEvpPKeyHandle handle);
     }
 }

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.ECDsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.ECDsa.cs
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class libcrypto
     {
         [DllImport(Libraries.LibCrypto)]
-        internal static extern SafeEvpPKeyHandle EVP_PKEY_new();
+        internal static extern SafeEcKeyHandle EVP_PKEY_get1_EC_KEY(SafeEvpPKeyHandle pkey);
 
         [DllImport(Libraries.LibCrypto)]
-        internal static extern void EVP_PKEY_free(IntPtr pkey);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool EVP_PKEY_set1_EC_KEY(SafeEvpPKeyHandle pkey, SafeEcKeyHandle rsa);
     }
 }

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.Rsa.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.EvpPkey.Rsa.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;
-
+using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -10,6 +10,10 @@ internal static partial class Interop
     internal static partial class libcrypto
     {
         [DllImport(Libraries.LibCrypto)]
-        internal static extern SafeRsaHandle EVP_PKEY_get1_RSA(SafeEvpPkeyHandle pkey);
+        internal static extern SafeRsaHandle EVP_PKEY_get1_RSA(SafeEvpPKeyHandle pkey);
+
+        [DllImport(Libraries.LibCrypto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool EVP_PKEY_set1_RSA(SafeEvpPKeyHandle pkey, SafeRsaHandle rsa);
     }
 }

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.Pkcs12.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.Pkcs12.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-
+using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -28,7 +28,7 @@ internal static partial class Interop
         internal static extern SafePkcs12Handle PKCS12_create(
             string pass,
             string name,
-            SafeEvpPkeyHandle pkey,
+            SafeEvpPKeyHandle pkey,
             SafeX509Handle cert,
             SafeX509StackHandle ca,
             int nid_key,
@@ -39,6 +39,6 @@ internal static partial class Interop
 
         [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool PKCS12_parse(SafePkcs12Handle p12, string pass, out SafeEvpPkeyHandle pkey, out SafeX509Handle cert, out SafeX509StackHandle ca);
+        internal static extern bool PKCS12_parse(SafePkcs12Handle p12, string pass, out SafeEvpPKeyHandle pkey, out SafeX509Handle cert, out SafeX509StackHandle ca);
     }
 }

--- a/src/System.Security.Cryptography.OpenSsl/System.Security.Cryptography.OpenSsl.sln
+++ b/src/System.Security.Cryptography.OpenSsl/System.Security.Cryptography.OpenSsl.sln
@@ -5,8 +5,11 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.OpenSsl", "src\System.Security.Cryptography.OpenSsl.csproj", "{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.OpenSsl.Tests", "tests\System.Security.Cryptography.OpenSsl.Tests.csproj", "{A05C2EF2-A986-448C-9C63-735CC17409AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		FreeBSD_Debug|Any CPU = FreeBSD_Debug|Any CPU
 		FreeBSD_Release|Any CPU = FreeBSD_Release|Any CPU
 		Linux_Debug|Any CPU = Linux_Debug|Any CPU
@@ -15,6 +18,8 @@ Global
 		OSX_Release|Any CPU = OSX_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
+		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.FreeBSD_Debug|Any CPU.ActiveCfg = FreeBSD_Debug|Any CPU
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.FreeBSD_Debug|Any CPU.Build.0 = FreeBSD_Debug|Any CPU
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.FreeBSD_Release|Any CPU.ActiveCfg = FreeBSD_Release|Any CPU
@@ -27,6 +32,20 @@ Global
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.FreeBSD_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.FreeBSD_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.FreeBSD_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.FreeBSD_Release|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Linux_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Linux_Release|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.OSX_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.OSX_Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RSAOpenSsl.cs" />
+    <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslAsymmetricAlgorithmCore.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
@@ -41,14 +42,20 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Bignum.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EvpPkey.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.EvpPkey.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EvpPkey.ECDsa.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.EvpPkey.Rsa.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EvpPkey.Rsa.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.EvpPkey.Rsa.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Rsa.cs</Link>
@@ -58,6 +65,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EcDsa.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.EcDsa.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>

--- a/src/System.Security.Cryptography.OpenSsl/tests/RsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RsaOpenSslTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.OpenSsl.Tests
+{
+    public static class RsaOpenSslTests
+    {
+        [Fact]
+        public static void VerifyDuplicateKey_ValidHandle()
+        {
+            byte[] data = ByteUtils.RepeatByte(0x71, 11);
+
+            using (RSAOpenSsl first = new RSAOpenSsl())
+            using (SafeEvpPKeyHandle firstHandle = first.DuplicateKeyHandle())
+            {
+                using (RSA second = new RSAOpenSsl(firstHandle))
+                {
+                    byte[] signed = second.SignData(data, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1);
+                    Assert.True(first.VerifyData(data, signed, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1));
+                }
+            }
+        }
+
+        [Fact]
+        public static void VerifyDuplicateKey_DistinctHandles()
+        {
+            using (RSAOpenSsl first = new RSAOpenSsl())
+            using (SafeEvpPKeyHandle firstHandle = first.DuplicateKeyHandle())
+            using (SafeEvpPKeyHandle firstHandle2 = first.DuplicateKeyHandle())
+            {
+                Assert.NotSame(firstHandle, firstHandle2);
+            }
+        }
+
+        [Fact]
+        public static void VerifyDuplicateKey_RefCounts()
+        {
+            byte[] data = ByteUtils.RepeatByte(0x74, 11);
+            byte[] signature;
+            RSA second;
+
+            using (RSAOpenSsl first = new RSAOpenSsl())
+            using (SafeEvpPKeyHandle firstHandle = first.DuplicateKeyHandle())
+            {
+                signature = first.SignData(data, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1);
+                second = new RSAOpenSsl(firstHandle);
+            }
+
+            // Now show that second still works, despite first and firstHandle being Disposed.
+            using (second)
+            {
+                Assert.True(second.VerifyData(data, signature, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1));
+            }
+        }
+
+        [Fact]
+        public static void VerifyDuplicateKey_NullHandle()
+        {
+            SafeEvpPKeyHandle pkey = null;
+            Assert.Throws<ArgumentNullException>(() => new RSAOpenSsl(pkey));
+        }
+
+        [Fact]
+        public static void VerifyDuplicateKey_InvalidHandle()
+        {
+            using (RSAOpenSsl rsa = new RSAOpenSsl())
+            {
+                SafeEvpPKeyHandle pkey = rsa.DuplicateKeyHandle();
+
+                using (pkey)
+                {
+                }
+
+                Assert.Throws<ArgumentException>(() => new RSAOpenSsl(pkey));
+            }
+        }
+
+        [Fact]
+        public static void VerifyDuplicateKey_NeverValidHandle()
+        {
+            using (SafeEvpPKeyHandle pkey = new SafeEvpPKeyHandle(IntPtr.Zero, false))
+            {
+                Assert.Throws<ArgumentException>(() => new RSAOpenSsl(pkey));
+            }
+        }
+
+        [Fact]
+        public static void VerifyDuplicateKey_ECDsaHandle()
+        {
+            using (ECDsaOpenSsl ecdsa = new ECDsaOpenSsl())
+            using (SafeEvpPKeyHandle pkey = ecdsa.DuplicateKeyHandle())
+            {
+                Assert.ThrowsAny<CryptographicException>(() => new RSAOpenSsl(pkey));
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -51,7 +51,6 @@
     <Compile Include="$(CommonTestPath)\Streams\PositionValueStream.cs">
       <Link>CommonTest\Streams\PositionValueStream.cs</Link>
     </Compile>
-
     <Compile Include="EcDsaOpenSslProvider.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs</Link>
@@ -62,7 +61,7 @@
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs</Link>
     </Compile>
-
+    <Compile Include="RsaOpenSslTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
@@ -11,6 +11,7 @@ namespace Internal.Cryptography.Pal
     internal class CollectionBackedStoreProvider : IStorePal
     {
         private readonly X509Certificate2[] _certs;
+        private static readonly SafeEvpPKeyHandle InvalidPKeyHandle = new SafeEvpPKeyHandle(IntPtr.Zero, false);
 
         internal CollectionBackedStoreProvider(X509Certificate2 cert)
         {
@@ -100,18 +101,18 @@ namespace Internal.Cryptography.Pal
                 }
 
                 SafeX509Handle privateCertHandle;
-                SafeEvpPkeyHandle privateCertKeyHandle;
+                SafeEvpPKeyHandle privateCertKeyHandle;
 
                 if (privateCert != null)
                 {
                     OpenSslX509CertificateReader pal = (OpenSslX509CertificateReader)privateCert.Pal;
                     privateCertHandle = pal.SafeHandle;
-                    privateCertKeyHandle = pal.PrivateKeyHandle ?? SafeEvpPkeyHandle.InvalidHandle;
+                    privateCertKeyHandle = pal.PrivateKeyHandle ?? InvalidPKeyHandle;
                 }
                 else
                 {
                     privateCertHandle = SafeX509Handle.InvalidHandle;
-                    privateCertKeyHandle = SafeEvpPkeyHandle.InvalidHandle;
+                    privateCertKeyHandle = InvalidPKeyHandle;
                 }
 
                 using (SafePkcs12Handle pkcs12 = Interop.libcrypto.PKCS12_create(

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
@@ -11,7 +11,7 @@ namespace Internal.Cryptography.Pal
     internal sealed class OpenSslPkcs12Reader : IDisposable
     {
         private readonly SafePkcs12Handle _pkcs12Handle;
-        private SafeEvpPkeyHandle _evpPkeyHandle;
+        private SafeEvpPKeyHandle _evpPkeyHandle;
         private SafeX509Handle _x509Handle;
         private SafeX509StackHandle _caStackHandle;
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -18,7 +18,7 @@ namespace Internal.Cryptography.Pal
         private static DateTimeFormatInfo s_validityDateTimeFormatInfo;
 
         private SafeX509Handle _cert;
-        private SafeEvpPkeyHandle _privateKey;
+        private SafeEvpPKeyHandle _privateKey;
         private X500DistinguishedName _subjectName;
         private X500DistinguishedName _issuerName;
 
@@ -228,12 +228,12 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        internal void SetPrivateKey(SafeEvpPkeyHandle privateKey)
+        internal void SetPrivateKey(SafeEvpPKeyHandle privateKey)
         {
             _privateKey = privateKey;
         }
 
-        internal SafeEvpPkeyHandle PrivateKeyHandle
+        internal SafeEvpPKeyHandle PrivateKeyHandle
         {
             get { return _privateKey; }
         }
@@ -319,7 +319,7 @@ namespace Internal.Cryptography.Pal
 
             if (_privateKey != null)
             {
-                SafeEvpPkeyHandle keyHandle = SafeEvpPkeyHandle.DuplicateHandle(_privateKey);
+                SafeEvpPKeyHandle keyHandle = _privateKey.DuplicateHandle();
                 duplicate.SetPrivateKey(keyHandle);
             }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -259,9 +259,6 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpPkeyHandle.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpPkeyHandle.Unix.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs</Link>
     </Compile>


### PR DESCRIPTION
A lot of the lines in the change are from changing the casing on SafeEvpPKeyHandle while making it public, and/or updating usings to account for it having a new namespace.

X509Certificates no longer needs to include the file because it sees it publicly from the OpenSsl library.