### PR TITLE
Move max path directory check up front.

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -242,7 +242,6 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        [OuterLoop] // takes more than a minute
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);


### PR DESCRIPTION
No need to create a bunch of intermediate directories when we'll fail at the end.
This was having significant impact on test times with #3192.

@nguerrera, @weshaggard, @stephentoub 

This takes times back down to something reasonable when testing the exception on CreateDirectory.

Note that this doesn't address the device name issue that Wes is seeing. Still looking into what we can do with that. I get the same sort of crazy increased times when I'm connected to corpnet.