### PR TITLE
Updating SSLConnectionInfo with correct protocol version and Cipher algorithms

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -184,15 +184,17 @@ internal static partial class Interop
             return libssl.SSL_get_peer_cert_chain(context);
         }
 
-        internal static libssl.SSL_CIPHER GetConnectionInfo(SafeSslHandle context)
+        internal static libssl.SSL_CIPHER GetConnectionInfo(SafeSslHandle sslHandle, out string protocolVersion)
         {
-            IntPtr cipherPtr = libssl.SSL_get_current_cipher(context);
+            IntPtr cipherPtr = libssl.SSL_get_current_cipher(sslHandle);
             var cipher = new libssl.SSL_CIPHER();
             if (IntPtr.Zero != cipherPtr)
             {
                 cipher = Marshal.PtrToStructure<libssl.SSL_CIPHER>(cipherPtr);
             }
 
+            IntPtr versionPtr = libssl.SSL_get_version(sslHandle);
+            protocolVersion = Marshal.PtrToStringAnsi(versionPtr);
             return cipher;
         }
 

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
         internal static extern IntPtr TLSv1_1_method();
 
         [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr TLSv1_2_method();     
+        internal static extern IntPtr TLSv1_2_method();
 
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern IntPtr SSL_CTX_new(IntPtr meth);
@@ -122,5 +122,8 @@ internal static partial class Interop
 
             return handle;
         }
+
+        [DllImport(Interop.Libraries.LibSsl)]
+        internal static extern IntPtr SSL_get_version(SafeSslHandle ssl);
     }
 }

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
@@ -101,5 +101,57 @@ internal static partial class Interop
         {
             SSL_ST_OK = 3
         }
+
+        internal enum CipherAlgorithm
+        {
+            SSL_DES = 1,
+            SSL_3DES = 2,
+            SSL_RC4 = 4,
+            SSL_RC2 = 8,
+            SSL_IDEA = 16,
+            SSL_eNULL = 32,
+            SSL_AES128 = 64,
+            SSL_AES256 = 128,
+            SSL_CAMELLIA128 = 256,
+            SSL_CAMELLIA256 = 512,
+            SSL_eGOST2814789CNT = 1024,
+            SSL_SEED = 2048,
+            SSL_AES128GCM = 4096,
+            SSL_AES256GCM = 8192
+          
+        }
+
+        internal enum KeyExchangeAlgorithm
+        {
+            SSL_kRSA = 1,
+            /* DH cert, RSA CA cert */
+            SSL_kDHr = 2,
+            /* DH cert, DSA CA cert */
+            SSL_kDHd = 4,
+            /* tmp DH key no DH cert */
+            SSL_kEDH = 8,
+            /* Kerberos5 key exchange */
+            SSL_kKRB5 = 16,
+            /* ECDH cert, RSA CA cert */
+            SSL_kECDHr = 32,
+            /* ECDH cert, ECDSA CA cert */
+            SSL_kECDHe = 64,
+            SSL_kEECDH = 128,
+            SSL_kPSK = 256,
+            SSL_kGOST = 512,
+            SSL_kSRP = 1024,
+        }
+
+        internal enum DataHashAlgorithm
+        {
+            SSL_MD5 = 1,
+            SSL_SHA1 = 2,
+            SSL_GOST94 = 4,
+            SSL_GOST89MAC = 8,
+            SSL_SHA256 = 16,
+            SSL_SHA384 = 32,
+            SSL_AEAD = 64
+        }
+
     }
 }

--- a/src/Common/src/Interop/Unix/libssl/SslConnectionInfo.cs
+++ b/src/Common/src/Interop/Unix/libssl/SslConnectionInfo.cs
@@ -7,6 +7,30 @@ namespace System.Net
 {
     internal class SslConnectionInfo
     {
+        //Windows constants for algorithms without matching enums in SslStream
+        //Taken from wincrypt.h 
+        internal const int SSL_SHA256 = 32780;
+        internal const int SSL_SHA384 = 32781;
+        internal const int SSL_ECDH = 43525;
+        internal const int SSL_ECDSA = 41475;
+
+        //Algorithm constants which are not present in wincrypt.h(not supported in Windows)
+        //These constants values are not conflicting with existing constants in wincrypt.h
+        internal const int SSL_IDEA = 229380;
+        internal const int SSL_CAMELLIA128 = 229381;
+        internal const int SSL_CAMELLIA256 = 229382;
+        internal const int SSL_eGOST2814789CNT = 229383;
+        internal const int SSL_SEED = 229384;
+
+        internal const int SSL_kPSK = 229390;
+        internal const int SSL_kGOST = 229391;
+        internal const int SSL_kSRP = 229392;
+        internal const int SSL_kKRB5 = 229393;
+
+        internal const int SSL_GOST94 = 229410;
+        internal const int SSL_GOST89 = 229411;
+        internal const int SSL_AEAD = 229412;
+
         public readonly int Protocol;
         public readonly int DataCipherAlg;
         public readonly int DataKeySize = 0;
@@ -15,85 +39,154 @@ namespace System.Net
         public readonly int KeyExchangeAlg;
         public readonly int KeyExchKeySize = 0;
 
-        internal SslConnectionInfo(Interop.libssl.SSL_CIPHER cipher)
+        internal SslConnectionInfo(Interop.libssl.SSL_CIPHER cipher, string protocol)
         {
-            Protocol = (int) MapProtocol(cipher.algorithm_ssl);
-            DataCipherAlg = (int) MapCipherAlgorithmType(cipher.algorithm_enc);
-            KeyExchangeAlg = (int) MapExchangeAlgorithmType(cipher.algorithm_mkey);
-            DataHashAlg = (int) MapHashAlgorithmType(cipher.algorithm_mac);
+            Protocol = (int) MapProtocolVersion(protocol);
+            DataCipherAlg = (int) MapCipherAlgorithmType((Interop.libssl.CipherAlgorithm) cipher.algorithm_enc);
+            KeyExchangeAlg = (int) MapExchangeAlgorithmType((Interop.libssl.KeyExchangeAlgorithm) cipher.algorithm_mkey);
+            DataHashAlg = (int) MapHashAlgorithmType((Interop.libssl.DataHashAlgorithm) cipher.algorithm_mac);
+            DataKeySize = cipher.alg_bits;
             // TODO (Issue #3362) map key sizes
         }
 
-        private static SslProtocols MapProtocol(long algorithm)
+        private SslProtocols MapProtocolVersion(string protocolVersion)
         {
-            switch (algorithm)
+            switch (protocolVersion)
             {
-                case 1:
+                case "SSLv2":
                     return SslProtocols.Ssl2;
-                case 2:
+                case "SSLv3":
                     return SslProtocols.Ssl3;
-                case 3:
+                case "TLSv1":
+                    return SslProtocols.Tls;
+                case "TLSv1.1":
                     return SslProtocols.Tls11;
-                case 4:
+                case "TLSv1.2":
                     return SslProtocols.Tls12;
                 default:
-                    // TODO (Issue #3362) Figure out correct value for this
-                    return SslProtocols.Tls;
+                    return SslProtocols.None;
             }
         }
 
-        private static CipherAlgorithmType MapCipherAlgorithmType(long encryption)
+        private static CipherAlgorithmType MapCipherAlgorithmType(Interop.libssl.CipherAlgorithm encryption)
         {
             switch (encryption)
             {
-                case 1:
+                case Interop.libssl.CipherAlgorithm.SSL_DES:
                     return CipherAlgorithmType.Des;
-                case 2:
+
+                case Interop.libssl.CipherAlgorithm.SSL_3DES:
                     return CipherAlgorithmType.TripleDes;
-                case 4:
+
+                case Interop.libssl.CipherAlgorithm.SSL_RC4:
                     return CipherAlgorithmType.Rc4;
-                case 8:
+
+                case Interop.libssl.CipherAlgorithm.SSL_RC2:
                     return CipherAlgorithmType.Rc2;
-                case 16:
-                    return CipherAlgorithmType.None;
-                case 32:
+
+                case Interop.libssl.CipherAlgorithm.SSL_eNULL:
                     return CipherAlgorithmType.Null;
-                case 64:
+
+                case Interop.libssl.CipherAlgorithm.SSL_AES128:
                     return CipherAlgorithmType.Aes128;
-                case 128:
+
+                case Interop.libssl.CipherAlgorithm.SSL_AES256:
                     return CipherAlgorithmType.Aes256;
+
+                case Interop.libssl.CipherAlgorithm.SSL_IDEA:
+                    return (CipherAlgorithmType) SSL_IDEA;
+
+                case Interop.libssl.CipherAlgorithm.SSL_CAMELLIA128:
+                    return (CipherAlgorithmType) SSL_CAMELLIA128;
+
+                case Interop.libssl.CipherAlgorithm.SSL_CAMELLIA256:
+                    return (CipherAlgorithmType) SSL_CAMELLIA256;
+
+                case Interop.libssl.CipherAlgorithm.SSL_eGOST2814789CNT:
+                    return (CipherAlgorithmType) SSL_eGOST2814789CNT;
+
+                case Interop.libssl.CipherAlgorithm.SSL_SEED:
+                    return (CipherAlgorithmType) SSL_SEED;
+
+                case Interop.libssl.CipherAlgorithm.SSL_AES128GCM:
+                    return CipherAlgorithmType.Aes128;
+
+                case Interop.libssl.CipherAlgorithm.SSL_AES256GCM:
+                    return CipherAlgorithmType.Aes256;
+
                 default:
-                    // TODO (Issue #3362) Handle other values
                     return CipherAlgorithmType.None;
             }
         }
 
-        private static ExchangeAlgorithmType MapExchangeAlgorithmType(long mac)
+        private static ExchangeAlgorithmType MapExchangeAlgorithmType(Interop.libssl.KeyExchangeAlgorithm mkey)
         {
-            switch (mac)
+            switch (mkey)
             {
-                case 1:
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kRSA:
                     return ExchangeAlgorithmType.RsaKeyX;
-                case 2 | 32:
-                    return ExchangeAlgorithmType.RsaSign;
-                case 128:
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kDHr:
                     return ExchangeAlgorithmType.DiffieHellman;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kDHd:
+                    return ExchangeAlgorithmType.DiffieHellman;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kEDH:
+                    return ExchangeAlgorithmType.DiffieHellman;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kKRB5:
+                    return (ExchangeAlgorithmType) SSL_kKRB5;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kECDHr:
+                    return (ExchangeAlgorithmType) SSL_ECDH;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kECDHe:
+                    return (ExchangeAlgorithmType) SSL_ECDSA;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kEECDH:
+                    return (ExchangeAlgorithmType) SSL_ECDSA;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kPSK:
+                    return (ExchangeAlgorithmType) SSL_kPSK;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kGOST:
+                    return (ExchangeAlgorithmType) SSL_kGOST;
+
+                case Interop.libssl.KeyExchangeAlgorithm.SSL_kSRP:
+                    return (ExchangeAlgorithmType) SSL_kSRP;
+
                 default:
-                    // TODO (Issue #3362) Handle other values
                     return ExchangeAlgorithmType.None;
             }
         }
 
-        private static HashAlgorithmType MapHashAlgorithmType(long mac)
+        private static HashAlgorithmType MapHashAlgorithmType(Interop.libssl.DataHashAlgorithm mac)
         {
             switch (mac)
             {
-                case 1:
+                case Interop.libssl.DataHashAlgorithm.SSL_MD5:
                     return HashAlgorithmType.Md5;
-                case 2:
+
+                case Interop.libssl.DataHashAlgorithm.SSL_SHA1:
                     return HashAlgorithmType.Sha1;
+
+                case Interop.libssl.DataHashAlgorithm.SSL_GOST94:
+                    return (HashAlgorithmType) SSL_GOST94;
+
+                case Interop.libssl.DataHashAlgorithm.SSL_GOST89MAC:
+                    return (HashAlgorithmType) SSL_GOST89;
+
+                case Interop.libssl.DataHashAlgorithm.SSL_SHA256:
+                    return (HashAlgorithmType) SSL_SHA256;
+
+                case Interop.libssl.DataHashAlgorithm.SSL_SHA384:
+                    return (HashAlgorithmType) SSL_SHA384;
+
+                case Interop.libssl.DataHashAlgorithm.SSL_AEAD:
+                    return (HashAlgorithmType) SSL_AEAD;
+
                 default:
-                    // TODO (Issue #3362) Handle other values
                     return HashAlgorithmType.None;
             }
         }

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -76,11 +76,21 @@ namespace System.Net
             streamSizes = new StreamSizes(Interop.libssl.SslSizes.HEADER_SIZE, Interop.libssl.SslSizes.TRAILER_SIZE, Interop.libssl.SslSizes.SSL3_RT_MAX_PLAIN_LENGTH);
         }
 
-        public static void QueryContextConnectionInfo(SafeDeleteContext securityContext, out SslConnectionInfo connectionInfo)
+        public static int QueryContextConnectionInfo(SafeDeleteContext securityContext, out SslConnectionInfo connectionInfo)
         {
+            string protocolVersion;
             connectionInfo = null;
-            Interop.libssl.SSL_CIPHER cipher = Interop.OpenSsl.GetConnectionInfo(securityContext.SslContext);
-            connectionInfo =  new SslConnectionInfo(cipher);
+            try
+            {
+                Interop.libssl.SSL_CIPHER cipher = Interop.OpenSsl.GetConnectionInfo(securityContext.SslContext, out protocolVersion);
+                connectionInfo =  new SslConnectionInfo(cipher, protocolVersion);
+               
+                return 0;
+            }
+            catch
+            {
+                return -1;
+            }
         }
 
         private static long GetOptions(SslProtocols protocols)


### PR DESCRIPTION
It includes 
a. mapping the Cipher / KeyExchange / DataHash algorithms mapping logic to the corresponding enums , In case for a few algorithms if enum is not already defined, it will return the numeric value representing that type in Openssl. (this behavior is similar to the Windows in which for unsupported enums we get the numeric value as it is).
 b. Protocol Mapping 