### PR TITLE
Unix X509Chains treats root certs in ExtraStore differently than Windows

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -45,17 +45,20 @@ namespace Internal.Cryptography.Pal
             TimeSpan remainingDownloadTime = timeout;
             X509Certificate2 leaf = new X509Certificate2(cert.Handle);
             List<X509Certificate2> downloaded = new List<X509Certificate2>();
+            List<X509Certificate2> systemTrusted = new List<X509Certificate2>();
 
             List<X509Certificate2> candidates = OpenSslX509ChainProcessor.FindCandidates(
                 leaf,
                 extraStore,
                 downloaded,
+                systemTrusted,
                 ref remainingDownloadTime);
 
             IChainPal chain = OpenSslX509ChainProcessor.BuildChain(
                 leaf,
                 candidates,
                 downloaded,
+                systemTrusted,
                 applicationPolicy,
                 certificatePolicy,
                 revocationMode,


### PR DESCRIPTION
When building an X509Chain on Unix, if the root cert isn't in the system store, the building still succeeds with no errors for UntrustedRoot.  This is different than how it works on Windows.

I changed OpenSslX509ChainProcessor.BuildChain to check if the root cert is contained in the LocalMachine root or CurrentUser root store.  If it isn't, add an UntrustedRoot error.

Fix #3226.

@bartonjs 