### PR TITLE
Ensure X509 directory based store uses correct file permissions.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -17,7 +17,7 @@ namespace Internal.Cryptography.Pal
     internal class DirectoryBasedStoreProvider : IStorePal
     {
         // {thumbprint}.1.pfx to {thumbprint}.9.pfx
-        private const int MaxSaveAttempts = 9; 
+        private const int MaxSaveAttempts = 9;
         private const string PfxExtension = ".pfx";
         // *.pfx ({thumbprint}.pfx or {thumbprint}.{ordinal}.pfx)
         private const string PfxWildcard = "*" + PfxExtension;
@@ -80,7 +80,7 @@ namespace Internal.Cryptography.Pal
                 _readOnly = true;
             }
         }
-        
+
         public void Dispose()
         {
             if (_watcher != null)
@@ -229,10 +229,13 @@ namespace Internal.Cryptography.Pal
                 // This may well be the first time that we've added something to this store.
                 Directory.CreateDirectory(_storePath);
 
+                uint userId = Interop.Sys.GetEUid();
+                EnsureDirectoryPermissions(_storePath, userId);
+
                 string thumbprint = copy.Thumbprint;
                 bool findOpenSlot;
 
-                // The odds are low that we'd have a thumbprint colission, but check anyways.
+                // The odds are low that we'd have a thumbprint collision, but check anyways.
                 string existingFilename = FindExistingFilename(copy, _storePath, out findOpenSlot);
 
                 if (existingFilename != null)
@@ -282,6 +285,7 @@ namespace Internal.Cryptography.Pal
                 {
                     destinationFilename = existingFilename;
                     mode = FileMode.Create;
+                    EnsureFilePermissions(destinationFilename, userId);
                 }
                 else if (findOpenSlot)
                 {
@@ -298,24 +302,7 @@ namespace Internal.Cryptography.Pal
                     stream.Write(pkcs12, 0, pkcs12.Length);
                 }
 
-#if DEBUG
-                // Verify that we're creating files with u+rw and o-rw, g-rw.
-                const Interop.Sys.Permissions requiredPermissions =
-                    Interop.Sys.Permissions.S_IRUSR |
-                    Interop.Sys.Permissions.S_IWUSR;
-
-                const Interop.Sys.Permissions forbiddenPermissions =
-                    Interop.Sys.Permissions.S_IROTH |
-                    Interop.Sys.Permissions.S_IWOTH |
-                    Interop.Sys.Permissions.S_IRGRP |
-                    Interop.Sys.Permissions.S_IWGRP;
-
-                Interop.Sys.FileStatus stat;
-
-                Debug.Assert(Interop.Sys.Stat(destinationFilename, out stat) == 0);
-                Debug.Assert((stat.Mode & (int)requiredPermissions) == (int)requiredPermissions, "Created PFX has insufficient permissions to function");
-                Debug.Assert((stat.Mode & (int)forbiddenPermissions) == 0, "Created PFX has too broad of permissions");
-#endif
+                EnsureFilePermissions(destinationFilename, userId);
             }
 
             // Null out _certificates so the next call to get_Certificates causes a re-scan.
@@ -390,7 +377,7 @@ namespace Internal.Cryptography.Pal
             for (int i = 1; i <= MaxSaveAttempts; i++)
             {
                 pathBuilder.Length = prefixLength;
-                
+
                 pathBuilder.Append(i);
                 pathBuilder.Append(PfxExtension);
 
@@ -443,6 +430,77 @@ namespace Internal.Cryptography.Pal
             }
 
             return storeName.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Checks the store directory has the correct permissions.
+        /// </summary>
+        /// <param name="path">
+        /// The path of the directory to check.
+        /// </param>
+        /// <param name="userId">
+        /// The current userId from GetEUid().
+        /// </param>
+        private static void EnsureDirectoryPermissions(string path, uint userId)
+        {
+            int mode = GetFileMode(path, userId, isDirectory: true);
+            if ((mode & (int)Interop.Sys.Permissions.Mask) != (int)Interop.Sys.Permissions.S_IRWXU)
+            {
+                throw new CryptographicException(SR.Format(SR.Cryptography_InvalidDirectoryPermissions, path));
+            }
+        }
+
+        /// <summary>
+        /// Checks the file has the correct permissions.
+        /// </summary>
+        /// <param name="path">
+        /// The path of the file to check.
+        /// </param>
+        /// <param name="userId">
+        /// The current userId from GetEUid().
+        /// </param>
+        private static void EnsureFilePermissions(string path, uint userId)
+        {
+            // Verify that we're creating files with u+rw and o-rw, g-rw.
+            const Interop.Sys.Permissions requiredPermissions =
+                Interop.Sys.Permissions.S_IRUSR |
+                Interop.Sys.Permissions.S_IWUSR;
+
+            const Interop.Sys.Permissions forbiddenPermissions =
+                Interop.Sys.Permissions.S_IROTH |
+                Interop.Sys.Permissions.S_IWOTH |
+                Interop.Sys.Permissions.S_IRGRP |
+                Interop.Sys.Permissions.S_IWGRP;
+
+            int mode = GetFileMode(path, userId, isDirectory: false);
+
+            if ((mode & (int)requiredPermissions) != (int)requiredPermissions)
+            {
+                throw new CryptographicException(SR.Format(SR.Cryptography_InsufficientFilePermissions, path));
+            }
+
+            if ((mode & (int)forbiddenPermissions) != 0)
+            {
+                throw new CryptographicException(SR.Format(SR.Cryptography_TooBroadFilePermissions, path));
+            }
+        }
+
+        private static int GetFileMode(string path, uint userId, bool isDirectory)
+        {
+            Interop.Sys.FileStatus stat;
+            if (Interop.Sys.Stat(path, out stat) != 0)
+            {
+                throw new CryptographicException(
+                    SR.Cryptography_FileStatusError,
+                    Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo(), path, isDirectory));
+            }
+
+            if (stat.Uid != userId)
+            {
+                throw new CryptographicException(SR.Format(SR.Cryptography_OwnerNotCurrentUser, path));
+            }
+
+            return stat.Mode;
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -150,6 +150,9 @@
   <data name="Argument_InvalidOidValue" xml:space="preserve">
     <value>The OID value was invalid.</value>
   </data>
+  <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
+    <value>Specified file length was too large for the file system.</value>
+  </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
   </data>
@@ -201,6 +204,30 @@
   <data name="Cryptography_X509_StoreReadOnly" xml:space="preserve">
     <value>The X509 certificate store is read-only.</value>
   </data>
+  <data name="IO_FileExists_Name" xml:space="preserve">
+    <value>The file '{0}' already exists.</value>
+  </data>
+  <data name="IO_FileNotFound" xml:space="preserve">
+    <value>Unable to find the specified file.</value>
+  </data>
+  <data name="IO_FileNotFound_FileName" xml:space="preserve">
+    <value>Could not find file '{0}'.</value>
+  </data>
+  <data name="IO_PathNotFound_Path" xml:space="preserve">
+    <value>Could not find a part of the path '{0}'.</value>
+  </data>
+  <data name="IO_PathNotFound_NoPathName" xml:space="preserve">
+    <value>Could not find a part of the path.</value>
+  </data>
+  <data name="IO_PathTooLong" xml:space="preserve">
+    <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
+  </data>
+  <data name="IO_SharingViolation_File" xml:space="preserve">
+    <value>The process cannot access the file '{0}' because it is being used by another process.</value>
+  </data>
+  <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
+    <value>The process cannot access the file because it is being used by another process.</value>
+  </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started.  Call MoveNext.</value>
   </data>
@@ -225,10 +252,31 @@
   <data name="Security_InvalidValue" xml:space="preserve">
     <value>The {0} value was invalid.</value>
   </data>
+  <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
+    <value>Access to the path '{0}' is denied.</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
+    <value>Access to the path is denied.</value>
+  </data>
   <data name="Unknown_Error" xml:space="preserve">
     <value>Unknown error.</value>
   </data>
   <data name="WorkInProgress" xml:space="preserve">
     <value>WorkInProgress.</value>
+  </data>
+  <data name="Cryptography_FileStatusError" xml:space="preserve">
+    <value>Unable to get file status.</value>
+  </data>
+  <data name="Cryptography_InsufficientFilePermissions" xml:space="preserve">
+    <value>Invalid file permissions. The file '{0}' must be readable and writable by the owner.</value>
+  </data>
+  <data name="Cryptography_InvalidDirectoryPermissions" xml:space="preserve">
+    <value>Invalid directory permissions. The directory '{0}' must be readable, writable and executable by the owner. It must not be readable, writable or executable by anyone other than the owner.</value>
+  </data>
+  <data name="Cryptography_OwnerNotCurrentUser" xml:space="preserve">
+    <value>The owner of '{0}' is not the current user.</value>
+  </data>
+  <data name="Cryptography_TooBroadFilePermissions" xml:space="preserve">
+    <value>Invalid file permissions. The file '{0}' must not be readable or writable by anyone other than the owner.</value>
   </data>
 </root>

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -150,9 +150,6 @@
   <data name="Argument_InvalidOidValue" xml:space="preserve">
     <value>The OID value was invalid.</value>
   </data>
-  <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
-    <value>Specified file length was too large for the file system.</value>
-  </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
   </data>
@@ -204,30 +201,6 @@
   <data name="Cryptography_X509_StoreReadOnly" xml:space="preserve">
     <value>The X509 certificate store is read-only.</value>
   </data>
-  <data name="IO_FileExists_Name" xml:space="preserve">
-    <value>The file '{0}' already exists.</value>
-  </data>
-  <data name="IO_FileNotFound" xml:space="preserve">
-    <value>Unable to find the specified file.</value>
-  </data>
-  <data name="IO_FileNotFound_FileName" xml:space="preserve">
-    <value>Could not find file '{0}'.</value>
-  </data>
-  <data name="IO_PathNotFound_Path" xml:space="preserve">
-    <value>Could not find a part of the path '{0}'.</value>
-  </data>
-  <data name="IO_PathNotFound_NoPathName" xml:space="preserve">
-    <value>Could not find a part of the path.</value>
-  </data>
-  <data name="IO_PathTooLong" xml:space="preserve">
-    <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
-  </data>
-  <data name="IO_SharingViolation_File" xml:space="preserve">
-    <value>The process cannot access the file '{0}' because it is being used by another process.</value>
-  </data>
-  <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
-    <value>The process cannot access the file because it is being used by another process.</value>
-  </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started.  Call MoveNext.</value>
   </data>
@@ -251,12 +224,6 @@
   </data>
   <data name="Security_InvalidValue" xml:space="preserve">
     <value>The {0} value was invalid.</value>
-  </data>
-  <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
-    <value>Access to the path '{0}' is denied.</value>
-  </data>
-  <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
-    <value>Access to the path is denied.</value>
   </data>
   <data name="Unknown_Error" xml:space="preserve">
     <value>Unknown error.</value>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -177,9 +177,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
-      <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Permissions.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -177,6 +177,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
+      <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Permissions.cs</Link>
     </Compile>


### PR DESCRIPTION
When creating a .pfx file, we need to ensure the directory and file
permissions are set as securely as they can be.

This change ensures:
1. The directory and file are owned by the current user.
2. The directory is readable, writable and executable by only the owner.
3. The file is readable and writable by the owner, and not readable or
writable by anyone else.

@bartonjs, @morganbr 