### PR TITLE
Simple removal one line redundant code.

### DIFF
--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -23,7 +23,6 @@ namespace System.Linq
             // check for args changed
             if (obj != m.Object || args != m.Arguments)
             {
-                Expression[] argArray = args.ToArray();
                 Type[] typeArgs = (m.Method.IsGenericMethod) ? m.Method.GetGenericArguments() : null;
 
                 if ((m.Method.IsStatic || m.Method.DeclaringType.IsAssignableFrom(obj.Type))


### PR DESCRIPTION
ReadOnlyCollection is used to create an array, but that array is then never
used.

As the collection cannot be null, doesn't even change exception timing of null
reference to remove it, just removes redundant array construction.