### PR TITLE
Fix #3290: Fix XmlWriter test issue related to non-existing file

### DIFF
--- a/src/Common/tests/SystemXml/XmlCoreTest/FilePathUtil.cs
+++ b/src/Common/tests/SystemXml/XmlCoreTest/FilePathUtil.cs
@@ -147,30 +147,26 @@ namespace XmlCoreTest.Common
 
             string normalizedFileName = NormalizeFilePath(filename);
 
-            try
+            Stream s = s_XmlFileInMemoryCache[normalizedFileName];
+            if (s == null)
             {
-                Stream s = s_XmlFileInMemoryCache[normalizedFileName];
-                if (s.CanSeek)
-                {
-                    s.Position = 0;
-                }
-                else
-                {
-                    Stream msbak = s_XmlFileInMemoryCacheBackup[normalizedFileName];
-                    MemoryStream msnew = new MemoryStream();
-                    msbak.Position = 0;
-                    msbak.CopyTo(msnew);
-
-                    s_XmlFileInMemoryCache[normalizedFileName] = msnew;
-                    msnew.Position = 0;
-                    return msnew;
-                }
+                throw new FileNotFoundException("File Not Found: " + filename);
+            }
+            if (s.CanSeek)
+            {
+                s.Position = 0;
                 return s;
             }
-            catch (Exception e)
+            else
             {
-                Console.WriteLine("File Not Found: " + filename);
-                throw e;
+                Stream msbak = s_XmlFileInMemoryCacheBackup[normalizedFileName];
+                MemoryStream msnew = new MemoryStream();
+                msbak.Position = 0;
+                msbak.CopyTo(msnew);
+
+                s_XmlFileInMemoryCache[normalizedFileName] = msnew;
+                msnew.Position = 0;
+                return msnew;
             }
         }
 

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlFactoryWriterTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlFactoryWriterTests.cs
@@ -2255,7 +2255,7 @@ namespace XmlWriterAPI.Test
                     wSettings.Encoding = Encoding.Unicode;
                     break;
             }
-            Stream writerStream = FilePathUtil.getStream("writer.out"); /*new FileStream("writer.out", FileMode.Create);*/
+            Stream writerStream = new MemoryStream();
             switch (CurVariation.Param.ToString())
             {
                 case "Stream":


### PR DESCRIPTION
Instead of creating new file or stream we were reading it from the cache. The test is checking if underlying stream is closed which in this case is irrelevant and we should be creating MemoryStream.

At the same time fixed error reporting - instead of getting "FileNotFound" we were getting "object reference not set to an instance of an object" which is not really helpful