### PR TITLE
ET Interpreter: More null checks on instance member accesses.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -359,6 +359,7 @@ namespace System.Linq.Expressions.Interpreter
 
             try
             {
+                NullCheck(instance);
                 return _target.Invoke(instance, args);
             }
             catch (TargetInvocationException e)
@@ -390,7 +391,9 @@ namespace System.Linq.Expressions.Interpreter
 
             try
             {
-                return _target.Invoke(args[0], SkipFirstArg(args));
+                var instance = args[0];
+                NullCheck(instance);
+                return _target.Invoke(instance, SkipFirstArg(args));
             }
             catch (TargetInvocationException e)
             {
@@ -492,6 +495,7 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         try
                         {
+                            NullCheck(instance);
                             ret = _target.Invoke(instance, args);
                         }
                         catch (TargetInvocationException e)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -54,11 +54,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             object self = frame.Pop();
 
-            if (self == null)
-            {
-                throw new NullReferenceException();
-            }
-
+            NullCheck(self);
             frame.Push(_field.GetValue(self));
             return +1;
         }
@@ -85,11 +81,7 @@ namespace System.Linq.Expressions.Interpreter
             object value = frame.Pop();
             object self = frame.Pop();
 
-            if (self == null)
-            {
-                throw new NullReferenceException();
-            }
-
+            NullCheck(self);
             _field.SetValue(self, value);
             return +1;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -55,6 +55,15 @@ namespace System.Linq.Expressions.Interpreter
         {
             return null;
         }
+
+        // throws NRE when o is null
+        protected static void NullCheck(object o)
+        {
+            if (o == null)
+            {
+                o.GetType();
+            }
+        }
     }
 
     internal abstract class NotInstruction : Instruction

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -963,10 +963,6 @@ namespace System.Linq.Expressions.Interpreter
             Emit(NullableMethodCallInstruction.Create(method.Name, parameters.Length, method));
         }
 
-        public void EmitNullCheck(int stackOffset)
-        {
-            Emit(NullCheckInstruction.Create(stackOffset));
-        }
         #endregion
 
         #region Control Flow

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2138,13 +2138,6 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                if (!node.Method.IsStatic)
-                {
-                    // emit null check, our instructions don't always do this when they're
-                    // calling via a delegate.  
-                    _instructions.EmitNullCheck(node.Arguments.Count);
-                }
-
                 if (updaters == null)
                 {
                     _instructions.EmitCall(node.Method, parameters);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -2165,43 +2165,6 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal class NullCheckInstruction : Instruction
-    {
-        private readonly int _stackOffset;
-        private const int CacheSize = 12;
-        private static readonly NullCheckInstruction[] s_cache = new NullCheckInstruction[CacheSize];
-
-        public override int ConsumedStack { get { return 0; } }
-        public override int ProducedStack { get { return 0; } }
-        public override string InstructionName
-        {
-            get { return "NullCheck"; }
-        }
-        private NullCheckInstruction(int stackOffset)
-        {
-            _stackOffset = stackOffset;
-        }
-
-        public static Instruction Create(int stackOffset)
-        {
-            if (stackOffset < CacheSize)
-            {
-                return s_cache[stackOffset] ?? (s_cache[stackOffset] = new NullCheckInstruction(stackOffset));
-            }
-
-            return new NullCheckInstruction(stackOffset);
-        }
-
-        public override int Run(InterpretedFrame frame)
-        {
-            if (frame.Data[frame.StackIndex - 1 - _stackOffset] == null)
-            {
-                throw new NullReferenceException();
-            }
-            return +1;
-        }
-    }
-
 #if DEBUG
     internal class LogInstruction : Instruction
     {

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -221,6 +221,12 @@ namespace Tests.ExpressionCompiler
     {
         public int II { get; set; }
         public static int SI { get; set; }
+
+        public int this[int i]
+        {
+            get { return 1; }
+            set { }
+        }
     }
 
     public struct PS

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -229,17 +229,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 
-            var err = default(Exception);
-            try
-            {
-                f();
-            }
-            catch (NullReferenceException ex)
-            {
-                err = ex;
-            }
-
-            Assert.NotNull(err);
+            Assert.Throws<NullReferenceException>(()=>f());
         }
 
         [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
@@ -255,17 +245,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 
-            var err = default(Exception);
-            try
-            {
-                f();
-            }
-            catch (NullReferenceException ex)
-            {
-                err = ex;
-            }
-
-            Assert.NotNull(err);
+            Assert.Throws<NullReferenceException>(() => f());
         }
 
         [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
@@ -279,17 +259,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 
-            var err = default(Exception);
-            try
-            {
-                f();
-            }
-            catch (NullReferenceException ex)
-            {
-                err = ex;
-            }
-
-            Assert.NotNull(err);
+            Assert.Throws<NullReferenceException>(() => f());
         }
 
         [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
@@ -304,17 +274,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 
-            var err = default(Exception);
-            try
-            {
-                f();
-            }
-            catch (NullReferenceException ex)
-            {
-                err = ex;
-            }
-
-            Assert.NotNull(err);
+            Assert.Throws<NullReferenceException>(() => f());
         }
 
         [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
@@ -331,17 +291,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 
-            var err = default(Exception);
-            try
-            {
-                f();
-            }
-            catch (NullReferenceException ex)
-            {
-                err = ex;
-            }
-
-            Assert.NotNull(err);
+            Assert.Throws<NullReferenceException>(() => f());
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -243,6 +243,32 @@ namespace Tests.ExpressionCompiler.MemberAccess
         }
 
         [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
+        public static void CheckMemberAccessClassInstanceFieldAssignNullReferenceTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Assign(
+                        Expression.Field(
+                            Expression.Constant(null, typeof(FC)),
+                            "II"),
+                        Expression.Constant(1)),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            var err = default(Exception);
+            try
+            {
+                f();
+            }
+            catch (NullReferenceException ex)
+            {
+                err = ex;
+            }
+
+            Assert.NotNull(err);
+        }
+
+        [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
         public static void CheckMemberAccessClassInstancePropertyNullReferenceTest()
         {
             Expression<Func<int>> e =
@@ -250,6 +276,58 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Expression.Property(
                         Expression.Constant(null, typeof(PC)),
                         "II"),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            var err = default(Exception);
+            try
+            {
+                f();
+            }
+            catch (NullReferenceException ex)
+            {
+                err = ex;
+            }
+
+            Assert.NotNull(err);
+        }
+
+        [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
+        public static void CheckMemberAccessClassInstanceIndexerNullReferenceTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Property(
+                        Expression.Constant(null, typeof(PC)),
+                        "Item",
+                        Expression.Constant(1)),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+
+            var err = default(Exception);
+            try
+            {
+                f();
+            }
+            catch (NullReferenceException ex)
+            {
+                err = ex;
+            }
+
+            Assert.NotNull(err);
+        }
+
+        [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]
+        public static void CheckMemberAccessClassInstanceIndexerAssignNullReferenceTest()
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Assign(
+                        Expression.Property(
+                            Expression.Constant(null, typeof(PC)),
+                            "Item",
+                            Expression.Constant(1)),
+                        Expression.Constant(1)),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 


### PR DESCRIPTION
Accessing an instance member on null should throw NRE.
We were already handling field accesses and method calls, but properties and indexers were getting around it and could result in InvalidOperationException from reflection, which is unexpected.

Since all instance accesses eventually result in either a field access or a call, performing these checks on the spot seems more robust and also cheaper than to represent them as a special instruction. Therefore NullCheckInstruction is gone.