### PR TITLE
System.Collections.NonGeneric: populate collections in debugger attribute tests

### DIFF
--- a/src/System.Collections.NonGeneric/tests/ArrayList/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/CtorTests.cs
@@ -89,7 +89,7 @@ namespace System.Collections.Tests
         public void DebuggerAttributeTests()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ArrayList());
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ArrayList());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ArrayList() { "a", 1, "b", 2 });
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Hashtable/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/CtorTests.cs
@@ -311,7 +311,7 @@ namespace System.Collections.Tests
         public void DebuggerAttributeTests()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Hashtable());
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Hashtable());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Hashtable() { { "a", 1 }, { "b", 2 } });
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor.cs
@@ -78,7 +78,13 @@ public class Queue_ctor
     public void DebuggerAttributeTests()
     {
         DebuggerAttributes.ValidateDebuggerDisplayReferences(new Queue());
-        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Queue());
+
+        var testQueue = new Queue();
+        testQueue.Enqueue("a");
+        testQueue.Enqueue(1);
+        testQueue.Enqueue("b");
+        testQueue.Enqueue(2);
+        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(testQueue);
     }
 
 }

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorTests.cs
@@ -113,7 +113,7 @@ namespace System.Collections.Tests
         public void DebuggerAttributeTests()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new SortedList());
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new SortedList());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new SortedList() { { "a", 1 }, { "b", 2 } });
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Stack/StackBasicTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/StackBasicTests.cs
@@ -362,7 +362,13 @@ public class StackBasicTests
     public void DebuggerAttributeTests()
     {
         DebuggerAttributes.ValidateDebuggerDisplayReferences(new Stack());
-        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Stack());
+
+        var testStack = new Stack();
+        testStack.Push("a");
+        testStack.Push(1);
+        testStack.Push("b");
+        testStack.Push(2);
+        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(testStack);
     }
 }
 }


### PR DESCRIPTION
This follows the lead of ImmutableCollections [tests](https://github.com/dotnet/corefx/blob/7a29d7da5f1e4be319fb7bf0c2f2d1d141f45eba/src/System.Collections.Immutable/tests/ImmutableListTest.cs#L731) and ensures the previously uncovered
KeyValuePairs internal class is covered.

Coverage of this package slightly increases from 94.3% to 94.6%.