### PR TITLE
Fix handle leak in xplat SslStream.SafeFreeCredentials

### DIFF
--- a/src/System.Net.Security/src/System/Net/Unix/SSPISecureChannelType.cs
+++ b/src/System.Net.Security/src/System/Net/Unix/SSPISecureChannelType.cs
@@ -27,15 +27,7 @@ namespace System.Net
         public SafeFreeCredentials AcquireCredentialsHandle(X509Certificate certificate,
             SslProtocols protocols, EncryptionPolicy policy, bool isServer)
         {
-            SafeFreeCredentials retVal = new SafeFreeCredentials(certificate, protocols, policy);
-            if ((null != retVal) && !retVal.IsInvalid)
-            {
-                // Caller does a ref count decrement
-                bool ignore = false;
-                retVal.DangerousAddRef(ref ignore);
-                //TODO retVal is not getting released now, need to be fixed.
-            }
-            return retVal;
+            return new SafeFreeCredentials(certificate, protocols, policy);
         }
 
         public SecurityStatus AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context,
@@ -193,7 +185,7 @@ namespace System.Net
                 {
                     long options = GetOptions(credential.Protocols);               
                     IntPtr contextPtr = Interop.OpenSsl.AllocateSslContext(options, credential.CertHandle, isServer, remoteCertRequired);                 
-                    context = new SafeDeleteContext(contextPtr);
+                    context = new SafeDeleteContext(contextPtr, credential);
                 }
 
                 context.DangerousAddRef(ref gotContextReference);


### PR DESCRIPTION
If a cert is used in SSL handshake, the certificate information needs
to persist for the SSL session. This is achieved by storing the cert
in a SafeFreeCredentials and bumping up its refcount. But we were
incorrectly doing this in AcquireCredentials instead of the first
invocation of InitializeSecurityContext/AcceptSecurityContext

cc: @stephentoub, @bartonjs, @rajansingh10, @shrutigarg, @pgavlin , @CIPop , @davidsh, @SidharthNabar 