### PR TITLE
Remove some redundancies from System.Linq.Queryable

### DIFF
--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
@@ -22,7 +22,6 @@ namespace System.Linq
     public class EnumerableExecutor<T> : EnumerableExecutor
     {
         private Expression _expression;
-        private Func<T> _func;
 
         // Must remain public for Silverlight
         public EnumerableExecutor(Expression expression)
@@ -37,14 +36,11 @@ namespace System.Linq
 
         internal T Execute()
         {
-            if (_func == null)
-            {
-                EnumerableRewriter rewriter = new EnumerableRewriter();
-                Expression body = rewriter.Visit(_expression);
-                Expression<Func<T>> f = Expression.Lambda<Func<T>>(body, (IEnumerable<ParameterExpression>)null);
-                _func = f.Compile();
-            }
-            return _func();
+            EnumerableRewriter rewriter = new EnumerableRewriter();
+            Expression body = rewriter.Visit(_expression);
+            Expression<Func<T>> f = Expression.Lambda<Func<T>>(body, (IEnumerable<ParameterExpression>)null);
+            Func<T> func = f.Compile();
+            return func();
         }
     }
 }

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -23,25 +23,26 @@ namespace System.Linq
             // check for args changed
             if (obj != m.Object || args != m.Arguments)
             {
-                Type[] typeArgs = (m.Method.IsGenericMethod) ? m.Method.GetGenericArguments() : null;
+                MethodInfo mInfo = m.Method;
+                Type[] typeArgs = (mInfo.IsGenericMethod) ? mInfo.GetGenericArguments() : null;
 
-                if ((m.Method.IsStatic || m.Method.DeclaringType.IsAssignableFrom(obj.Type))
-                    && ArgsMatch(m.Method, args, typeArgs))
+                if ((mInfo.IsStatic || mInfo.DeclaringType.IsAssignableFrom(obj.Type))
+                    && ArgsMatch(mInfo, args, typeArgs))
                 {
                     // current method is still valid
-                    return Expression.Call(obj, m.Method, args);
+                    return Expression.Call(obj, mInfo, args);
                 }
-                else if (m.Method.DeclaringType == typeof(Queryable))
+                else if (mInfo.DeclaringType == typeof(Queryable))
                 {
                     // convert Queryable method to Enumerable method
-                    MethodInfo seqMethod = FindEnumerableMethod(m.Method.Name, args, typeArgs);
+                    MethodInfo seqMethod = FindEnumerableMethod(mInfo.Name, args, typeArgs);
                     args = this.FixupQuotedArgs(seqMethod, args);
                     return Expression.Call(obj, seqMethod, args);
                 }
                 else
                 {
                     // rebind to new method
-                    MethodInfo method = FindMethod(m.Method.DeclaringType, m.Method.Name, args, typeArgs);
+                    MethodInfo method = FindMethod(mInfo.DeclaringType, mInfo.Name, args, typeArgs);
                     args = this.FixupQuotedArgs(method, args);
                     return Expression.Call(obj, method, args);
                 }
@@ -120,13 +121,15 @@ namespace System.Linq
             // we cannot use the expression tree in a context which has only execution
             // permissions.  We should endeavour to translate constants into 
             // new constants which have public types.
-            if (t.GetTypeInfo().IsGenericType && t.GetTypeInfo().GetGenericTypeDefinition().GetTypeInfo().ImplementedInterfaces.Contains(typeof(IGrouping<,>)))
+            TypeInfo typeInfo = t.GetTypeInfo();
+            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().ImplementedInterfaces.Contains(typeof(IGrouping<,>)))
                 return typeof(IGrouping<,>).MakeGenericType(t.GetGenericArguments());
-            if (!t.GetTypeInfo().IsNestedPrivate)
+            if (!typeInfo.IsNestedPrivate)
                 return t;
             foreach (Type iType in t.GetTypeInfo().ImplementedInterfaces)
             {
-                if (iType.GetTypeInfo().IsGenericType && iType.GetTypeInfo().GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                TypeInfo iTypeInfo = iType.GetTypeInfo();
+                if (iTypeInfo.IsGenericType && iTypeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>))
                     return iType;
             }
             if (typeof(IEnumerable).IsAssignableFrom(t))
@@ -171,15 +174,18 @@ namespace System.Linq
 
         internal static MethodInfo FindMethod(Type type, string name, ReadOnlyCollection<Expression> args, Type[] typeArgs)
         {
-            MethodInfo[] methods = type.GetStaticMethods().Where(m => m.Name == name).ToArray();
-            if (methods.Length == 0)
-                throw Error.NoMethodOnType(name, type);
-            MethodInfo mi = methods.FirstOrDefault(m => ArgsMatch(m, args, typeArgs));
-            if (mi == null)
-                throw Error.NoMethodOnTypeMatchingArguments(name, type);
-            if (typeArgs != null)
-                return mi.MakeGenericMethod(typeArgs);
-            return mi;
+            using (IEnumerator<MethodInfo> en = type.GetStaticMethods().Where(m => m.Name == name).GetEnumerator())
+            {
+                if (!en.MoveNext())
+                    throw Error.NoMethodOnType(name, type);
+                do
+                {
+                    MethodInfo mi = en.Current;
+                    if (ArgsMatch(mi, args, typeArgs))
+                        return (typeArgs != null) ? mi.MakeGenericMethod(typeArgs) : mi;
+                } while (en.MoveNext());
+            }
+            throw Error.NoMethodOnTypeMatchingArguments(name, type);
         }
 
         private static bool ArgsMatch(MethodInfo m, ReadOnlyCollection<Expression> args, Type[] typeArgs)

--- a/src/System.Linq.Queryable/src/System/Linq/TypeHelper.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/TypeHelper.cs
@@ -13,13 +13,17 @@ namespace System.Linq
     {
         internal static Type FindGenericType(Type definition, Type type)
         {
+            bool? definitionIsInterface = null;
             while (type != null && type != typeof(object))
             {
-                if (type.GetTypeInfo().IsGenericType && type.GetTypeInfo().GetGenericTypeDefinition() == definition)
+                TypeInfo typeInfo = type.GetTypeInfo();
+                if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == definition)
                     return type;
-                if (definition.GetTypeInfo().IsInterface)
+                if (!definitionIsInterface.HasValue)
+                    definitionIsInterface = definition.GetTypeInfo().IsInterface;
+                if (definitionIsInterface.GetValueOrDefault())
                 {
-                    foreach (Type itype in type.GetTypeInfo().ImplementedInterfaces)
+                    foreach (Type itype in typeInfo.ImplementedInterfaces)
                     {
                         Type found = FindGenericType(definition, itype);
                         if (found != null)
@@ -45,17 +49,9 @@ namespace System.Linq
             return t.IsGenericTypeDefinition ? t.GenericTypeParameters : t.GenericTypeArguments;
         }
 
-        internal static MethodInfo[] GetStaticMethods(this Type type)
+        internal static IEnumerable<MethodInfo> GetStaticMethods(this Type type)
         {
-            var list = new List<MethodInfo>();
-            foreach (var method in type.GetRuntimeMethods())
-            {
-                if (method.IsStatic)
-                {
-                    list.Add(method);
-                }
-            }
-            return list.ToArray();
+            return type.GetRuntimeMethods().Where(m => m.IsStatic);
         }
     }
 }


### PR DESCRIPTION
Don't cache Func<T> produced in field in EnumerableExecutor<T> as it's never used twice.

Conversely store local values of some repeated method/property calls.

Don't create array for GetStaticMethods as no calling code benefits from it being an array.

Should probably be squashed into a single commit before merge, but may be easier to review separately.