### PR TITLE
Fix the Globalization test with checking date/time formats

### DIFF
--- a/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -39,55 +39,14 @@ namespace System.Globalization.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "h:mm tt")]
-        public void TestShortTimePatternLocale(string locale, string expected)
+        [InlineData("fi-FI")]
+        public void TestLongTimePatternLocale2(string locale)
         {
             CultureInfo myTestCulture = new CultureInfo(locale);
-            DateTimeFormatInfo dtf = myTestCulture.DateTimeFormat;
-            Assert.Equal(expected, dtf.ShortTimePattern);
-        }
-
-        [Theory]
-        [InlineData("fi-FI", "H:mm", "H.mm")]
-        public void TestShortTimePatternLocale2(string locale, string expectedWindows, string expectedIcu)
-        {
-            CultureInfo myTestCulture = new CultureInfo(locale);
-            DateTimeFormatInfo dtf = myTestCulture.DateTimeFormat;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Windows 10 uses ICU data here, this should be cleaned up as part of #3243
-                Assert.True(dtf.ShortTimePattern == expectedWindows || dtf.ShortTimePattern == expectedIcu);
-            }
-            else
-            {
-                Assert.Equal(expectedIcu, dtf.ShortTimePattern);
-            }
-        }
-
-        [Theory]
-        [InlineData("en-US", "h:mm:ss tt")]
-        public void TestLongTimePatternLocale(string locale, string expected)
-        {
-            CultureInfo myTestCulture = new CultureInfo(locale);
-            DateTimeFormatInfo dtf = myTestCulture.DateTimeFormat;
-            Assert.Equal(expected, dtf.LongTimePattern);
-        }
-
-        [Theory]
-        [InlineData("fi-FI", "H:mm:ss", "H.mm.ss")]
-        public void TestLongTimePatternLocale2(string locale, string expectedWindows, string expectedIcu)
-        {
-            CultureInfo myTestCulture = new CultureInfo(locale);
-            DateTimeFormatInfo dtf = myTestCulture.DateTimeFormat;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Windows 10 uses ICU data here, this should be cleaned up as part of #3243
-                Assert.True(dtf.LongTimePattern == expectedWindows || dtf.LongTimePattern == expectedIcu);
-            }
-            else
-            {
-                Assert.Equal(expectedIcu, dtf.LongTimePattern);
-            }
+            DateTimeFormatInfo myDateTimeFormat = new DateTimeFormatInfo();
+            myDateTimeFormat.LongTimePattern = "H:mm:ss";
+            myTestCulture.DateTimeFormat = myDateTimeFormat;
+            Assert.Equal("H:mm:ss", myTestCulture.DateTimeFormat.LongTimePattern);
         }
 
         [Fact]


### PR DESCRIPTION
All globalization tests shouldn't be written assuming any fixed culture data. 
culture data (including the date/time formats) can be changed by the OS or
can be overriden by the users which make the tests to fail.