### PR TITLE
Correct test namespaces for System.Diagnostics.*

### DIFF
--- a/src/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     internal class Interop
     {

--- a/src/System.Diagnostics.Process/tests/ProcessCollectionTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessCollectionTests.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Linq;
 using Xunit;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessCollectionTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -1,14 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Security;
-using System.IO;
 using Xunit;
-using System.Threading;
-using System.ComponentModel;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessModuleTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessStandardConsoleTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using Microsoft.Win32;
-using Microsoft.Win32.SafeHandles;
 using Xunit;
 using System.Text;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessStartInfoTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
 using System.IO;
-using Xunit;
+using System.Text;
 using System.Threading;
+using Xunit;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessStreamReadTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessTestBase : RemoteExecutorTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Security;
-using System.IO;
-using Xunit;
-using System.Threading;
-using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Xunit;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessThreadTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class ProcessWaitingTests : ProcessTestBase
     {

--- a/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
+++ b/src/System.Diagnostics.Tracing.Telemetry/tests/TelemetryTests.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using Xunit;
 using System.Threading.Tasks;
+using Xunit;
 using TelemData = System.Collections.Generic.KeyValuePair<string, object>;
 
-namespace System.Diagnostics.Tracing.Telemetry.Tests
+namespace System.Diagnostics.Tracing.Tests
 {
     /// <summary>
     /// Tests for TelemetrySource and TelemetryListener


### PR DESCRIPTION
Correct namespaces for some System.Diagnostics.* assemblies, fer #2898 

Only those assemblies listed here have been corrected.

Namespaces were added or corrected.  No other changes were made.