### PR TITLE
Update test namespaces in some System.Runtime.* assmblies

### DIFF
--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Environment.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Environment.cs
@@ -4,7 +4,7 @@
 using Microsoft.Xunit.Performance;
 using System.Runtime.InteropServices;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class Perf_Environment
     {

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using Microsoft.Xunit.Performance;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.IO.Tests
 {
     public class Perf_Path
     {

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Random.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Random.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using Microsoft.Xunit.Performance;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class Perf_Random
     {

--- a/src/System.Runtime.Extensions/tests/System/Environment.NewLine.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.NewLine.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class EnvironmentNewLine
     {

--- a/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class EnvironmentProcessorCount
     {

--- a/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class EnvironmentStackTrace
     {
@@ -21,10 +19,10 @@ namespace System.Runtime.Extensions.Tests
             //arrange
             List<string> knownFrames = new List<string>()
             {
-                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.StaticFrame(Object obj)",
-                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.TestClass..ctor()",
-                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.GenericFrame[T1,T2](T1 t1, T2 t2)",
-                "System.Runtime.Extensions.Tests.EnvironmentStackTrace.TestFrame()"
+                "System.Tests.EnvironmentStackTrace.StaticFrame(Object obj)",
+                "System.Tests.EnvironmentStackTrace.TestClass..ctor()",
+                "System.Tests.EnvironmentStackTrace.GenericFrame[T1,T2](T1 t1, T2 t2)",
+                "System.Tests.EnvironmentStackTrace.TestFrame()"
             };
 
             //act
@@ -32,7 +30,7 @@ namespace System.Runtime.Extensions.Tests
 
             //assert
             int index = 0;
-            foreach(string frame in knownFrames)
+            foreach (string frame in knownFrames)
             {
                 index = s_stackTrace.IndexOf(frame, index);
                 Assert.True(index > -1);

--- a/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class EnvironmentTickCount
     {

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Net;
 using Xunit;
 
-namespace HttpWebUtilityTests
+namespace System.Net.Tests
 {
     public class WebUtilityTests
     {

--- a/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/Driver.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/Driver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Numerics;
-using Xunit;
 
-namespace Tools
+namespace System.Numerics.Tests
 {
     public static class MyBigIntImp
     {

--- a/src/System.Runtime.Numerics/tests/BigInteger/absolutevalue.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/absolutevalue.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/add.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/add.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/gcd.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/gcd.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/log.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/log02.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log02.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/log10.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log10.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/max.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/max.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/min.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/min.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/negate.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/negate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_add.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_add.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_and.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_and.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_decrement.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_decrement.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_increment.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_increment.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_minus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_minus.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_modulus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_modulus.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_not.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_not.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_or.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_or.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_plus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_plus.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_subtract.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_subtract.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_xor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_xor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/properties.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/properties.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/remainder.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/remainder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/sign.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/sign.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Numerics;
 using Xunit;
 
-namespace Tools
+namespace System.Numerics.Tests
 {
     public class StackCalc
     {

--- a/src/System.Runtime.Numerics/tests/BigInteger/subtract.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/subtract.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/ComplexTestSupport.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/ComplexTestSupport.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Numerics;
 using Xunit;
 
-namespace ComplexTestSupport
+namespace System.Numerics.Tests
 {
     public static class Support
     {

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Abs.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Abs.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryDivide_Divide.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryDivide_Divide.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMinus_Subtract.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMinus_Subtract.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMultiply_Multiply.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMultiply_Multiply.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryPlus_Add.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryPlus_Add.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Conjugate.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Conjugate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Reciprocal.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Reciprocal.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_UnaryMinus_Negate.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_UnaryMinus_Negate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/ctor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/factoryMethod.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/factoryMethod.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/formattingOperations.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/formattingOperations.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using System.Globalization;
 using Xunit;
 

--- a/src/System.Runtime.Numerics/tests/Complex/implicitExplicitCastOperators.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/implicitExplicitCastOperators.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/operation_ComparisonHashCode.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/operation_ComparisonHashCode.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Exp.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Exp.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Log.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Log.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Pow.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Pow.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Sqrt.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Sqrt.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/staticConstants.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/staticConstants.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ATan.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ATan.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cos.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cos.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cosh.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cosh.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sin.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sin.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sinh.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sinh.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tan.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tan.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tanh.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tanh.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ComplexTestSupport;
 using Xunit;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttribute.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using Xunit;
 
-namespace System.Runtime.Tests
+namespace System.ComponentModel.Tests
 {
     public static class DefaultValueAttributeTests
     {

--- a/src/System.Runtime/tests/System/ComponentModel/EditorBrowsableAttribute.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/EditorBrowsableAttribute.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using Xunit;
 
-namespace System.Runtime.Tests
+namespace System.ComponentModel.Tests
 {
     public static class EditorBrowsableAttributeTests
     {

--- a/src/System.Runtime/tests/System/Lazy.cs
+++ b/src/System.Runtime/tests/System/Lazy.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using Xunit;
 
-namespace System.Runtime.Tests
+namespace System.Tests
 {
     public static class LazyTests
     {

--- a/src/System.Runtime/tests/System/LazyOfTMetadata.cs
+++ b/src/System.Runtime/tests/System/LazyOfTMetadata.cs
@@ -4,7 +4,7 @@
 using System.Threading;
 using Xunit;
 
-namespace System.Runtime.Tests
+namespace System.Tests
 {
     public static class LazyOfTMetadataTests
     {

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/StrongBox.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/StrongBox.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.CompilerServices;
 using Xunit;
 
-namespace System.Runtime.Tests
+namespace System.Runtime.CompilerServices.Tests
 {
     public static class StrongBoxTests
     {


### PR DESCRIPTION
Update test namespaces in some System.Runtime.* assemblies, per #2898 .

Usings were also cleaned up.  No other work was performed.