### PR TITLE
Remove faulty assert in TaskWaitAllAnyTest

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
@@ -391,8 +391,6 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
                 }
                 else if (ti.Task.IsCompleted && !CheckResult(ti.Result))
                     Assert.True(false, string.Format("Failed result verification in Task at Index = {0}", i));
-                else if (ti.Task.Status == TaskStatus.WaitingToRun && ti.Result != -1)
-                    Assert.True(false, string.Format("Result must remain uninitialized for unstarted task"));
             }
 
             if (!expCaught && _caughtException != null)


### PR DESCRIPTION
The verification for the TaskWaitAllAnyTest is trying to assert that if the task is in the WaitingToRun state then it won't have set a result into the result structure yet.  This is a race condition, however, as the task can run between the time the status is checked and the result is checked, causing the assertion to fail.  I'm simply removing the bad check.

Fixes https://github.com/dotnet/corefx/issues/3388
cc: @mellinoe 