### PR TITLE
Correct test namespaces for System.ObjectModel

### DIFF
--- a/src/System.ObjectModel/tests/KeyedCollection/ConcreteTestClasses.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/ConcreteTestClasses.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using Xunit;
 
-namespace System.ObjectModel.Tests
+namespace System.Collections.ObjectModel.Tests
 {
     public class KeyedCollectionTest
     {

--- a/src/System.ObjectModel/tests/KeyedCollection/TestMethods.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/TestMethods.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Tests.Collections;
 using Xunit;
 
-namespace System.ObjectModel.Tests
+namespace System.Collections.ObjectModel.Tests
 {
     public abstract class KeyedCollectionTests<TKey, TValue>
         where TValue : IComparable<TValue> where TKey : IEquatable<TKey>

--- a/src/System.ObjectModel/tests/KeyedCollection/Utils.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/Utils.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using Tests.Collections;
 using Xunit;
 
-namespace System.ObjectModel.Tests
+namespace System.Collections.ObjectModel.Tests
 {
     public class BadKey<T> : IComparable<BadKey<T>>,
                              IEquatable<BadKey<T>>

--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
-using Tests.Collections;
+using Xunit;
 
-namespace Test
+namespace System.Collections.ObjectModel.Tests
 {
     /// <summary>
     /// Tests the public properties and constructor in ObservableCollection<T>.

--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_MethodsTest.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_MethodsTest.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using Tests.Collections;
+using Xunit;
 
-namespace Test
+namespace System.Collections.ObjectModel.Tests
 {
     /// <summary>
     /// Tests the public methods in ObservableCollection<T> as well as verifies

--- a/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
+using Xunit;
 
-namespace Collections
+namespace System.Collections.ObjectModel.Tests
 {
     /// <summary>
     /// Tests the public methods in ReadOnlyDictionary<TKey, Value>.

--- a/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollectionTests.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollectionTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
+using Xunit;
 
-namespace Test
+namespace System.Collections.ObjectModel.Tests
 {
     /// <summary>
     /// Tests the public properties and constructor in ObservableCollection<T>.

--- a/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollection_EventsTests.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollection_EventsTests.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Collections;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using Tests.Collections;
+using Xunit;
 
-namespace Test
+namespace System.Collections.ObjectModel.Tests
 {
     /// <summary>
     /// Tests that the INotifyCollectionChanged and IPropertyChanged events are fired 


### PR DESCRIPTION
Correct test namespaces for System.ObjectModel, per #2898 .

Only namespaces were adjusted, usings cleaned up, no other work was performed.