### PR TITLE
Fix file casing in S.D.Process.csproj.

### DIFF
--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -139,10 +139,10 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetPriorityClass.cs">
       <Link>Common\Interop\Windows\Interop.SetPriorityClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ntdll\Interop.NtQueryInformationProcess.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs">
       <Link>Common\Interop\Windows\Interop.NtQueryInformationProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ntdll\Interop.NtQuerySystemInformation.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs">
       <Link>Common\Interop\Windows\Interop.NtQuerySystemInformation.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.DuplicateHandle_SafeProcessHandle.cs">


### PR DESCRIPTION
This fixes a break when cross-compiling the Windows code on other
platforms.