### PR TITLE
Resurrect NuGet.config for a more pleasant VS experience

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -69,7 +69,6 @@
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-coreclr/" />
-    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- NOTE: Leave this file here and keep it in sync with list in dir.props. -->
+  <!-- The command-line doesn't need it, but the IDE does.                    -->
+  <packageSources>
+    <clear/>
+    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
+    <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
+    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
+    <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+  <config>
+    <add key="repositoryPath" value="..\packages" />
+  </config>
+</configuration>

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -6,7 +6,6 @@
     <clear/>
     <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
     <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
-    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
     <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />


### PR DESCRIPTION
The deletion of nuget.config made VS unaware of our feeds and was causing builds in VS 2015 to "fail" package restore, but still build. So even successful builds had "errors" in the  error list, which was most annoying.

Putting the file back gets clean builds without any junk in the error list. :)

cc @ericstj @weshaggard @jhendrixMSFT 