### PR TITLE
Update test namespace in System.ServiceProcess.ServiceController

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.ServiceProcess;
-using System.Threading;
-using Xunit;
 using Microsoft.Win32;
+using System.Diagnostics;
+using Xunit;
 
-namespace System.ServiceProcessServiceController.Tests
+namespace System.ServiceProcess.Tests
 {
     internal sealed class ServiceProvider
     {


### PR DESCRIPTION
Update test namespace in System.ServiceProcess.ServiceController, per #2898 

Clean up `using`s.  No other work was performed.