### PR TITLE
OpenSSL multi-threading support on OSX

### DIFF
--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -1063,6 +1063,26 @@ LockingCallback(int mode, int n, const char* file, int line)
     }
 }
 
+#ifdef __APPLE__
+/*
+Function:
+GetCurrentThreadId
+
+Called back by OpenSSL to get the current thread id.
+
+This is necessary because OSX uses an earlier version of
+OpenSSL, which requires setting the CRYPTO_set_id_callback.
+*/
+static
+unsigned long
+GetCurrentThreadId()
+{
+    uint64_t tid;
+    pthread_threadid_np(pthread_self(), &tid);
+    return tid;
+}
+#endif // __APPLE__
+
 /*
 Function:
 EnsureOpenSslInitialized
@@ -1120,6 +1140,11 @@ EnsureOpenSslInitialized()
 
     // Initialize the callback
     CRYPTO_set_locking_callback(LockingCallback);
+
+#ifdef __APPLE__
+    // OSX uses an earlier version of OpenSSL which requires setting the CRYPTO_set_id_callback
+    CRYPTO_set_id_callback(GetCurrentThreadId);
+#endif
 
     // Initialize the random number generator seed
     randPollResult = RAND_poll();


### PR DESCRIPTION
In order to support multi-threading in OpenSSL on OSX, we need to set the CRYPTO_set_id_callback to a method that will return the current thread id.

This is necessary because OSX uses a version of OpenSSL less than 1.0.  Before 1.0, setting this callback was necessary because the default uses getpid(), which will be the same value for multiple threads in the same process.  Any version 1.0 or greater of OpenSSL will use the address of errno to differentiate between threads.

Fix #2210