### PR TITLE
Correct test namespace in System.IO.FileSystem

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_CreateDirectory : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_Delete_str : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/Directory/EnumerableAPIs.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     #region EnumerateFiles
 

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_Exists : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetDirectories_str : Directory_GetFileSystemEntries_str
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetDirectoryRoot : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetFileSystemEntries_str : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -4,7 +4,7 @@
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetFileSystemEntries_str_str : Directory_GetFileSystemEntries_str
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetFileSystemEntries_str_str_so : Directory_GetFileSystemEntries_str_str
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetFiles_str : Directory_GetFileSystemEntries_str
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetParent.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetParent.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetParent : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_GetSetTimes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_Move : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
@@ -4,7 +4,7 @@
 using System.Runtime.CompilerServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Directory_SetCurrentDirectory : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_Create : Directory_CreateDirectory
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_CreateSubDirectory : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Delete.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Delete.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_Delete : Directory_Delete_str
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/EnumerableAPIs.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     #region EnumerateFiles
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class DirectoryInfo_Exists : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_GetDirectories : Directory_GetDirectories_str
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_GetFileSystemInfos : Directory_GetFileSystemEntries_str
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_GetFiles : Directory_GetFiles_str
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_GetSetAttributes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_GetSetTimes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_MoveTo : Directory_Move
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Name.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Name.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_Name : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Parent.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Parent.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_Parent : Directory_GetParent
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Refresh.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Refresh.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_Refresh : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Root.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Root.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_Root : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class DirectoryInfo_ToString : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FSAssert.cs
+++ b/src/System.IO.FileSystem/tests/FSAssert.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public static class FSAssert
     {

--- a/src/System.IO.FileSystem/tests/File/Append.cs
+++ b/src/System.IO.FileSystem/tests/File/Append.cs
@@ -4,7 +4,7 @@
 using System.Text;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_AppendText : File_ReadWriteAllText
     {

--- a/src/System.IO.FileSystem/tests/File/ChangeExtension.cs
+++ b/src/System.IO.FileSystem/tests/File/ChangeExtension.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_ChangeExtension : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_Copy_str_str : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_Create_str : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_Delete : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_Exists : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetAttributes.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_GetSetAttributes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_GetSetTimes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_Move : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/Open.cs
+++ b/src/System.IO.FileSystem/tests/File/Open.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_Open_str_fm : FileStream_ctor_str_fm
     {

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -4,7 +4,7 @@
 using System.Text;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_ReadWriteAllBytes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllLines.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllLines.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_ReadWriteAllLines : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllText.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllText.cs
@@ -4,7 +4,7 @@
 using System.Text;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class File_ReadWriteAllText : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/AppendText.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/AppendText.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_AppendText : File_ReadWriteAllText
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_CopyTo_str : File_Copy_str_str
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Create : File_Create_str
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Delete.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Delete.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Delete : File_Delete
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Directory.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Directory.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Directory : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Exists : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Extension.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Extension.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Extension : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributes.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_GetSetAttributes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_GetSetTimes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Length.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Length.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Length : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/MoveTo.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/MoveTo.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_MoveTo : File_Move
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Name.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Name.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Name : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Open.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Open.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Open_fm : FileStream_ctor_str_fm
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/Refresh.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Refresh.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_Refresh : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/ToString.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileInfo_ToString : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Buffering_regression.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Buffering_regression.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Buffering_regression: FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/CanRead.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CanRead.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_CanRead : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/CanSeek.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CanSeek.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.IO.Pipes;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_CanSeek : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/CanTimeout.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CanTimeout.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_CanTimeout : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/CanWrite.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CanWrite.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_CanWrite : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Dispose : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_Flush : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/FlushAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/FlushAsync.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_FlushAsync : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/IsAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/IsAsync.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_IsAsync : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Length.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Length.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Length : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Name.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Name.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Name : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Pipes : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Position.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Position.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Position : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Read : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ReadAsync : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ReadByte.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ReadByte.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ReadByte : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_SafeFileHandle : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Seek.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Seek.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Seek : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/SetLength.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SetLength.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_SetLength : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ToString.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ToString.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ToString : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/Write.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Write.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_Write : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_WriteAsync : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/WriteByte.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteByte.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_WriteByte : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_sfh_fa : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_sfh_fa_buffer : FileStream_ctor_sfh_fa
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer_async.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer_async.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_sfh_fa_buffer_async : FileStream_ctor_sfh_fa_buffer
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_str_fm : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_str_fm_fa : FileStream_ctor_str_fm
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_ctor_str_fm_fa_fs : FileStream_ctor_str_fm_fa
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.delete.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.delete.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_ctor_str_fm_fa_fs
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.read.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.read.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_ctor_str_fm_fa_fs
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.write.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.write.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public partial class FileStream_ctor_str_fm_fa_fs
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_str_fm_fa_fs_buffer : FileStream_ctor_str_fm_fa_fs
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_async.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_async.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_str_fm_fa_fs_buffer_async : FileStream_ctor_str_fm_fa_fs_buffer
     {

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class FileStream_ctor_str_fm_fa_fs_buffer_fo : FileStream_ctor_str_fm_fa_fs_buffer
     {

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public abstract class FileSystemTest : FileCleanupTestBase
     {

--- a/src/System.IO.FileSystem/tests/UnseekableFileStream.cs
+++ b/src/System.IO.FileSystem/tests/UnseekableFileStream.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     internal class UnseekableFileStream : FileStream
     {


### PR DESCRIPTION
Correct test namespace in System.IO.FileSystem, per #2898 .

Namespaces were corrected as required, and `using`s cleaned up, no other work was performed.
Some files will need to have a namespace added.