### PR TITLE
Fix a behavior mismatch in Linux Sockets.

### DIFF
--- a/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
+++ b/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net.Sockets.Tests
+{
+    static class SocketTestExtensions
+    {
+        // Binds to an IP address and OS-assigned port. Returns the chosen port.
+        public static int Bind(this Socket socket, IPAddress address)
+        {
+            socket.Bind(new IPEndPoint(address, 0));
+            return ((IPEndPoint)socket.LocalEndPoint).Port;
+        }
+    }
+}

--- a/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
+++ b/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
@@ -6,7 +6,7 @@ namespace System.Net.Sockets.Tests
     static class SocketTestExtensions
     {
         // Binds to an IP address and OS-assigned port. Returns the chosen port.
-        public static int Bind(this Socket socket, IPAddress address)
+        public static int BindToAnonymousPort(this Socket socket, IPAddress address)
         {
             socket.Bind(new IPEndPoint(address, 0));
             return ((IPEndPoint)socket.LocalEndPoint).Port;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4432,7 +4432,7 @@ namespace System.Net.Sockets
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Shutdown() how:" + how.ToString());
 
             // This can throw ObjectDisposedException.
-            SocketError errorCode = SocketPal.Shutdown(_handle, _isConnected, how);
+            SocketError errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, how);
 
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Shutdown() Interop.Winsock.shutdown returns errorCode:" + errorCode);
 
@@ -5516,7 +5516,7 @@ namespace System.Net.Sockets
                     else
                     {
                         // Since our timeout is in ms and linger is in seconds, implement our own sortof linger here.
-                        errorCode = SocketPal.Shutdown(_handle, true, SocketShutdown.Send);
+                        errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, SocketShutdown.Send);
                         GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") shutdown():" + (errorCode == SocketError.SocketError ? SocketPal.GetLastSocketError() : errorCode).ToString());
 
                         // This should give us a timeout in milliseconds.
@@ -5604,7 +5604,7 @@ namespace System.Net.Sockets
 
             try
             {
-                SocketPal.Shutdown(_handle, _isConnected, how);
+                SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, how);
             }
             catch (ObjectDisposedException) { }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4432,7 +4432,7 @@ namespace System.Net.Sockets
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Shutdown() how:" + how.ToString());
 
             // This can throw ObjectDisposedException.
-            SocketError errorCode = SocketPal.Shutdown(_handle, how);
+            SocketError errorCode = SocketPal.Shutdown(_handle, _isConnected, how);
 
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Shutdown() Interop.Winsock.shutdown returns errorCode:" + errorCode);
 
@@ -5516,7 +5516,7 @@ namespace System.Net.Sockets
                     else
                     {
                         // Since our timeout is in ms and linger is in seconds, implement our own sortof linger here.
-                        errorCode = SocketPal.Shutdown(_handle, SocketShutdown.Send);
+                        errorCode = SocketPal.Shutdown(_handle, true, SocketShutdown.Send);
                         GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") shutdown():" + (errorCode == SocketError.SocketError ? SocketPal.GetLastSocketError() : errorCode).ToString());
 
                         // This should give us a timeout in milliseconds.
@@ -5604,7 +5604,7 @@ namespace System.Net.Sockets
 
             try
             {
-                SocketPal.Shutdown(_handle, how);
+                SocketPal.Shutdown(_handle, _isConnected, how);
             }
             catch (ObjectDisposedException) { }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1695,7 +1695,7 @@ namespace System.Net.Sockets
             return (SocketError)socketCount;
         }
 
-        public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, SocketShutdown how)
+        public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, bool isDisconnected, SocketShutdown how)
         {
             int err = Interop.libc.shutdown(handle.FileDescriptor, GetPlatformSocketShutdown(how));
             if (err != -1)
@@ -1705,10 +1705,10 @@ namespace System.Net.Sockets
 
             Interop.Error errno = Interop.Sys.GetLastError();
 
-            // If shutdown returns ENOTCONN but the socket we think that this socket is connected,
+            // If shutdown returns ENOTCONN and we think that this socket has ever been connected,
             // ignore the error. This can happen for TCP connections if the underlying connection
-            // has reached the CLOSE state.
-            if (errno == Interop.Error.ENOTCONN && isConnected)
+            // has reached the CLOSE state. Ignoring the error matches Winsock behavior.
+            if (errno == Interop.Error.ENOTCONN && (isConnected || isDisconnected))
             {
                 return SocketError.Success;
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1695,10 +1695,25 @@ namespace System.Net.Sockets
             return (SocketError)socketCount;
         }
 
-        public static SocketError Shutdown(SafeCloseSocket handle, SocketShutdown how)
+        public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, SocketShutdown how)
         {
             int err = Interop.libc.shutdown(handle.FileDescriptor, GetPlatformSocketShutdown(how));
-            return err == -1 ? GetLastSocketError() : SocketError.Success;
+            if (err != -1)
+            {
+                return SocketError.Success;
+            }
+
+            Interop.Error errno = Interop.Sys.GetLastError();
+
+            // If shutdown returns ENOTCONN but the socket we think that this socket is connected,
+            // ignore the error. This can happen for TCP connections if the underlying connection
+            // has reached the CLOSE state.
+            if (errno == Interop.Error.ENOTCONN && isConnected)
+            {
+                return SocketError.Success;
+            }
+
+            return GetSocketErrorForErrorCode(errno);
         }
 
         public static SocketError ConnectAsync(Socket socket, SafeCloseSocket handle, byte[] socketAddress, int socketAddressLen, ConnectOverlappedAsyncResult asyncResult)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -802,10 +802,17 @@ namespace System.Net.Sockets
             return (SocketError)socketCount;
         }
 
-        public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, SocketShutdown how)
+        public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, bool isDisconnected, SocketShutdown how)
         {
             SocketError err = Interop.Winsock.shutdown(handle, (int)how);
-            return err == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
+            if (err != SocketError.SocketError)
+            {
+                return SocketError.Success;
+            }
+
+            err = GetLastSocketError();
+            Debug.Assert(err != SocketError.NotConnected || (!isConnected && !isDisconnected));
+            return err;
         }
 
         public static unsafe SocketError ConnectAsync(Socket socket, SafeCloseSocket handle, byte[] socketAddress, int socketAddressLen, ConnectOverlappedAsyncResult asyncResult)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -802,7 +802,7 @@ namespace System.Net.Sockets
             return (SocketError)socketCount;
         }
 
-        public static SocketError Shutdown(SafeCloseSocket handle, SocketShutdown how)
+        public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, SocketShutdown how)
         {
             SocketError err = Interop.Winsock.shutdown(handle, (int)how);
             return err == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;

--- a/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Xunit.Abstractions;
+
+using System.Threading.Tasks;
+
+namespace System.Net.Sockets.Tests
+{
+    public class Shutdown
+    {
+        private readonly ITestOutputHelper _log;
+
+        public Shutdown(ITestOutputHelper output)
+        {
+            _log = output;
+        }
+
+        private static void OnOperationCompleted(object sender, SocketAsyncEventArgs args)
+        {
+            Assert.Equal(SocketError.Success, args.SocketError);
+
+            switch (args.LastOperation)
+            {
+                case SocketAsyncOperation.Accept:
+                {
+                    Socket client = args.AcceptSocket;
+                    args.SetBuffer(new byte[1], 0, 1);
+                    args.UserToken = client;
+
+                    Assert.True(client.ReceiveAsync(args));
+                    break;
+                }
+
+                case SocketAsyncOperation.Receive:
+                {
+                    var client = (Socket)args.UserToken;
+                    if (args.BytesTransferred == 0)
+                    {
+                        client.Dispose();
+                        break;
+                    }
+
+                    Assert.True(client.SendAsync(args));
+                    break;
+                }
+
+                case SocketAsyncOperation.Send:
+                {
+                    var client = (Socket)args.UserToken;
+
+                    Assert.True(args.BytesTransferred == args.Buffer.Length);
+                    Assert.True(client.ReceiveAsync(args));
+                    break;
+                }
+            }
+        }
+
+        [Fact]
+        public void Shutdown_TCP_CLOSED_Success()
+        {
+            using (Socket server = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            using (Socket client = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                int port = server.Bind(IPAddress.IPv6Any);
+                server.Listen(1);
+
+                var args = new SocketAsyncEventArgs();
+                args.Completed += OnOperationCompleted;
+                Assert.True(server.AcceptAsync(args));
+
+                client.Connect(IPAddress.IPv6Loopback, port);
+
+                var buffer = new byte[] { 42 };
+                for (int i = 0; i < 32; i++)
+                {
+                    int sent = client.Send(buffer);
+                    Assert.Equal(1, sent);
+                }
+
+                client.Shutdown(SocketShutdown.Send);
+
+                int received = 0;
+                do
+                {
+                    received = client.Receive(buffer);
+                } while (received != 0);
+
+                // Wait for the underlying connection to transition from TIME_WAIT to
+                // CLOSED.
+                Task.Delay(5000).Wait();
+
+                client.Shutdown(SocketShutdown.Both);
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
@@ -60,10 +60,17 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Shutdown_TCP_CLOSED_Success()
         {
+            // NOTE: this value should technically be at least as long as the amount
+            //       of time that a TCP connection will stay in the TIME_WAIT state.
+            //       That value, however, is technically defined as 2 * MSL, which is
+            //       officially 4 minutes, and may differ between systems. In practice,
+            //       5 seconds has proved to be long enough.
+            const int TimeWaitTimeout = 5000;
+
             using (Socket server = new Socket(SocketType.Stream, ProtocolType.Tcp))
             using (Socket client = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                int port = server.Bind(IPAddress.IPv6Any);
+                int port = server.BindToAnonymousPort(IPAddress.IPv6Any);
                 server.Listen(1);
 
                 var args = new SocketAsyncEventArgs();
@@ -89,7 +96,7 @@ namespace System.Net.Sockets.Tests
 
                 // Wait for the underlying connection to transition from TIME_WAIT to
                 // CLOSED.
-                Task.Delay(5000).Wait();
+                Task.Delay(TimeWaitTimeout).Wait();
 
                 client.Shutdown(SocketShutdown.Both);
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -17,10 +17,14 @@
     <Compile Include="ConnectExTest.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
+    <Compile Include="Shutdown.cs" />
     <Compile Include="SocketTestServerAPMMock.cs" />
     <Compile Include="UdpClientTest.cs" />
     
     <!-- Common Sockets files -->
+    <Compile Include="$(CommonTestPath)\System.Net\Sockets\SocketTestExtensions.cs">
+      <Link>SocketCommon\SocketTestExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System.Net\Sockets\SocketTestServer.DefaultAsyncFactoryConfiguration.cs">
       <Link>SocketCommon\SocketTestServer.DefaultAsyncFactoryConfiguration.cs</Link>
     </Compile>


### PR DESCRIPTION
Winsock tolerates a call to shutdown[1, 2] on a TCP socket whose underlying
connection has already transitioned to the CLOSED state[3]. Linux, however,
returns ENOTCONN, since the connection is already closed.

This change fixes the mismatch by exposing the socket instance's connection
state (i.e. Socket._isConnected) to the PAL and changing the *nix
implementation of SocketPal.Shutdown to ignore ENOTCONN if the socket is
connected.