### PR TITLE
Implement IDNA2008 on top of ICU

### DIFF
--- a/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
+++ b/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class GlobalizationNative
+    {
+        internal const int AllowUnassigned = 0x1;
+        internal const int UseStd3AsciiRules = 0x2;
+
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode)]
+        internal static extern int ToAscii(uint flags, string src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
+
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode)]
+        internal static extern int ToUnicode(uint flags, string src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
+    }
+}

--- a/src/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
+++ b/src/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
@@ -55,6 +55,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Globalization.Native\Interop.Normalization.cs">
       <Link>Common\Interop\Unix\System.Globalization.Native\Interop.Normalization.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Globalization.Native\Interop.Idna.cs">
+      <Link>Common\Interop\Unix\System.Globalization.Native\Interop.Idna.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Globalization\IdnMapping.Unix.cs">
       <Link>Common\System\Globalization\IdnMapping.Unix.cs</Link>
     </Compile>

--- a/src/System.Globalization.Extensions/tests/IdnMapping/GetAsciiTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/GetAsciiTests.cs
@@ -10,7 +10,6 @@ namespace System.Globalization.Extensions.Tests
     public class GetAsciiTests
     {
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void SimpleValidationTests()
         {
             var idn = new IdnMapping();
@@ -25,7 +24,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void SurrogatePairsConsecutive()
         {
             var idn = new IdnMapping();
@@ -34,7 +32,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void SurrogatePairsSeparatedByAscii()
         {
             var idn = new IdnMapping();
@@ -43,7 +40,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void SurrogatePairsSeparatedByNonAscii()
         {
             var idn = new IdnMapping();
@@ -52,7 +48,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void SurrogatePairsSeparatedByAsciiAndNonAscii()
         {
             var idn = new IdnMapping();
@@ -61,7 +56,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void FullyQualifiedDomainNameVsIndividualLabels()
         {
             var idn = new IdnMapping();
@@ -77,7 +71,7 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void EmbeddedNulls()
         {
             var idn = new IdnMapping();
@@ -111,7 +105,6 @@ namespace System.Globalization.Extensions.Tests
         /// with one.  This will cause an ArgumentException.
         /// </remarks>
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void EmbeddedDomainNameConversion()
         {
             var idn = new IdnMapping();

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingThrows.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingThrows.cs
@@ -22,7 +22,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public static void GetUnicodeThrows()
         {
             IdnMapping idnMapping = new IdnMapping();

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnaConformanceTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnaConformanceTests.cs
@@ -34,7 +34,6 @@ namespace System.Globalization.Extensions.Tests
         /// Tests positive cases for GetAscii. 
         /// </summary>
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void TestAsciiPositive()
         {
             foreach (var entry in Factory.GetDataset())
@@ -56,7 +55,7 @@ namespace System.Globalization.Extensions.Tests
         /// There are some others that failed which have been commented out and marked in the dataset as "GETUNICODE DOES FAILS ON WINDOWS 8.1"
         /// </summary>
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void TestUnicodePositive()
         {
             foreach (var entry in Factory.GetDataset())
@@ -86,7 +85,6 @@ namespace System.Globalization.Extensions.Tests
         /// from the 6.0\IdnaTest.txt.  To find them, search for "GETASCII DOES NOT FAIL ON WINDOWS 8.1"
         /// </remarks>
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void TestAsciiNegative()
         {
             foreach (var entry in Factory.GetDataset())
@@ -107,7 +105,7 @@ namespace System.Globalization.Extensions.Tests
         /// from the 6.0\IdnaTest.txt.  To find them, search for "GETUNICODE DOES NOT FAIL ON WINDOWS 8.1"
         /// </remarks>
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void TestUnicodeNegative()
         {
             foreach (var entry in Factory.GetDataset())

--- a/src/System.Globalization.Extensions/tests/IdnMapping/UseStd3AsciiRules.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/UseStd3AsciiRules.cs
@@ -37,7 +37,6 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
         public void SanityCheck()
         {
             VerifyStd3AsciiRules("\u0020\u0061\u0062");
@@ -51,49 +50,49 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void LeadingHyphenMinus()
         {
             VerifyStd3AsciiRules("\u002D\u0061\u0062");
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void LeadingHyphenMinusInFirstLabel()
         {
             VerifyStd3AsciiRules("\u002D\u0061\u0062\u002E\u0063\u0064");
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void LeadingHyphenMinusInSecondLabel()
         {
             VerifyStd3AsciiRules("\u0061\u0062\u002E\u002D\u0063\u0064");
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void TrailingHyphenMinus()
         {
             VerifyStd3AsciiRules("\u0061\u0062\u002D");
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void TrailingHyphenMinusInFirstLabel()
         {
             VerifyStd3AsciiRules("\u0061\u0062\u002D\u002E\u0063\u0064");
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void TrailingHyphenMinusInSecondLabel()
         {
             VerifyStd3AsciiRules("\u0061\u0062\u002E\u0063\u0064\u002D");
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void LeadingAndTrailingHyphenMinus()
         {
             VerifyStd3AsciiRules("\u002D");
@@ -101,7 +100,7 @@ namespace System.Globalization.Extensions.Tests
         }
 
         [Fact]
-        [ActiveIssue(810, PlatformID.AnyUnix)]
+        [ActiveIssue(3406, PlatformID.AnyUnix)]
         public void NonLDH_ASCII_Codepoint()
         {
             var idnStd3False = new IdnMapping { UseStd3AsciiRules = false };

--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -140,6 +140,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Globalization.Native\Interop.Normalization.cs">
       <Link>Common\Interop\Unix\System.Globalization.Native\Interop.Normalization.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Globalization.Native\Interop.Idna.cs">
+      <Link>Common\Interop\Unix\System.Globalization.Native\Interop.Idna.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>
     </Compile>


### PR DESCRIPTION
This change uses the ToUnicode and ToAscii methods from
System.Globalization.Native which are implemented on top of ICU's UTS46
implementation.

There are some test issues that need to be addressed due to differences
between Windows implementation of the standard and ICUs (which follows
the standard more closely). These will be addressed at a later date. I
have confirmed manually that things are working as expected.

Fixes #2779
Fixes #810