### PR TITLE
Updated performance tests

### DIFF
--- a/src/Common/tests/Performance/PerfUtils.cs
+++ b/src/Common/tests/Performance/PerfUtils.cs
@@ -8,30 +8,44 @@ using System.IO;
 namespace System
 {
     /// <summary>Static helper class for performance tests</summary>
-    public static class PerfUtils
+    public class PerfUtils
     {
-        private static Random rand = new Random(1234132);
+        private Random rand;
+
+        /// <summary>
+        /// Initializes a new PerfUtils object with the default random seed.
+        /// </summary>
+        public PerfUtils()
+        {
+            rand = new Random(1234132);
+        }
+
+        /// <summary>
+        /// Initializes a new PerfUtils object with the given seed. Use this if also
+        /// using MemberData that was created using PerfUtils to avoid possible collision
+        /// errors.
+        /// </summary>
+        public PerfUtils(int seed)
+        {
+            rand = new Random(seed);
+        }
 
         /// <summary>
         /// Helper method to create a string containing a number of random
         /// characters equal to the specified length
         /// </summary>
-        public static string CreateString(int length)
+        public string CreateString(int length)
         {
-            // Random is not thread safe and will cause intermittent thread deadlock if used without being locked
-            lock (rand)
-            {
-                byte[] bytes = new byte[length];
-                rand.NextBytes(bytes);
-                return System.Convert.ToBase64String(bytes);
-            }
+            byte[] bytes = new byte[length];
+            rand.NextBytes(bytes);
+            return System.Convert.ToBase64String(bytes);
         }
 
         /// <summary>Gets a test file full path that is associated with the call site.</summary>
         /// <param name="index">An optional index value to use as a suffix on the file name.  Typically a loop index.</param>
         /// <param name="memberName">The member name of the function calling this method.</param>
         /// <param name="lineNumber">The line number of the function calling this method.</param>
-        public static string GetTestFilePath(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        public string GetTestFilePath(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
             return Path.Combine(Path.GetTempPath(), string.Format(
                 index.HasValue ? "{0}_{1}_{2}_{3}" : "{0}_{1}_{2}",

--- a/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
+++ b/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
@@ -16,8 +16,8 @@ namespace System.Collections.Tests
             if (_testData == null)
             {
                 _testData = new List<object[]>();
-                _testData.Add(new object[] { CreateHashtable(100) });
-                _testData.Add(new object[] { CreateHashtable(1000) });
+                _testData.Add(new object[] { CreateHashtable(10000) });
+                _testData.Add(new object[] { CreateHashtable(1000000) });
             }
             return _testData;
         }
@@ -25,8 +25,9 @@ namespace System.Collections.Tests
         public static Hashtable CreateHashtable(int size)
         {
             Hashtable ht = new Hashtable();
+            PerfUtils utils = new PerfUtils();
             for (int i = 0; i < size; i++)
-                ht.Add(PerfUtils.CreateString(50), PerfUtils.CreateString(50));
+                ht.Add(utils.CreateString(50), utils.CreateString(50));
             return ht;
         }
 
@@ -36,10 +37,13 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
-                    new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
-                    new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
-                    new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
+                        new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
+                        new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
+                        new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable(); new Hashtable();
+                    }
                 }
         }
 
@@ -47,17 +51,22 @@ namespace System.Collections.Tests
         [MemberData("TestData")]
         public void GetItem(Hashtable table)
         {
+            // Setup - utils needs a specific seed to prevent key collision with TestData
             object result;
-            string key = PerfUtils.CreateString(50);
+            PerfUtils utils = new PerfUtils(983452);
+            string key = utils.CreateString(50);
             table.Add(key, "value");
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    result = table[key]; result = table[key]; result = table[key]; result = table[key];
-                    result = table[key]; result = table[key]; result = table[key]; result = table[key];
-                    result = table[key]; result = table[key]; result = table[key]; result = table[key];
-                    result = table[key]; result = table[key]; result = table[key]; result = table[key];
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        result = table[key]; result = table[key]; result = table[key]; result = table[key];
+                        result = table[key]; result = table[key]; result = table[key]; result = table[key];
+                        result = table[key]; result = table[key]; result = table[key]; result = table[key];
+                        result = table[key]; result = table[key]; result = table[key]; result = table[key];
+                    }
                 }
             }
             table.Remove(key);
@@ -69,14 +78,16 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
             {
+                Hashtable tableCopy = new Hashtable(table);
                 using (iteration.StartMeasurement())
                 {
-                    table.Add("key1", "value"); table.Add("key2", "value"); table.Add("key3", "value");
-                    table.Add("key4", "value"); table.Add("key5", "value"); table.Add("key6", "value");
-                    table.Add("key7", "value"); table.Add("key8", "value"); table.Add("key9", "value");
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        tableCopy.Add(i * 10 + 1, "value"); tableCopy.Add(i * 10 + 2, "value"); tableCopy.Add(i * 10 + 3, "value");
+                        tableCopy.Add(i * 10 + 4, "value"); tableCopy.Add(i * 10 + 5, "value"); tableCopy.Add(i * 10 + 6, "value");
+                        tableCopy.Add(i * 10 + 7, "value"); tableCopy.Add(i * 10 + 8, "value"); tableCopy.Add(i * 10 + 9, "value");
+                    }
                 }
-                for (int i = 1; i <= 9; i++)
-                    table.Remove("key" + i);
             }
         }
     }

--- a/src/System.Collections/tests/Performance/Perf.Dictionary.cs
+++ b/src/System.Collections/tests/Performance/Perf.Dictionary.cs
@@ -22,43 +22,68 @@ namespace System.Collections.Tests
         {
             if (_testData == null)
             {
+                PerfUtils utils = new PerfUtils();
                 _testData = new List<object[]>();
-                _testData.Add(new object[] { CreateDictionary(100) });
-                _testData.Add(new object[] { CreateDictionary(1000) });
+                _testData.Add(new object[] { CreateDictionary(utils, 1000) });
+                _testData.Add(new object[] { CreateDictionary(utils, 10000) });
+                _testData.Add(new object[] { CreateDictionary(utils, 100000) });
             }
             return _testData;
+        }
+
+        public static IEnumerable<object[]> TestDataIntString()
+        {
+            Random rand = new Random(12);
+            yield return new object[] { CreateDictionaryIntInt(rand, 1000) };
+            yield return new object[] { CreateDictionaryIntInt(rand, 10000) };
+            yield return new object[] { CreateDictionaryIntInt(rand, 100000) };
         }
 
         /// <summary>
         /// Creates a Dictionary of string-string with the specified number of pairs
         /// </summary>
-        public static Dictionary<string, string> CreateDictionary(int size)
+        public static Dictionary<string, string> CreateDictionary(PerfUtils utils, int size)
         {
             Dictionary<string, string> dict = new Dictionary<string, string>();
             while (dict.Count < size)
             {
-                string key = PerfUtils.CreateString(50);
+                string key = utils.CreateString(50);
                 while (dict.ContainsKey(key))
-                    key = PerfUtils.CreateString(50);
-                dict.Add(key, PerfUtils.CreateString(50));
+                    key = utils.CreateString(50);
+                dict.Add(key, utils.CreateString(50));
             }
             return dict;
         }
 
+        /// <summary>
+        /// Creates a Dictionary of int-int with the specified number of pairs
+        /// </summary>
+        public static Dictionary<int, int> CreateDictionaryIntInt(Random rand, int size)
+        {
+            Dictionary<int, int> dict = new Dictionary<int, int>();
+            while (dict.Count < size)
+            {
+                int key = rand.Next(500000, int.MaxValue);
+                if (!dict.ContainsKey(key))
+                    dict.Add(key, 0);
+            }
+           return dict1;
+        }
+
         [Benchmark]
-        [MemberData("TestData")]
-        public void Add(Dictionary<string, string> dict)
+        [MemberData("TestDataIntString")]
+        public void Add(Dictionary<int, int> dict)
         {
             foreach (var iteration in Benchmark.Iterations)
             {
+                Dictionary<int, int> copyDict = new Dictionary<int, int>(dict);
                 using (iteration.StartMeasurement())
-                {
-                    dict.Add("key1", "string"); dict.Add("key2", "string"); dict.Add("key3", "string");
-                    dict.Add("key4", "string"); dict.Add("key5", "string"); dict.Add("key6", "string");
-                    dict.Add("key7", "string"); dict.Add("key8", "string"); dict.Add("key9", "string");
-                }
-                for (int i = 1; i <= 9; i++)
-                    Assert.True(dict.Remove("key" + i));
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        copyDict.Add(i * 10 + 1, 0); copyDict.Add(i * 10 + 2, 0); copyDict.Add(i * 10 + 3, 0);
+                        copyDict.Add(i * 10 + 4, 0); copyDict.Add(i * 10 + 5, 0); copyDict.Add(i * 10 + 6, 0);
+                        copyDict.Add(i * 10 + 7, 0); copyDict.Add(i * 10 + 8, 0); copyDict.Add(i * 10 + 9, 0);
+                    }
             }
         }
 
@@ -67,11 +92,12 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new Dictionary<int, string>(); new Dictionary<int, string>(); new Dictionary<int, string>();
-                    new Dictionary<int, string>(); new Dictionary<int, string>(); new Dictionary<int, string>();
-                    new Dictionary<int, string>(); new Dictionary<int, string>(); new Dictionary<int, string>();
-                }
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        new Dictionary<int, string>(); new Dictionary<int, string>(); new Dictionary<int, string>();
+                        new Dictionary<int, string>(); new Dictionary<int, string>(); new Dictionary<int, string>();
+                        new Dictionary<int, string>(); new Dictionary<int, string>(); new Dictionary<int, string>();
+                    }
         }
 
         [Benchmark]
@@ -83,11 +109,12 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new Dictionary<int, string>(size); new Dictionary<int, string>(size); new Dictionary<int, string>(size);
-                    new Dictionary<int, string>(size); new Dictionary<int, string>(size); new Dictionary<int, string>(size);
-                    new Dictionary<int, string>(size); new Dictionary<int, string>(size); new Dictionary<int, string>(size);
-                }
+                    for (int i = 0; i <= 500; i++)
+                    {
+                        new Dictionary<int, string>(size); new Dictionary<int, string>(size); new Dictionary<int, string>(size);
+                        new Dictionary<int, string>(size); new Dictionary<int, string>(size); new Dictionary<int, string>(size);
+                        new Dictionary<int, string>(size); new Dictionary<int, string>(size); new Dictionary<int, string>(size);
+                    }
         }
 
         [Benchmark]
@@ -103,11 +130,12 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
-                {
-                    retrieved = dict["key1"]; retrieved = dict["key2"]; retrieved = dict["key3"];
-                    retrieved = dict["key4"]; retrieved = dict["key5"]; retrieved = dict["key6"];
-                    retrieved = dict["key7"]; retrieved = dict["key8"]; retrieved = dict["key9"];
-                }
+                    for (int i = 0; i <= 10000; i++)
+                    {
+                        retrieved = dict["key1"]; retrieved = dict["key2"]; retrieved = dict["key3"];
+                        retrieved = dict["key4"]; retrieved = dict["key5"]; retrieved = dict["key6"];
+                        retrieved = dict["key7"]; retrieved = dict["key8"]; retrieved = dict["key9"];
+                    }
             }
 
             // Teardown
@@ -127,11 +155,12 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
-                {
-                    dict["key1"] = "string"; dict["key2"] = "string"; dict["key3"] = "string";
-                    dict["key4"] = "string"; dict["key5"] = "string"; dict["key6"] = "string";
-                    dict["key7"] = "string"; dict["key8"] = "string"; dict["key9"] = "string";
-                }
+                    for (int i = 0; i <= 10000; i++)
+                    {
+                        dict["key1"] = "string"; dict["key2"] = "string"; dict["key3"] = "string";
+                        dict["key4"] = "string"; dict["key5"] = "string"; dict["key6"] = "string";
+                        dict["key7"] = "string"; dict["key8"] = "string"; dict["key9"] = "string";
+                    }
             }
 
             // Teardown
@@ -146,33 +175,34 @@ namespace System.Collections.Tests
             IEnumerable<string> result;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    result = dict.Keys; result = dict.Keys; result = dict.Keys;
-                    result = dict.Keys; result = dict.Keys; result = dict.Keys;
-                    result = dict.Keys; result = dict.Keys; result = dict.Keys;
-                }
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        result = dict.Keys; result = dict.Keys; result = dict.Keys;
+                        result = dict.Keys; result = dict.Keys; result = dict.Keys;
+                        result = dict.Keys; result = dict.Keys; result = dict.Keys;
+                    }
         }
 
         [Benchmark]
         [MemberData("TestData")]
         public void TryGetValue(Dictionary<string, string> dict)
         {
-            // Setup
+            // Setup - utils needs a specific seed to prevent key collision with TestData
             string retrieved;
-            string key = PerfUtils.CreateString(50);
+            PerfUtils utils = new PerfUtils(56334);
+            string key = utils.CreateString(50);
             dict.Add(key, "value");
 
             // Actual perf testing
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
-                    dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
-                    dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
-                    dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
-                }
-            }
+                    for (int i = 0; i <= 1000; i++)
+                    {
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                    }
 
             // Teardown
             dict.Remove(key);
@@ -182,21 +212,21 @@ namespace System.Collections.Tests
         [MemberData("TestData")]
         public void ContainsKey(Dictionary<string, string> dict)
         {
-            // Setup
-            string key = PerfUtils.CreateString(50);
+            // Setup - utils needs a specific seed to prevent key collision with TestData
+            PerfUtils utils = new PerfUtils(152891);
+            string key = utils.CreateString(50);
             dict.Add(key, "value");
 
             // Actual perf testing
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
-                    dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
-                    dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
-                    dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
-                }
-            }
+                    for (int i = 0; i <= 10000; i++)
+                    {
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                    }
             dict.Remove(key);
         }
     }

--- a/src/System.Collections/tests/Performance/Perf.List.cs
+++ b/src/System.Collections/tests/Performance/Perf.List.cs
@@ -22,9 +22,11 @@ namespace System.Collections.Tests
         {
             if (_testData == null)
             {
+                PerfUtils utils = new PerfUtils();
                 _testData = new List<object[]>();
-                _testData.Add(new object[] { CreateList(100) });
-                _testData.Add(new object[] { CreateList(1000) });
+                _testData.Add(new object[] { CreateList(utils, 1000) });
+                _testData.Add(new object[] { CreateList(utils, 10000) });
+                _testData.Add(new object[] { CreateList(utils, 100000) });
             }
             return _testData;
         }
@@ -32,11 +34,11 @@ namespace System.Collections.Tests
         /// <summary>
         /// Creates a list containing a number of elements equal to the specified size
         /// </summary>
-        public static List<object> CreateList(int size)
+        public static List<object> CreateList(PerfUtils utils, int size)
         {
             List<object> list = new List<object>();
             for (int i = 0; i < size; i++)
-                list.Add(PerfUtils.CreateString(100));
+                list.Add(utils.CreateString(100));
             return list;
         }
 
@@ -46,12 +48,15 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
             {
+                List<object> copyList = new List<object>(list);
                 using (iteration.StartMeasurement())
                 {
-                    list.Add("TestString1"); list.Add("TestString2"); list.Add("TestString3"); list.Add("TestString4");
-                    list.Add("TestString5"); list.Add("TestString6"); list.Add("TestString7"); list.Add("TestString8");
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        copyList.Add("TestString1"); copyList.Add("TestString2"); copyList.Add("TestString3"); copyList.Add("TestString4");
+                        copyList.Add("TestString5"); copyList.Add("TestString6"); copyList.Add("TestString7"); copyList.Add("TestString8");
+                    }
                 }
-                list.RemoveRange(list.Count - 8, 8);
             }
         }
 
@@ -60,11 +65,12 @@ namespace System.Collections.Tests
         public void AddRange(List<object> list)
         {
             foreach (var iteration in Benchmark.Iterations)
-            {
-                List<object> emptyList = new List<object>();
                 using (iteration.StartMeasurement())
-                    emptyList.AddRange(list);
-            }
+                    for (int i = 0; i < 5000; i++)
+                    {
+                        List<object> emptyList = new List<object>();
+                        emptyList.AddRange(list);
+                    }
         }
 
         [Benchmark]
@@ -73,10 +79,15 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
             {
-                // Create a local hard copy so that future iterations aren't affected
-                var copy = new List<object>(list);
+                // Setup lists to clear
+                List<object>[] listlist = new List<object>[5000];
+                for (int i = 0; i < 5000; i++)
+                    listlist[i] = new List<object>(list);
+
+                // Clear the lists
                 using (iteration.StartMeasurement())
-                    copy.Clear();
+                    for (int i = 0; i < 5000; i++)
+                        listlist[i].Clear();
             }
         }
 
@@ -88,9 +99,12 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    list.Contains(contained); list.Contains(contained); list.Contains(contained); list.Contains(contained);
-                    list.Contains(contained); list.Contains(contained); list.Contains(contained); list.Contains(contained);
-                    list.Contains(contained); list.Contains(contained); list.Contains(contained); list.Contains(contained);
+                    for (int i = 0; i < 500; i++)
+                    {
+                        list.Contains(contained); list.Contains(contained); list.Contains(contained); list.Contains(contained);
+                        list.Contains(contained); list.Contains(contained); list.Contains(contained); list.Contains(contained);
+                        list.Contains(contained); list.Contains(contained); list.Contains(contained); list.Contains(contained);
+                    }
                 }
         }
 
@@ -100,9 +114,12 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
-                    new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
-                    new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
+                        new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
+                        new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
+                    }
                 }
         }
 
@@ -113,7 +130,8 @@ namespace System.Collections.Tests
             var array = list.ToArray();
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    new List<object>(array);
+                    for (int i = 0; i < 10000; i++)
+                        new List<object>(array);
         }
 
         [Benchmark]
@@ -124,9 +142,12 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count;
-                    temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count;
-                    temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count;
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count;
+                        temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count;
+                        temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count; temp = list.Count;
+                    }
                 }
         }
 
@@ -138,10 +159,13 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
-                    temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
-                    temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
-                    temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
+                        temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
+                        temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
+                        temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50]; temp = list[50];
+                    }
                 }
         }
 
@@ -151,7 +175,8 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    foreach (var element in list) { }
+                    for (int i = 0; i < 10000; i++)
+                        foreach (var element in list) { }
         }
 
         [Benchmark]
@@ -160,7 +185,8 @@ namespace System.Collections.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    list.ToArray();
+                    for (int i = 0; i < 10000; i++)
+                        list.ToArray();
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs
+++ b/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs
@@ -5,7 +5,7 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 using System.IO;
 
-namespace System.Diagnostics.ProcessTests
+namespace System.Diagnostics.Tests
 {
     public class Perf_Process : ProcessTestBase
     {
@@ -14,21 +14,41 @@ namespace System.Diagnostics.ProcessTests
         {
             foreach (var iteration in Benchmark.Iterations)
             {
-                using (Process proc = CreateProcessInfinite())
+                // Create several processes to test on
+                Process[] processes = new Process[500];
+                for (int i = 0; i < 500; i++)
                 {
-                    proc.Start();
-                    using (iteration.StartMeasurement())
-                        proc.Kill();
+                    processes[i] = CreateProcessInfinite();
+                    processes[i].Start();
                 }
+
+                // Begin Testing - Kill all of the processes
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 500; i++)
+                        processes[i].Kill();
+
+                // Cleanup the processes
+                for (int i = 0; i < 500; i++)
+                    processes[i].Dispose();
             }
         }
 
         [Benchmark]
-        public void GetProcessesByName()
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void GetProcessesByName(int innerIterations)
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    Process.GetProcessesByName("1");
+                {
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Process.GetProcessesByName("1"); Process.GetProcessesByName("1"); Process.GetProcessesByName("1");
+                        Process.GetProcessesByName("1"); Process.GetProcessesByName("1"); Process.GetProcessesByName("1");
+                        Process.GetProcessesByName("1"); Process.GetProcessesByName("1"); Process.GetProcessesByName("1");
+                    }
+                }
         }
 
         [Benchmark]
@@ -37,13 +57,22 @@ namespace System.Diagnostics.ProcessTests
             int id;
             foreach (var iteration in Benchmark.Iterations)
             {
-                using (Process proc = CreateProcess())
+                // Create several processes to test on
+                Process[] processes = new Process[500];
+                for (int i = 0; i < 500; i++)
                 {
-                    proc.Start();
-                    using (iteration.StartMeasurement())
-                        id = proc.Id;
-                    proc.Kill();
+                    processes[i] = CreateProcess();
+                    processes[i].Start();
                 }
+
+                // Begin Testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 500; i++)
+                        id = processes[i].Id;
+
+                // Cleanup the processes
+                for (int i = 0; i < 500; i++)
+                    processes[i].Dispose();
             }
         }
 
@@ -51,14 +80,23 @@ namespace System.Diagnostics.ProcessTests
         public void Start()
         {
             foreach (var iteration in Benchmark.Iterations)
-                using (Process proc = CreateProcess())
+            {
+                // Create several processes to test on
+                Process[] processes = new Process[500];
+                for (int i = 0; i < 500; i++)
                 {
-                    using (iteration.StartMeasurement())
-                    {
-                        proc.Start();
-                    }
-                    proc.Kill();
+                    processes[i] = CreateProcess();
                 }
+
+                // Begin Testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 500; i++)
+                        processes[i].Start();
+
+                // Cleanup the processes
+                for (int i = 0; i < 500; i++)
+                    processes[i].Dispose();
+            }
         }
 
         [Benchmark]
@@ -67,13 +105,22 @@ namespace System.Diagnostics.ProcessTests
             bool result;
             foreach (var iteration in Benchmark.Iterations)
             {
-                using (Process proc = CreateProcess())
+                // Create several processes to test on
+                Process[] processes = new Process[500];
+                for (int i = 0; i < 500; i++)
                 {
-                    proc.Start();
-                    using (iteration.StartMeasurement())
-                        result = proc.HasExited;
-                    proc.Kill();
+                    processes[i] = CreateProcess();
+                    processes[i].Start();
                 }
+
+                // Begin Testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 500; i++)
+                        result = processes[i].HasExited;
+
+                // Cleanup the processes
+                for (int i = 0; i < 500; i++)
+                    processes[i].Dispose();
             }
         }
 
@@ -83,13 +130,23 @@ namespace System.Diagnostics.ProcessTests
             int result;
             foreach (var iteration in Benchmark.Iterations)
             {
-                using (Process proc = CreateProcess())
+                // Create several processes to test on
+                Process[] processes = new Process[500];
+                for (int i = 0; i < 500; i++)
                 {
-                    proc.Start();
-                    proc.WaitForExit();
-                    using (iteration.StartMeasurement())
-                        result = proc.ExitCode;
+                    processes[i] = CreateProcess();
+                    processes[i].Start();
+                    processes[i].WaitForExit();
                 }
+
+                // Begin Testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 500; i++)
+                        result = processes[i].ExitCode;
+
+                // Cleanup the processes
+                for (int i = 0; i < 500; i++)
+                    processes[i].Dispose();
             }
         }
 
@@ -98,26 +155,56 @@ namespace System.Diagnostics.ProcessTests
         {
             ProcessStartInfo result;
             foreach (var iteration in Benchmark.Iterations)
-                using (Process proc = CreateProcess())
+            {
+                // Create several processes to test on
+                Process[] processes = new Process[500];
+                for (int i = 0; i < 500; i++)
+                {
+                    processes[i] = CreateProcess();
+                }
+
+                // Begin Testing
                 using (iteration.StartMeasurement())
-                    result = proc.StartInfo;
+                    for (int i = 0; i < 500; i++)
+                        result = processes[i].StartInfo;
+
+                // Cleanup the processes
+                for (int i = 0; i < 500; i++)
+                    processes[i].Dispose();
+            }
         }
 
         [Benchmark]
         public void GetStandardOutput()
         {
-            StreamReader result;
+            const int innerIterations = 200;
             foreach (var iteration in Benchmark.Iterations)
             {
-                using (Process proc = CreateProcess())
+                // Create several processes to test on
+                Process[] processes = new Process[innerIterations];
+
+                Func<int> method = () =>
                 {
-                    proc.StartInfo.RedirectStandardOutput = true;
-                    proc.Start();
-                    
-                    using (iteration.StartMeasurement())
-                        result = proc.StandardOutput;
-                    proc.Kill();
+                    for (int j = 0; j < innerIterations; j++)
+                        Console.WriteLine("Redirected String");
+                    return SuccessExitCode;
+                };
+
+                for (int i = 0; i < innerIterations; i++)
+                {
+                    processes[i] = CreateProcess(method);
+                    processes[i].StartInfo.RedirectStandardOutput = true;
+                    processes[i].Start();
                 }
+
+                // Begin Testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                        processes[i].StandardOutput.ReadToEnd();
+
+                // Cleanup the processes
+                for (int i = 0; i < innerIterations; i++)
+                    processes[i].Dispose();
             }
         }
     }

--- a/src/System.Globalization/tests/Performance/Perf.CultureInfo.cs
+++ b/src/System.Globalization/tests/Performance/Perf.CultureInfo.cs
@@ -15,9 +15,12 @@ namespace System.Globalization.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture;
-                    result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture;
-                    result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture;
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture;
+                        result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture;
+                        result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture; result = CultureInfo.CurrentCulture;
+                    }
                 }
         }
 
@@ -28,9 +31,12 @@ namespace System.Globalization.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture;
-                    result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture;
-                    result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture;
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture;
+                        result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture;
+                        result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture; result = CultureInfo.InvariantCulture;
+                    }
                 }
         }
     }

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -178,7 +178,6 @@
   <!-- Performance Tests -->
   <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
     <Compile Include="Performance\Perf.CultureInfo.cs" />
-    <Compile Include="Performance\Perf.StringBuilder.cs" />
     <Compile Include="$(CommonTestPath)\Performance\PerfUtils.cs">
       <Link>Common\Performance\PerfUtils.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/tests/Performance/Perf.Directory.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.Directory.cs
@@ -5,20 +5,19 @@ using Microsoft.Xunit.Performance;
 
 namespace System.IO.FileSystem.Tests
 {
-    public class Perf_Directory
+    public class Perf_Directory : FileSystemTest
     {
         [Benchmark]
         public void GetCurrentDirectory()
         {
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory();
-                    Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory();
-                    Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory();
-                }
-            }
+                    for (int i = 0; i < 20000; i++)
+                    {
+                        Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory();
+                        Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory();
+                        Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory(); Directory.GetCurrentDirectory();
+                    }
         }
 
         [Benchmark]
@@ -27,14 +26,12 @@ namespace System.IO.FileSystem.Tests
             foreach (var iteration in Benchmark.Iterations)
             {
                 // Setup
-                string testFile = PerfUtils.GetTestFilePath();
+                string testFile = GetTestFilePath();
 
                 // Actual perf testing
                 using (iteration.StartMeasurement())
-                    Directory.CreateDirectory(testFile);
-
-                // Teardown
-                Directory.Delete(testFile);
+                    for (int i = 0; i < 20000; i++)
+                        Directory.CreateDirectory(testFile + i);
             }
         }
 
@@ -42,22 +39,22 @@ namespace System.IO.FileSystem.Tests
         public void Exists()
         {
             // Setup
-            string testFile = PerfUtils.GetTestFilePath();
+            string testFile = GetTestFilePath();
             Directory.CreateDirectory(testFile);
 
             foreach (var iteration in Benchmark.Iterations)
-            {
-                // Actual perf testing
                 using (iteration.StartMeasurement())
-                {
-                    Directory.Exists(testFile); Directory.Exists(testFile); Directory.Exists(testFile);
-                    Directory.Exists(testFile); Directory.Exists(testFile); Directory.Exists(testFile);
-                    Directory.Exists(testFile); Directory.Exists(testFile); Directory.Exists(testFile);
-                }
-            }
+                    for (int i = 0; i < 20000; i++)
+                    {
+                        Directory.Exists(testFile); Directory.Exists(testFile); Directory.Exists(testFile);
+                        Directory.Exists(testFile); Directory.Exists(testFile); Directory.Exists(testFile);
+                        Directory.Exists(testFile); Directory.Exists(testFile); Directory.Exists(testFile);
+                    }
 
             // Teardown
             Directory.Delete(testFile);
         }
     }
+
+
 }

--- a/src/System.IO.FileSystem/tests/Performance/Perf.File.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.File.cs
@@ -5,13 +5,13 @@ using Microsoft.Xunit.Performance;
 
 namespace System.IO.FileSystem.Tests
 {
-    public class Perf_File
+    public class Perf_File : FileSystemTest
     {
         [Benchmark]
         public void Exists()
         {
             // Setup
-            string testFile = PerfUtils.GetTestFilePath();
+            string testFile = GetTestFilePath();
             File.Create(testFile).Dispose();
 
             foreach (var iteration in Benchmark.Iterations)
@@ -19,9 +19,12 @@ namespace System.IO.FileSystem.Tests
                 // Actual perf testing
                 using (iteration.StartMeasurement())
                 {
-                    File.Exists(testFile); File.Exists(testFile); File.Exists(testFile);
-                    File.Exists(testFile); File.Exists(testFile); File.Exists(testFile);
-                    File.Exists(testFile); File.Exists(testFile); File.Exists(testFile);
+                    for (int i = 0; i < 20000; i++)
+                    {
+                        File.Exists(testFile); File.Exists(testFile); File.Exists(testFile);
+                        File.Exists(testFile); File.Exists(testFile); File.Exists(testFile);
+                        File.Exists(testFile); File.Exists(testFile); File.Exists(testFile);
+                    }
                 }
             }
 
@@ -35,14 +38,14 @@ namespace System.IO.FileSystem.Tests
             foreach (var iteration in Benchmark.Iterations)
             {
                 // Setup
-                string testFile = PerfUtils.GetTestFilePath();
-                File.Create(testFile + 1).Dispose(); File.Create(testFile + 2).Dispose(); File.Create(testFile + 3).Dispose();
+                string testFile = GetTestFilePath();
+                for (int i = 0; i < 10000; i++)
+                    File.Create(testFile + 1).Dispose();
 
                 // Actual perf testing
                 using (iteration.StartMeasurement())
-                {
-                    File.Delete(testFile + 1); File.Delete(testFile + 2); File.Delete(testFile + 3);
-                }
+                    for (int i = 0; i < 10000; i++)
+                        File.Delete(testFile + 1);
             }
         }
     }

--- a/src/System.IO.FileSystem/tests/Performance/Perf.FileInfo.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.FileInfo.cs
@@ -5,19 +5,22 @@ using Microsoft.Xunit.Performance;
 
 namespace System.IO.FileSystem.Tests
 {
-    public class Perf_FileInfo
+    public class Perf_FileInfo : FileSystemTest
     {
         [Benchmark]
         public void ctor_str()
         {
-            string path = PerfUtils.GetTestFilePath();
+            string path = GetTestFilePath();
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    new FileInfo(path); new FileInfo(path); new FileInfo(path);
-                    new FileInfo(path); new FileInfo(path); new FileInfo(path);
-                    new FileInfo(path); new FileInfo(path); new FileInfo(path);
+                    for (int i = 0; i < 20000; i++)
+                    {
+                        new FileInfo(path); new FileInfo(path); new FileInfo(path);
+                        new FileInfo(path); new FileInfo(path); new FileInfo(path);
+                        new FileInfo(path); new FileInfo(path); new FileInfo(path);
+                    }
                 }
             }
         }

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Environment.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Environment.cs
@@ -11,7 +11,8 @@ namespace System.Runtime.Extensions.Tests
         [Benchmark]
         public void GetEnvironmentVariable()
         {
-            string env = PerfUtils.CreateString(15);
+            PerfUtils utils = new PerfUtils();
+            string env = utils.CreateString(15);
             try
             {
                 // setup the environment variable so we can read it
@@ -19,14 +20,13 @@ namespace System.Runtime.Extensions.Tests
 
                 // read the valid environment variable for the test
                 foreach (var iteration in Benchmark.Iterations)
-                {
                     using (iteration.StartMeasurement())
-                    {
-                        Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env);
-                        Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env);
-                        Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env);
-                    }
-                }
+                        for (int i = 0; i < 40000; i++)
+                        {
+                            Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env);
+                            Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env);
+                            Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env); Environment.GetEnvironmentVariable(env);
+                        }
             }
             finally
             {
@@ -38,7 +38,8 @@ namespace System.Runtime.Extensions.Tests
         [Benchmark]
         public void ExpandEnvironmentVariables()
         {
-            string env = PerfUtils.CreateString(15);
+            PerfUtils utils = new PerfUtils();
+            string env = utils.CreateString(15);
             string inputEnv = "%" + env + "%";
             try
             {
@@ -47,16 +48,15 @@ namespace System.Runtime.Extensions.Tests
 
                 // read the valid environment variable
                 foreach (var iteration in Benchmark.Iterations)
-                {
                     using (iteration.StartMeasurement())
-                    {
-                        Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
-                        Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
-                        Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
-                        Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
-                        Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
-                    }
-                }
+                        for (int i = 0; i < 40000; i++)
+                        {
+                            Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
+                            Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
+                            Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
+                            Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
+                            Environment.ExpandEnvironmentVariables(inputEnv); Environment.ExpandEnvironmentVariables(inputEnv);
+                        }
             }
             finally
             {

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
@@ -3,58 +3,63 @@
 
 using System.IO;
 using Microsoft.Xunit.Performance;
+using Xunit;
 
 namespace System.Runtime.Extensions.Tests
 {
     public class Perf_Path
     {
         [Benchmark]
-        public void Combine()
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void Combine(int innerIterations)
         {
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                // Setup
-                string testPath1 = PerfUtils.GetTestFilePath();
-                string testPath2 = PerfUtils.CreateString(10);
+            PerfUtils utils = new PerfUtils();
+            string testPath1 = utils.GetTestFilePath();
+            string testPath2 = utils.CreateString(10);
 
-                // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2);
-                    Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2);
-                    Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2);
-                }
-            }
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2);
+                        Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2);
+                        Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2); Path.Combine(testPath1, testPath2);
+                    }
         }
 
         [Benchmark]
-        public void GetFileName()
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetFileName(int innerIterations)
         {
-            string testPath = PerfUtils.GetTestFilePath();
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    Path.GetFileName(testPath); Path.GetFileName(testPath); Path.GetFileName(testPath);
-                    Path.GetFileName(testPath); Path.GetFileName(testPath); Path.GetFileName(testPath);
-                    Path.GetFileName(testPath); Path.GetFileName(testPath); Path.GetFileName(testPath);
-                }
-            }
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetFileName(testPath); Path.GetFileName(testPath); Path.GetFileName(testPath);
+                        Path.GetFileName(testPath); Path.GetFileName(testPath); Path.GetFileName(testPath);
+                        Path.GetFileName(testPath); Path.GetFileName(testPath); Path.GetFileName(testPath);
+                    }
         }
 
         [Benchmark]
         public void GetDirectoryName()
         {
-            string testPath = PerfUtils.GetTestFilePath();
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
-                    Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
-                    Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
-                }
-            }
+                    for (int i = 0; i < 20000; i++)
+                    {
+                        Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
+                        Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
+                        Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
+                    }
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Random.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Random.cs
@@ -13,11 +13,12 @@ namespace System.Runtime.Extensions.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new Random(); new Random(); new Random();
-                    new Random(); new Random(); new Random();
-                    new Random(); new Random(); new Random();
-                }
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        new Random(); new Random(); new Random();
+                        new Random(); new Random(); new Random();
+                        new Random(); new Random(); new Random();
+                    }
         }
 
         [Benchmark]
@@ -25,14 +26,13 @@ namespace System.Runtime.Extensions.Tests
         {
             Random rand = new Random(123456);
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    rand.Next(10000); rand.Next(10000); rand.Next(10000);
-                    rand.Next(10000); rand.Next(10000); rand.Next(10000);
-                    rand.Next(10000); rand.Next(10000); rand.Next(10000);
-                }
-            }
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        rand.Next(10000); rand.Next(10000); rand.Next(10000);
+                        rand.Next(10000); rand.Next(10000); rand.Next(10000);
+                        rand.Next(10000); rand.Next(10000); rand.Next(10000);
+                    }
         }
 
         [Benchmark]
@@ -40,14 +40,13 @@ namespace System.Runtime.Extensions.Tests
         {
             Random rand = new Random(123456);
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    rand.Next(100, 10000); rand.Next(100, 10000); rand.Next(100, 10000);
-                    rand.Next(100, 10000); rand.Next(100, 10000); rand.Next(100, 10000);
-                    rand.Next(100, 10000); rand.Next(100, 10000); rand.Next(100, 10000);
-                }
-            }
+                    for (int i = 0; i < 40000; i++)
+                    {
+                        rand.Next(100, 10000); rand.Next(100, 10000); rand.Next(100, 10000);
+                        rand.Next(100, 10000); rand.Next(100, 10000); rand.Next(100, 10000);
+                        rand.Next(100, 10000); rand.Next(100, 10000); rand.Next(100, 10000);
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Boolean.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Boolean.cs
@@ -13,11 +13,12 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
-                    Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
-                    Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
+                        Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
+                        Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
+                    }
         }
 
         [Benchmark]
@@ -26,11 +27,12 @@ namespace System.Runtime.Tests
             Boolean boo = true;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    boo.ToString(); boo.ToString(); boo.ToString();
-                    boo.ToString(); boo.ToString(); boo.ToString();
-                    boo.ToString(); boo.ToString(); boo.ToString();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        boo.ToString(); boo.ToString(); boo.ToString();
+                        boo.ToString(); boo.ToString(); boo.ToString();
+                        boo.ToString(); boo.ToString(); boo.ToString();
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.DateTime.cs
+++ b/src/System.Runtime/tests/Performance/Perf.DateTime.cs
@@ -13,11 +13,12 @@ namespace System.Runtime.Tests
             DateTime dt;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    dt = DateTime.Now; dt = DateTime.Now; dt = DateTime.Now;
-                    dt = DateTime.Now; dt = DateTime.Now; dt = DateTime.Now;
-                    dt = DateTime.Now; dt = DateTime.Now; dt = DateTime.Now;
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        dt = DateTime.Now; dt = DateTime.Now; dt = DateTime.Now;
+                        dt = DateTime.Now; dt = DateTime.Now; dt = DateTime.Now;
+                        dt = DateTime.Now; dt = DateTime.Now; dt = DateTime.Now;
+                    }
         }
 
         [Benchmark]
@@ -26,11 +27,12 @@ namespace System.Runtime.Tests
             DateTime dt = DateTime.Now;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    dt.ToString("g"); dt.ToString("g"); dt.ToString("g");
-                    dt.ToString("g"); dt.ToString("g"); dt.ToString("g");
-                    dt.ToString("g"); dt.ToString("g"); dt.ToString("g");
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        dt.ToString("g"); dt.ToString("g"); dt.ToString("g");
+                        dt.ToString("g"); dt.ToString("g"); dt.ToString("g");
+                        dt.ToString("g"); dt.ToString("g"); dt.ToString("g");
+                    }
         }
 
         [Benchmark]
@@ -41,11 +43,12 @@ namespace System.Runtime.Tests
             DateTime date2 = new DateTime(1996, 12, 6, 13, 2, 0);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    result = date1 - date2; result = date1 - date2; result = date1 - date2;
-                    result = date1 - date2; result = date1 - date2; result = date1 - date2;
-                    result = date1 - date2; result = date1 - date2; result = date1 - date2;
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        result = date1 - date2; result = date1 - date2; result = date1 - date2;
+                        result = date1 - date2; result = date1 - date2; result = date1 - date2;
+                        result = date1 - date2; result = date1 - date2; result = date1 - date2;
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Enum.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Enum.cs
@@ -18,11 +18,12 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red");
-                    Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red");
-                    Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red");
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red");
+                        Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red");
+                        Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red"); Enum.Parse(typeof(testEnum), "Red");
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Guid.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Guid.cs
@@ -13,25 +13,26 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    Guid.NewGuid(); Guid.NewGuid(); Guid.NewGuid();
-                    Guid.NewGuid(); Guid.NewGuid(); Guid.NewGuid();
-                    Guid.NewGuid(); Guid.NewGuid(); Guid.NewGuid();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        Guid.NewGuid(); Guid.NewGuid(); Guid.NewGuid();
+                        Guid.NewGuid(); Guid.NewGuid(); Guid.NewGuid();
+                        Guid.NewGuid(); Guid.NewGuid(); Guid.NewGuid();
+                    }
         }
 
         [Benchmark]
         public void ctor_str()
         {
+            const string guidStr = "a8a110d5-fc49-43c5-bf46-802db8f843ff";
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff"); new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff");
-                    new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff"); new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff");
-                    new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff"); new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff");
-                    new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff"); new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff");
-                    new Guid("a8a110d5-fc49-43c5-bf46-802db8f843ff");
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        new Guid(guidStr); new Guid(guidStr); new Guid(guidStr);
+                        new Guid(guidStr); new Guid(guidStr); new Guid(guidStr);
+                        new Guid(guidStr); new Guid(guidStr); new Guid(guidStr);
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Int32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Int32.cs
@@ -14,11 +14,12 @@ namespace System.Runtime.Tests
             Int32 i32 = 32;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    i32.ToString(); i32.ToString(); i32.ToString();
-                    i32.ToString(); i32.ToString(); i32.ToString();
-                    i32.ToString(); i32.ToString(); i32.ToString();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        i32.ToString(); i32.ToString(); i32.ToString();
+                        i32.ToString(); i32.ToString(); i32.ToString();
+                        i32.ToString(); i32.ToString(); i32.ToString();
+                    }
         }
 
         [Benchmark]
@@ -27,11 +28,12 @@ namespace System.Runtime.Tests
             string builtString = "1111111";
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
-                    Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
-                    Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
+                        Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
+                        Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.IntPtr.cs
+++ b/src/System.Runtime/tests/Performance/Perf.IntPtr.cs
@@ -12,11 +12,12 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new IntPtr(0); new IntPtr(0); new IntPtr(0);
-                    new IntPtr(0); new IntPtr(0); new IntPtr(0);
-                    new IntPtr(0); new IntPtr(0); new IntPtr(0);
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        new IntPtr(0); new IntPtr(0); new IntPtr(0);
+                        new IntPtr(0); new IntPtr(0); new IntPtr(0);
+                        new IntPtr(0); new IntPtr(0); new IntPtr(0);
+                    }
         }
 
         [Benchmark]
@@ -27,11 +28,12 @@ namespace System.Runtime.Tests
             IntPtr ptr2 = new IntPtr(0);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    res = ptr1 == ptr2; res = ptr1 == ptr2; res = ptr1 == ptr2;
-                    res = ptr1 == ptr2; res = ptr1 == ptr2; res = ptr1 == ptr2;
-                    res = ptr1 == ptr2; res = ptr1 == ptr2; res = ptr1 == ptr2;
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        res = ptr1 == ptr2; res = ptr1 == ptr2; res = ptr1 == ptr2;
+                        res = ptr1 == ptr2; res = ptr1 == ptr2; res = ptr1 == ptr2;
+                        res = ptr1 == ptr2; res = ptr1 == ptr2; res = ptr1 == ptr2;
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Object.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Object.cs
@@ -12,11 +12,12 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new Object(); new Object(); new Object();
-                    new Object(); new Object(); new Object();
-                    new Object(); new Object(); new Object();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        new Object(); new Object(); new Object();
+                        new Object(); new Object(); new Object();
+                        new Object(); new Object(); new Object();
+                    }
         }
 
         [Benchmark]
@@ -25,11 +26,12 @@ namespace System.Runtime.Tests
             Object obj = new Object();
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    obj.GetType(); obj.GetType(); obj.GetType();
-                    obj.GetType(); obj.GetType(); obj.GetType();
-                    obj.GetType(); obj.GetType(); obj.GetType();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        obj.GetType(); obj.GetType(); obj.GetType();
+                        obj.GetType(); obj.GetType(); obj.GetType();
+                        obj.GetType(); obj.GetType(); obj.GetType();
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.String.cs
+++ b/src/System.Runtime/tests/Performance/Perf.String.cs
@@ -21,68 +21,80 @@ namespace System.Runtime.Tests
         [MemberData("TestStringSizes")]
         public void GetChars(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.ToCharArray();
+                    for (int i = 0; i < 10000; i++)
+                        testString.ToCharArray();
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Concat_str_str(int size)
         {
-            string testString1 = PerfUtils.CreateString(size);
-            string testString2 = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString1 = utils.CreateString(size);
+            string testString2 = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    string.Concat(testString1, testString2);
+                    for (int i = 0; i < 10000; i++)
+                        string.Concat(testString1, testString2);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Concat_str_str_str(int size)
         {
-            string testString1 = PerfUtils.CreateString(size);
-            string testString2 = PerfUtils.CreateString(size);
-            string testString3 = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString1 = utils.CreateString(size);
+            string testString2 = utils.CreateString(size);
+            string testString3 = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    string.Concat(testString1, testString2, testString3);
+                    for (int i = 0; i < 10000; i++)
+                        string.Concat(testString1, testString2, testString3);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Concat_str_str_str_str(int size)
         {
-            string testString1 = PerfUtils.CreateString(size);
-            string testString2 = PerfUtils.CreateString(size);
-            string testString3 = PerfUtils.CreateString(size);
-            string testString4 = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString1 = utils.CreateString(size);
+            string testString2 = utils.CreateString(size);
+            string testString3 = utils.CreateString(size);
+            string testString4 = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    string.Concat(testString1, testString2, testString3, testString4);
+                    for (int i = 0; i < 10000; i++)
+                        string.Concat(testString1, testString2, testString3, testString4);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Contains(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             string subString = testString.Substring(testString.Length / 2, testString.Length / 4);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Contains(subString);
+                    for (int i = 0; i < 10000; i++)
+                        testString.Contains(subString);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Equals(int size)
         {
-            string testString1 = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString1 = utils.CreateString(size);
             string testString2 = new string(testString1.ToCharArray());
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString1.Equals(testString2);
+                    for (int i = 0; i < 10000; i++)
+                        testString1.Equals(testString2);
         }
 
         [Benchmark]
@@ -93,13 +105,14 @@ namespace System.Runtime.Tests
         [InlineData(100)]
         public void Format(int numberOfObjects)
         {
+            PerfUtils utils = new PerfUtils();
             // Setup the format string and the list of objects to format
             StringBuilder formatter = new StringBuilder();
             List<string> objects = new List<string>();
             for (int i = 0; i < numberOfObjects; i++)
             {
                 formatter.Append("%s, ");
-                objects.Add(PerfUtils.CreateString(10));
+                objects.Add(utils.CreateString(10));
             }
             string format = formatter.ToString();
             string[] objectArr = objects.ToArray();
@@ -107,134 +120,157 @@ namespace System.Runtime.Tests
             // Perform the actual formatting
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    string.Format(format, objectArr);
+                    for (int i = 0; i < 5000; i++)
+                        string.Format(format, objectArr);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void GetLength(int size)
         {
+            PerfUtils utils = new PerfUtils();
             int result;
-            string testString = PerfUtils.CreateString(size);
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    result = testString.Length; result = testString.Length; result = testString.Length;
-                    result = testString.Length; result = testString.Length; result = testString.Length;
-                    result = testString.Length; result = testString.Length; result = testString.Length;
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        result = testString.Length; result = testString.Length; result = testString.Length;
+                        result = testString.Length; result = testString.Length; result = testString.Length;
+                        result = testString.Length; result = testString.Length; result = testString.Length;
+                    }
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void op_Equality(int size)
         {
+            PerfUtils utils = new PerfUtils();
             bool result;
-            string testString1 = PerfUtils.CreateString(size);
-            string testString2 = PerfUtils.CreateString(size);
+            string testString1 = utils.CreateString(size);
+            string testString2 = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    result = testString1 == testString2; result = testString1 == testString2;
-                    result = testString1 == testString2; result = testString1 == testString2;
-                    result = testString1 == testString2; result = testString1 == testString2;
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        result = testString1 == testString2; result = testString1 == testString2;
+                        result = testString1 == testString2; result = testString1 == testString2;
+                        result = testString1 == testString2; result = testString1 == testString2;
+                    }
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Replace(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             string existingValue = testString.Substring(testString.Length / 2, 1);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Replace(existingValue, "1");
+                    for (int i = 0; i < 10000; i++)
+                        testString.Replace(existingValue, "1");
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Split(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             string existingValue = testString.Substring(testString.Length / 2, 1);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Split(existingValue);
+                    for (int i = 0; i < 10000; i++)
+                        testString.Split(existingValue);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void StartsWith(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             string subString = testString.Substring(0, testString.Length / 4);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.StartsWith(subString);
+                    for (int i = 0; i < 10000; i++)
+                        testString.StartsWith(subString);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Substring_int(int size)
         {
+            PerfUtils utils = new PerfUtils();
             int startIndex = size / 2;
-            string testString = PerfUtils.CreateString(size);
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Substring(startIndex);
+                    for (int i = 0; i < 10000; i++)
+                        testString.Substring(startIndex);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Substring_int_int(int size)
         {
+            PerfUtils utils = new PerfUtils();
             int startIndex = size / 2;
             int length = size / 4;
-            string testString = PerfUtils.CreateString(size);
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Substring(startIndex, length);
+                    for (int i = 0; i < 10000; i++)
+                        testString.Substring(startIndex, length);
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void ToLower(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.ToLower();
+                    for (int i = 0; i < 10000; i++)
+                        testString.ToLower();
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void ToUpper(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.ToUpper();
+                    for (int i = 0; i < 10000; i++)
+                        testString.ToUpper();
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Trim_WithWhitespace(int size)
         {
-            string testString = "   " + PerfUtils.CreateString(size) + "   ";
+            PerfUtils utils = new PerfUtils();
+            string testString = "   " + utils.CreateString(size) + "   ";
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Trim();
+                    for (int i = 0; i < 10000; i++)
+                        testString.Trim();
         }
 
         [Benchmark]
         [MemberData("TestStringSizes")]
         public void Trim_NothingToDo(int size)
         {
-            string testString = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string testString = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                    testString.Trim();
+                    for (int i = 0; i < 10000; i++)
+                        testString.Trim();
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
+++ b/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
@@ -15,11 +15,12 @@ namespace System.Runtime.Tests
             StringBuilder builder;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    builder = new StringBuilder(); builder = new StringBuilder(); builder = new StringBuilder();
-                    builder = new StringBuilder(); builder = new StringBuilder(); builder = new StringBuilder();
-                    builder = new StringBuilder(); builder = new StringBuilder(); builder = new StringBuilder();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        builder = new StringBuilder(); builder = new StringBuilder(); builder = new StringBuilder();
+                        builder = new StringBuilder(); builder = new StringBuilder(); builder = new StringBuilder();
+                        builder = new StringBuilder(); builder = new StringBuilder(); builder = new StringBuilder();
+                    }
         }
 
         [Benchmark]
@@ -27,15 +28,17 @@ namespace System.Runtime.Tests
         [InlineData(200)]
         public void Append(int length)
         {
+            PerfUtils utils = new PerfUtils();
             foreach (var iteration in Benchmark.Iterations)
             {
                 // Setup - Create a string of the specified length
-                string builtString = PerfUtils.CreateString(length);
+                string builtString = utils.CreateString(length);
                 StringBuilder empty = new StringBuilder();
 
                 // Actual perf testing
                 using (iteration.StartMeasurement())
-                    empty.Append(builtString); // Appends a string of length "length" to an empty StringBuilder object
+                    for (int i = 0; i < 10000; i++)
+                        empty.Append(builtString); // Appends a string of length "length" to an increasingly large StringBuilder
             }
         }
     }

--- a/src/System.Runtime/tests/Performance/Perf.TimeSpan.cs
+++ b/src/System.Runtime/tests/Performance/Perf.TimeSpan.cs
@@ -12,11 +12,12 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10);
-                    new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10);
-                    new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10);
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10);
+                        new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10);
+                        new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10); new TimeSpan(7, 8, 10);
+                    }
         }
 
         [Benchmark]
@@ -24,11 +25,12 @@ namespace System.Runtime.Tests
         {
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50);
-                    TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50);
-                    TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50);
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50);
+                        TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50);
+                        TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50); TimeSpan.FromSeconds(50);
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Type.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Type.cs
@@ -13,11 +13,12 @@ namespace System.Runtime.Tests
             RuntimeTypeHandle type1 = typeof(int).TypeHandle;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1);
-                    Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1);
-                    Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1);
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1);
+                        Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1);
+                        Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1); Type.GetTypeFromHandle(type1);
+                    }
         }
 
         [Benchmark]
@@ -28,11 +29,12 @@ namespace System.Runtime.Tests
             Type type2 = typeof(string);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    result = type1 == type2; result = type1 == type2; result = type1 == type2;
-                    result = type1 == type2; result = type1 == type2; result = type1 == type2;
-                    result = type1 == type2; result = type1 == type2; result = type1 == type2;
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        result = type1 == type2; result = type1 == type2; result = type1 == type2;
+                        result = type1 == type2; result = type1 == type2; result = type1 == type2;
+                        result = type1 == type2; result = type1 == type2; result = type1 == type2;
+                    }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.UInt32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.UInt32.cs
@@ -10,14 +10,15 @@ namespace System.Runtime.Tests
         [Benchmark]
         public void ToString_()
         {
-            UInt32 i = new UInt32();
+            UInt32 testint = new UInt32();
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
-                {
-                    i.ToString(); i.ToString(); i.ToString();
-                    i.ToString(); i.ToString(); i.ToString();
-                    i.ToString(); i.ToString(); i.ToString();
-                }
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        testint.ToString(); testint.ToString(); testint.ToString();
+                        testint.ToString(); testint.ToString(); testint.ToString();
+                        testint.ToString(); testint.ToString(); testint.ToString();
+                    }
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Performance/Perf.Encoding.cs
+++ b/src/System.Text.Encoding/tests/Performance/Perf.Encoding.cs
@@ -5,26 +5,28 @@ using System.Text;
 using Xunit;
 using Microsoft.Xunit.Performance;
 
-namespace System.Runtime.Tests
+namespace System.Text.EncodingTests
 {
     public class Perf_Encoding
     {
         [Benchmark]
+        [InlineData(1000)]
         [InlineData(10000)]
+        [InlineData(100000)]
         [InlineData(1000000)]
         public void GetBytes_str(int size)
         {
             Encoding enc = Encoding.UTF8;
-            string toEncode = PerfUtils.CreateString(size);
+            PerfUtils utils = new PerfUtils();
+            string toEncode = utils.CreateString(size);
             foreach (var iteration in Benchmark.Iterations)
-            {
                 using (iteration.StartMeasurement())
-                {
-                    enc.GetBytes(toEncode); enc.GetBytes(toEncode); enc.GetBytes(toEncode);
-                    enc.GetBytes(toEncode); enc.GetBytes(toEncode); enc.GetBytes(toEncode);
-                    enc.GetBytes(toEncode); enc.GetBytes(toEncode); enc.GetBytes(toEncode);
-                }
-            }
+                    for (int i = 0; i < 100; i++)
+                    {
+                        enc.GetBytes(toEncode); enc.GetBytes(toEncode); enc.GetBytes(toEncode);
+                        enc.GetBytes(toEncode); enc.GetBytes(toEncode); enc.GetBytes(toEncode);
+                        enc.GetBytes(toEncode); enc.GetBytes(toEncode); enc.GetBytes(toEncode);
+                    }
         }
     }
 }


### PR DESCRIPTION
Made some changes to the perf tests so that the data was more easily comparable and made some minor cleanliness updates while I was at it.

- PerfUtils is no longer static and is instantiated on a test-by-test basis
- Greatly increased the size of the testable area for a number of the tests
- Tweaked the collection and innerIteration sizes for a number of tests
- Fixed some namespace bugs


Still to do:
- Add perf tests that exist to "lock in" optimizations we have in place. For example, Trim is optimized to return the same string instance if nothing needs to be trimmed.
- Add Dictionary test that has a fixed-time GetHashCode/Equals type so that we can test 
- Make System.IO.Compression tests inherit from FileCleanupTestBase

@stephentoub 
