### PR TITLE
Remove overaggressive assert in UnixFileStream

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -418,10 +418,7 @@ namespace System.IO
                         // Since we still have the file open, this will end up deleting
                         // it (assuming we're the only link to it) once it's closed, but the
                         // name will be removed immediatly.
-                        int result = Interop.Sys.Unlink(_path);
-                        Debug.Assert(result == 0,
-                            string.Format("unlink on {0} failed with result {1} and error {2}",
-                                _path, result, Interop.Sys.GetLastErrorInfo()));
+                        Interop.Sys.Unlink(_path); // ignore errors; it's valid that the path may no longer exist
                     }
                 }
             }


### PR DESCRIPTION
I'd added an assert that fires if a DeleteOnClose file's unlink during disposal fails.  But it's valid for it to fail, e.g. if something elsewhere in this process or otherwise deletes or moves the file while it's open.  This happens, for example, in a bunch of our FileSystemWatcher tests.

Removing the assert

cc: @nguerrera, @sokket 