### PR TITLE
Remove Assert(asynchronous failure) from Sockets tests.

### DIFF
--- a/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
+++ b/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
@@ -20,18 +20,5 @@ namespace System.Net.Sockets.Tests
             port = ((IPEndPoint)listener.LocalEndpoint).Port;
             return listener;
         }
-
-        public static void DoAsyncCall(
-            this Socket socket,
-            Func<Socket, SocketAsyncEventArgs, bool> call,
-            EventHandler<SocketAsyncEventArgs> callback,
-            SocketAsyncEventArgs args)
-        {
-            bool willRaiseEvent = call(socket, args);
-            if (!willRaiseEvent)
-            {
-                callback(null, args);
-            }
-        }
     }
 }

--- a/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
+++ b/src/Common/tests/System.Net/Sockets/SocketTestExtensions.cs
@@ -20,5 +20,18 @@ namespace System.Net.Sockets.Tests
             port = ((IPEndPoint)listener.LocalEndpoint).Port;
             return listener;
         }
+
+        public static void DoAsyncCall(
+            this Socket socket,
+            Func<Socket, SocketAsyncEventArgs, bool> call,
+            EventHandler<SocketAsyncEventArgs> callback,
+            SocketAsyncEventArgs args)
+        {
+            bool willRaiseEvent = call(socket, args);
+            if (!willRaiseEvent)
+            {
+                callback(null, args);
+            }
+        }
     }
 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
@@ -155,9 +155,12 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
-            complete.WaitOne();
+            bool willRaiseEvent = sock.ConnectAsync(args);
+            if (willRaiseEvent)
+            {
+                complete.WaitOne();
+            }
 
             Assert.Equal(SocketError.Success, args.SocketError);
             Assert.Null(args.ConnectByNameError);
@@ -178,9 +181,12 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
-            complete.WaitOne();
+            bool willRaiseEvent = sock.ConnectAsync(args);
+            if (willRaiseEvent)
+            {
+                complete.WaitOne();
+            }
 
             AssertHostNotFoundOrNoData(args);
 
@@ -199,9 +205,12 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
-            complete.WaitOne();
+            bool willRaiseEvent = sock.ConnectAsync(args);
+            if (willRaiseEvent)
+            {
+                complete.WaitOne();
+            }
 
             Assert.Equal(SocketError.ConnectionRefused, args.SocketError);
             Assert.True(args.ConnectByNameError is SocketException);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
@@ -155,7 +155,7 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            Assert.True(sock.ConnectAsync(args));
+            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
             complete.WaitOne();
 
@@ -178,7 +178,7 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            Assert.True(sock.ConnectAsync(args));
+            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
             complete.WaitOne();
 
@@ -199,7 +199,7 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            Assert.True(sock.ConnectAsync(args));
+            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
             complete.WaitOne();
 
@@ -270,7 +270,11 @@ namespace System.Net.Sockets.Tests
             ManualResetEvent complete = new ManualResetEvent(false);
             args.UserToken = complete;
 
-            Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
+            bool willRaiseEvent = Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args);
+            if (!willRaiseEvent)
+            {
+                OnConnectAsyncCompleted(null, args);
+            }
 
             complete.WaitOne();
 
@@ -291,7 +295,11 @@ namespace System.Net.Sockets.Tests
             ManualResetEvent complete = new ManualResetEvent(false);
             args.UserToken = complete;
 
-            Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
+            bool willRaiseEvent = Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args);
+            if (!willRaiseEvent)
+            {
+                OnConnectAsyncCompleted(null, args);
+            }
 
             complete.WaitOne();
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -74,7 +74,7 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            Assert.True(sock.ConnectAsync(args));
+            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
             complete.WaitOne();
 
@@ -98,7 +98,7 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            Assert.True(sock.ConnectAsync(args));
+            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
             complete.WaitOne();
 
@@ -172,7 +172,11 @@ namespace System.Net.Sockets.Tests
             ManualResetEvent complete = new ManualResetEvent(false);
             args.UserToken = complete;
 
-            Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
+            bool willRaiseEvent = Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args);
+            if (!willRaiseEvent)
+            {
+                OnConnectAsyncCompleted(null, args);
+            }
 
             complete.WaitOne();
 
@@ -193,7 +197,11 @@ namespace System.Net.Sockets.Tests
             ManualResetEvent complete = new ManualResetEvent(false);
             args.UserToken = complete;
 
-            Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
+            bool willRaiseEvent = Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args);
+            if (!willRaiseEvent)
+            {
+                OnConnectAsyncCompleted(null, args);
+            }
 
             complete.WaitOne();
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -74,9 +74,12 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
-            complete.WaitOne();
+            bool willRaiseEvent = sock.ConnectAsync(args);
+            if (willRaiseEvent)
+            {
+                complete.WaitOne();
+            }
 
             AssertHostNotFoundOrNoData(args);
 
@@ -98,9 +101,12 @@ namespace System.Net.Sockets.Tests
             args.UserToken = complete;
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.DoAsyncCall((s, a) => s.ConnectAsync(a), OnConnectAsyncCompleted, args);
 
-            complete.WaitOne();
+            bool willRaiseEvent = sock.ConnectAsync(args);
+            if (willRaiseEvent)
+            {
+                complete.WaitOne();
+            }
 
             Assert.Equal(SocketError.ConnectionRefused, args.SocketError);
             Assert.True(args.ConnectByNameError is SocketException);


### PR DESCRIPTION
In principle, any call that fails ansynchronously may also fail synchronously.