### PR TITLE
Disable test against #3391 on Windows too.

### DIFF
--- a/src/System.Runtime/tests/System/DateTime.cs
+++ b/src/System.Runtime/tests/System/DateTime.cs
@@ -335,7 +335,7 @@ public static unsafe class DateTimeTests
     [InlineData("sr-Latn-ME")]
     [InlineData("sr-Latn-RS")]
     [InlineData("sr-Latn-XK")]
-    [ActiveIssue(3391, PlatformID.AnyUnix)]
+    [ActiveIssue(3391)]
     public static void TestDateTimeParsingWithSpecialCultures(string cultureName)
     {
         // Test DateTime parsing with cultures which has the date separator and time separator are same


### PR DESCRIPTION
The test is failing on Windows 10 as well.

cc @tarekgh @ellismg 