### PR TITLE
Correct test namespaces for some System.Reflection.* assemblies

### DIFF
--- a/src/System.Reflection.Extensions/tests/Definitions/ConstructorDefinitions.cs
+++ b/src/System.Reflection.Extensions/tests/Definitions/ConstructorDefinitions.cs
@@ -2,50 +2,49 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable 3026
-using System;
 
-namespace ConstructorDefinitions
+namespace System.Reflection.Tests
 {
-    public static class StaticClass
+    public static class ConstructorTestStaticClass
     {
         public static int Members = 3;
         public static int MembersEverything = 9;
-        static StaticClass() { }
+        static ConstructorTestStaticClass() { }
     }
 
-    public class ClassWithMultipleConstructors
+    public class ConstructorTestClassWithMultipleConstructors
     {
         public static int Members = 9;
         public static int MembersEverything = 15;
 
-        static ClassWithMultipleConstructors() { }
+        static ConstructorTestClassWithMultipleConstructors() { }
 
-        private ClassWithMultipleConstructors(String s) { }
+        private ConstructorTestClassWithMultipleConstructors(String s) { }
 
-        protected ClassWithMultipleConstructors(int i) { }
+        protected ConstructorTestClassWithMultipleConstructors(int i) { }
 
-        public ClassWithMultipleConstructors() { }
-        public ClassWithMultipleConstructors(TimeSpan ts) { }
-        public ClassWithMultipleConstructors(Object o1, Object o2) { }
-        public ClassWithMultipleConstructors(Object obj0, Int32 i4) { }
+        public ConstructorTestClassWithMultipleConstructors() { }
+        public ConstructorTestClassWithMultipleConstructors(TimeSpan ts) { }
+        public ConstructorTestClassWithMultipleConstructors(Object o1, Object o2) { }
+        public ConstructorTestClassWithMultipleConstructors(Object obj0, Int32 i4) { }
     }
 
-    public class BaseClass
+    public class ConstructorTestBaseClass
     {
         public static int Members = 5;
         public static int MembersEverything = 11;
 
-        static BaseClass() { }
-        public BaseClass() { }
-        public BaseClass(Int16 i2) { }
+        static ConstructorTestBaseClass() { }
+        public ConstructorTestBaseClass() { }
+        public ConstructorTestBaseClass(Int16 i2) { }
     }
 
-    public class SubClass : BaseClass
+    public class ConstructorTestSubClass : ConstructorTestBaseClass
     {
         public new static int Members = 5; //.cctor is added
         public new static int MembersEverything = 11;
 
-        public SubClass(String s) { }
-        public SubClass(Int16 i2) { }
+        public ConstructorTestSubClass(String s) { }
+        public ConstructorTestSubClass(Int16 i2) { }
     }
 }

--- a/src/System.Reflection.Extensions/tests/Definitions/EventDefinitions.cs
+++ b/src/System.Reflection.Extensions/tests/Definitions/EventDefinitions.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable 3026, 0067, 3005 // Disabling a few CLS-compliance warnings
-using System;
 
-namespace EventDefinitions
+namespace System.Reflection.Tests
 {
     public interface IEventTestInterface
     {

--- a/src/System.Reflection.Extensions/tests/Definitions/FieldDefinitions.cs
+++ b/src/System.Reflection.Extensions/tests/Definitions/FieldDefinitions.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable 3026
-using System;
 
-namespace FieldDefinitions
+namespace System.Reflection.Tests
 {
-    public class BaseClass
+    public class FieldTestBaseClass
     {
         public static int Members = 35;
         public static int MembersEverything = 41;
@@ -55,7 +54,7 @@ namespace FieldDefinitions
         protected internal static volatile string ProIntfld6 = "";
     }
 
-    public class SubClass : BaseClass
+    public class FieldTestSubClass : FieldTestBaseClass
     {
         public new static int Members = 32;
         public new static int MembersEverything = 54;

--- a/src/System.Reflection.Extensions/tests/Definitions/MethodDefinitions.cs
+++ b/src/System.Reflection.Extensions/tests/Definitions/MethodDefinitions.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
-
-namespace MethodDefinitions
+namespace System.Reflection.Tests
 {
-    public class BaseClass
+    public class MethodTestBaseClass
     {
         public static int Members = 38;
         public static int MembersEverything = 44;
@@ -82,7 +79,7 @@ namespace MethodDefinitions
         private static void PrivMeth3() { }
     }
 
-    public class SubClass : BaseClass
+    public class MethodTestSubClass : MethodTestBaseClass
     {
         public new static int Members = 31;
         public new static int MembersEverything = 51;
@@ -151,7 +148,7 @@ namespace MethodDefinitions
         private static void PrivMeth3() { }
     }
 
-    public abstract class AbsBaseClass
+    public abstract class MethodTestAbsBaseClass
     {
         public static int Members = 11;
         public static int MembersEverything = 17;
@@ -166,7 +163,7 @@ namespace MethodDefinitions
         protected internal abstract void meth4();
     }
 
-    public abstract class AbsSubClass : AbsBaseClass
+    public abstract class MethodTestAbsSubClass : MethodTestAbsBaseClass
     {
         public new static int Members = 7;
         public new static int MembersEverything = 17;

--- a/src/System.Reflection.Extensions/tests/Definitions/PropertyDefinitions.cs
+++ b/src/System.Reflection.Extensions/tests/Definitions/PropertyDefinitions.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
-
-namespace PropertyDefinitions
+namespace System.Reflection.Tests
 {
-    internal class BaseClass
+    internal class PropertyTestBaseClass
     {
         public static int Members = 67;
         public static int MembersEverything = 73;
@@ -42,7 +39,7 @@ namespace PropertyDefinitions
         protected internal static string ProIntprop3 { get { return ""; } set { } }
     }
 
-    internal class SubClass : BaseClass
+    internal class PropertyTestSubClass : PropertyTestBaseClass
     {
         public new static int Members = 55;
         public new static int MembersEverything = 89;
@@ -75,7 +72,7 @@ namespace PropertyDefinitions
         protected new internal static string ProIntprop3 { get { return ""; } set { } }
     }
 
-    public class BaseIndexerClass
+    public class PropertyTestBaseIndexerClass
     {
         public static int Members = 16;
         public static int MembersEverything = 22;
@@ -90,7 +87,7 @@ namespace PropertyDefinitions
         public int this[DateTime i] { get { return 1; } set { } }
     }
 
-    public class SubIndexerClass : BaseIndexerClass
+    public class PropertyTestSubIndexerClass : PropertyTestBaseIndexerClass
     {
         public new static int Members = 13;
         public new static int MembersEverything = 26;
@@ -104,7 +101,7 @@ namespace PropertyDefinitions
         public new int this[string i] { get { return 1; } set { } }
     }
 
-    internal abstract class BaseAbsClass
+    internal abstract class PropertyTestBaseAbsClass
     {
         public static int Members = 19;
         public static int MembersEverything = 25;
@@ -120,7 +117,7 @@ namespace PropertyDefinitions
         protected internal abstract string prop4 { get; set; }
     }
 
-    internal abstract class SubAbsClass : BaseAbsClass
+    internal abstract class PropertyTestSubAbsClass : PropertyTestBaseAbsClass
     {
         public new static int Members = 19;
         public new static int MembersEverything = 25;

--- a/src/System.Reflection.Extensions/tests/GetCustomAttributes_Assembly.cs
+++ b/src/System.Reflection.Extensions/tests/GetCustomAttributes_Assembly.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Security;
 using Xunit;
-using Assembly = System.Reflection.Extensions.Tests;
+using Assembly = System.Reflection.Tests;
 
 [assembly: Assembly.MyAttribute_Single("single"), Assembly.MyAttribute_AllowMultiple("multiple1"), Assembly.MyAttribute_AllowMultiple("multiple2")]
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public class GetCustomAttributes_Assembly
     {
@@ -21,9 +19,9 @@ namespace System.Reflection.Extensions.Tests
             IEnumerable<Attribute> attributes = CustomAttributeExtensions.GetCustomAttributes(thisAsm);
             //There are other attributes added as default:
 
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple multiple2", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple multiple2", StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -45,7 +43,7 @@ namespace System.Reflection.Extensions.Tests
             Assert.Null(attribute);
 
             attribute = CustomAttributeExtensions.GetCustomAttribute(thisAsm, typeof(MyAttribute_Single));
-            Assert.Equal("System.Reflection.Extensions.Tests.MyAttribute_Single single", attribute.ToString());
+            Assert.Equal("System.Reflection.Tests.MyAttribute_Single single", attribute.ToString());
 
             Assert.Throws<AmbiguousMatchException>(() =>
             {
@@ -60,8 +58,8 @@ namespace System.Reflection.Extensions.Tests
             IEnumerable<Attribute> attributes;
             attributes = CustomAttributeExtensions.GetCustomAttributes(thisAsm, typeof(MyAttribute_AllowMultiple));
             Assert.Equal(2, attributes.Count());
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
 
             attributes = CustomAttributeExtensions.GetCustomAttributes(thisAsm, typeof(SecurityCriticalAttribute));
             Assert.Equal(0, attributes.Count());
@@ -82,7 +80,7 @@ namespace System.Reflection.Extensions.Tests
             });
 
             attribute = CustomAttributeExtensions.GetCustomAttribute<MyAttribute_Single>(thisAsm);
-            Assert.Equal("System.Reflection.Extensions.Tests.MyAttribute_Single single", attribute.ToString());
+            Assert.Equal("System.Reflection.Tests.MyAttribute_Single single", attribute.ToString());
 
             Assert.Throws<AmbiguousMatchException>(() =>
             {
@@ -98,8 +96,8 @@ namespace System.Reflection.Extensions.Tests
 
             attributes = CustomAttributeExtensions.GetCustomAttributes<MyAttribute_AllowMultiple>(thisAsm);
             Assert.Equal(2, attributes.Count());
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple multiple2", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple multiple2", StringComparison.Ordinal)));
 
             attributes = CustomAttributeExtensions.GetCustomAttributes<SecurityCriticalAttribute>(thisAsm);
             Assert.Equal(0, attributes.Count());

--- a/src/System.Reflection.Extensions/tests/GetCustomAttributes_Compat.cs
+++ b/src/System.Reflection.Extensions/tests/GetCustomAttributes_Compat.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public class GetCustomAttributes_Compat
     {

--- a/src/System.Reflection.Extensions/tests/GetCustomAttributes_MemberInfo.cs
+++ b/src/System.Reflection.Extensions/tests/GetCustomAttributes_MemberInfo.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Security;
 using Xunit;
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public class GetCustomAttributes_MemberInfo
     {
@@ -130,10 +128,10 @@ namespace System.Reflection.Extensions.Tests
         {
             IEnumerable<Attribute> attributes = CustomAttributeExtensions.GetCustomAttributes(s_typeTestClass.GetTypeInfo(), false);
             Assert.Equal(4, attributes.Count());
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_M single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_M multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_M multiple2", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_Inherited multiple", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_M single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_M multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_M multiple2", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_Inherited multiple", StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -147,13 +145,12 @@ namespace System.Reflection.Extensions.Tests
             IEnumerator<Attribute> customAttrs = attributes.GetEnumerator();
 
             Assert.Equal(6, attributes.Count());
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_M single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_M multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_M multiple2", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_Inherited singleBase", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_Inherited multiple", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_Inherited multipleBase", StringComparison.Ordinal)));
-
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_M single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_M multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_M multiple2", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_Inherited singleBase", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_Inherited multiple", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_Inherited multipleBase", StringComparison.Ordinal)));
 
             IEnumerable<CustomAttributeData> attributeData = s_typeTestClass.GetTypeInfo().CustomAttributes;
 

--- a/src/System.Reflection.Extensions/tests/GetCustomAttributes_ParamterInfo.cs
+++ b/src/System.Reflection.Extensions/tests/GetCustomAttributes_ParamterInfo.cs
@@ -3,11 +3,11 @@
 
 using System.Collections.Generic;
 using Xunit;
-using Assembly = System.Reflection.Extensions.Tests;
+using Assembly = System.Reflection.Tests;
 
 [module: Assembly.MyAttribute_Single_P("single"), Assembly.MyAttribute_AllowMultiple_P("multiple1"), Assembly.MyAttribute_AllowMultiple_P("multiple2")]
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public class GetCustomAttributes_ParameterInfo
     {
@@ -195,11 +195,11 @@ namespace System.Reflection.Extensions.Tests
 
             attributes = CustomAttributeExtensions.GetCustomAttributes(piWithAttributes, false);
             Assert.Equal(5, attributes.Count());
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_P single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_P multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_P multiple2", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_Inherited_P single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_Inherited_P multiple", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_P single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_P multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_P multiple2", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_Inherited_P single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_Inherited_P multiple", StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -221,19 +221,19 @@ namespace System.Reflection.Extensions.Tests
 
             attributes = CustomAttributeExtensions.GetCustomAttributes(piWithAttributes);
             Assert.Equal(5, attributes.Count());
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_P single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_P multiple1", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_P multiple2", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_Inherited_P single", StringComparison.Ordinal)));
-            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_Inherited_P multiple", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_P single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_P multiple1", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_P multiple2", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_Inherited_P single", StringComparison.Ordinal)));
+            Assert.Equal(1, attributes.Count(attr => attr.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_Inherited_P multiple", StringComparison.Ordinal)));
 
             attributeData = piWithAttributes.CustomAttributes;
             Assert.Equal(5, attributeData.Count());
 
-            Assert.Equal(2, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_P", StringComparison.Ordinal)));
-            Assert.Equal(1, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_P", StringComparison.Ordinal)));
-            Assert.Equal(1, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_Single_Inherited_P", StringComparison.Ordinal)));
-            Assert.Equal(1, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Extensions.Tests.MyAttribute_AllowMultiple_Inherited_P", StringComparison.Ordinal)));
+            Assert.Equal(2, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_P", StringComparison.Ordinal)));
+            Assert.Equal(1, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_P", StringComparison.Ordinal)));
+            Assert.Equal(1, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Tests.MyAttribute_Single_Inherited_P", StringComparison.Ordinal)));
+            Assert.Equal(1, attributeData.Count(attr => attr.AttributeType.ToString().Equals("System.Reflection.Tests.MyAttribute_AllowMultiple_Inherited_P", StringComparison.Ordinal)));
         }
     }
 

--- a/src/System.Reflection.Extensions/tests/ReflectionTestExtensions.cs
+++ b/src/System.Reflection.Extensions/tests/ReflectionTestExtensions.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public static class Extensions
     {

--- a/src/System.Reflection.Extensions/tests/RuntimeReflectionExtensionTests.cs
+++ b/src/System.Reflection.Extensions/tests/RuntimeReflectionExtensionTests.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public class RuntimeReflectionExtensionsTests
     {
@@ -257,7 +257,7 @@ namespace System.Reflection.Extensions.Tests
 
         private static TypeInfo[] GetTypes()
         {
-            Assembly asm = typeof(PropertyDefinitions.BaseClass).GetTypeInfo().Assembly;
+            Assembly asm = typeof(PropertyTestBaseClass).GetTypeInfo().Assembly;
             var list = new List<TypeInfo>();
             foreach (var t in asm.DefinedTypes)
             {

--- a/src/System.Reflection.Extensions/tests/RuntimeReflectionExtensionTestsWithQuirks.cs
+++ b/src/System.Reflection.Extensions/tests/RuntimeReflectionExtensionTestsWithQuirks.cs
@@ -14,7 +14,7 @@ using Xunit;
 //   members from base classes.)
 //
 
-namespace System.Reflection.Extensions.Tests
+namespace System.Reflection.Tests
 {
     public class RuntimeReflectionExtensionsTestsWithQuirks
     {
@@ -75,7 +75,7 @@ namespace System.Reflection.Extensions.Tests
 
         private static TypeInfo[] GetTypes()
         {
-            Assembly asm = typeof(PropertyDefinitions.BaseClass).GetTypeInfo().Assembly;
+            Assembly asm = typeof(PropertyTestBaseClass).GetTypeInfo().Assembly;
             var list = new List<TypeInfo>();
             foreach (var t in asm.DefinedTypes)
             {

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataAggregatorTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataAggregatorTests.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection.Internal;
-using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
 using Xunit;
 using RowCounts = System.Reflection.Metadata.Ecma335.MetadataAggregator.RowCounts;
 
-namespace System.Reflection.Metadata.Tests
+namespace System.Reflection.Metadata.Ecma335.Tests
 {
     public class MetadataAggregatorTests
     {

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataTokensTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataTokensTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection.Metadata.Ecma335;
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests
+namespace System.Reflection.Metadata.Ecma335.Tests
 {
     public class MetadataTokensTests
     {

--- a/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -10,7 +10,6 @@ using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using TestUtilities;
 using Xunit;
 
 namespace System.Reflection.Metadata.Tests
@@ -110,7 +109,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void StreamLengths()
         {
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
             Assert.Equal(0x038, reader.GetHeapSize(HeapIndex.UserString));
             Assert.Equal(0x3c2, reader.GetHeapSize(HeapIndex.String));
             Assert.Equal(0x1cc, reader.GetHeapSize(HeapIndex.Blob));
@@ -121,7 +120,7 @@ namespace System.Reflection.Metadata.Tests
         public void CannotInstantiateReaderWithNonUtf8Decoder()
         {
             var decoder = new MetadataStringDecoder(Encoding.ASCII);
-            var exception = Assert.Throws<ArgumentException>(() => GetMetadataReader(TestResources.Misc.Members, decoder: decoder));
+            var exception = Assert.Throws<ArgumentException>(() => GetMetadataReader(Misc.Members, decoder: decoder));
             Assert.Equal("utf8Decoder", exception.ParamName);
         }
 
@@ -129,7 +128,7 @@ namespace System.Reflection.Metadata.Tests
         public void CanCustomizeReaderUtf8Fallback()
         {
             // start with a valid PE (cloned because we'll mutate it).
-            byte[] peImage = (byte[])TestResources.Namespace.NamespaceTests.Clone();
+            byte[] peImage = (byte[])Namespace.NamespaceTests.Clone();
 
             // find a System string in its string heap.
             int metadataStartOffset;
@@ -193,7 +192,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void ValidateAssemblyTableExe()
         {
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             // only one
             Assert.Equal(1, reader.AssemblyTable.NumberOfRows);
@@ -249,7 +248,7 @@ namespace System.Reflection.Metadata.Tests
                 new Version(/*VB*/10, 0, 0, 0),
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             int i = 0;
             foreach (var assemblyRef in reader.AssemblyReferences)
@@ -287,7 +286,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void ValidateModuleTable()
         {
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             ModuleDefinition moduleDef = reader.GetModuleDefinition();
 
@@ -301,7 +300,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void ValidateModuleTableMod()
         {
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            var reader = GetMetadataReader(NetModule.ModuleVB01, true);
             ModuleDefinition moduleDef = reader.GetModuleDefinition();
 
             // Validity Rules
@@ -334,7 +333,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 0xA7, 0xF0, 0x25, 0x28, 0x0F, 0x3C, 0x29, 0x2E, 0x83, 0x90, 0xF0, 0xFA, 0xA7, 0x13, 0x8E, 0xE4, 0x54, 0x16, 0xD7, 0xA0 }
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             Assert.Equal(expMods.Length, reader.GetTableRowCount(TableIndex.ModuleRef));
             int m = 0;
@@ -390,7 +389,7 @@ namespace System.Reflection.Metadata.Tests
             };
 
             // ModuleVB01
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            var reader = GetMetadataReader(NetModule.ModuleVB01, true);
 
             Assert.Equal(expMods.Length, reader.ModuleRefTable.NumberOfRows);
             int m = 0;
@@ -402,7 +401,7 @@ namespace System.Reflection.Metadata.Tests
 
             // ==================================================
             // ModuleCS01
-            reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            reader = GetMetadataReader(NetModule.ModuleCS01, true);
 
             Assert.Equal(expMods.Length, reader.ModuleRefTable.NumberOfRows);
             m = 0;
@@ -456,7 +455,7 @@ namespace System.Reflection.Metadata.Tests
                 0x26000001, 0x26000002, 0x26000002, 0x27000009, 0x2700000a, 0x2700000a, 0x2700000c
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             Assert.Equal(expTypes.Length, reader.ExportedTypeTable.NumberOfRows);
             for (int i = 0; i < reader.ExportedTypeTable.NumberOfRows; i++)
@@ -504,7 +503,7 @@ namespace System.Reflection.Metadata.Tests
                 0x1a000001, 0x23000001, 0x23000001, 0x23000001
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             Assert.Equal(expNames.Length, reader.TypeReferences.Count);
             int i = 0;
@@ -555,7 +554,7 @@ namespace System.Reflection.Metadata.Tests
                 0x23000001, 0x23000002, 0x23000001, 0x23000001, 0x23000001, 0x23000001, 0x23000001,
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            var reader = GetMetadataReader(NetModule.ModuleCS01, true);
             Assert.Equal(expNames.Length, reader.TypeReferences.Count);
 
             int i = 0;
@@ -604,7 +603,7 @@ namespace System.Reflection.Metadata.Tests
             };
             var expNest = new bool[] { false, false, false, false, false, false, false, false, false, false, false, false };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
             Assert.Equal(expNames.Length, reader.TypeDefinitions.Count);
 
             uint prevFieldStart = 0;
@@ -696,7 +695,7 @@ namespace System.Reflection.Metadata.Tests
                 /*ModVBInnerEnum*/ 0, 0, /*ModVBInnerStruct*/ 0, 0, /*ModVBDele*/0, 0, /*ModVBInnerIFoo*/0, 0,
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            var reader = GetMetadataReader(NetModule.ModuleVB01, true);
             Assert.Equal(expNames.Length, reader.TypeDefinitions.Count);
 
             bool first = true;
@@ -942,7 +941,7 @@ namespace System.Reflection.Metadata.Tests
             uniqueDefinitions.Add("SkipFirst.AndSecond", new string[] { });
             uniqueDefinitions.Add("SkipFirstOnce", new string[] { });
 
-            var reader = GetMetadataReader(TestResources.Namespace.NamespaceTests);
+            var reader = GetMetadataReader(Namespace.NamespaceTests);
 
             NamespaceDefinitionHandle globalHandle = NamespaceDefinitionHandle.FromFullNameOffset(0);
             ValidateNamespaceChildren(reader, globalHandle, expNamespaces, uniqueDefinitions, uniqueForwarders);
@@ -954,7 +953,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void ValidateNamespaceCacheLaziness()
         {
-            var reader = GetMetadataReader(TestResources.Namespace.NamespaceTests);
+            var reader = GetMetadataReader(Namespace.NamespaceTests);
 
             Assert.False(reader.NamespaceCache.CacheIsRealized);
 
@@ -1029,7 +1028,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 0x15, 0x12, 0x18, 0x01, 0x12, 0x28 },
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
             var table = reader.TypeSpecTable;
 
             // Validity Rules
@@ -1053,7 +1052,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 0x14, 0x11, 0x14, 0x02, 0x00, 0x02, 0x00, 0x00 },
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            var reader = GetMetadataReader(NetModule.ModuleVB01, true);
             var table = reader.TypeSpecTable;
 
             // Validity Rules
@@ -1623,7 +1622,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 00, 02, 0x12, 0x41, 0x12, 0x41, 0x12, 0x41 },
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            var reader = GetMetadataReader(NetModule.ModuleVB01, true);
 
             // Validity Rules
             Assert.Equal(expNames.Length, reader.MemberReferences.Count);
@@ -1656,7 +1655,7 @@ namespace System.Reflection.Metadata.Tests
             var expTDef = new int[] { 0x02000007, 0x2000008 }; // class other who implements the interface
             var expIfs = new int[] { 0x1b000001, 0x1b000002 }; // TypeSpec table 
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            var reader = GetMetadataReader(NetModule.ModuleCS01, true);
             Assert.Equal(2, reader.InterfaceImplTable.NumberOfRows);
 
             // uint ct = 0;
@@ -1711,7 +1710,7 @@ namespace System.Reflection.Metadata.Tests
             var modNumber = new ushort[] { 0, 0, 1, 0, 0 };
             var modTypeTokens = new int[] { 0x02000006, 0x02000007, 0x02000007, 0x02000008, 0x06000025, };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             // Validity Rules
             Assert.Equal(expNames.Length, reader.GenericParamTable.NumberOfRows);
@@ -1727,7 +1726,7 @@ namespace System.Reflection.Metadata.Tests
 
             // =======================================
 
-            reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            reader = GetMetadataReader(NetModule.ModuleCS01, true);
 
             // Validity Rules
             Assert.Equal(modNames.Length, reader.GenericParamTable.NumberOfRows);
@@ -1761,7 +1760,7 @@ namespace System.Reflection.Metadata.Tests
             var modPkSize = new ushort[] { 0 };
             var modCsSize = new uint[] { 1 };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01);
+            var reader = GetMetadataReader(Interop.Interop_Mock01);
 
             for (uint i = 0; i < reader.ClassLayoutTable.NumberOfRows; i++)
             {
@@ -1771,7 +1770,7 @@ namespace System.Reflection.Metadata.Tests
             }
 
             // =============================================
-            reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            reader = GetMetadataReader(NetModule.ModuleVB01, true);
             for (uint i = 0; i < reader.ClassLayoutTable.NumberOfRows; i++)
             {
                 var row = reader.GetTypeLayout(TypeDefinitionHandle.FromRowId(modTypeRids[i]));
@@ -1792,7 +1791,7 @@ namespace System.Reflection.Metadata.Tests
             var comFieldRids = new int[] { 7, 8, 9, 10 };
             var comOffset = new int[] { 0, 0, 0, 0 };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01);
+            var reader = GetMetadataReader(Interop.Interop_Mock01);
 
             for (int i = 0; i < comFieldRids.Length; i++)
             {
@@ -1825,7 +1824,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 0x2a, 0x50 }, new byte[] { 0x2a, 0x50 },
             };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01);
+            var reader = GetMetadataReader(Interop.Interop_Mock01);
 
             for (int i = 0; i < reader.FieldMarshalTable.NumberOfRows; i++)
             {
@@ -1858,7 +1857,7 @@ namespace System.Reflection.Metadata.Tests
             var modClassRids = new int[] { 8, 9 }; // 0x02000008, 0x2000009 };
             var modInterface = new int[] { 0x1b000001, 0x1b000002 };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01_Impl);
+            var reader = GetMetadataReader(Interop.Interop_Mock01_Impl);
 
             for (int i = 0; i < comClassRids.Length; i++)
             {
@@ -1866,7 +1865,7 @@ namespace System.Reflection.Metadata.Tests
                 Assert.Equal(comInterface[i], reader.GetInterfaceImplementation(impls.Single()).Interface.Token);
             }
 
-            reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            reader = GetMetadataReader(NetModule.ModuleCS01, true);
             for (int i = 0; i < modClassRids.Length; i++)
             {
                 var impls = reader.GetTypeDefinition(TypeDefinitionHandle.FromRowId(modClassRids[i])).GetInterfaceImplementations();
@@ -1888,7 +1887,7 @@ namespace System.Reflection.Metadata.Tests
             var comMthBody = new int[] { 0x06000001, 0x06000002, 0x06000003, 0x06000004, 0x06000005, 0x06000006, };
             var comMthDecl = new int[] { 0x0a000001, 0x0a000002, 0x0a000003, 0x0a000004, 0x0a000005, 0x0a000006, };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01_Impl);
+            var reader = GetMetadataReader(Interop.Interop_Mock01_Impl);
 
             // Validity Rules
             Assert.Equal(comClassRids.Length, reader.MethodImplTable.NumberOfRows);
@@ -1951,7 +1950,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 0x01, 00, 0x10, 0x4d, 0x6f, 0x64, 0x56, 0x42, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x50, 0x72, 0x6f, 0x70, 00, 00 }
             };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01);
+            var reader = GetMetadataReader(Interop.Interop_Mock01);
 
             int i = 0;
             foreach (var caHandle in reader.CustomAttributes)
@@ -1976,7 +1975,7 @@ namespace System.Reflection.Metadata.Tests
             Assert.Equal(0x37, i);
 
             // ====================================================
-            reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            reader = GetMetadataReader(NetModule.ModuleVB01, true);
 
             i = 0;
             foreach (var caHandle in reader.CustomAttributes)
@@ -2012,7 +2011,7 @@ namespace System.Reflection.Metadata.Tests
             var expMets = new int[] { /*0x6000018*/ 0x19, 0x1a, 0x017, 0x2c, 0x28, };
             var expAsso = new int[] { 0x14000001, 0x14000002, 0x17000003, 0x14000005, 0x17000006, };
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            var reader = GetMetadataReader(NetModule.ModuleCS01, true);
 
             // Validity Rules
             // Assert.Equal((uint)expSems.Length, table1.NumberOfRows);
@@ -2054,7 +2053,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 0x07, 01, 0x1c }
             };
 
-            var reader = GetMetadataReader(TestResources.Interop.Interop_Mock01_Impl);
+            var reader = GetMetadataReader(Interop.Interop_Mock01_Impl);
 
             // Validity Rules
             Assert.Equal(expSigs.Length, reader.StandAloneSigTable.NumberOfRows);
@@ -2070,7 +2069,7 @@ namespace System.Reflection.Metadata.Tests
             }
 
             // ==============================================================
-            reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            reader = GetMetadataReader(NetModule.ModuleVB01, true);
 
             // Validity Rules
             Assert.Equal(modSigs.Length, reader.StandAloneSigTable.NumberOfRows);
@@ -2145,7 +2144,7 @@ namespace System.Reflection.Metadata.Tests
                 new byte[] { 3, 0, 0, 0 },
             };
 
-            var reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            var reader = GetMetadataReader(NetModule.ModuleCS01, true);
 
             // Validity Rules
             Assert.Equal(expTypes.Length, reader.GetTableRowCount(TableIndex.Constant));
@@ -2167,7 +2166,7 @@ namespace System.Reflection.Metadata.Tests
             }
 
             // =======================================
-            reader = GetMetadataReader(TestResources.NetModule.ModuleVB01, true);
+            reader = GetMetadataReader(NetModule.ModuleVB01, true);
 
             // Validity Rules
             Assert.Equal(modTypes.Length, reader.GetTableRowCount(TableIndex.Constant));
@@ -2206,7 +2205,7 @@ namespace System.Reflection.Metadata.Tests
             var modCount = new int[] { 22, 24 };
             var modValues = new string[] { "Static String Constant", "Readonly-String_Constant" };
 
-            var reader = GetMetadataReader(TestResources.NetModule.AppCS);
+            var reader = GetMetadataReader(NetModule.AppCS);
 
             for (uint i = 0; i < expOffset.Length; i++)
             {
@@ -2216,7 +2215,7 @@ namespace System.Reflection.Metadata.Tests
             }
 
             // =============================================
-            reader = GetMetadataReader(TestResources.NetModule.ModuleCS01, true);
+            reader = GetMetadataReader(NetModule.ModuleCS01, true);
 
             for (uint i = 0; i < modOffset.Length; i++)
             {
@@ -2229,7 +2228,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void EmptyType()
         {
-            var reader = GetMetadataReader(TestResources.Misc.EmptyType);
+            var reader = GetMetadataReader(Misc.EmptyType);
             var typeDef = reader.GetTypeDefinition(reader.TypeDefinitions.Skip(2).First());
 
             Assert.Equal("C", reader.GetString(typeDef.Name));
@@ -2251,7 +2250,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void Bug17109()
         {
-            var reader = GetMetadataReader(TestResources.Misc.CPPClassLibrary2);
+            var reader = GetMetadataReader(Misc.CPPClassLibrary2);
 
             var typeDef = reader.GetTypeDefinition(reader.TypeDefinitions.First());
             string name = reader.GetString(typeDef.Name);
@@ -2271,7 +2270,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void MemberCollections_AllMembers()
         {
-            var reader = GetMetadataReader(TestResources.Misc.Members);
+            var reader = GetMetadataReader(Misc.Members);
             var methodNames = (from m in reader.MethodDefinitions
                                select reader.GetString(reader.GetMethodDefinition(m).Name)).ToArray();
 
@@ -2336,7 +2335,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void MemberCollections_TypeMembers_FirstTypeDef()
         {
-            var reader = GetMetadataReader(TestResources.Misc.Members);
+            var reader = GetMetadataReader(Misc.Members);
             var typeModule = reader.GetTypeDefinition(reader.TypeDefinitions.First());
             Assert.Equal("<Module>", reader.GetString(typeModule.Name));
 
@@ -2361,7 +2360,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void MemberCollections_TypeMembers_MiddleTypeDef()
         {
-            var reader = GetMetadataReader(TestResources.Misc.Members);
+            var reader = GetMetadataReader(Misc.Members);
             var typeC = reader.GetTypeDefinition(reader.TypeDefinitions.Where(t => reader.GetString(reader.GetTypeDefinition(t).Name) == "C").Single());
 
             var methodNames = (from m in typeC.GetMethods()
@@ -2406,7 +2405,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void MemberCollections_TypeMembers_LastTypeDef()
         {
-            var reader = GetMetadataReader(TestResources.Misc.Members);
+            var reader = GetMetadataReader(Misc.Members);
             var typeE = reader.GetTypeDefinition(reader.TypeDefinitions.Last());
             Assert.Equal("E", reader.GetString(typeE.Name));
 
@@ -2492,7 +2491,7 @@ namespace System.Reflection.Metadata.Tests
                 4096,
                 FileOptions.DeleteOnClose);
 
-            using (var testData = new MemoryStream(TestResources.Misc.Members))
+            using (var testData = new MemoryStream(Misc.Members))
             {
                 while (stream.Length <= StreamMemoryBlockProvider.MemoryMapThreshold)
                 {

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/AbstractMemoryBlockTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/AbstractMemoryBlockTests.cs
@@ -3,11 +3,9 @@
 
 using System.Collections.Immutable;
 using System.IO;
-using System.Reflection.Internal;
-using TestUtilities;
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests
+namespace System.Reflection.Internal.Tests
 {
     public class AbstractMemoryBlockTests
     {

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/BadImageFormat.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/BadImageFormat.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Reflection.PortableExecutable;
-using TestUtilities;
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests
+namespace System.Reflection.PortableExecutable.Tests
 {
     public class BadImageFormat
     {

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Text;
-
-using TestUtilities;
 
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests.PortableExecutable
+namespace System.Reflection.PortableExecutable.Tests
 {
     public class PEBinaryReaderTests
     {

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.Reflection.PortableExecutable;
-using TestUtilities;
+using System.Reflection.Metadata.Tests;
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests
+namespace System.Reflection.PortableExecutable.Tests
 {
     public class PEReaderTests
     {
@@ -43,7 +43,7 @@ namespace System.Reflection.Metadata.Tests
             Assert.True(invalid.CanRead);
 
             // valid metadata:
-            var valid = new MemoryStream(TestResources.Misc.Members);
+            var valid = new MemoryStream(Misc.Members);
             var peReader = new PEReader(valid, PEStreamOptions.Default);
             Assert.True(valid.CanRead);
             peReader.Dispose();
@@ -68,7 +68,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void IL_LazyLoad()
         {
-            var peStream = new MemoryStream(TestResources.Misc.Members);
+            var peStream = new MemoryStream(Misc.Members);
             using (var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen))
             {
                 var md = reader.GetMetadataReader();
@@ -82,7 +82,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void IL_EagerLoad()
         {
-            var peStream = new MemoryStream(TestResources.Misc.Members);
+            var peStream = new MemoryStream(Misc.Members);
             using (var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen | PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage))
             {
                 var md = reader.GetMetadataReader();
@@ -96,7 +96,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void Metadata_LazyLoad()
         {
-            var peStream = new MemoryStream(TestResources.Misc.Members);
+            var peStream = new MemoryStream(Misc.Members);
             using (var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen))
             {
                 var md = reader.GetMetadataReader();
@@ -109,7 +109,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void Metadata_EagerLoad()
         {
-            var peStream = new MemoryStream(TestResources.Misc.Members);
+            var peStream = new MemoryStream(Misc.Members);
             using (var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen | PEStreamOptions.PrefetchMetadata))
             {
                 var md = reader.GetMetadataReader();
@@ -124,7 +124,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void EntireImage_LazyLoad()
         {
-            var peStream = new MemoryStream(TestResources.Misc.Members);
+            var peStream = new MemoryStream(Misc.Members);
             using (var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen))
             {
                 Assert.Equal(4608, reader.GetEntireImage().Length);
@@ -134,7 +134,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void EntireImage_EagerLoad()
         {
-            var peStream = new MemoryStream(TestResources.Misc.Members);
+            var peStream = new MemoryStream(Misc.Members);
             using (var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen | PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage))
             {
                 Assert.Equal(4608, reader.GetEntireImage().Length);

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Text;
-
-using TestUtilities;
 
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests.PortableExecutable
+namespace System.Reflection.PortableExecutable.Tests
 {
     public class SectionHeaderTests
     {

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/StreamExtensionsTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/StreamExtensionsTests.cs
@@ -3,11 +3,9 @@
 
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Reflection.Internal;
-using TestUtilities;
 using Xunit;
 
-namespace System.Reflection.Metadata.Tests
+namespace System.Reflection.Internal.Tests
 {
     public class StreamExtensionsTests
     {

--- a/src/System.Reflection.Metadata/tests/Resources/TestResources.cs
+++ b/src/System.Reflection.Metadata/tests/Resources/TestResources.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Reflection;
 
-namespace TestResources
+namespace System.Reflection.Metadata.Tests
 {
     internal static class Interop
     {

--- a/src/System.Reflection.Metadata/tests/TestUtilities/AssertEx.cs
+++ b/src/System.Reflection.Metadata/tests/TestUtilities/AssertEx.cs
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using Xunit;
 
-namespace TestUtilities
+namespace System.Reflection.Internal.Tests
 {
     /// <summary>
     /// Assert style type to deal with the lack of features in xUnit's Assert type

--- a/src/System.Reflection.Metadata/tests/TestUtilities/DiffUtil.cs
+++ b/src/System.Reflection.Metadata/tests/TestUtilities/DiffUtil.cs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace TestUtilities
+namespace System.Reflection.Metadata.Tests
 {
     public class DiffUtil
     {

--- a/src/System.Reflection.Metadata/tests/Utilities/BlobReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/BlobReaderTests.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection.Internal;
 using System.Text;
-using TestUtilities;
 using Xunit;
 
 namespace System.Reflection.Metadata.Tests

--- a/src/System.Reflection.Metadata/tests/Utilities/CompressedIntegerTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/CompressedIntegerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection.Internal;
-using TestUtilities;
 using Xunit;
 
 namespace System.Reflection.Metadata.Tests

--- a/src/System.Reflection.Metadata/tests/Utilities/MemoryBlockTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/MemoryBlockTests.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using System.Reflection.Internal;
 using System.Text;
-using TestUtilities;
 using Xunit;
 
 namespace System.Reflection.Metadata.Tests

--- a/src/System.Reflection.TypeExtensions/tests/Assembly/AssemblyExtensionTests.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Assembly/AssemblyExtensionTests.cs
@@ -2,13 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace System.Reflection.Compatibility.UnitTests.AssemblyTests
+namespace System.Reflection.Tests
 {
     public class AssemblyExtensionTests
     {

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoConstructorName.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoConstructorName.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
-using System.Reflection.Compatibility;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.ConstructorTests
+namespace System.Reflection.Tests
 {
     public class ConstructorInfoConstructorName
     {

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvoke1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvoke1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // Invoke(System.Object[])
     public class ConstructorInfoInvokeTests

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvoke2.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvoke2.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Globalization;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // Invoke(System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)
     public class ConstructorInfoInvoke2

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoMemberType.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoMemberType.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // MemberType
     public class ConstructorInfoMemberType

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoTypeConstructorName.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoTypeConstructorName.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Reflection;
-using System.Reflection.Compatibility.UnitTests;
 using Xunit;
 
 // TypeConstructorName

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/InvokeArrayCtors.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/InvokeArrayCtors.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.ConstructorTests
+namespace System.Reflection.Tests
 {
     public class TestMultiDimensionalArray
     {

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoAddEventHandler.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoAddEventHandler.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     public delegate void TestForEvent1();
 

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoAttributesProperty.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoAttributesProperty.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.Attributes
     public class EventInfoAttributesProperty

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoEventHandlerType.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoEventHandlerType.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.EventHandlerType
     public class EventInfoEventHandlerType

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetAddMethod1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetAddMethod1.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.GetAddMethod()
     public class EventInfoGetAddMethod1

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetAddMethod2.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetAddMethod2.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.GetAddMethod(System.Boolean)
     public class EventInfoGetAddMethod2

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRaiseMethod1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRaiseMethod1.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.GetRaiseMethod()
     public class EventInfoGetRaiseMethod1

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRaiseMethod2.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRaiseMethod2.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.GetRaiseMethod(System Boolean)
     public class EventInfoGetRaiseMethod2

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRemoveMethod1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRemoveMethod1.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.GetRemoveMethod()
     public class EventInfoGetRemoveMethod1

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRemoveMethod2.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoGetRemoveMethod2.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.GetRemoveMethod(System Boolean)
     public class EventInfoGetRemoveMethod2

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoIsSpecialName.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoIsSpecialName.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.IsSpecialNameProperty
     public class EventInfoIsSpecialName

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoMemberType.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoMemberType.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.MemberTypeProperty
     public class EventInfoMemberType

--- a/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoRemoveEventHandler.cs
+++ b/src/System.Reflection.TypeExtensions/tests/EventInfo/EventInfoRemoveEventHandler.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.EventInfo.RemoveEvenHandler(System object,System delegate)
     public class EventInfoRemoveEventHandler

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoAttributes.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoAttributes.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoAttributes
     {

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoFieldType.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoFieldType.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
-    using System.Reflection.Compatibility.UnitTests.FieldInfoTests.HelperObjects;
-
     public class FieldInfoFieldType
     {
         private BindingFlags _allFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
@@ -101,11 +97,9 @@ namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
             Assert.Equal(expected, actual);
         }
     }
-}
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests.HelperObjects
-{
     #region Helper Objects
+
     internal struct UserMadeStruct
     {
     }
@@ -128,5 +122,6 @@ namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests.HelperObjects
         val1,
         val2
     }
+
     #endregion
 }

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoGetValue1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoGetValue1.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Security;
-using System;
-using System.Reflection;
 using Xunit;
-using System.Reflection.Compatibility.UnitTests;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.FieldInfo.GetValue(System.Object)
     public class FieldInfoGetValue1

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsAssembly.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsAssembly.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoIsAssembly
     {

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsFamily.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsFamily.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoIsFamily
     {

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsFamilyAndAssembly.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsFamilyAndAssembly.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.FieldInfo.IsFamilyAndAssembly
     public class FieldInfoIsFamilyAndAssembly

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsFamilyOrAssembly.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsFamilyOrAssembly.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.FieldInfo.IsFamilyOrAssembly
     public class FieldInfoIsFamilyOrAssembly

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsInitOnly.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsInitOnly.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.FieldInfo.IsInitOnly
     public class FieldInfoIsInitOnly

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsLiteral.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsLiteral.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     // System.Reflection.FieldInfo.IsLiteral
     public class FieldInfoIsLiteral

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsPrivate.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsPrivate.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoIsPrivate
     {

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsPublic.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsPublic.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoIsPublic
     {

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsStatic.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoIsStatic.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoIsStatic
     {

--- a/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoMemberType.cs
+++ b/src/System.Reflection.TypeExtensions/tests/FieldInfo/FieldInfoMemberType.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.FieldInfoTests
+namespace System.Reflection.Tests
 {
     public class FieldInfoMemberType
     {

--- a/src/System.Reflection.TypeExtensions/tests/MemberInfo/MemberInfoMemberType.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MemberInfo/MemberInfoMemberType.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.MemberInfoTests
+namespace System.Reflection.Tests
 {
     // MemberInfo.MemberType Property  
     // When overridden in a derived class, gets a MemberTypes value indicating 

--- a/src/System.Reflection.TypeExtensions/tests/MemberInfo/MemberInfoModule.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MemberInfo/MemberInfoModule.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.MemberInfoTests
+namespace System.Reflection.Tests
 {
     // MemberInfo.Module Property  
     public class ReflectionMemberInfoModule

--- a/src/System.Reflection.TypeExtensions/tests/MemberInfo/MemberInfoName.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MemberInfo/MemberInfoName.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Reflection.Compatibility.UnitTests;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.MemberInfoTests
+namespace System.Reflection.Tests
 {
     // MemberInfo.Name Property  
     // Gets the name of the current member. 

--- a/src/System.Reflection.TypeExtensions/tests/MethodBase/MethodBaseContainsGenericParameters.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MethodBase/MethodBaseContainsGenericParameters.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests
+namespace System.Reflection.Tests
 {
     // ContainsGenericParameters
     public class MethodBaseContainsGenericParameters

--- a/src/System.Reflection.TypeExtensions/tests/MethodInfo/GetBaseDefinition.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MethodInfo/GetBaseDefinition.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.Diagnostics;
-using System.Reflection;
-using System.Reflection.Emit;
+using Xunit;
 
-
-namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
+namespace System.Reflection.Tests
 {
     internal class Binding_Flags
     {
@@ -33,7 +29,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
 
             // [A] Vanila: Class does not extend (other than Object)/implement
 
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_a3");
+            type = Type.GetType("System.Reflection.Tests.Co4611_a3");
             Assert.NotNull(type);
             Assert.Equal("Co4611_a3", type.Name);
 
@@ -81,7 +77,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             MethodInfo mInfo = null;
             MethodInfo mInfo2 = null;
 
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Ab_Co4611_a1");
+            type = Type.GetType("System.Reflection.Tests.Ab_Co4611_a1");
             Assert.NotNull(type);
             Assert.Equal("Ab_Co4611_a1", type.Name);
 
@@ -116,7 +112,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             MethodInfo mInfo2 = null;
 
             // Extended class Co4611_X1
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_X1");
+            type = Type.GetType("System.Reflection.Tests.Co4611_X1");
             Assert.NotNull(type);
             Assert.Equal("Co4611_X1", type.Name);
 
@@ -150,7 +146,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             Type[] types = null;
             MethodInfo mInfo = null;
             MethodInfo mInfo2 = null;
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_a6");
+            type = Type.GetType("System.Reflection.Tests.Co4611_a6");
             Assert.NotNull(type);
             Assert.Equal("Co4611_a6", type.Name);
 
@@ -172,7 +168,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             Type[] types = null;
             MethodInfo mInfo = null;
             MethodInfo mInfo2 = null;
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_a4");
+            type = Type.GetType("System.Reflection.Tests.Co4611_a4");
             Assert.NotNull(type);
             Assert.Equal("Co4611_a4", type.Name);
 
@@ -193,7 +189,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             Type[] types = null;
             MethodInfo mInfo = null;
             MethodInfo mInfo2 = null;
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_a5");
+            type = Type.GetType("System.Reflection.Tests.Co4611_a5");
             Assert.NotNull(type);
             Assert.Equal("Co4611_a5", type.Name);
 
@@ -216,7 +212,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             MethodInfo mInfo = null;
             MethodInfo mInfo2 = null;
             // interface I_Co4611_a2
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.I_Co4611_a2");
+            type = Type.GetType("System.Reflection.Tests.I_Co4611_a2");
             Assert.NotNull(type);
             Assert.Equal("I_Co4611_a2", type.Name);
 
@@ -237,7 +233,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             Type type = null;
             MethodInfo mInfo = null;
             MethodInfo mInfo2 = null;
-            type = Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_X2");
+            type = Type.GetType("System.Reflection.Tests.Co4611_X2");
             Assert.NotNull(type);
             Assert.Equal("Co4611_X2", type.Name);
 
@@ -246,7 +242,7 @@ namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
             Assert.NotNull(mInfo);
             mInfo2 = mInfo.GetBaseDefinition();
             Assert.Equal("MethodA", mInfo2.Name);
-            Assert.Equal(Type.GetType("System.Reflection.Compatibility.UnitTests.MethodInfoTests.Co4611_X2"), mInfo2.DeclaringType);
+            Assert.Equal(Type.GetType("System.Reflection.Tests.Co4611_X2"), mInfo2.DeclaringType);
         }
     }
 

--- a/src/System.Reflection.TypeExtensions/tests/MethodInfo/MethodInfoGetGenericArguments.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MethodInfo/MethodInfoGetGenericArguments.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.MethodInfoTests
+namespace System.Reflection.Tests
 {
     public class TestClass
     {

--- a/src/System.Reflection.TypeExtensions/tests/Nullable/NullableMisc.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Nullable/NullableMisc.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
-using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.Nullable
+namespace System.Reflection.Tests
 {
     public class NullableObjectTests
     {

--- a/src/System.Reflection.TypeExtensions/tests/PropertyInfo/GetAccessors.cs
+++ b/src/System.Reflection.TypeExtensions/tests/PropertyInfo/GetAccessors.cs
@@ -1,22 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
-using System.Reflection.Emit;
-using System;
 using System.Text;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
+namespace System.Reflection.Tests
 {
-    internal class Binding_Flags
-    {
-        internal static BindingFlags LookupAll = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-        internal static BindingFlags DefaultLookup = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
-        internal static BindingFlags Default = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-        internal static BindingFlags ConstructorLookupAll = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-    }
-
     public class Co4389GetAccessors
     {
         private static String s_strLoc = String.Empty;
@@ -64,7 +53,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
 
 
             ///// [] Reflect on this class and set up propinfo structures
-            clObj = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.Co4389GetAccessors");
+            clObj = Type.GetType("System.Reflection.Tests.Co4389GetAccessors");
 
             pInfo = clObj.GetProperty("MyPropBB", Binding_Flags.DefaultLookup);
             pInfo2 = clObj.GetProperty("MyPropCC", BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);

--- a/src/System.Reflection.TypeExtensions/tests/PropertyInfo/PropertyGetAccessors2.cs
+++ b/src/System.Reflection.TypeExtensions/tests/PropertyInfo/PropertyGetAccessors2.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Reflection;
-using System.Reflection.Compatibility.UnitTests;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
+namespace System.Reflection.Tests
 {
     /// <summary>
     /// System.Reflection.PropertyInfo.GetAccessors(System.Boolean)
@@ -90,7 +86,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest1()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property1", BindingFlags.Public | BindingFlags.Instance);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(false);
             Assert.Equal(2, myMethodInfos.Length);
@@ -102,7 +98,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest2()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property1", BindingFlags.Public | BindingFlags.Instance);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(true);
             Assert.Equal(2, myMethodInfos.Length);
@@ -114,7 +110,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest3()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property2", BindingFlags.NonPublic | BindingFlags.Instance);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(true);
             Assert.Equal(2, myMethodInfos.Length);
@@ -126,7 +122,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest4()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property2", BindingFlags.NonPublic | BindingFlags.Instance);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(false);
             Assert.Equal(0, myMethodInfos.Length);
@@ -136,7 +132,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest5()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property3", BindingFlags.Public | BindingFlags.Static);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(false);
             Assert.Equal(2, myMethodInfos.Length);
@@ -148,7 +144,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest6()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property3", BindingFlags.Public | BindingFlags.Static);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(true);
             Assert.Equal(2, myMethodInfos.Length);
@@ -160,7 +156,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest7()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property4", BindingFlags.NonPublic | BindingFlags.Static);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(false);
             Assert.Equal(0, myMethodInfos.Length);
@@ -170,7 +166,7 @@ namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
         [Fact]
         public void PosTest8()
         {
-            Type myType = Type.GetType("System.Reflection.Compatibility.UnitTests.PropertyInfoTests.MyProperty");
+            Type myType = Type.GetType("System.Reflection.Tests.MyProperty");
             PropertyInfo myPropertyInfo = myType.GetProperty("Property4", BindingFlags.NonPublic | BindingFlags.Static);
             MethodInfo[] myMethodInfos = myPropertyInfo.GetAccessors(true);
             Assert.Equal(2, myMethodInfos.Length);

--- a/src/System.Reflection.TypeExtensions/tests/PropertyInfo/PropertyInfoGetAccessors1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/PropertyInfo/PropertyInfoGetAccessors1.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Reflection.Compatibility.UnitTests;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.PropertyInfoTests
+namespace System.Reflection.Tests
 {
     /// <summary>
     /// System.Reflection.PropertyInfo.GetAccessors()

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetDefaultMembers.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetDefaultMembers.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GenericGetDefaultMembersTest
     {
@@ -59,27 +57,27 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         [Fact]
         public void Test1()
         {
-            TryGetDefaultMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1[System.String]", new string[] { "System.String Item [Int32]" });
+            TryGetDefaultMembers("System.Reflection.Tests.GenericArrayWrapperClass`1[System.String]", new string[] { "System.String Item [Int32]" });
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetDefaultMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1", new string[] { "T Item [Int32]" });
+            TryGetDefaultMembers("System.Reflection.Tests.GenericArrayWrapperClass`1", new string[] { "T Item [Int32]" });
         }
 
         [Fact]
         public void Test3()
         {
             //Test003
-            TryGetDefaultMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClass`1", new string[] { "T ReturnAndSetField(T)" });
+            TryGetDefaultMembers("System.Reflection.Tests.GenericClass`1", new string[] { "T ReturnAndSetField(T)" });
         }
 
         [Fact]
         public void Test4()
         {
             //Test004
-            TryGetDefaultMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClass`1[System.Int32]", new string[] { "Int32 ReturnAndSetField(Int32)" });
+            TryGetDefaultMembers("System.Reflection.Tests.GenericClass`1[System.Int32]", new string[] { "Int32 ReturnAndSetField(Int32)" });
         }
     }
 

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetEvents.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetEvents.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetEventsTests
     {
@@ -89,391 +86,391 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         [Fact]
         public void Test1()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged" });
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged" });
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase);
         }
 
         [Fact]
         public void Test3()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly);
         }
 
         [Fact]
         public void Test4()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly);
         }
 
         [Fact]
         public void Test5()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Instance);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Instance);
         }
 
         [Fact]
         public void Test6()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Instance);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Instance);
         }
 
         [Fact]
         public void Test7()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Instance);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Instance);
         }
 
         [Fact]
         public void Test8()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance);
         }
 
         [Fact]
         public void Test9()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static);
         }
 
         [Fact]
         public void Test10()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static);
         }
 
         [Fact]
         public void Test11()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static);
         }
 
         [Fact]
         public void Test12()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static);
         }
 
         [Fact]
         public void Test13()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Instance | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Instance | BindingFlags.Static);
         }
 
         [Fact]
         public void Test14()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static);
         }
 
         [Fact]
         public void Test15()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static);
         }
 
         [Fact]
         public void Test16()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static);
         }
 
         [Fact]
         public void Test17()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Public);
         }
 
         [Fact]
         public void Test18()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Public);
         }
 
         [Fact]
         public void Test19()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Public);
         }
 
         [Fact]
         public void Test20()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Public);
         }
 
         [Fact]
         public void Test21()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.Instance | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.Instance | BindingFlags.Public);
         }
 
         [Fact]
         public void Test22()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public);
         }
 
         [Fact]
         public void Test23()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
         }
 
         [Fact]
         public void Test24()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
         }
 
         [Fact]
         public void Test25()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test26()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test27()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test28()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test29()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test30()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test31()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test32()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
         }
 
         [Fact]
         public void Test33()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test34()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test35()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test36()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test37()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test38()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test39()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test40()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test41()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test42()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test43()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test44()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test45()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test46()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test47()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test48()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test49()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test50()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test51()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test52()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test53()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test54()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test55()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test56()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test57()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test58()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test59()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test60()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test61()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test62()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test63()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test64()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", }, BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         }
 
         [Fact]
         public void Test65()
         {
-            TryGetEvents("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { }, BindingFlags.FlattenHierarchy);
+            TryGetEvents("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { }, BindingFlags.FlattenHierarchy);
         }
     }
 }

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetFields.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetFields.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetFieldsTests
     {
@@ -70,31 +68,31 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         [Fact]
         public void Test1()
         {
-            TryGetFields("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", new string[] { "System.String FieldZero", "System.String FieldOne", "Int32 FieldTwo", "Int32 FieldThree" });
+            TryGetFields("System.Reflection.Tests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", new string[] { "System.String FieldZero", "System.String FieldOne", "Int32 FieldTwo", "Int32 FieldThree" });
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetFields("System.Reflection.Compatibility.UnitTests.TypeTests.GenericStructWithInterface`1[System.String]", new string[] { "Int32 field2", "System.String field" });
+            TryGetFields("System.Reflection.Tests.GenericStructWithInterface`1[System.String]", new string[] { "Int32 field2", "System.String field" });
         }
 
         [Fact]
         public void Test3()
         {
-            TryGetFields("System.Reflection.Compatibility.UnitTests.TypeTests.NonGenericClassWithGenericInterface", new string[] { "Int32 field" });
+            TryGetFields("System.Reflection.Tests.NonGenericClassWithGenericInterface", new string[] { "Int32 field" });
         }
 
         [Fact]
         public void Test4()
         {
-            TryGetFields("System.Reflection.Compatibility.UnitTests.TypeTests.GenericStruct2TP`2[System.Int32,System.String]", new string[] { "System.String field2", "Int32 field" });
+            TryGetFields("System.Reflection.Tests.GenericStruct2TP`2[System.Int32,System.String]", new string[] { "System.String field2", "Int32 field" });
         }
 
         [Fact]
         public void Test5()
         {
-            TryGetFields("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1", new string[] { "T field" });
+            TryGetFields("System.Reflection.Tests.GenericClassWithVarArgMethod`1", new string[] { "T field" });
         }
     }
 }

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetInterfaces.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetInterfaces.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Reflection;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetInterfacesTest
     {
@@ -55,55 +53,55 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         [Fact]
         public void Test1()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClass`1[System.String]", new string[0]);
+            TryGetInterfaces("System.Reflection.Tests.GenericClass`1[System.String]", new string[0]);
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1[System.String]", new string[0]);
+            TryGetInterfaces("System.Reflection.Tests.IGenericInterface`1[System.String]", new string[0]);
         }
 
         [Fact]
         public void Test3()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.String]", new string[] { "System.Reflection.Compatibility.UnitTests.TypeTests.IConsume" });
+            TryGetInterfaces("System.Reflection.Tests.Cat`1[System.String]", new string[] { "System.Reflection.Tests.IConsume" });
         }
 
         [Fact]
         public void Test4()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1", new string[] { "System.Reflection.Compatibility.UnitTests.TypeTests.IConsume" });
+            TryGetInterfaces("System.Reflection.Tests.Cat`1", new string[] { "System.Reflection.Tests.IConsume" });
         }
 
         [Fact]
         public void Test5()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.PackOfCarnivores`1[[System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]]]", new string[0]);
+            TryGetInterfaces("System.Reflection.Tests.PackOfCarnivores`1[[System.Reflection.Tests.Cat`1[System.Int32]]]", new string[0]);
         }
 
         [Fact]
         public void Test6()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterfaceInherits`2[System.Int32,System.String]", new string[] { "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1[System.Int32]", "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface2`2[System.String,System.Int32]" });
+            TryGetInterfaces("System.Reflection.Tests.IGenericInterfaceInherits`2[System.Int32,System.String]", new string[] { "System.Reflection.Tests.IGenericInterface`1[System.Int32]", "System.Reflection.Tests.IGenericInterface2`2[System.String,System.Int32]" });
         }
 
         [Fact]
         public void Test7()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassUsingNestedInterfaces`2[System.Int32,System.String]", new string[] { "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterfaceInherits`2[System.Int32,System.String]", "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1[System.Int32]", "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface2`2[System.String,System.Int32]" });
+            TryGetInterfaces("System.Reflection.Tests.GenericClassUsingNestedInterfaces`2[System.Int32,System.String]", new string[] { "System.Reflection.Tests.IGenericInterfaceInherits`2[System.Int32,System.String]", "System.Reflection.Tests.IGenericInterface`1[System.Int32]", "System.Reflection.Tests.IGenericInterface2`2[System.String,System.Int32]" });
         }
 
         [Fact]
         public void Test8()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithInterface`1", new string[] { "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1[T]" });
+            TryGetInterfaces("System.Reflection.Tests.GenericClassWithInterface`1", new string[] { "System.Reflection.Tests.IGenericInterface`1[T]" });
         }
 
         [Fact]
         public void Test9()
         {
-            TryGetInterfaces("System.Reflection.Compatibility.UnitTests.TypeTests.NonGenericClassWithGenericInterface", new string[] { "System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1[System.Int32]" });
+            TryGetInterfaces("System.Reflection.Tests.NonGenericClassWithGenericInterface", new string[] { "System.Reflection.Tests.IGenericInterface`1[System.Int32]" });
         }
     }
 }

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetMember.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetMember.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetMemberTests
     {
@@ -80,51 +78,51 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         [Fact]
         public void Test1()
         {
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", "Field*", new string[] { "System.String FieldZero", "System.String FieldOne", "Int32 FieldTwo", "Int32 FieldThree" });
+            TryGetMember("System.Reflection.Tests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", "Field*", new string[] { "System.String FieldZero", "System.String FieldOne", "Int32 FieldTwo", "Int32 FieldThree" });
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", "Return*", new string[] { "System.String ReturnAndSetFieldZero(System.String)", "Int32 ReturnAndSetFieldThree(Int32)" });
+            TryGetMember("System.Reflection.Tests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", "Return*", new string[] { "System.String ReturnAndSetFieldZero(System.String)", "Int32 ReturnAndSetFieldThree(Int32)" });
         }
 
         [Fact]
         public void Test3()
         {
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithInterface`1[System.Int32]", "*", new string[] { "W GenericMethod[W](W)", "Int32 ReturnAndSetFieldZero(Int32)", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()", "System.String ToString()", "Void .ctor(Int32)", "Int32 field" });
+            TryGetMember("System.Reflection.Tests.GenericClassWithInterface`1[System.Int32]", "*", new string[] { "W GenericMethod[W](W)", "Int32 ReturnAndSetFieldZero(Int32)", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()", "System.String ToString()", "Void .ctor(Int32)", "Int32 field" });
         }
 
         [Fact]
         public void Test4()
         {
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1", "ReturnAndSetFieldZero", new string[] { "T ReturnAndSetFieldZero(T)" });
+            TryGetMember("System.Reflection.Tests.IGenericInterface`1", "ReturnAndSetFieldZero", new string[] { "T ReturnAndSetFieldZero(T)" });
         }
 
         [Fact]
         public void Test5()
         {
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1", "*", new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "T get_Item(Int32)", "Void set_Item(Int32, T)", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()", "System.String ToString()", "Void .ctor(T[])", "Int32 myProperty", "T Item [Int32]" });
+            TryGetMember("System.Reflection.Tests.GenericArrayWrapperClass`1", "*", new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "T get_Item(Int32)", "Void set_Item(Int32, T)", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()", "System.String ToString()", "Void .ctor(T[])", "Int32 myProperty", "T Item [Int32]" });
         }
 
         [Fact]
         public void Test6()
         {
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", "*", new string[] { "Void add_WeightChanged(System.EventHandler)", "Void remove_WeightChanged(System.EventHandler)", "System.Object[] get_StuffConsumed()", "Void Eat(System.Object)", "System.Object[] Puke(Int32)", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()", "System.String ToString()", "Void .ctor()", "System.Object[] StuffConsumed", "System.EventHandler WeightChanged" });
+            TryGetMember("System.Reflection.Tests.Cat`1[System.Int32]", "*", new string[] { "Void add_WeightChanged(System.EventHandler)", "Void remove_WeightChanged(System.EventHandler)", "System.Object[] get_StuffConsumed()", "Void Eat(System.Object)", "System.Object[] Puke(Int32)", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()", "System.String ToString()", "Void .ctor()", "System.Object[] StuffConsumed", "System.EventHandler WeightChanged" });
         }
 
         [Fact]
         public void Test7()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", "*", allBindingFlags, new string[] { "Void add_WeightChanged(System.EventHandler)", "Void remove_WeightChanged(System.EventHandler)", "Void add_WeightStayedTheSame(System.EventHandler)", "Void remove_WeightStayedTheSame(System.EventHandler)", "System.Object[] get_StuffConsumed()", "Void Eat(System.Object)", "System.Object[] Puke(Int32)", "Void .ctor()", "System.Object[] StuffConsumed", "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", "System.Collections.Generic.List`1[System.Object] _pStuffConsumed", "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", "System.EventHandler s_catDisappeared" });
+            TryGetMember("System.Reflection.Tests.Cat`1[System.Int32]", "*", allBindingFlags, new string[] { "Void add_WeightChanged(System.EventHandler)", "Void remove_WeightChanged(System.EventHandler)", "Void add_WeightStayedTheSame(System.EventHandler)", "Void remove_WeightStayedTheSame(System.EventHandler)", "System.Object[] get_StuffConsumed()", "Void Eat(System.Object)", "System.Object[] Puke(Int32)", "Void .ctor()", "System.Object[] StuffConsumed", "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", "System.Collections.Generic.List`1[System.Object] _pStuffConsumed", "System.EventHandler WeightChanged", "System.EventHandler WeightStayedTheSame", "System.EventHandler s_catDisappeared" });
         }
 
         [Fact]
         public void Test8()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMember("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1", "*", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "T get_Item(Int32)", "Void set_Item(Int32, T)", "Void .ctor(T[])", "Int32 myProperty", "T Item [Int32]", "T[] _field", "Int32 _field1" });
+            TryGetMember("System.Reflection.Tests.GenericArrayWrapperClass`1", "*", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "T get_Item(Int32)", "Void set_Item(Int32, T)", "Void .ctor(T[])", "Int32 myProperty", "T Item [Int32]", "T[] _field", "Int32 _field1" });
         }
     }
 }

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetMembers.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetMembers.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Reflection;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetMembersTests
     {
@@ -86,48 +84,48 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         public void Test1()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", allBindingFlags, new string[] { "System.String ReturnAndSetFieldZero(System.String)", "Void SetFieldOne(Int32)", "Void SetFieldTwo(System.String)", "Int32 ReturnAndSetFieldThree(Int32)", "Void .ctor(System.String, System.String, Int32, Int32)", "System.String FieldZero", "System.String FieldOne", "Int32 FieldTwo", "Int32 FieldThree" });
+            TryGetMembers("System.Reflection.Tests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", allBindingFlags, new string[] { "System.String ReturnAndSetFieldZero(System.String)", "Void SetFieldOne(Int32)", "Void SetFieldTwo(System.String)", "Int32 ReturnAndSetFieldThree(Int32)", "Void .ctor(System.String, System.String, Int32, Int32)", "System.String FieldZero", "System.String FieldOne", "Int32 FieldTwo", "Int32 FieldThree" });
         }
 
         [Fact]
         public void Test2()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithInterface`1[System.Int32]", allBindingFlags, new string[] { "W GenericMethod[W](W)", "Int32 ReturnAndSetFieldZero(Int32)", "Void .ctor(Int32)", "Int32 field" });
+            TryGetMembers("System.Reflection.Tests.GenericClassWithInterface`1[System.Int32]", allBindingFlags, new string[] { "W GenericMethod[W](W)", "Int32 ReturnAndSetFieldZero(Int32)", "Void .ctor(Int32)", "Int32 field" });
         }
 
         [Fact]
         public void Test3()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.IGenericInterface`1", allBindingFlags, new string[] { "T ReturnAndSetFieldZero(T)" });
+            TryGetMembers("System.Reflection.Tests.IGenericInterface`1", allBindingFlags, new string[] { "T ReturnAndSetFieldZero(T)" });
         }
 
         [Fact]
         public void Test4()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "T get_Item(Int32)", "Void set_Item(Int32, T)", "Void .ctor(T[])", "Int32 myProperty", "T Item [Int32]", "T[] _field", "Int32 _field1" });
+            TryGetMembers("System.Reflection.Tests.GenericArrayWrapperClass`1", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "T get_Item(Int32)", "Void set_Item(Int32, T)", "Void .ctor(T[])", "Int32 myProperty", "T Item [Int32]", "T[] _field", "Int32 _field1" });
         }
 
         [Fact]
         public void Test5()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", allBindingFlags, new string[] { "Void add_WeightChanged(System.EventHandler)", "Void remove_WeightChanged(System.EventHandler)", "System.Object[] get_StuffConsumed()", "Void Eat(System.Object)", "System.Object[] Puke(Int32)", "Void .ctor()", "System.Object[] StuffConsumed", "System.EventHandler WeightChanged", "System.Collections.ArrayList _pStuffConsumed", "Void add_WeightStayedTheSame(System.EventHandler)", "Void remove_WeightStayedTheSame(System.EventHandler)", "System.EventHandler WeightStayedTheSame", "System.EventHandler WeightStayedTheSame", "System.EventHandler s_catDisappeared", "System.Collections.Generic.List`1[System.Object] _pStuffConsumed" });
+            TryGetMembers("System.Reflection.Tests.Cat`1[System.Int32]", allBindingFlags, new string[] { "Void add_WeightChanged(System.EventHandler)", "Void remove_WeightChanged(System.EventHandler)", "System.Object[] get_StuffConsumed()", "Void Eat(System.Object)", "System.Object[] Puke(Int32)", "Void .ctor()", "System.Object[] StuffConsumed", "System.EventHandler WeightChanged", "System.Collections.ArrayList _pStuffConsumed", "Void add_WeightStayedTheSame(System.EventHandler)", "Void remove_WeightStayedTheSame(System.EventHandler)", "System.EventHandler WeightStayedTheSame", "System.EventHandler WeightStayedTheSame", "System.EventHandler s_catDisappeared", "System.Collections.Generic.List`1[System.Object] _pStuffConsumed" });
         }
 
         [Fact]
         public void Test6()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1[System.String]", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "System.String get_Item(Int32)", "Void set_Item(Int32, System.String)", "Void .ctor(System.String[])", "Int32 myProperty", "System.String Item [Int32]", "System.String[] _field", "Int32 _field1" });
+            TryGetMembers("System.Reflection.Tests.GenericArrayWrapperClass`1[System.String]", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "System.String get_Item(Int32)", "Void set_Item(Int32, System.String)", "Void .ctor(System.String[])", "Int32 myProperty", "System.String Item [Int32]", "System.String[] _field", "Int32 _field1" });
         }
 
         [Fact]
         public void Test7()
         {
-            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1[System.String]", new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "System.String get_Item(Int32)", "Void set_Item(Int32, System.String)", "Void .ctor(System.String[])", "Int32 myProperty", "System.String Item [Int32]", "System.String ToString()", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()" });
+            TryGetMembers("System.Reflection.Tests.GenericArrayWrapperClass`1[System.String]", new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "System.String get_Item(Int32)", "Void set_Item(Int32, System.String)", "Void .ctor(System.String[])", "Int32 myProperty", "System.String Item [Int32]", "System.String ToString()", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()" });
         }
     }
 }

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetMethods.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetMethods.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Reflection;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetMethodsTests
     {
@@ -70,35 +68,35 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         public void Test1()
         {
             BindingFlags declaredPublicInstanceBindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-            TryGetMethods("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClass`1[System.String]", declaredPublicInstanceBindingFlags, new string[] { "System.String ReturnAndSetField(System.String)" });
+            TryGetMethods("System.Reflection.Tests.GenericClass`1[System.String]", declaredPublicInstanceBindingFlags, new string[] { "System.String ReturnAndSetField(System.String)" });
         }
 
         [Fact]
         public void Test2()
         {
             BindingFlags declaredPublicInstanceBindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-            TryGetMethods("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", declaredPublicInstanceBindingFlags, new string[] { "System.String ReturnAndSetFieldZero(System.String)", "Void SetFieldOne(Int32)", "Void SetFieldTwo(System.String)", "Int32 ReturnAndSetFieldThree(Int32)" });
+            TryGetMethods("System.Reflection.Tests.GenericClassUsingNestedInterfaces`2[System.String,System.Int32]", declaredPublicInstanceBindingFlags, new string[] { "System.String ReturnAndSetFieldZero(System.String)", "Void SetFieldOne(Int32)", "Void SetFieldTwo(System.String)", "Int32 ReturnAndSetFieldThree(Int32)" });
         }
 
         [Fact]
         public void Test3()
         {
             BindingFlags declaredPublicInstanceBindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-            TryGetMethods("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithInterface`1", declaredPublicInstanceBindingFlags, new string[] { "W GenericMethod[W](W)", "T ReturnAndSetFieldZero(T)" });
+            TryGetMethods("System.Reflection.Tests.GenericClassWithInterface`1", declaredPublicInstanceBindingFlags, new string[] { "W GenericMethod[W](W)", "T ReturnAndSetFieldZero(T)" });
         }
 
         [Fact]
         public void Test4()
         {
             BindingFlags declaredPublicInstanceBindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-            TryGetMethods("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithInterface`1[System.Int32]", declaredPublicInstanceBindingFlags, new string[] { "W GenericMethod[W](W)", "Int32 ReturnAndSetFieldZero(Int32)" });
+            TryGetMethods("System.Reflection.Tests.GenericClassWithInterface`1[System.Int32]", declaredPublicInstanceBindingFlags, new string[] { "W GenericMethod[W](W)", "Int32 ReturnAndSetFieldZero(Int32)" });
         }
 
         [Fact]
         public void Test5()
         {
             BindingFlags declaredPublicInstanceBindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-            TryGetMethods("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1", declaredPublicInstanceBindingFlags, new string[] { "T get_publicField()", "Void set_publicField(T)", "T ReturnAndSetField(T, T[])" });
+            TryGetMethods("System.Reflection.Tests.GenericClassWithVarArgMethod`1", declaredPublicInstanceBindingFlags, new string[] { "T get_publicField()", "Void set_publicField(T)", "T ReturnAndSetField(T, T[])" });
         }
 
         [Fact]

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetProperties.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetProperties.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Reflection;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetPropertiesTests
     {
@@ -39,38 +37,38 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
             for (int i = 0; i < propertiesReturned.Length; i++)
             {
                 foundIndex = Array.BinarySearch(propertiesExpected, propertiesReturned[i].ToString());
-                Assert.False(foundIndex < 0, "An unexpected property " + propertiesReturned[i].ToString() + " was returned");                
+                Assert.False(foundIndex < 0, "An unexpected property " + propertiesReturned[i].ToString() + " was returned");
             }
         }
 
         [Fact]
         public void Test1()
         {
-            TryGetProperties("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1[System.String]", new string[] { "System.String publicField" });
+            TryGetProperties("System.Reflection.Tests.GenericClassWithVarArgMethod`1[System.String]", new string[] { "System.String publicField" });
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetProperties("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", new string[] { "System.Object[] StuffConsumed" });
+            TryGetProperties("System.Reflection.Tests.Cat`1[System.Int32]", new string[] { "System.Object[] StuffConsumed" });
         }
 
         [Fact]
         public void Test3()
         {
-            TryGetProperties("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1[System.Int32]", new string[] { "Int32 publicField" });
+            TryGetProperties("System.Reflection.Tests.GenericClassWithVarArgMethod`1[System.Int32]", new string[] { "Int32 publicField" });
         }
 
         [Fact]
         public void Test4()
         {
-            TryGetProperties("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1", new string[] { "T publicField" });
+            TryGetProperties("System.Reflection.Tests.GenericClassWithVarArgMethod`1", new string[] { "T publicField" });
         }
 
         [Fact]
         public void Test5()
         {
-            TryGetProperties("System.Reflection.Compatibility.UnitTests.TypeTests.ClassWithVarArgMethod", new string[] { "Int32 publicField" });
+            TryGetProperties("System.Reflection.Tests.ClassWithVarArgMethod", new string[] { "Int32 publicField" });
         }
 
         [Fact]

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetProperty.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetProperty.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Reflection;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class GetPropertyTests
     {
@@ -62,44 +60,44 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
         [Fact]
         public void Test1()
         {
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1[System.String]", "publicField", typeof(string), "System.String publicField");
+            TryGetProperty("System.Reflection.Tests.GenericClassWithVarArgMethod`1[System.String]", "publicField", typeof(string), "System.String publicField");
         }
 
         [Fact]
         public void Test2()
         {
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.Cat`1[System.Int32]", "StuffConsumed", "System.Object[] StuffConsumed");
+            TryGetProperty("System.Reflection.Tests.Cat`1[System.Int32]", "StuffConsumed", "System.Object[] StuffConsumed");
         }
 
         [Fact]
         public void Test3()
         {
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1[System.Int32]", "publicField", typeof(int), "Int32 publicField");
+            TryGetProperty("System.Reflection.Tests.GenericClassWithVarArgMethod`1[System.Int32]", "publicField", typeof(int), "Int32 publicField");
         }
 
         [Fact]
         public void Test4()
         {
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1", "publicField", allBindingFlags, "T publicField");
+            TryGetProperty("System.Reflection.Tests.GenericClassWithVarArgMethod`1", "publicField", allBindingFlags, "T publicField");
         }
 
         [Fact]
         public void Test5()
         {
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1[System.Int32]", "publicField", "Int32 publicField");
+            TryGetProperty("System.Reflection.Tests.GenericClassWithVarArgMethod`1[System.Int32]", "publicField", "Int32 publicField");
         }
 
         [Fact]
         public void Test6()
         {
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.GenericClassWithVarArgMethod`1[System.Int32]", "publicField", typeof(int), new Type[] { }, "Int32 publicField");
+            TryGetProperty("System.Reflection.Tests.GenericClassWithVarArgMethod`1[System.Int32]", "publicField", typeof(int), new Type[] { }, "Int32 publicField");
         }
 
         [Fact]
         public void Test7()
         {
-            TryGetProperty("System.Reflection.Compatibility.UnitTests.TypeTests.ClassWithVarArgMethod", "publicField", "Int32 publicField");
+            TryGetProperty("System.Reflection.Tests.ClassWithVarArgMethod", "publicField", "Int32 publicField");
         }
     }
 }

--- a/src/System.Reflection.TypeExtensions/tests/Type/IsAssignableFrom.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/IsAssignableFrom.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     public class IsAssignableFromTest
     {

--- a/src/System.Reflection.TypeExtensions/tests/Type/TypeInfoAPIs.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/TypeInfoAPIs.cs
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
 #pragma warning disable 169, 649, 164
 
-namespace System.Reflection.Compatibility.UnitTests.TypeTests
+namespace System.Reflection.Tests
 {
     // Compare the results of RuntimeType and TypeInfo APIs results
     public class TypeInfoAPIsTest


### PR DESCRIPTION
Correct test namespaces for some System.Reflection.* assemblies, per #2898 .

Only those assemblies listed in this PR were changed.

Only namespaces were modified.  Some types were renamed to avoid conflicts.  `using` references on modified files were cleaned up.
No other changes were performed.