### PR TITLE
Correct test namespace in System.Globalization.Extensions

### DIFF
--- a/src/System.Globalization.Extensions/tests/GlobalizationExtensionsTests.cs
+++ b/src/System.Globalization.Extensions/tests/GlobalizationExtensionsTests.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public class GlobalizationExtensionsTests
     {

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/ConformanceIdnaTestResult.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/ConformanceIdnaTestResult.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public class ConformanceIdnaTestResult
     {

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Factory.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Factory.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public static class Factory
     {

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/IConformanceIdnaTest.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/IConformanceIdnaTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public enum IdnType { Transitional, Nontransitional, Both };
 

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_6_0/Unicode_6_0_IdnaTest.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_6_0/Unicode_6_0_IdnaTest.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.Text;
+using Xunit;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     /// <summary>
     /// Class to read data obtained from http://www.unicode.org/Public/idna.  For more information read the information

--- a/src/System.Globalization.Extensions/tests/IdnMapping/GetAsciiTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/GetAsciiTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Globalization;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public class GetAsciiTests
     {

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingThrows.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingThrows.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public class IdnMappingThrows
     {

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnaConformanceTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnaConformanceTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections.Generic;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     /// <summary>
     /// This suite of tests enumerate a set of input and outputs provided by the Unicode consortium.

--- a/src/System.Globalization.Extensions/tests/IdnMapping/UseStd3AsciiRules.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/UseStd3AsciiRules.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Globalization;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     /// <summary>
     /// According to the ToASCII algorithm, if the UseSTD3ASCIIRules flag is set, 

--- a/src/System.Globalization.Extensions/tests/Normalization/Normalization.cs
+++ b/src/System.Globalization.Extensions/tests/Normalization/Normalization.cs
@@ -6,7 +6,7 @@ using System;
 using System.Text;
 using System.Globalization;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public class StringNormalization
     {

--- a/src/System.Globalization.Extensions/tests/Normalization/NormalizationAll.cs
+++ b/src/System.Globalization.Extensions/tests/Normalization/NormalizationAll.cs
@@ -6,7 +6,7 @@ using System;
 using System.Text;
 using System.Globalization;
 
-namespace System.Globalization.Extensions.Tests
+namespace System.Globalization.Tests
 {
     public class NormalizationAll
     {


### PR DESCRIPTION
Correct test namespaces in System.Globalization.Extensions, per #2898 .

Namespaces were modified only, no other work was performed.