### PR TITLE
Fix handling of 0 returned by SSL_read or SSL_write

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -149,6 +149,11 @@ internal static partial class Interop
 
             if (retVal != count)
             {
+                int error = GetSslError(context.sslPtr, retVal, "");
+                if (libssl.SslErrorCode.SSL_ERROR_ZERO_RETURN == error)
+                {
+                    return 0; // indicate end-of-file
+                }
                 throw CreateSslException("OpenSsl::Encrypt failed");
             }
 
@@ -189,6 +194,11 @@ internal static partial class Interop
 
             if (retVal != count)
             {
+                int error = GetSslError(context.sslPtr, retVal, "");
+                if (libssl.SslErrorCode.SSL_ERROR_ZERO_RETURN == error)
+                {
+                    return 0; // indicate end-of-file
+                }
                 throw CreateSslException("OpenSsl::Decrypt failed");
             }
             return retVal;

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
@@ -60,6 +60,7 @@ internal static partial class Interop
         {
             internal const int SSL_ERROR_WANT_READ = 2;
             internal const int SSL_ERROR_SYSCALL = 5;
+            internal const int SSL_ERROR_ZERO_RETURN = 6;
         }
 
         internal static class SslState

--- a/src/System.Net.Security/src/System/Net/Unix/SSPISecureChannelType.cs
+++ b/src/System.Net.Security/src/System/Net/Unix/SSPISecureChannelType.cs
@@ -268,7 +268,7 @@ namespace System.Net
                 {
                     resultSize = Interop.OpenSsl.Decrypt(securityContext.DangerousGetHandle(), inputPtr, size);
                 }
-                return SecurityStatus.OK;
+                return ((size == 0) || (resultSize > 0)) ? SecurityStatus.OK : SecurityStatus.ContextExpired;
             }
             catch
             {


### PR DESCRIPTION
When EOF is received, SSL_read/SSL_write fail with SSL_ERROR_ZERO_RETURN.
This needs to be gracefully passed to caller which will map it to
SecurityStatus.ContextExpired.

cc: @stephentoub, @bartonjs, @rajansingh10, @shrutigarg, @pgavlin , @CIPop , @davidsh, @SidharthNabar 