### PR TITLE
Fix several issues in UnixFileStream

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/Common/src/Interop/Unix/Interop.Errors.cs
@@ -135,6 +135,13 @@ internal static partial class Interop
         {
             return Interop.Sys.StrError(RawErrno);
         }
+
+        public override string ToString()
+        {
+            return string.Format(
+                "RawErrno: {0} Error: {1} GetErrorMessage: {2}", // No localization required; text is member names used for debugging purposes
+                RawErrno, Error, GetErrorMessage());
+        }
     }
 
     internal partial class Sys

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Win32.SafeHandles
             if (result != 0)
             {
                 Debug.Fail(string.Format(
-                    "Close failed with result {0} and errno {1}", 
-                    result, Interop.Sys.GetLastErrorInfo().RawErrno));
+                    "Close failed with result {0} and error {1}", 
+                    result, Interop.Sys.GetLastErrorInfo()));
             }
 #endif
             return result == 0;

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -74,19 +74,26 @@ namespace Microsoft.Win32.SafeHandles
 
         private void SetHandle(int fd)
         {
-            Debug.Assert(fd >= 0);
             SetHandle((IntPtr)fd);
-            Debug.Assert(!IsInvalid);
+            Debug.Assert(!IsInvalid, "File descriptor is invalid");
         }
 
         [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
-            // Close the handle. Although close is documented to potentially fail with EINTR, we never want
+            int fd = (int)handle;
+
+            // When the SafeFileHandle was opened, we likely issued an flock on the created descriptor in order to add 
+            // an advisory lock.  This lock should be removed via closing the file descriptor, but close can be
+            // interrupted, and we don't retry closes.  As such, we could end up leaving the file locked,
+            // which could prevent subsequent usage of the file until this process dies.  To avoid that, we proactively
+            // try to release the lock before we close the handle. (If it's not locked, there's no behavioral
+            // problem trying to unlock it.)
+            Interop.Sys.FLock(fd, Interop.Sys.LockOperations.LOCK_UN); // ignore any errors
+
+            // Close the descriptor. Although close is documented to potentially fail with EINTR, we never want
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
-            int fd = (int)handle;
-            Debug.Assert(fd >= 0, "Negative file descriptor");
             int result = Interop.Sys.Close(fd);
 #if DEBUG
             if (result != 0)

--- a/src/Common/tests/System/IO/TempFile.cs
+++ b/src/Common/tests/System/IO/TempFile.cs
@@ -15,14 +15,7 @@ namespace System.IO
         public TempFile(string path, long length = 0)
         {
             Path = path;
-            using (FileStream fs = File.Create(path))
-            {
-                if (length > 0)
-                {
-                    // Fill with zeros up to the desired length.
-                    fs.Write(new byte[length], 0, (int)length);
-                }
-            }
+            File.WriteAllBytes(path, new byte[length]);
         }
 
         ~TempFile() { DeleteFile(); }

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -125,6 +125,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FileDescriptors.cs">
       <Link>Common\Interop\Unix\Interop.FileDescriptors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
+      <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.LSeek.cs">
       <Link>Common\Interop\Unix\Interop.LSeek.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -66,6 +66,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FileDescriptors.cs">
       <Link>Common\Interop\Unix\Interop.FileDescriptors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
+      <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.cs">
       <Link>Common\Interop\Unix\Interop.Open.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -89,40 +89,42 @@ namespace System.IO
 
             // Open the file and store the safe handle. Subsequent code in this method expects the safe handle to be initialized.
             _fileHandle = SafeFileHandle.Open(path, openFlags, (int)openPermissions);
-            _fileHandle.IsAsync = _useAsyncIO;
-
-            // Lock the file if requested via FileShare.  This is only advisory locking. FileShare.None implies an exclusive 
-            // lock on the file and all other modes use a shared lock.  While this is not as granular as Windows, not mandatory, 
-            // and not atomic with file opening, it's better than nothing.
             try
             {
+                _fileHandle.IsAsync = _useAsyncIO;
+
+                // Lock the file if requested via FileShare.  This is only advisory locking. FileShare.None implies an exclusive 
+                // lock on the file and all other modes use a shared lock.  While this is not as granular as Windows, not mandatory, 
+                // and not atomic with file opening, it's better than nothing.
                 Interop.Sys.LockOperations lockOperation = (share == FileShare.None) ? Interop.Sys.LockOperations.LOCK_EX : Interop.Sys.LockOperations.LOCK_SH;
                 SysCall<Interop.Sys.LockOperations, int>((fd, op, _) => Interop.Sys.FLock(fd, op), lockOperation | Interop.Sys.LockOperations.LOCK_NB);
+
+                // These provide hints around how the file will be accessed.
+                Interop.Sys.FileAdvice fadv =
+                    (_options & FileOptions.RandomAccess) != 0 ? Interop.Sys.FileAdvice.POSIX_FADV_RANDOM :
+                    (_options & FileOptions.SequentialScan) != 0 ? Interop.Sys.FileAdvice.POSIX_FADV_SEQUENTIAL :
+                    0;
+                if (fadv != 0)
+                {
+                    SysCall<Interop.Sys.FileAdvice, int>(
+                        (fd, advice, _) => Interop.Sys.PosixFAdvise(fd, 0, 0, advice),
+                        fadv,
+                        ignoreNotSupported: true); // just a hint.
+                }
+
+                // Jump to the end of the file if opened as Append.
+                if (_mode == FileMode.Append)
+                {
+                    _appendStart = SeekCore(0, SeekOrigin.End);
+                }
             }
             catch
             {
+                // If anything goes wrong while setting up the stream, make sure we deterministically dispose
+                // of the opened handle.
                 _fileHandle.Dispose();
+                _fileHandle = null;
                 throw;
-            }
-
-            // These provide hints around how the file will be accessed.
-            Interop.Sys.FileAdvice fadv =
-                _options == FileOptions.RandomAccess ? Interop.Sys.FileAdvice.POSIX_FADV_RANDOM :
-                _options == FileOptions.SequentialScan ? Interop.Sys.FileAdvice.POSIX_FADV_SEQUENTIAL :
-                0;
-
-            if (fadv != 0)
-            {
-                SysCall<Interop.Sys.FileAdvice, int>(
-                    (fd, advice, _) => Interop.Sys.PosixFAdvise(fd, 0, 0, advice),
-                    fadv,
-                    ignoreNotSupported: true); // just a hint.
-            }
-
-            // Jump to the end of the file if opened as Append.
-            if (_mode == FileMode.Append)
-            {
-                _appendStart = SeekCore(0, SeekOrigin.End);
             }
         }
 
@@ -216,18 +218,15 @@ namespace System.IO
             }
 
             // Translate some FileOptions; some just aren't supported, and others will be handled after calling open.
-            switch (options)
+            // - Asynchronous: Handled in ctor, setting _useAsync and SafeFileHandle.IsAsync to true
+            // - DeleteOnClose: Doesn't have a Unix equivalent, but we approximate it in Dispose
+            // - Encrypted: No equivalent on Unix and is ignored
+            // - RandomAccess: Implemented after open if posix_fadvise is available
+            // - SequentialScan: Implemented after open if posix_fadvise is available
+            // - WriteThrough: Handled here
+            if ((options & FileOptions.WriteThrough) != 0)
             {
-                case FileOptions.Asynchronous:    // Handled in ctor, setting _useAsync and SafeFileHandle.IsAsync to true
-                case FileOptions.DeleteOnClose:   // DeleteOnClose doesn't have a Unix equivalent, but we approximate it in Dispose
-                case FileOptions.Encrypted:       // Encrypted does not have an equivalent on Unix and is ignored.
-                case FileOptions.RandomAccess:    // Implemented after open if posix_fadvise is available
-                case FileOptions.SequentialScan:  // Implemented after open if posix_fadvise is available
-                    break;
-
-                case FileOptions.WriteThrough:
-                    flags |= Interop.Sys.OpenFlags.O_SYNC;
-                    break;
+                flags |= Interop.Sys.OpenFlags.O_SYNC;
             }
 
             return flags;
@@ -403,19 +402,24 @@ namespace System.IO
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
-            // Flush and close the file
             try
             {
                 if (_fileHandle != null && !_fileHandle.IsClosed)
                 {
+                    // Flush any remaining data in the file
                     FlushWriteBuffer();
 
-                    // Unix doesn't directly support DeleteOnClose but we can mimick it.
-                    if ((_options & FileOptions.DeleteOnClose) != 0)
+                    // If DeleteOnClose was requested when constructed, delete the file now.
+                    // (Unix doesn't directly support DeleteOnClose, so we mimick it here.)
+                    if (_path != null && (_options & FileOptions.DeleteOnClose) != 0)
                     {
                         // Since we still have the file open, this will end up deleting
-                        // it (assuming we're the only link to it) once it's closed.
-                        Interop.Sys.Unlink(_path); // ignore any error
+                        // it (assuming we're the only link to it) once it's closed, but the
+                        // name will be removed immediatly.
+                        int result = Interop.Sys.Unlink(_path);
+                        Debug.Assert(result == 0,
+                            string.Format("unlink on {0} failed with result {1} and errno {2}",
+                                _path, result, Marshal.GetLastWin32Error()));
                     }
                 }
             }
@@ -727,10 +731,16 @@ namespace System.IO
             if (_fileHandle.IsClosed)
                 throw __Error.GetFileNotOpen();
 
-            if (_useAsyncIO)
-            {
-                // TODO: Use async I/O instead of sync I/O
-            }
+            // No specialized handling based on _useAsyncIO. The options available on Unix
+            // for reading asynchronously from an arbitrary file handle typically amount
+            // to just using another thread to do the synchronous read, which is exactly
+            // what the base Stream implementation does.  This does mean there are subtle
+            // differences in certain FileStream behaviors between Windows and Unix when
+            // multiple asynchronous operations are issued against the stream to execute
+            // concurrently; on Unix the operations will be serialized due to the base
+            // Stream's usage of a semaphore, but the position/length information won't
+            // be updated until after the read/write has completed.
+
             return base.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
@@ -873,10 +883,16 @@ namespace System.IO
             if (_fileHandle.IsClosed)
                 throw __Error.GetFileNotOpen();
 
-            if (_useAsyncIO)
-            {
-                // TODO: Use async I/O instead of sync I/O
-            }
+            // No specialized handling based on _useAsyncIO. The options available on Unix
+            // for writing asynchronously to an arbitrary file handle typically amount
+            // to just using another thread to do the synchronous write, which is exactly
+            // what the base Stream implementation does. This does mean there are subtle
+            // differences in certain FileStream behaviors between Windows and Unix when
+            // multiple asynchronous operations are issued against the stream to execute
+            // concurrently; on Unix the operations will be serialized due to the base
+            // Stream's usage of a semaphore, but the position/length information won't
+            // be updated until after the read/write has completed.
+
             return base.WriteAsync(buffer, offset, count, cancellationToken);
         }
 

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -418,8 +418,8 @@ namespace System.IO
                         // name will be removed immediatly.
                         int result = Interop.Sys.Unlink(_path);
                         Debug.Assert(result == 0,
-                            string.Format("unlink on {0} failed with result {1} and errno {2}",
-                                _path, result, Marshal.GetLastWin32Error()));
+                            string.Format("unlink on {0} failed with result {1} and error {2}",
+                                _path, result, Interop.Sys.GetLastErrorInfo()));
                     }
                 }
             }

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -161,6 +161,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
       <Link>Common\Interop\Unix\Interop.Fcntl.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
+      <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gethostname.cs">
       <Link>Common\Interop\Unix\Interop.gethostname.cs</Link>
     </Compile>

--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -119,6 +119,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FileDescriptors.cs">
       <Link>Common\Interop\Unix\Interop.FileDescriptors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
+      <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Open.cs</Link>
     </Compile>


### PR DESCRIPTION
I'm trying to track down the cause of a sporadic failure in CI of the MemoryMappedFilesTests.DataShared test.  In doing so, I've run across a few issues to be fixed (though I'm not sure any of these is the cause):

- Fix the checking/setting of several FileOptions... we weren't correctly treating the options as a [Flags], which meant we'd incorrectly ignore some options if multiple options were specified.

- When opening a FileStream, if the PosixFAdvise or SeekCore failed, we weren't deterministically disposing of the file handle, instead leaving it up to finalization to close.

- If Close on the file descriptor fails (e.g. it's interrupted), we don't attempt a retry, by design.  However, closing of the handle is what releases the advisory lock we placed on the file descriptor when the UnixFileStream was constructed.  Added an explicit call to remove the lock, separate from closing the descriptor. (I thought this one would have been the cause of the sporadic test failure, but if it were the problem, the assert in SafeFileHandle.ReleaseHandle should have fired, and it didn't in the one occurence I saw since that assert got added.)

- Removed several stale TODOs and replaced them with explanatory comments.

- Added several more Debug.Asserts

Separately, I also tweaked TempFile to simplify its ctor to use File.WriteAllBytes.

cc: @nguerrera, @sokket, @ianhays 