### PR TITLE
Initialize OpenSSL RAND with an unpredictable seed.

### DIFF
--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -1074,7 +1074,9 @@ Return values:
 non-zero on failure
 */
 int
-EnsureOpenSslInitialized()
+EnsureOpenSslInitialized(
+    const char* randomSeed,
+    int randomSeedLength)
 {
     int ret = 0;
     int numLocks = 0;
@@ -1129,6 +1131,8 @@ EnsureOpenSslInitialized()
         ret = 4;
         goto done;
     }
+
+    RAND_add(randomSeed, randomSeedLength, 0);
 
 done:
     if (ret != 0)


### PR DESCRIPTION
When we initialize OpenSSL, we are currently calling RAND_poll(), which isn't guaranteed to always seed the PRNG with purely random numbers.

To fix this, OpenSSL will also be initialized with a random 32-byte seed from PAL_Random.  PAL_Random will be modified to block until it can ensure a purely random number, and if it can't it returns false.  If PAL_Random returns false while initializing OpenSSL, an exception is thrown.

@bartonjs, @morganbr, @ellismg, @stephentoub 