### PR TITLE
Restore the exception order in ValidateCreateContext.

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/_SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/_SslState.cs
@@ -117,18 +117,18 @@ namespace System.Net.Security
             if (targetHost == null)
             {
                 throw new ArgumentNullException("targetHost");
-            }            
+            }
+
+            if (isServer && serverCertificate == null)
+            {
+                throw new ArgumentNullException("serverCertificate");
+            }
 
             if ((int)enabledSslProtocols == 0)
             {
                 throw new ArgumentException(SR.Format(SR.net_invalid_enum, "SslProtocolType"), "sslProtocolType");
             }
          
-            if (isServer && serverCertificate == null)
-            {  
-                throw new ArgumentNullException("serverCertificate");
-            }         
-
             if (clientCertificates == null)
             {
                 clientCertificates = new X509CertificateCollection();


### PR DESCRIPTION
During PAL refactoring the order that a null server certificate and no valid protocols were checked got flipped, resulting in a minor observable difference in exception flows.

This restores the order to what it was before.