### PR TITLE
Native: Multiple fixes

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -11,6 +11,7 @@
 #cmakedefine01 HAVE_STRLCPY
 #cmakedefine01 HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP
 #cmakedefine01 HAVE_POSIX_ADVISE
+#cmakedefine01 PRIORITY_REQUIRES_INT_WHO
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -389,12 +389,20 @@ extern "C" int32_t GetPriority(PriorityWhich which, int32_t who)
 {
     // GetPriority uses errno 0 to show succes to make sure we don't have a stale value
     errno = 0;
+#if PRIORITY_REQUIRES_INT_WHO
+    return getpriority(which, who);
+#else
     return getpriority(which, static_cast<id_t>(who));
+#endif
 }
 
 extern "C" int32_t SetPriority(PriorityWhich which, int32_t who, int32_t nice)
 {
+#if PRIORITY_REQUIRES_INT_WHO
+    return setpriority(which, who, nice);
+#else
     return setpriority(which, static_cast<id_t>(who), nice);
+#endif
 }
 
 extern "C" char* GetCwd(char* buffer, int32_t bufferSize)

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -2,6 +2,7 @@ include(CheckFunctionExists)
 include(CheckStructHasMember)
 include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
+include(CheckPrototypeDefinition)
 
 #CMake does not include /usr/local/include into the include search path
 #thus add it manually. This is required on FreeBSD.
@@ -85,6 +86,13 @@ check_cxx_source_runs(
     }
     "
     HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP)
+
+check_prototype_definition(
+    getpriority
+    "int getpriority(int which, int who)"
+    "0"
+    "sys/resource.h"
+    PRIORITY_REQUIRES_INT_WHO)
 
 set (CMAKE_REQUIRED_LIBRARIES)
 

--- a/src/Native/gen-buildsys-clang.sh
+++ b/src/Native/gen-buildsys-clang.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This file invokes cmake and generates the build system for gcc.
+# This file invokes cmake and generates the build system for Clang.
 #
 
 if [ $# -lt 3 -o $# -gt 4 ]
@@ -41,59 +41,8 @@ else
   buildtype="$4"
 fi
 
-OS=`uname`
+cmake_extra_defines="-DCMAKE_BUILD_TYPE=$buildtype"
 
-# Locate llvm
-# This can be a little complicated, because the common use-case of Ubuntu with
-# llvm-3.5 installed uses a rather unusual llvm installation with the version
-# number postfixed (i.e. llvm-ar-3.5), so we check for that first.
-# On FreeBSD the version number is appended without point and dash (i.e.
-# llvm-ar35).
-# Additionally, OSX doesn't use the llvm- prefix.
-if [ $OS = "Linux" -o $OS = "FreeBSD" -o $OS = "OpenBSD" -o $OS = "NetBSD" ]; then
-  llvm_prefix="llvm-"
-elif [ $OS = "Darwin" ]; then
-  llvm_prefix=""
-else
-  echo "Unable to determine build platform"
-  exit 1
-fi
-
-desired_llvm_major_version=$2
-desired_llvm_minor_version=$3
-if [ $OS = "FreeBSD" ]; then
-    desired_llvm_version="$desired_llvm_major_version$desired_llvm_minor_version"
-elif [ $OS = "OpenBSD" ]; then
-    desired_llvm_version=""
-elif [ $OS = "NetBSD" ]; then
-    desired_llvm_version=""
-else
-  desired_llvm_version="-$desired_llvm_major_version.$desired_llvm_minor_version"
-fi
-locate_llvm_exec() {
-  if which "$llvm_prefix$1$desired_llvm_version" > /dev/null 2>&1
-  then
-    echo "$(which $llvm_prefix$1$desired_llvm_version)"
-  elif which "$llvm_prefix$1" > /dev/null 2>&1
-  then
-    echo "$(which $llvm_prefix$1)"
-  else
-    exit 1
-  fi
-}
-
-llvm_ar="$(locate_llvm_exec ar)"
-[[ $? -eq 0 ]] || { echo "Unable to locate llvm-ar"; exit 1; }
-llvm_link="$(locate_llvm_exec link)"
-[[ $? -eq 0 ]] || { echo "Unable to locate llvm-link"; exit 1; }
-llvm_nm="$(locate_llvm_exec nm)"
-[[ $? -eq 0 ]] || { echo "Unable to locate llvm-nm"; exit 1; }
-if [ $OS = "Linux" -o $OS = "FreeBSD" -o $OS = "OpenBSD" -o $OS = "NetBSD" ]; then
-  llvm_objdump="$(locate_llvm_exec objdump)"
-  [[ $? -eq 0 ]] || { echo "Unable to locate llvm-objdump"; exit 1; }
-fi
-
-cmake_extra_defines=
 if [[ -n "$LLDB_LIB_DIR" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_LIBS=$LLDB_LIB_DIR"
 fi
@@ -101,12 +50,4 @@ if [[ -n "$LLDB_INCLUDE_DIR" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_INCLUDES=$LLDB_INCLUDE_DIR"
 fi
 
-cmake \
-  "-DCMAKE_AR=$llvm_ar" \
-  "-DCMAKE_LINKER=$llvm_link" \
-  "-DCMAKE_NM=$llvm_nm" \
-  "-DCMAKE_OBJDUMP=$llvm_objdump" \
-  "-DCMAKE_RANLIB=$llvm_ranlib" \
-  "-DCMAKE_BUILD_TYPE=$buildtype" \
-  $cmake_extra_defines \
-  "$1"
+cmake $cmake_extra_defines $1


### PR DESCRIPTION
##### <del>067ea11</del> d9cf2d8

* Fix wrong cast. Clang on FreeBSD caught this as error as `id_t` is not the type `[get/set]priority` functions are expecting:
  * Linux man (uses `id_t who`): http://man7.org/linux/man-pages/man2/getpriority.2.html
  * FreeBSD man (uses `int who`): https://www.freebsd.org/cgi/man.cgi?query=getpriority&sektion=2 (this applies to other BSDs as well, such as [DragonFly](https://www.dragonflybsd.org/cgi/web-man?command=getpriority&section=2) and [NetBSD](http://nixdoc.net/man-pages/NetBSD/man2/getpriority.2.html), except for [OpenBSD](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man2/getpriority.2?query=getpriority), hence I've used <del>`#if !defined(BSD) ..`</del> `cmake_prototype_definition` to detect the correct prototype).

##### <del>207d186</del> e348434

* Removes unrequired dependencies from native ` src/Native/gen-buildsys-clang.sh`.
  * It builds without llvm-* dependencies.
  * Cleanup unused code blocks.
  * Minor conditions and comment fixes.