### PR TITLE
Tweak and run native code formatting script

### DIFF
--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -1,7 +1,7 @@
 C# Coding Style
 ===============
 
-For C++ files (*.cpp and *.h), we use clang-format (version 3.6+) to ensure code styling. After changing any Cpp or H file and before merging, be sure to run ./formatCode.sh from within the Native directory; this script will ensure that all native code files adhere to the coding style guidelines.
+For C++ files (*.cpp and *.h), we use clang-format (version 3.6+) to ensure code styling. After changing any Cpp or H file and before merging, be sure to run src/Native/format-code.sh; this script will ensure that all native code files adhere to the coding style guidelines.
 
 For non code files (xml etc) our current best guidance is consistency. When editing files, keep new code and changes consistent with the style in the files. For new files, it should conform to the style for that component. Last, if there's a completely new component, anything that is reasonably broadly accepted is fine.
 

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -220,7 +220,7 @@ extern "C" int32_t Close(int32_t fd)
 
 extern "C" int32_t Dup(int oldfd)
 {
-	return dup(oldfd);
+    return dup(oldfd);
 }
 
 extern "C" int32_t Unlink(const char* path)

--- a/src/Native/System.Native/pal_process.h
+++ b/src/Native/System.Native/pal_process.h
@@ -230,7 +230,7 @@ extern "C" int64_t GetMaximumPath();
  * Gets the priority (nice value) of a certain execution group.
  *
  * Returns the nice value (from -20 to 20) of the group on success; otherwise, returns -1. Unfortunately, -1 is also a
- * valid nice value, meaning we can't use that value to determine valid output or not. Errno is set on failure so 
+ * valid nice value, meaning we can't use that value to determine valid output or not. Errno is set on failure so
  * we need to reset errno before a call and check the value if we get -1.
  */
 extern "C" int32_t GetPriority(PriorityWhich which, int32_t who);

--- a/src/Native/format-code.sh
+++ b/src/Native/format-code.sh
@@ -11,6 +11,8 @@ else
    exit 1
 fi
 
+cd $(dirname "$0")
+
 for D in */; do
     for file in "${D}"*.cpp; do
         if [ -e $file ] ; then


### PR DESCRIPTION
* Rename script to format-code.sh to match naming convention of other shell scripts in the repo.

* Make script work when executed from any working directory.

* Run script to mop up some minor formatting issues that crept in.