### PR TITLE
Change S.N.Sockets/tests to use (mostly) anonymous ports.

### DIFF
--- a/src/Common/tests/System.Net/Sockets/SocketTestServer.cs
+++ b/src/Common/tests/System.Net/Sockets/SocketTestServer.cs
@@ -7,9 +7,19 @@ namespace System.Net.Sockets.Tests
     // SocketTestServer.DefaultFactoryConfiguration.cs
     public abstract partial class SocketTestServer : IDisposable
     {
+        private const int DefaultNumConnections = 5;
+        private const int DefaultReceiveBufferSize = 1024;
+
+        protected abstract int Port { get; }
+
         public static SocketTestServer SocketTestServerFactory(EndPoint endpoint)
         {
-            return SocketTestServerFactory(5, 1024, endpoint);
+            return SocketTestServerFactory(DefaultNumConnections, DefaultReceiveBufferSize, endpoint);
+        }
+
+        public static SocketTestServer SocketTestServerFactory(IPAddress address, out int port)
+        {
+            return SocketTestServerFactory(DefaultNumConnections, DefaultReceiveBufferSize, address, out port);
         }
 
         public static SocketTestServer SocketTestServerFactory(
@@ -22,6 +32,20 @@ namespace System.Net.Sockets.Tests
                 numConnections,
                 receiveBufferSize,
                 localEndPoint);
+        }
+
+        public static SocketTestServer SocketTestServerFactory(
+            int numConnections,
+            int receiveBufferSize,
+            IPAddress address,
+            out int port)
+        {
+            return SocketTestServerFactory(
+                s_implementationType,
+                numConnections,
+                receiveBufferSize,
+                address,
+                out port);
         }
 
         public static SocketTestServer SocketTestServerFactory(
@@ -39,6 +63,18 @@ namespace System.Net.Sockets.Tests
                 default:
                     throw new ArgumentOutOfRangeException("type");
             }
+        }
+
+        public static SocketTestServer SocketTestServerFactory(
+            SocketImplementationType type,
+            int numConnections,
+            int receiveBufferSize,
+            IPAddress address,
+            out int port)
+        {
+            SocketTestServer server = SocketTestServerFactory(type, numConnections, receiveBufferSize, new IPEndPoint(address, 0));
+            port = server.Port;
+            return server;
         }
 
         public void Dispose()

--- a/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
@@ -11,7 +11,6 @@ namespace System.Net.Sockets.Tests
 {
     public class AcceptAsync
     {
-        private const int TestPortBase = 7000;
         private readonly ITestOutputHelper _log;
 
         public AcceptAsync(ITestOutputHelper output)
@@ -43,7 +42,7 @@ namespace System.Net.Sockets.Tests
 
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                sock.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase));
+                int port = sock.BindToAnonymousPort(IPAddress.Loopback);
                 sock.Listen(1);
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -56,7 +55,7 @@ namespace System.Net.Sockets.Tests
                 using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
                     SocketAsyncEventArgs argsClient = new SocketAsyncEventArgs();
-                    argsClient.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase);
+                    argsClient.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, port);
                     argsClient.Completed += OnConnectCompleted;
                     argsClient.UserToken = completedClient;
                     client.ConnectAsync(argsClient);
@@ -84,7 +83,7 @@ namespace System.Net.Sockets.Tests
 
             using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             {
-                sock.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase));
+                int port = sock.BindToAnonymousPort(IPAddress.IPv6Loopback);
                 sock.Listen(1);
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -97,7 +96,7 @@ namespace System.Net.Sockets.Tests
                 using (Socket client = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
                     SocketAsyncEventArgs argsClient = new SocketAsyncEventArgs();
-                    argsClient.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase);
+                    argsClient.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port);
                     argsClient.Completed += OnConnectCompleted;
                     argsClient.UserToken = completedClient;
                     client.ConnectAsync(argsClient);

--- a/src/System.Net.Sockets/tests/FunctionalTests/ConnectAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ConnectAsync.cs
@@ -11,7 +11,6 @@ namespace System.Net.Sockets.Tests
 {
     public class ConnectAsync
     {
-        private const int TestPortBase = 7020;
         private readonly ITestOutputHelper _log;
 
         public ConnectAsync(ITestOutputHelper output)
@@ -34,11 +33,12 @@ namespace System.Net.Sockets.Tests
 
             AutoResetEvent completed = new AutoResetEvent(false);
 
-            using (SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase)))
+            int port;
+            using (SocketTestServer.SocketTestServerFactory(IPAddress.Loopback, out port))
             {
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase);
+                args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, port);
                 args.Completed += OnConnectCompleted;
                 args.UserToken = completed;
 
@@ -59,10 +59,11 @@ namespace System.Net.Sockets.Tests
 
             AutoResetEvent completed = new AutoResetEvent(false);
 
-            using (SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase)))
+            int port;
+            using (SocketTestServer.SocketTestServerFactory(IPAddress.IPv6Loopback, out port))
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase);
+                args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port);
                 args.Completed += OnConnectCompleted;
                 args.UserToken = completed;
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/ConnectExTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ConnectExTest.cs
@@ -11,7 +11,6 @@ namespace System.Net.Sockets.Tests
 {
     public class ConnectExTest
     {
-        private const int TestPortBase = 7030;
         private readonly ITestOutputHelper _log;
 
         public ConnectExTest(ITestOutputHelper output)
@@ -32,18 +31,17 @@ namespace System.Net.Sockets.Tests
         {
             Assert.True(Capability.IPv4Support() && Capability.IPv6Support());
 
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(
-                        new IPEndPoint(IPAddress.Loopback, TestPortBase));
+            int port;
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(IPAddress.Loopback, out port);
 
-            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(
-                        new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase));
+            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, port));
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
             try
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase);
+                args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, port);
                 args.Completed += OnConnectAsyncCompleted;
 
                 ManualResetEvent complete = new ManualResetEvent(false);
@@ -56,7 +54,7 @@ namespace System.Net.Sockets.Tests
                 sock.Dispose();
 
                 sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-                args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase);
+                args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port);
                 complete.Reset();
 
                 Assert.True(sock.ConnectAsync(args));

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -15,7 +15,9 @@ namespace System.Net.Sockets.Tests
         //       once this code is merged into corefx/master.
         private const int DummyLoopbackV6Issue = 123456;
 
-        private const int TestPortBase = 7080;
+        // Port 8 is unassigned as per https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
+        private const int UnusedPort = 8;
+
         private readonly ITestOutputHelper _log;
 
         public DnsEndPointTest(ITestOutputHelper output)
@@ -35,11 +37,11 @@ namespace System.Net.Sockets.Tests
         {
             Assert.True(Capability.IPv4Support());
 
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(
-                new IPEndPoint(IPAddress.Loopback, TestPortBase));
+            int port;
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(IPAddress.Loopback, out port);
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", port);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -65,7 +67,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv4Support());
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 1);
+            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -89,7 +91,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv4Support());
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 2);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", UnusedPort);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -116,14 +118,14 @@ namespace System.Net.Sockets.Tests
         {
             Assert.True(Capability.IPv4Support() && Capability.IPv6Support());
 
-            SocketTestServer server4 = SocketTestServer.SocketTestServerFactory(
-                new IPEndPoint(IPAddress.Loopback, TestPortBase + 3));
+            int port;
+            SocketTestServer server4 = SocketTestServer.SocketTestServerFactory(IPAddress.Loopback, out port);
 
-            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(
-                new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 4));
+            int port6;
+            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(IPAddress.IPv6Loopback, out port6);
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 3);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", port);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -141,7 +143,7 @@ namespace System.Net.Sockets.Tests
 
             args.ConnectSocket.Dispose();
 
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 4);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", port6);
             complete.Reset();
 
             Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
@@ -164,7 +166,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 5);
+            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -185,7 +187,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_ConnectionRefused()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 6);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", UnusedPort);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -215,7 +217,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv6Support());
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", TestPortBase + 7, AddressFamily.InterNetworkV6);
+            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", UnusedPort, AddressFamily.InterNetworkV6);
             args.Completed += CallbackThatShouldNotBeCalled;
 
             Assert.False(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketTestServerAPMMock.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketTestServerAPMMock.cs
@@ -8,6 +8,8 @@ namespace System.Net.Sockets.Tests
 {
     public class SocketTestServerAPM : SocketTestServer
     {
+        protected override int Port { get { throw new NotSupportedException(); } }
+
         public SocketTestServerAPM(int numConnections, int receiveBufferSize, EndPoint localEndPoint) 
         {
             throw new NotSupportedException();

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -11,7 +11,9 @@ namespace System.Net.Sockets.Tests
 {
     public class UdpClientTest
     {
-        private const int TestPortBase = 7400;
+        // Port 8 is unassigned as per https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
+        private const int UnusedPort = 8;
+
         private ManualResetEvent _waitHandle = new ManualResetEvent(false);
 
         private void AsyncCompleted(IAsyncResult ar)
@@ -26,7 +28,7 @@ namespace System.Net.Sockets.Tests
         {
             UdpClient udpClient = new UdpClient();
             byte[] sendBytes = new byte[1];
-            IPEndPoint remoteServer = new IPEndPoint(IPAddress.Loopback, TestPortBase);
+            IPEndPoint remoteServer = new IPEndPoint(IPAddress.Loopback, UnusedPort);
 
             Assert.Throws<ArgumentOutOfRangeException>("bytes", () =>
             {
@@ -39,7 +41,7 @@ namespace System.Net.Sockets.Tests
         {
             UdpClient udpClient = new UdpClient();
             byte[] sendBytes = new byte[1];
-            IPEndPoint remoteServer = new IPEndPoint(IPAddress.Loopback, TestPortBase + 1);
+            IPEndPoint remoteServer = new IPEndPoint(IPAddress.Loopback, UnusedPort);
 
             Assert.Throws<ArgumentOutOfRangeException>("bytes", () =>
             {
@@ -52,7 +54,7 @@ namespace System.Net.Sockets.Tests
         {
             UdpClient udpClient = new UdpClient();
             byte[] sendBytes = new byte[1];
-            IPEndPoint remoteServer = new IPEndPoint(IPAddress.Loopback, TestPortBase + 2);
+            IPEndPoint remoteServer = new IPEndPoint(IPAddress.Loopback, UnusedPort);
             _waitHandle.Reset();
             udpClient.BeginSend(sendBytes, sendBytes.Length, remoteServer, new AsyncCallback(AsyncCompleted), udpClient);
 

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -14,7 +14,6 @@ namespace System.Net.Sockets.Performance.Tests
     {
         private const int DummyOSXPerfIssue = 123456;
 
-        public const int TestPortBase = 9310;
         private readonly ITestOutputHelper _log;
 
         public SocketPerformanceAsyncTests(ITestOutputHelper output)
@@ -25,7 +24,6 @@ namespace System.Net.Sockets.Performance.Tests
         [Fact]
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
         {
-            int port = TestPortBase + 6;
             SocketImplementationType serverType = SocketImplementationType.Async;
             SocketImplementationType clientType = SocketImplementationType.Async;
             int iterations = 5000;
@@ -36,7 +34,6 @@ namespace System.Net.Sockets.Performance.Tests
             var test = new SocketPerformanceTests(_log);
 
             test.ClientServerTest(
-                port,
                 serverType,
                 clientType,
                 iterations,
@@ -49,7 +46,6 @@ namespace System.Net.Sockets.Performance.Tests
         [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()
         {
-            int port = TestPortBase + 7;
             SocketImplementationType serverType = SocketImplementationType.Async;
             SocketImplementationType clientType = SocketImplementationType.Async;
             int iterations = 1000;
@@ -60,7 +56,6 @@ namespace System.Net.Sockets.Performance.Tests
             var test = new SocketPerformanceTests(_log);
 
             test.ClientServerTest(
-                port, 
                 serverType, 
                 clientType, 
                 iterations, 

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketTestServerAPMMock.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketTestServerAPMMock.cs
@@ -5,6 +5,8 @@ namespace System.Net.Sockets.Tests
 {
     public class SocketTestServerAPM : SocketTestServer
     {
+        protected override int Port { get { throw new NotSupportedException(); } }
+
         public SocketTestServerAPM(int numConnections, int receiveBufferSize, EndPoint localEndPoint) 
         {
             throw new NotSupportedException();


### PR DESCRIPTION
This change only touches tests in System.Net.Sockets/tests; those under
S.N.Sockets.Legacy/tests will be taken care of in a follow-up commit.