### PR TITLE
Disabling System.Net.Sockets tests intermittently failing in CI.

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
@@ -311,6 +311,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
+        [ActiveIssue(3497, PlatformID.Windows)]
         public void SendPacketsElement_FilePart_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 10, 20), 20);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
@@ -42,6 +42,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(3447, PlatformID.Windows)]
         public void BeginSend_AsyncOperationCompletes_Success()
         {
             UdpClient udpClient = new UdpClient();


### PR DESCRIPTION
Disabling intermittently failing Sockets tests in CI.

Related #3497 #3447