### PR TITLE
Correct test namespaces for System.Collections.*

### DIFF
--- a/src/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
+++ b/src/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Test
+namespace System.Collections.Concurrent.Tests
 {
     public class BlockingCollectionCancellationTests
     {

--- a/src/System.Collections.Immutable/tests/BadHasher.cs
+++ b/src/System.Collections.Immutable/tests/BadHasher.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     /// <summary>
     /// Produces the same hash for every value.

--- a/src/System.Collections.Immutable/tests/EverythingEqual.cs
+++ b/src/System.Collections.Immutable/tests/EverythingEqual.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     /// <summary>
     /// An equality comparer that considers all values to be equal.

--- a/src/System.Collections.Immutable/tests/GenericParameterHelper.cs
+++ b/src/System.Collections.Immutable/tests/GenericParameterHelper.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class GenericParameterHelper
     {

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableArrayBuilderTest : SimpleElementImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableArrayExtensionsTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayExtensionsTest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableArrayExtensionsTest
     {

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableArrayTest : SimpleElementImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTestBase.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class ImmutableArrayTestBase : SimpleElementImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableDictionaryBuilderTest : ImmutableDictionaryBuilderTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTestBase.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class ImmutableDictionaryBuilderTestBase : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableDictionaryTest : ImmutableDictionaryTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using Validation;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class ImmutableDictionaryTestBase : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetBuilderTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableHashSetBuilderTest : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableHashSetTest : ImmutableSetTest
     {

--- a/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableInterlockedTests
     {

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableListBuilderTest : ImmutableListTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableListTest : ImmutableListTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -7,7 +7,7 @@ using Xunit;
 using Validation;
 using System.Diagnostics;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class ImmutableListTestBase : SimpleElementImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableQueueTest : SimpleElementImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -8,7 +8,7 @@ using Validation;
 using Xunit;
 using SetTriad = System.Tuple<System.Collections.Generic.IEnumerable<int>, System.Collections.Generic.IEnumerable<int>, bool>;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class ImmutableSetTest : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableSortedDictionaryBuilderTest : ImmutableDictionaryBuilderTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableSortedDictionaryTest : ImmutableDictionaryTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableSortedSetBuilderTest : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableSortedSetTest : ImmutableSetTest
     {

--- a/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class ImmutableStackTest : SimpleElementImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
@@ -10,7 +10,7 @@ using System.Text;
 using Validation;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/IndexOfTests.cs
+++ b/src/System.Collections.Immutable/tests/IndexOfTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public static class IndexOfTests
     {

--- a/src/System.Collections.Immutable/tests/RequiresTests.cs
+++ b/src/System.Collections.Immutable/tests/RequiresTests.cs
@@ -4,7 +4,7 @@
 using Validation;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public class RequiresTests : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/SimpleElementImmutablesTestBase.cs
+++ b/src/System.Collections.Immutable/tests/SimpleElementImmutablesTestBase.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     public abstract class SimpleElementImmutablesTestBase : ImmutablesTestBase
     {

--- a/src/System.Collections.Immutable/tests/TestExtensionsMethods.cs
+++ b/src/System.Collections.Immutable/tests/TestExtensionsMethods.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using Validation;
 using Xunit;
 
-namespace System.Collections.Immutable.Test
+namespace System.Collections.Immutable.Tests
 {
     internal static class TestExtensionsMethods
     {

--- a/src/System.Collections.NonGeneric/tests/ArrayList/AdapterTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/AdapterTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class AdapterTests
+    public class ArrayList_AdapterTests
     {
         [Fact]
         public void TestNullIListParameter()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/AddRangeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/AddRangeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class AddRangeTests
+    public class ArrayList_AddRangeTests
     {
         [Fact]
         public void TestAddRangeBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/AddTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/AddTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class AddTests
+    public class ArrayList_AddTests
     {
         [Fact]
         public void TestAddAndRemove()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/BinarySearchTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/BinarySearchTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class BinarySearchTests : IComparer
+    public class ArrayList_BinarySearchTests : IComparer
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
 
@@ -200,7 +198,7 @@ namespace System.Collections.ArrayListTests
             for (int ii = 0; ii < strFindHeroes.Length; ++ii)
             {
                 // Locate item.
-                int ndx = list.BinarySearch(strFindHeroes[ii], new BinarySearchTests());
+                int ndx = list.BinarySearch(strFindHeroes[ii], new ArrayList_BinarySearchTests());
                 Assert.True(ndx < strHeroes.Length);
 
                 // Verify item.
@@ -216,10 +214,10 @@ namespace System.Collections.ArrayListTests
                 list.Add(i);
             list.Sort();
 
-            Assert.Equal(100, ~list.BinarySearch(150, new BinarySearchTests()));
+            Assert.Equal(100, ~list.BinarySearch(150, new ArrayList_BinarySearchTests()));
 
             //[]null - should return -1
-            Assert.Equal(-1, list.BinarySearch(null, new BinarySearchTests()));
+            Assert.Equal(-1, list.BinarySearch(null, new ArrayList_BinarySearchTests()));
 
             //[]we can add null as a value and then search it!!!
 
@@ -235,7 +233,7 @@ namespace System.Collections.ArrayListTests
             list.Sort();
 
             //remember this is BinarySeearch
-            Assert.Equal(49, list.BinarySearch(5, new BinarySearchTests()));
+            Assert.Equal(49, list.BinarySearch(5, new ArrayList_BinarySearchTests()));
 
             //[]IC as null
             list = new ArrayList();

--- a/src/System.Collections.NonGeneric/tests/ArrayList/ClearTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/ClearTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class ClearTests
+    public class ArrayList_ClearTests
     {
         [Fact]
         public void TestClearBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/CloneTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/CloneTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class CloneTests
+    public class ArrayList_CloneTests
     {
         [Fact]
         public void TestCloneBasic()
@@ -83,15 +81,15 @@ namespace System.Collections.ArrayListTests
             strValue = "Hello World";
             Assert.Equal(strValue, ((Foo)alst2[0]).strValue);
         }
-    }
 
-    internal class Foo
-    {
-        internal String strValue;
-
-        internal Foo()
+        internal class Foo
         {
-            strValue = "Hello World";
+            internal String strValue;
+
+            internal Foo()
+            {
+                strValue = "Hello World";
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/ArrayList/ContainsTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/ContainsTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class ContainsTests
+    public class ArrayList_ContainsTests
     {
         [Fact]
         public void TestArrayListWrappers()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/CopyToTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/CopyToTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class CopyToTests
+    public class ArrayList_CopyToTests
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
 

--- a/src/System.Collections.NonGeneric/tests/ArrayList/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/CtorTests.cs
@@ -4,9 +4,9 @@
 using System.Diagnostics;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class CtorTests
+    public class ArrayList_CtorTests
     {
         [Fact]
         public void CtorTest()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/DerivedClassTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/DerivedClassTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class DerivedClassTest
+    public class ArrayList_DerivedClassTest
     {
         [Fact]
         public void TestEnumerator()
@@ -22,42 +20,44 @@ namespace System.Collections.ArrayListTests
             enumerator.MoveNext();
             Assert.Equal(5, (int)enumerator.Current);
         }
-    }
 
-    public class MySimpleArrayList : ArrayList
-    {
-        public MySimpleArrayList() : base() { }
-
-        private Object _val;
-        private bool _filled;
-
-        public override int Add(Object o)
+        public class MySimpleArrayList : ArrayList
         {
-            if (_filled)
+            public MySimpleArrayList() : base()
             {
-                throw new Exception();
             }
 
-            _filled = true;
-            _val = o;
+            private Object _val;
+            private bool _filled;
 
-            return 1;
-        }
-
-        public override int Count
-        {
-            get
+            public override int Add(Object o)
             {
-                return _filled ? 1 : 0;
+                if (_filled)
+                {
+                    throw new Exception();
+                }
+
+                _filled = true;
+                _val = o;
+
+                return 1;
             }
-        }
 
-        public override Object this[int x]
-        {
-            get
+            public override int Count
             {
-                if (x != 0 || !_filled) throw new Exception();
-                return _val;
+                get
+                {
+                    return _filled ? 1 : 0;
+                }
+            }
+
+            public override Object this[int x]
+            {
+                get
+                {
+                    if (x != 0 || !_filled) throw new Exception();
+                    return _val;
+                }
             }
         }
     }

--- a/src/System.Collections.NonGeneric/tests/ArrayList/FixedSizeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/FixedSizeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class FixedSizeTests
+    public class ArrayList_FixedSizeTests
     {
         [Fact]
         public void TestArrayListParameter()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/GetEnumeratorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/GetEnumeratorTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class GetEnumeratorTests
+    public class ArrayList_GetEnumeratorTests
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
 
@@ -376,10 +374,12 @@ namespace System.Collections.ArrayListTests
                 });
             }
         }
-    }
 
-    public class MyArrayList : ArrayList
-    {
-        public MyArrayList(ICollection c) : base(c) { }
+        public class MyArrayList : ArrayList
+        {
+            public MyArrayList(ICollection c) : base(c)
+            {
+            }
+        }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/ArrayList/GetSetRangeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/GetSetRangeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class GetSetRangeTests
+    public class ArrayList_GetSetRangeTests
     {
         [Fact]
         public void TestGetRange()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/IndexOfTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/IndexOfTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class IndexOfTests
+    public class ArrayList_IndexOfTests
     {
         [Fact]
         public void TestArrayListWrappers01()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/InsertRangeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/InsertRangeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class InsertRangeTests
+    public class ArrayList_InsertRangeTests
     {
         #region "Test data - Keep the data close to tests so it can vary independently from other tests"
         string[] strHeroes =
@@ -298,69 +296,69 @@ namespace System.Collections.ArrayListTests
             }
 
         }
-    }
 
-    public class MyCollection : ICollection
-    {
-        private ICollection _collection;
-        private Array _array;
-        private int _startIndex;
-
-        public MyCollection(ICollection collection)
+        public class MyCollection : ICollection
         {
-            _collection = collection;
-        }
+            private ICollection _collection;
+            private Array _array;
+            private int _startIndex;
 
-        public Array Array
-        {
-            get
+            public MyCollection(ICollection collection)
             {
-                return _array;
+                _collection = collection;
             }
-        }
 
-        public int StartIndex
-        {
-            get
+            public Array Array
             {
-                return _startIndex;
+                get
+                {
+                    return _array;
+                }
             }
-        }
 
-        public int Count
-        {
-            get
+            public int StartIndex
             {
-                return _collection.Count;
+                get
+                {
+                    return _startIndex;
+                }
             }
-        }
 
-        public Object SyncRoot
-        {
-            get
+            public int Count
             {
-                return _collection.SyncRoot;
+                get
+                {
+                    return _collection.Count;
+                }
             }
-        }
 
-        public bool IsSynchronized
-        {
-            get
+            public Object SyncRoot
             {
-                return _collection.IsSynchronized;
+                get
+                {
+                    return _collection.SyncRoot;
+                }
             }
-        }
 
-        public void CopyTo(Array array, int startIndex)
-        {
-            _array = array;
-            _startIndex = startIndex;
-            _collection.CopyTo(array, startIndex);
-        }
+            public bool IsSynchronized
+            {
+                get
+                {
+                    return _collection.IsSynchronized;
+                }
+            }
 
-        public IEnumerator GetEnumerator()
-        {
-            throw new NotSupportedException();
+            public void CopyTo(Array array, int startIndex)
+            {
+                _array = array;
+                _startIndex = startIndex;
+                _collection.CopyTo(array, startIndex);
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/ArrayList/InsertTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/InsertTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class InsertTests
+    public class ArrayList_InsertTests
     {
         [Fact]
         public void TestArrayListWrappers()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/LastIndexOfTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/LastIndexOfTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class LastIndexOfTests
+    public class ArrayList_LastIndexOfTests
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
         string[] strHeroes =

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertyCapacityTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertyCapacityTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class CapacityTests
+    public class ArrayList_CapacityTests
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
 

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertyCountTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertyCountTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class CountTests
+    public class ArrayList_CountTests
     {
         [Fact]
         public void TestGetCountBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertyIsFixedSizeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertyIsFixedSizeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class IsFixedSizeTests
+    public class ArrayList_IsFixedSizeTests
     {
         [Fact]
         public void TestGetIsFixedSizeBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertyIsReadOnlyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertyIsReadOnlyTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class IsReadOnlyTests
+    public class ArrayList_IsReadOnlyTests
     {
         [Fact]
         public void TestGetIsReadOnlyBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertyIsSynchronizedTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertyIsSynchronizedTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class GetIsSynchronizedTests
+    public class ArrayList_GetIsSynchronizedTests
     {
         private ArrayList _alst2;
         private Int32 _iNumberOfElements = 10;

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertyItemTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertyItemTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class ItemTests
+    public class ArrayList_ItemTests
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
         string[] strHeroes =

--- a/src/System.Collections.NonGeneric/tests/ArrayList/PropertySyncRootTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/PropertySyncRootTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class SyncRootTests
+    public class ArrayList_SyncRootTests
     {
         private ArrayList _arrDaughter;
         private ArrayList _arrGrandDaughter;

--- a/src/System.Collections.NonGeneric/tests/ArrayList/ReadOnlyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/ReadOnlyTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class ReadOnlyTests
+    public class ArrayList_ReadOnlyTests
     {
         [Fact]
         public void TestArrayListParameter()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/RemoveAtTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/RemoveAtTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class RemoveAtTests
+    public class ArrayList_RemoveAtTests
     {
         [Fact]
         public void TestArrayListWrappers()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/RemoveRangeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/RemoveRangeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class RemoveRangeTests
+    public class ArrayList_RemoveRangeTests
     {
         [Fact]
         public void TestArrayListWrappers()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/RemoveTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/RemoveTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class RemoveTests
+    public class ArrayList_RemoveTests
     {
         [Fact]
         public void TestNullItems()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/RepeatTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/RepeatTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class RepeatTests
+    public class ArrayList_RepeatTests
     {
         [Fact]
         public void TestRepeatBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/ReverseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/ReverseTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class ReverseTests
+    public class ArrayList_ReverseTests
     {
         [Fact]
         public void TestArrayListWrappers()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/SortTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/SortTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class SortTests
+    public class ArrayList_SortTests
     {
         #region "Test Data - Keep the data close to tests so it can vary independently from other tests"
 

--- a/src/System.Collections.NonGeneric/tests/ArrayList/SynchronizedTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/SynchronizedTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class SynchronizedTests
+    public class ArrayList_SynchronizedTests
     {
         private IList _ilst1;
         private Int32 _iNumberOfElements = 10;

--- a/src/System.Collections.NonGeneric/tests/ArrayList/ToArrayTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/ToArrayTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class ToArrayTests
+    public class ArrayList_ToArrayTests
     {
         [Fact]
         public void TestToArrayBasic()

--- a/src/System.Collections.NonGeneric/tests/ArrayList/TrimToSizeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/TrimToSizeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.ArrayListTests
+namespace System.Collections.Tests
 {
-    public class TrimToSizeTests
+    public class ArrayList_TrimToSizeTests
     {
         [Fact]
         public void TestTrimToSizeBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/AddStressTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/AddStressTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public partial class AddStressTests
+    public partial class HashTable_AddStressTests
     {
         [Fact]
         [OuterLoop]

--- a/src/System.Collections.NonGeneric/tests/Hashtable/AddStressTestsInputData.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/AddStressTestsInputData.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public partial class AddStressTests
+    public partial class HashTable_AddStressTests
     {
         private static readonly long[] s_AddStressInputData = new long[] {
 16869846,16869847,13803764,16869848,16869849,

--- a/src/System.Collections.NonGeneric/tests/Hashtable/AddTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/AddTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class AddTests
+    public class Hashtable_AddTests
     {
         [Fact]
         public void TestAddBasic()
@@ -241,40 +239,40 @@ namespace System.Collections.HashtableTests
                 Assert.Equal(i, (int)ht[i.ToString()]);
             }
         }
-    }
 
-    public class BadHashCode
-    {
-        private uint _value;
-
-        public BadHashCode(int value)
+        public class BadHashCode
         {
-            _value = (uint)value;
-        }
+            private uint _value;
 
-        public override bool Equals(object o)
-        {
-            BadHashCode rhValue = o as BadHashCode;
-
-            if (null != rhValue)
+            public BadHashCode(int value)
             {
-                return _value.Equals(rhValue);
+                _value = (uint)value;
             }
-            else
+
+            public override bool Equals(object o)
             {
-                throw new ArgumentException("o", "is not BadHashCode type actual " + o.GetType());
+                BadHashCode rhValue = o as BadHashCode;
+
+                if (null != rhValue)
+                {
+                    return _value.Equals(rhValue);
+                }
+                else
+                {
+                    throw new ArgumentException("o", "is not BadHashCode type actual " + o.GetType());
+                }
             }
-        }
 
-        public override int GetHashCode()
-        {
-            // Return 0 for everything to force hash collisions.
-            return 0;
-        }
+            public override int GetHashCode()
+            {
+                // Return 0 for everything to force hash collisions.
+                return 0;
+            }
 
-        public override string ToString()
-        {
-            return _value.ToString();
+            public override string ToString()
+            {
+                return _value.ToString();
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Hashtable/ClearTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/ClearTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class ClearTests
+    public class HashTable_ClearTests
     {
         [Fact]
         public void TestClearBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/CloneTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/CloneTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class CloneTests
+    public class Hashtable_CloneTests
     {
         [Fact]
         public void TestCloneBasic()
@@ -156,14 +154,14 @@ namespace System.Collections.HashtableTests
             iclone1 = (Hashtable)hsh1.Clone();
             Assert.Equal(hsh1.Count, iclone1.Count);
         }
-    }
 
-    internal class Foo
-    {
-        internal string strValue;
-        internal Foo()
+        internal class Foo
         {
-            strValue = "Hello World";
+            internal string strValue;
+            internal Foo()
+            {
+                strValue = "Hello World";
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Hashtable/ContainsKeyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/ContainsKeyTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class ContainsKeyTests
+    public class Hashtable_ContainsKeyTests
     {
         [Fact]
         public void TestContainKeyBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/ContainsTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/ContainsTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class ContainsTests
+    public class Hashtable_ContainsTests
     {
         [Fact]
         public void TestContainsBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/ContainsValueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/ContainsValueTests.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
 using System.Text;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class ContainsValueTests
+    public class Hashtable_ContainsValueTests
     {
         [Fact]
         public void TestContainsValueBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/CopyToTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/CopyToTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Globalization;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class CopyToTests
+    public class Hashtable_CopyToTests
     {
         [Fact]
         public void TestCopyToBasic()
@@ -35,7 +32,7 @@ namespace System.Collections.HashtableTests
                 new int [] { 1, 2, 3, 4, 5 },
                 new Hashtable(),
                 new Exception(),
-                new CopyToTests(),
+                new Hashtable_CopyToTests(),
                 null
             };
 

--- a/src/System.Collections.NonGeneric/tests/Hashtable/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/CtorTests.cs
@@ -4,9 +4,9 @@
 using System.Diagnostics;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class CtorTests
+    public class Hashtable_CtorTests
     {
         [Fact]
         public void TestCtorDefault()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/GetEnumeratorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/GetEnumeratorTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Text;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class GetEnumeratorTests
+    public class Hashtable_GetEnumeratorTests
     {
         [Fact]
         public void TestGetEnumeratorBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyCountTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyCountTests.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
 using System.Text;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class CountTests
+    public class Hashtable_CountTests
     {
         [Fact]
         public void TestGetCountBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyEqualityComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyEqualityComparerTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class EqualityComparerTests
+    public class Hashtable_EqualityComparerTests
     {
         [Fact]
         public void TestEqualityComparerBasic()
@@ -28,18 +26,23 @@ namespace System.Collections.HashtableTests
             Assert.Equal(ikc, hsh1.EqualityComparer);
             System.Globalization.CultureInfo.DefaultThreadCurrentCulture = prevCulture;
         }
-    }
 
-    public class MyHashtable : Hashtable
-    {
-        public MyHashtable() : base() { }
-        public MyHashtable(int capacity, float loadFactor, IEqualityComparer ikc) : base(capacity, loadFactor, ikc) { }
-
-        public new IEqualityComparer EqualityComparer
+        public class MyHashtable : Hashtable
         {
-            get
+            public MyHashtable() : base()
             {
-                return base.EqualityComparer;
+            }
+
+            public MyHashtable(int capacity, float loadFactor, IEqualityComparer ikc) : base(capacity, loadFactor, ikc)
+            {
+            }
+
+            public new IEqualityComparer EqualityComparer
+            {
+                get
+                {
+                    return base.EqualityComparer;
+                }
             }
         }
     }

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyIsFixedSizeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyIsFixedSizeTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class IsFixedSizeTests
+    public class Hashtable_IsFixedSizeTests
     {
         [Fact]
         public void TestGetFixedSizeBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyIsReadOnlyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyIsReadOnlyTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class IsReadOnlyTests
+    public class Hashtable_IsReadOnlyTests
     {
         [Fact]
         public void TestGetIsReadOnlyBasic()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyIsSynchronizedTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyIsSynchronizedTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class IsSynchronizedTests
+    public class Hashtable_IsSynchronizedTests
     {
         private Hashtable _hsh2;
         private int _iNumberOfElements = 20;

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyItemTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyItemTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class ItemTests
+    public class Hashtable_ItemTests
     {
         public void TestGetItem()
         {

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyKeysTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyKeysTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Text;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class KeysTests
+    public class Hashtable_KeysTests
     {
         [Fact]
         public void TestGetKeys()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertySyncRootTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertySyncRootTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class SyncRootTests
+    public class Hashtable_SyncRootTests
     {
         private Hashtable _arrDaughter;
         private Hashtable _arrGrandDaughter;

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyValuesTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyValuesTests.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
 using System.Text;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class ValueTests
+    public class Hashtable_ValueTests
     {
         public void TestGetValues()
         {

--- a/src/System.Collections.NonGeneric/tests/Hashtable/RemoveTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/RemoveTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Text;
-using System;
-using System.Collections;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class RemoveTests
+    public class Hashtable_RemoveTests
     {
         [Fact]
         public void TestRemove()

--- a/src/System.Collections.NonGeneric/tests/Hashtable/SynchronizedTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/SynchronizedTests.cs
@@ -2,15 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Threading;
-using System.Collections;
-using System.IO;
 using System.Threading.Tasks;
 
-namespace System.Collections.HashtableTests
+namespace System.Collections.Tests
 {
-    public class SynchronizedTests
+    public class Hashtable_SynchronizedTests
     {
         private Hashtable _hsh2;
         private int _iNumberOfElements = 20;

--- a/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBase/ReadOnlyCollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBase/ReadOnlyCollectionBaseTests.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.NonGenericTests
+namespace System.Collections.Tests
 {
     public class ReadOnlyCollectionBaseTests
     {
@@ -174,114 +171,114 @@ namespace System.Collections.NonGenericTests
 
             Assert.Null(collectionBase.GetEnumerator());
         }
-    }
 
-    //ReadOnlyCollectionBase is provided to be used as the base class for strongly typed collections. Lets use one of our own here.
-    //This collection only allows the type Foo
-    public class MyReadOnlyCollectionBase : ReadOnlyCollectionBase
-    {
-        //we need a way of initializing this collection
-        public MyReadOnlyCollectionBase(Foo[] values)
+        //ReadOnlyCollectionBase is provided to be used as the base class for strongly typed collections. Lets use one of our own here.
+        //This collection only allows the type Foo
+        public class MyReadOnlyCollectionBase : ReadOnlyCollectionBase
         {
-            InnerList.AddRange(values);
-        }
-
-        public Foo this[int indx]
-        {
-            get { return (Foo)InnerList[indx]; }
-        }
-
-        public void CopyTo(Array array, int index)
-        {
-            ((ICollection)this).CopyTo(array, index);// Use the base class explicit implemenation of ICollection.CopyTo
-        }
-
-        public virtual object SyncRoot
-        {
-            get
+            //we need a way of initializing this collection
+            public MyReadOnlyCollectionBase(Foo[] values)
             {
-                return ((ICollection)this).SyncRoot;// Use the base class explicit implemenation of ICollection.SyncRoot
+                InnerList.AddRange(values);
+            }
+
+            public Foo this[int indx]
+            {
+                get { return (Foo)InnerList[indx]; }
+            }
+
+            public void CopyTo(Array array, int index)
+            {
+                ((ICollection)this).CopyTo(array, index);// Use the base class explicit implemenation of ICollection.CopyTo
+            }
+
+            public virtual object SyncRoot
+            {
+                get
+                {
+                    return ((ICollection)this).SyncRoot;// Use the base class explicit implemenation of ICollection.SyncRoot
+                }
+            }
+
+            public int IndexOf(Foo f)
+            {
+                return ((IList)InnerList).IndexOf(f);
+            }
+
+            public Boolean Contains(Foo f)
+            {
+                return ((IList)InnerList).Contains(f);
+            }
+
+            public Boolean IsFixedSize
+            {
+                get { return true; }
+            }
+
+            public Boolean IsReadOnly
+            {
+                get { return true; }
             }
         }
 
-        public int IndexOf(Foo f)
+        public class VirtualTestReadOnlyCollection : ReadOnlyCollectionBase
         {
-            return ((IList)InnerList).IndexOf(f);
-        }
-
-        public Boolean Contains(Foo f)
-        {
-            return ((IList)InnerList).Contains(f);
-        }
-
-        public Boolean IsFixedSize
-        {
-            get { return true; }
-        }
-
-        public Boolean IsReadOnly
-        {
-            get { return true; }
-        }
-    }
-
-    public class VirtualTestReadOnlyCollection : ReadOnlyCollectionBase
-    {
-        public override int Count
-        {
-            get
+            public override int Count
             {
-                return int.MinValue;
+                get
+                {
+                    return int.MinValue;
+                }
+            }
+
+            public override IEnumerator GetEnumerator()
+            {
+                return null;
             }
         }
 
-        public override IEnumerator GetEnumerator()
+        public class Foo
         {
-            return null;
-        }
-    }
+            private int _iValue;
+            private String _strValue;
 
-    public class Foo
-    {
-        private int _iValue;
-        private String _strValue;
+            public Foo()
+            {
+            }
 
-        public Foo()
-        {
-        }
+            public Foo(int i, String str)
+            {
+                _iValue = i;
+                _strValue = str;
+            }
 
-        public Foo(int i, String str)
-        {
-            _iValue = i;
-            _strValue = str;
-        }
+            public int IValue
+            {
+                get { return _iValue; }
+                set { _iValue = value; }
+            }
 
-        public int IValue
-        {
-            get { return _iValue; }
-            set { _iValue = value; }
-        }
+            public String SValue
+            {
+                get { return _strValue; }
+                set { _strValue = value; }
+            }
 
-        public String SValue
-        {
-            get { return _strValue; }
-            set { _strValue = value; }
-        }
-
-        public override Boolean Equals(object obj)
-        {
-            if (obj == null)
+            public override Boolean Equals(object obj)
+            {
+                if (obj == null)
+                    return false;
+                if (!(obj is Foo))
+                    return false;
+                if ((((Foo)obj).IValue == _iValue) && (((Foo)obj).SValue == _strValue))
+                    return true;
                 return false;
-            if (!(obj is Foo))
-                return false;
-            if ((((Foo)obj).IValue == _iValue) && (((Foo)obj).SValue == _strValue))
-                return true;
-            return false;
-        }
+            }
 
-        public override int GetHashCode()
-        {
-            return _iValue;
+            public override int GetHashCode()
+            {
+                return _iValue;
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/SortedList/ClearTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/ClearTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class ClearTests : IComparer
+    public class SortedList_ClearTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/CloneTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CloneTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CloneTests
+    public class SortedList_CloneTests
     {
         [Fact]
         public void TestCloneBasic()
@@ -80,14 +78,14 @@ namespace System.Collections.SortedListTests
             strValue = "Hello World";
             Assert.Equal(strValue, ((Foo)hsh2[0]).strValue);
         }
-    }
 
-    internal class Foo
-    {
-        internal string strValue;
-        internal Foo()
+        internal class Foo
         {
-            strValue = "Hello World";
+            internal string strValue;
+            internal Foo()
+            {
+                strValue = "Hello World";
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/SortedList/ContainsKeyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/ContainsKeyTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class ContainsKeyTests : IComparer
+    public class SortedList_ContainsKeyTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/ContainsValueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/ContainsValueTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class ContainsValueTests : IComparer
+    public class SortedList_ContainsValueTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorDictionaryIComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorDictionaryIComparerTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CtorDictionaryIComparerTests : IComparer
+    public class SortedList_CtorDictionaryIComparerTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorDictionaryTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorDictionaryTests.cs
@@ -1,47 +1,47 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class SortedListCtorTestClass : IComparable
+    public class SortedList_CtorDictionaryTests
     {
-        internal string str = null; //key value
-
-        public SortedListCtorTestClass() { }
-
-        public SortedListCtorTestClass(string tstr)
+        public class SortedListCtorTestClass : IComparable
         {
-            str = tstr;
+            internal string str = null; //key value
+
+            public SortedListCtorTestClass()
+            {
+            }
+
+            public SortedListCtorTestClass(string tstr)
+            {
+                str = tstr;
+            }
+
+            public virtual int CompareTo(Object obj)
+            {
+                return str.CompareTo(obj.ToString());
+            }
+
+            public override bool Equals(Object obj)
+            {
+                return str.Equals(obj.ToString());
+            }
+
+            public override int GetHashCode()
+            {
+                return str.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return str.ToString();
+            }
         }
 
-        public virtual int CompareTo(Object obj)
-        {
-            return str.CompareTo(obj.ToString());
-        }
-
-        public override bool Equals(Object obj)
-        {
-            return str.Equals(obj.ToString());
-        }
-
-        public override int GetHashCode()
-        {
-            return str.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            return str.ToString();
-        }
-    }
-
-    public class CtorDictionaryTests
-    {
         [Fact]
         public void Test01()
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorIComparerIntTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorIComparerIntTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CtorIComparerIntTests : IComparer
+    public class SortedList_CtorIComparerIntTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorIComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorIComparerTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CtorIComparerTests : IComparer
+    public class SortedList_CtorIComparerTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorTests.cs
@@ -1,57 +1,57 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Diagnostics;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CtorTestClass : IComparable
+    public class SortedList_CtorTests
     {
-        internal string str = null;
-
-        public CtorTestClass() { }
-
-        public CtorTestClass(string tstr)
+        public class CtorTestClass : IComparable
         {
-            str = tstr;
+            internal string str = null;
+
+            public CtorTestClass()
+            {
+            }
+
+            public CtorTestClass(string tstr)
+            {
+                str = tstr;
+            }
+
+            public virtual int CompareTo(object obj2)
+            {
+                return str.CompareTo(obj2.ToString());
+            }
+
+            public override bool Equals(object obj)
+            {
+                return str.Equals(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return str.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return str.ToString();
+            }
+
+            /// <summary>
+            /// named it as GetString() to distinguish it from ToString() even though the purpose is same
+            /// </summary>
+            /// <returns></returns>
+            public virtual string GetString()
+            {
+                return str.ToString();
+            }
         }
 
-        public virtual int CompareTo(object obj2)
-        {
-            return str.CompareTo(obj2.ToString());
-        }
-
-        public override bool Equals(object obj)
-        {
-            return str.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return str.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            return str.ToString();
-        }
-
-        /// <summary>
-        /// named it as GetString() to distinguish it from ToString() even though the purpose is same
-        /// </summary>
-        /// <returns></returns>
-        public virtual string GetString()
-        {
-            return str.ToString();
-        }
-    }
-
-    public class CtorTests
-    {
         [Fact]
         public void TestCtorDefault()
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetByIndexITests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetByIndexITests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class GetByIndexTests : IComparer
+    public class SortedList_GetByIndexTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetEnumeratorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetEnumeratorTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class GetEnumeratorTests : IComparer
+    public class SortedList_GetEnumeratorTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetKeyListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetKeyListTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class GetKeyListTests
+    public class SortedList_GetKeyListTests
     {
         [Fact]
         public void TestGetKeyListBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetKeyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetKeyTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class GetKeyTests : IComparer
+    public class SortedList_GetKeyTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetObjectTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetObjectTests.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Globalization;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class GetObjectTests : IComparer
+    public class SortedList_GetObjectTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetValueListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetValueListTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class GetValueListTests
+    public class SortedList_GetValueListTests
     {
         [Fact]
         public void TestGetValueListBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/IndexOfKeyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/IndexOfKeyTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class IndexOfKeyTests : IComparer
+    public class SortedList_IndexOfKeyTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/IndexOfValueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/IndexOfValueTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class IndexOfValueTests : IComparer
+    public class SortedList_IndexOfValueTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/MultiMethodsTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/MultiMethodsTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
-using System.Reflection;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class MultiMethodsTests
+    public class SortedList_MultiMethodsTests
     {
         [Fact]
         public void Test01()

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyCapacityTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyCapacityTests.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Globalization;
-using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CapacityTests
+    public class SortedList_CapacityTests
     {
         [Fact]
         public void TestGetCapacityBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyCountTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyCountTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class CountTests : IComparer
+    public class SortedList_CountTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyIsFixedSizeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyIsFixedSizeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class IsFixedSizeTests
+    public class SortedList_IsFixedSizeTests
     {
         [Fact]
         public void TestGetIsFixedSizeBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyIsReadOnlyTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyIsReadOnlyTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class IsReadOnlyTests
+    public class SortedList_IsReadOnlyTests
     {
         [Fact]
         public void TestGetIsReadOnlyBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyIsSynchronizedTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyIsSynchronizedTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class IsSynchronizedTests
+    public class SortedList_IsSynchronizedTests
     {
         private SortedList _slst2;
         private int _iNumberOfElements = 20;

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyKeysTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyKeysTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class KeysTests
+    public class SortedList_KeysTests
     {
         [Fact]
         public void TestGetKeysBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertySyncRootTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertySyncRootTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class SyncRootTests
+    public class SortedList_SyncRootTests
     {
         private SortedList _arrDaughter;
         private SortedList _arrGrandDaughter;

--- a/src/System.Collections.NonGeneric/tests/SortedList/PropertyValuesTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/PropertyValuesTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class ValuesTests
+    public class SortedList_ValuesTests
     {
         [Fact]
         public void TestGetValuesBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/RemoveAtTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/RemoveAtTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class RemoveAtTests : IComparer
+    public class SortedList_RemoveAtTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/RemoveTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/RemoveTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class RemoveTests : IComparer
+    public class SortedList_RemoveTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/SetCapacityTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/SetCapacityTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
-using System.Globalization;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class PropertyCapacityTests01
+    public class SortedList_PropertyCapacityTests01
     {
         [Fact]
         public void TestSetCapacityBasic()

--- a/src/System.Collections.NonGeneric/tests/SortedList/SetObjectObjectTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/SetObjectObjectTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class IndexcAccessTests : IComparer
+    public class SortedList_IndexcAccessTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/SynchronizedTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/SynchronizedTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class SynchronizedTests
+    public class SortedList_SynchronizedTests
     {
         private SortedList _slst2;
         private Int32 _iNumberOfElements = 20;

--- a/src/System.Collections.NonGeneric/tests/SortedList/TrimToSizeTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/TrimToSizeTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
-    public class TrimToSizeTests : IComparer
+    public class SortedList_TrimToSizeTests : IComparer
     {
         public virtual int Compare(object obj1, object obj2)  // ICompare satisfier.
         {

--- a/src/System.Collections.NonGeneric/tests/SortedList/WrapperTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/WrapperTests.cs
@@ -1,18 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Text;
 using Xunit;
 
-namespace System.Collections.SortedListTests
+namespace System.Collections.Tests
 {
     /// <summary>
     /// The goal is to call the methods of the base class on the wrapper
     /// classes to ensure that the right thing is happening in SortedList
     /// </summary>
-    public class WrapperTests
+    public class SortedList_WrapperTests
     {
         [Fact]
         public void TestKeys()

--- a/src/System.Collections.NonGeneric/tests/Stack/StackBasicTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/StackBasicTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Diagnostics;
 using Xunit;
 
-namespace System.Collections.StackTests
+namespace System.Collections.Tests
 {
 public class StackBasicTests
 {

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_Clone.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_Clone.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Globalization;
 using Xunit;
 
-namespace System.Collections.StackTests
+namespace System.Collections.Tests
 {
     public class StackCloneTests
     {
@@ -64,20 +61,20 @@ namespace System.Collections.StackTests
                 Assert.True(stkClone.Contains(i));
             }
         }
-    }
 
-    class A
-    {
-        private int _i;
-        public A(int i)
+        private class A
         {
-            _i = i;
-        }
-        
-        internal int I
-        {
-            set { _i = value; }
-            get { return _i; }
+            private int _i;
+            public A(int i)
+            {
+                _i = i;
+            }
+
+            internal int I
+            {
+                set { _i = value; }
+                get { return _i; }
+            }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_ToArray.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_ToArray.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-using System.Collections;
 using Xunit;
 
-namespace System.Collections.StackTests
+namespace System.Collections.Tests
 {
     public class StackToArrayTests
     {

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_get_SyncRoot.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_get_SyncRoot.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Collections.StackTests
+namespace System.Collections.Tests
 {
     public class StackGetSyncRootTests
     {


### PR DESCRIPTION
Correct test namespaces for some System.Collections.* projects, per #2898 .
Only those assemblies listed here were checked.

Namespaces were changed, and `using`s were cleaned up in updated files.
Some classes were renamed to avoid conflicts.
