### PR TITLE
improve FileOptions tests for FileStream

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -99,7 +99,9 @@ namespace System.IO
                 Interop.Sys.LockOperations lockOperation = (share == FileShare.None) ? Interop.Sys.LockOperations.LOCK_EX : Interop.Sys.LockOperations.LOCK_SH;
                 SysCall<Interop.Sys.LockOperations, int>((fd, op, _) => Interop.Sys.FLock(fd, op), lockOperation | Interop.Sys.LockOperations.LOCK_NB);
 
-                // These provide hints around how the file will be accessed.
+                // These provide hints around how the file will be accessed.  Specifying both RandomAccess
+                // and Sequential together doesn't make sense as they are two competing options on the same spectrum,
+                // so if both are specified, we prefer RandomAccess (behavior on Windows is unspecified if both are provided).
                 Interop.Sys.FileAdvice fadv =
                     (_options & FileOptions.RandomAccess) != 0 ? Interop.Sys.FileAdvice.POSIX_FADV_RANDOM :
                     (_options & FileOptions.SequentialScan) != 0 ? Interop.Sys.FileAdvice.POSIX_FADV_SEQUENTIAL :

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -25,19 +25,58 @@ namespace System.IO.FileSystem.Tests
             Assert.Throws<ArgumentOutOfRangeException>("options", () => CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, ~FileOptions.None));
         }
 
-        [Fact]
-        public void ValidFileOptions()
+        [Theory]
+        [InlineData(FileOptions.None)]
+        [InlineData(FileOptions.DeleteOnClose)]
+        [InlineData(FileOptions.Encrypted)]
+        [InlineData(FileOptions.RandomAccess)]
+        [InlineData(FileOptions.SequentialScan)]
+        [InlineData(FileOptions.WriteThrough)]
+        [InlineData((FileOptions)0x20000000)] // FILE_FLAG_NO_BUFFERING on Windows
+        [InlineData(FileOptions.Asynchronous)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.Encrypted)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.RandomAccess)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.SequentialScan)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.WriteThrough)]
+        [InlineData(FileOptions.Asynchronous | (FileOptions)0x20000000)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose | FileOptions.Encrypted | FileOptions.RandomAccess | FileOptions.SequentialScan | FileOptions.WriteThrough)]
+        public void ValidFileOptions(FileOptions option)
         {
-            int i = 0;
-            foreach(FileOptions option in Enum.GetValues(typeof(FileOptions)))
-            {
-                using (CreateFileStream(GetTestFilePath(i++), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, option))
-                { }
-            }
+            byte[] data = new byte[c_DefaultBufferSize];
+            new Random(1).NextBytes(data);
 
-            // FILE_FLAG_NO_BUFFERRING is also supported
-            using (CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, (FileOptions)0x20000000))
-            { }
+            using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, option))
+            {
+                // make sure we can write, seek, and read data with this option set
+                fs.Write(data, 0, data.Length);
+                fs.Position = 0;
+
+                byte[] tmp = new byte[data.Length];
+                int totalRead = 0;
+                while (true)
+                {
+                    int numRead = fs.Read(tmp, totalRead, tmp.Length - totalRead);
+                    Assert.InRange(numRead, 0, tmp.Length);
+                    if (numRead == 0)
+                        break;
+                    totalRead += numRead;
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(FileOptions.DeleteOnClose)]
+        [InlineData(FileOptions.DeleteOnClose | FileOptions.Asynchronous)]
+        public void DeleteOnClose_FileDeletedAfterClose(FileOptions options)
+        {
+            string path = GetTestFilePath();
+            Assert.False(File.Exists(path));
+            using (CreateFileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x1000, options))
+            {
+                Assert.True(File.Exists(path));
+            }
+            Assert.False(File.Exists(path));
         }
 
     }


### PR DESCRIPTION
We didn't have any tests for the DeleteOnClose behavior with FileStream.  We also weren't testing combinations of FileOptions, nor validating that we could read/write files created with non-default options.

cc: @ianhays 