### PR TITLE
Adjust the PAL separation for certificate verification

### DIFF
--- a/src/System.Net.Security/src/System/Net/CertInterface.cs
+++ b/src/System.Net.Security/src/System/Net/CertInterface.cs
@@ -11,7 +11,7 @@ namespace System.Net
     {
         internal abstract  X509Certificate2 GetRemoteCertificate(SafeDeleteContext securityContext, out X509Certificate2Collection remoteCertificateStore);
 
-        internal abstract SslPolicyErrors VerifyRemoteCertName(X509Chain chain, bool isServer, string hostName);
+        internal abstract SslPolicyErrors VerifyCertificateProperties(X509Chain chain, X509Certificate2 certificate, bool checkCertName, bool isServer, string hostName);
 
         internal abstract string[] GetRequestCertificateAuthorities(SafeDeleteContext securityContext);
 

--- a/src/System.Net.Security/src/System/Net/CertWrapper.cs
+++ b/src/System.Net.Security/src/System/Net/CertWrapper.cs
@@ -11,9 +11,9 @@ namespace System.Net
     {
         static CertInterface certModule = new CertModule();
 
-        internal static SslPolicyErrors VerifyRemoteCertName(X509Chain chain, bool isServer, string hostName)
+        internal static SslPolicyErrors VerifyCertificateProperties(X509Chain chain, X509Certificate2 certificate, bool checkCertName, bool isServer, string hostName)
         {
-            return certModule.VerifyRemoteCertName(chain, isServer, hostName);
+            return certModule.VerifyCertificateProperties(chain, certificate, checkCertName, isServer, hostName);
         }
 
         internal static X509Certificate2 GetRemoteCertificate(SafeDeleteContext securityContext, out X509Certificate2Collection remoteCertificateStore)

--- a/src/System.Net.Security/src/System/Net/Unix/CertModule.cs
+++ b/src/System.Net.Security/src/System/Net/Unix/CertModule.cs
@@ -11,7 +11,7 @@ namespace System.Net
     internal partial class CertModule : CertInterface
     {
         #region internal Methods
-        internal override SslPolicyErrors VerifyRemoteCertName(X509Chain chain, bool isServer, string hostName)
+        internal override SslPolicyErrors VerifyCertificateProperties(X509Chain chain, X509Certificate2 certificate, bool checkCertName, bool isServer, string hostName)
         {
             SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;         
 

--- a/src/System.Net.Security/src/System/Net/Unix/CertModule.cs
+++ b/src/System.Net.Security/src/System/Net/Unix/CertModule.cs
@@ -13,7 +13,14 @@ namespace System.Net
         #region internal Methods
         internal override SslPolicyErrors VerifyCertificateProperties(X509Chain chain, X509Certificate2 certificate, bool checkCertName, bool isServer, string hostName)
         {
-            SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;         
+            SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;
+
+            if (!chain.Build(certificate))
+            {
+                sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
+            }
+
+            // TODO (3431): Ensure that the certificate is valid for the hostName context.
 
             return sslPolicyErrors;
         }

--- a/src/System.Net.Security/src/System/Net/_SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/_SecureChannel.cs
@@ -1056,7 +1056,16 @@ namespace System.Net.Security
                         chain.ChainPolicy.ExtraStore.AddRange(remoteCertificateStore);
                     }
 
-                    sslPolicyErrors |= CertWrapper.VerifyCertificateProperties(chain, remoteCertificateEx, _checkCertName, _serverMode, _hostName);
+                    // Don't call chain.Build here in the common code, because the Windows version
+                    // is potentially going to check for GetLastWin32Error, and that call needs to be
+                    // guaranteed to be right after the call to chain.Build.
+
+                    sslPolicyErrors |= CertWrapper.VerifyCertificateProperties(
+                        chain,
+                        remoteCertificateEx,
+                        _checkCertName,
+                        _serverMode,
+                        _hostName);
                 }
 
                 if (remoteCertValidationCallback != null)

--- a/src/System.Net.Security/src/System/Net/_SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/_SecureChannel.cs
@@ -1056,22 +1056,7 @@ namespace System.Net.Security
                         chain.ChainPolicy.ExtraStore.AddRange(remoteCertificateStore);
                     }
 
-                    if (!chain.Build(remoteCertificateEx)       // Build failed on handle or on policy.
-                        && chain.SafeHandle.DangerousGetHandle() == IntPtr.Zero)   // Build failed to generate a valid handle.
-                    {
-                        throw new CryptographicException(Marshal.GetLastWin32Error());
-                    }
-
-                    if (_checkCertName)
-                    {
-                        sslPolicyErrors |= CertWrapper.VerifyRemoteCertName(chain, _serverMode, _hostName);
-                    }
-
-                    X509ChainStatus[] chainStatusArray = chain.ChainStatus;
-                    if (chainStatusArray != null && chainStatusArray.Length != 0)
-                    {
-                        sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
-                    }
+                    sslPolicyErrors |= CertWrapper.VerifyCertificateProperties(chain, remoteCertificateEx, _checkCertName, _serverMode, _hostName);
                 }
 
                 if (remoteCertValidationCallback != null)


### PR DESCRIPTION
The Windows version requires that there be a valid handle to the native chain representation; the Unix version never has a valid native handle.

So move the PAL separation to a slightly higher abstraction level, and let each side party on it in their own way.