### PR TITLE
Validate hostname when using SslStream as a client

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -111,6 +111,9 @@ internal static partial class Interop
             int second,
             [MarshalAs(UnmanagedType.Bool)] bool isDst);
 
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int CheckX509Hostname(SafeX509Handle x509, string hostname, int cchHostname);
+
         internal static byte[] GetAsn1StringBytes(IntPtr asn1)
         {
             return GetDynamicBuffer((ptr, buf, i) => GetAsn1StringBytes(ptr, buf, i), asn1);


### PR DESCRIPTION
Added a method in the crypto shim (CheckX509Hostname) which does the heavy lifting. It may end up making sense to push this up into managed for better flexibility when trying to add support for IDNA; but that would be greatly assisted by having good managed decoders for the subject name pieces and the SubjectAltNames extension.

Verified that it works against an explicit SAN entry and a wildcard SAN entry.