### PR TITLE
Harden the assert in DirectoryBasedStoreProvider.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -313,7 +313,7 @@ namespace Internal.Cryptography.Pal
                 Interop.Sys.FileStatus stat;
 
                 Debug.Assert(Interop.Sys.Stat(destinationFilename, out stat) == 0);
-                Debug.Assert((stat.Mode & (int)requiredPermissions) != 0, "Created PFX has insufficient permissions to function");
+                Debug.Assert((stat.Mode & (int)requiredPermissions) == (int)requiredPermissions, "Created PFX has insufficient permissions to function");
                 Debug.Assert((stat.Mode & (int)forbiddenPermissions) == 0, "Created PFX has too broad of permissions");
 #endif
             }


### PR DESCRIPTION
When we are creating a .pfx store for X509 certificates, we want to ensure that we create the file with user read and write permissions, nothing more and nothing less.

I changed the DEBUG assert code to ensure this is the case.

@bartonjs 