### PR TITLE
Restrict the SSL handshake test to 3 seconds.

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -29,7 +29,8 @@ namespace System.Net.Security.Tests
                 auth[0] = client.AuthenticateAsClientAsync(certificate.Subject);
                 auth[1] = server.AuthenticateAsServerAsync(certificate);
 
-                Task.WaitAll(auth);
+                bool finished = Task.WaitAll(auth, TimeSpan.FromSeconds(3));
+                Assert.True(finished, "Handshake completed in the allotted time");
             }
         }
 


### PR DESCRIPTION
When things don't go so well this test takes significantly longer than an acceptable waiting period.  On success it's fractions of a second.