### PR TITLE
Native: Disables a warning for clang v3.6.

### DIFF
--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -6,7 +6,7 @@ include(CheckPrototypeDefinition)
 
 #CMake does not include /usr/local/include into the include search path
 #thus add it manually. This is required on FreeBSD.
-include_directories(/usr/local/include)
+include_directories(SYSTEM /usr/local/include)
 
 check_function_exists(
     stat64


### PR DESCRIPTION
While building with clang36 on FreeBSD (`./build native clang3.6`),
I was getting this warning: `macro name is a reserved identifier`.