### PR TITLE
Enabling fixed System.Text.Encoding tests.

### DIFF
--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -453,7 +453,6 @@ namespace Test
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestDefaultEncodings()
         {
             ValidateDefaultEncodings();

--- a/src/System.Text.Encoding.Extensions/tests/ASCII.cs
+++ b/src/System.Text.Encoding.Extensions/tests/ASCII.cs
@@ -103,7 +103,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequences()
         {
             s_encodingUtil_ASCII.GetCharsTest(new Byte[] { 0x7F }, 0, 1, -1, 0, "", 1);
@@ -126,7 +125,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_ASCII.GetMaxCharCountTest(0, 0);
@@ -137,7 +135,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_ASCII.GetMaxByteCountTest(0, 1);
@@ -148,14 +145,12 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_ASCII.GetPreambleTest(new Byte[] { });
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void DefaultFallback()
         {
             s_encodingUtil_ASCII.GetBytesTest("\u0080\u00FF\u0B71\uFFFF\uD800\uDFFF", 0, 6, -1, 0, new Byte[] { 0x3F, 0x3F, 0x3F, 0x3F, 0x3F, 0x3F }, 6);

--- a/src/System.Text.Encoding.Extensions/tests/ISO-8859-1.cs
+++ b/src/System.Text.Encoding.Extensions/tests/ISO-8859-1.cs
@@ -73,7 +73,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ValidCodes()
         {
             s_encodingUtil_Latin1.GetCharsTest(new Byte[] { 0x01, 0x09, 0x10, 0x3F, 0x5C, 0x9F, 0xCB, 0xE7, 0xFF }, 0, 9, -1, 0, "\u0001\u0009\u0010\u003F\u005C\u009F\u00CB\u00E7\u00FF", 9);
@@ -83,7 +82,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_Latin1.GetMaxCharCountTest(0, 0);
@@ -94,7 +92,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_Latin1.GetMaxByteCountTest(0, 1);
@@ -105,14 +102,12 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_Latin1.GetPreambleTest(new Byte[] { });
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void DefaultFallback()
         {
             s_encodingUtil_Latin1.GetBytesTest("\uD800\uDFFF", 0, 2, -1, 0, new Byte[] { 0x3F, 0x3F }, 2);

--- a/src/System.Text.Encoding.Extensions/tests/UTF16BE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/UTF16BE.cs
@@ -12,7 +12,6 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF16BE = new EncodingTestHelper("UTF-16BE");
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF16BE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -30,7 +29,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -88,7 +86,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0x00, 0x61, 0x00, 0x62, 0x00, 0x63 }, 0, 6, -2, 0, String.Empty, 0));
@@ -106,7 +103,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -124,7 +120,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -140,7 +135,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16BE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -156,14 +150,12 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void BasicValidInputs()
         {
             s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0x00, 0x61 }, 0, 2, -1, 0, "a", 1);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequences()
         {
             s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0x00, 0x61, 0x00 }, 0, 3, -1, 0, "\u0061\uFFFD", 2);
@@ -174,7 +166,6 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFFD
@@ -189,7 +180,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF16BE.GetCharsTest(new Byte[] { 0xD8, 0x00, 0xDC, 0x00 }, 0, 4, -1, 0, "\uD800\uDC00", 2);
@@ -232,7 +222,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF16BE.GetMaxCharCountTest(0, 1);
@@ -244,7 +233,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF16BE.GetMaxByteCountTest(0, 2);
@@ -258,7 +246,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF16BE.GetPreambleTest(new Byte[] { 0xFE, 0xFF });

--- a/src/System.Text.Encoding.Extensions/tests/UTF16LE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/UTF16LE.cs
@@ -12,7 +12,6 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF16LE = new EncodingTestHelper("UTF-16LE");
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF16LE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -30,7 +29,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -88,7 +86,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x62, 0x00, 0x63, 0x00 }, 0, 6, -2, 0, String.Empty, 0));
@@ -106,7 +103,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -124,7 +120,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -140,7 +135,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF16LE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -156,14 +150,12 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void BasicValidInputs()
         {
             s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x61, 0x00 }, 0, 2, -1, 0, "a", 1);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequences()
         {
             s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00 }, 0, 3, -1, 0, "\u0061\uFFFD", 2);
@@ -174,7 +166,6 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFF
@@ -189,7 +180,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF16LE.GetCharsTest(new Byte[] { 0x00, 0xD8, 0x00, 0xDC }, 0, 4, -1, 0, "\uD800\uDC00", 2);
@@ -222,7 +212,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF16LE.GetMaxCharCountTest(0, 1);
@@ -234,7 +223,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF16LE.GetMaxByteCountTest(0, 2);
@@ -248,7 +236,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF16LE.GetPreambleTest(new Byte[] { 0xFF, 0xFE });

--- a/src/System.Text.Encoding.Extensions/tests/UTF32BE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/UTF32BE.cs
@@ -12,7 +12,6 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF32BE = new EncodingTestHelper("UTF-32BE");
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF32BE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -30,7 +29,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -89,7 +87,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetCharsTest(new Byte[] { 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x62 }, 0, 8, -2, 0, String.Empty, 0));
@@ -107,7 +104,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -125,7 +121,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -141,7 +136,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32BE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -157,7 +151,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ValidCodePoints()
         {
             s_encodingUtil_UTF32BE.GetCharsTest(new Byte[] { 0x00, 0x00, 0x00, 0x61 }, 0, 4, -1, 0, "a", 1);
@@ -165,7 +158,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_InvalidSequence_OddNumberOfByte()
         {
             s_encodingUtil_UTF32BE.GetCharsTest(new Byte[] { 0x00, 0x61, 0x00 }, 0, 3, -1, 0, "\uFFFD", 1);
@@ -181,7 +173,6 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFFD
@@ -207,7 +198,6 @@ namespace EncodingTests
         /// DBFF + DFFF: 110110-1111-111111 110111-1111111111: U+000-10000-11111111-11111111
         /// </summary>
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF32BE.GetBytesTest("\uD800\uDC00", 0, 2, -1, 0, new Byte[] { 0x00, 0x01, 0x00, 0x00 }, 4);
@@ -258,7 +248,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetMaxCount()
         {
             s_encodingUtil_UTF32BE.GetMaxCharCountTest(0, 2);
@@ -280,7 +269,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetPreamble()
         {
             s_encodingUtil_UTF32BE.GetPreambleTest(false, false, new Byte[] { });

--- a/src/System.Text.Encoding.Extensions/tests/UTF32LE.cs
+++ b/src/System.Text.Encoding.Extensions/tests/UTF32LE.cs
@@ -12,7 +12,6 @@ namespace EncodingTests
         private static readonly EncodingTestHelper s_encodingUtil_UTF32LE = new EncodingTestHelper("UTF-32LE");
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetByteCount_InvalidArgumentAndBoundaryValues()
         {
             s_encodingUtil_UTF32LE.GetByteCountTest(String.Empty, 0, 0, 0);
@@ -30,7 +29,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetCharCount_InvalidArgumentAndBoundaryValues()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetCharCountTest((Byte[])null, 0, 0, 0));
@@ -89,7 +87,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00, 0x00, 0x62, 0x00, 0x00, 0x00 }, 0, 8, -2, 0, String.Empty, 0));
@@ -107,7 +104,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetBytesTest("abc", 0, 3, -2, 0, (Byte[])null, 0));
@@ -125,7 +121,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetChars_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetCharsTest((Byte[])null, 0, 0, 0, String.Empty, 0));
@@ -141,7 +136,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GetBytes_BufferBoundary_Pointer()
         {
             Assert.Throws<ArgumentNullException>(() => s_encodingUtil_UTF32LE.GetBytesTest((String)null, 0, 0, 0, new Byte[] { }, 0));
@@ -157,7 +151,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ValidCodePoints()
         {
             s_encodingUtil_UTF32LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00, 0x00 }, 0, 4, -1, 0, "a", 1);
@@ -165,7 +158,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void InvalidSequenceOddNumberOfBytes()
         {
             s_encodingUtil_UTF32LE.GetCharsTest(new Byte[] { 0x61, 0x00, 0x00 }, 0, 3, -1, 0, "\uFFFD", 1);
@@ -181,7 +173,6 @@ namespace EncodingTests
 
         // They don't represent abstract characters, but still need to be transmitted
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Specials()
         {
             // U+FFFF, U+FFFE, U+FFFD
@@ -207,7 +198,6 @@ namespace EncodingTests
         /// DBFF + DFFF: 110110-1111-111111 110111-1111111111: U+000-10000-11111111-1111111
         /// </summary>
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Surrogates()
         {
             s_encodingUtil_UTF32LE.GetBytesTest("\uD800\uDC00", 0, 2, -1, 0, new Byte[] { 0x00, 0x00, 0x01, 0x00 }, 4);
@@ -253,7 +243,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF32LE.GetMaxByteCountTest(0, 4);
@@ -264,7 +253,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF32LE.GetMaxCharCountTest(0, 2);
@@ -286,7 +274,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF32LE.GetPreambleTest(false, false, new Byte[] { });

--- a/src/System.Text.Encoding.Extensions/tests/UTF7.cs
+++ b/src/System.Text.Encoding.Extensions/tests/UTF7.cs
@@ -150,7 +150,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void CorrectClassesOfInput()
         {
             s_encodingUtil_UTF7.GetCharsTest(new Byte[] { 0x41, 0x09, 0x0D, 0x0A, 0x20, 0x2F, 0x7A }, 0, 7, -1, 0, "A\t\r\n /z", 7);
@@ -247,7 +246,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxCharCount()
         {
             s_encodingUtil_UTF7.GetMaxCharCountTest(0, 1);
@@ -258,7 +256,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void MaxByteCount()
         {
             s_encodingUtil_UTF7.GetMaxByteCountTest(0, 2);
@@ -273,7 +270,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void Preamble()
         {
             s_encodingUtil_UTF7.GetPreambleTest(new Byte[] { });

--- a/src/System.Text.Encoding/tests/Encoding/Encoding.cs
+++ b/src/System.Text.Encoding/tests/Encoding/Encoding.cs
@@ -17,7 +17,6 @@ namespace System.Text.EncodingTests
         private static byte[] s_UTF8BEBom = new byte[] { 0xFE, 0xFF };
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestGetEncoding()
         {
             Encoding encoding = Encoding.GetEncoding("UTF-32LE");
@@ -130,7 +129,6 @@ namespace System.Text.EncodingTests
     };
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestEncodingNameAndCopdepageNumber()
         {
             foreach (var map in s_mapping)
@@ -167,7 +165,6 @@ namespace System.Text.EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestCodePageToWebNameMappings()
         {
             foreach (var mapping in s_codePageToWebNameMappings)

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetChars1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetChars1.cs
@@ -215,35 +215,30 @@ namespace System.Text.EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest35()
         {
             PositiveTestString(Encoding.GetEncoding("UTF-16BE"), "TestTest\uFFFD", new byte[] { 0, 84, 0, 101, 0, 115, 0, 116, 0, 84, 0, 101, 0, 115, 0, 116, 216, 3 }, "00I4");
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest36()
         {
             PositiveTestString(Encoding.GetEncoding("UTF-16BE"), "\uFFFD\uFFFD", new byte[] { 216, 3, 48 }, "00J4");
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest37()
         {
             PositiveTestString(Encoding.GetEncoding("UTF-16BE"), "\uD803\uDD75\uD803\uDD75\uD803\uDD75", new byte[] { 216, 3, 221, 117, 216, 3, 221, 117, 216, 3, 221, 117 }, "00K4");
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest38()
         {
             PositiveTestString(Encoding.GetEncoding("UTF-16BE"), "\u0130", new byte[] { 1, 48 }, "00L4");
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest39()
         {
             PositiveTestString(Encoding.GetEncoding("UTF-16BE"), "\uD803\uDD75\uD803\uDD75", new byte[] { 216, 3, 221, 117, 216, 3, 221, 117 }, "0A24");

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetEncoding2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetEncoding2.cs
@@ -21,7 +21,6 @@ namespace System.Text.EncodingTests
 
         // PosTest2: Get Encoding with the defined name 4
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest2()
         {
             string name = "Unicode";
@@ -33,7 +32,6 @@ namespace System.Text.EncodingTests
         #region NegativeTest
         // NegTest1: the name is not valid codepage name
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void NegTest1()
         {
             string name = null;
@@ -45,7 +43,6 @@ namespace System.Text.EncodingTests
 
         // NegTest2: The platform do not support the named codepage
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void NegTest2()
         {
             string name = "helloworld";

--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void GetScalarValueFromUtf16()
         {
-            // TODO: [ActiveIssue(846, PlatformID.AnyUnix)]
+            // TODO: [ActiveIssue(3537, PlatformID.AnyUnix)]
             // This loop should instead be implemented as a [Theory] with multiple [InlineData]s.
             // However, until globalization support is implemented on Unix, this causes failures when
             // the xunit runner is configured with -xml to trace out results.  When it does so with 


### PR DESCRIPTION
I also logged a specific issue for a Encodings.Web test to use a Theory instead of a Fact, which is still causing an error after globalization has been implemented.

This PR can't be merged until https://github.com/dotnet/coreclr/pull/1645 is merged.

@ellismg 