### PR TITLE
Add initial Dictionary<TKey, TValue> constructor tests

### DIFF
--- a/src/System.Collections/tests/Generic/Dictionary/DictionaryTests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/DictionaryTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Justin Van Patten. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class DictionaryTests
+    {
+        [Fact]
+        public void CopyConstructorExceptions()
+        {
+            Assert.Throws<ArgumentNullException>("dictionary", () => new Dictionary<int, int>((IDictionary<int, int>)null));
+            Assert.Throws<ArgumentNullException>("dictionary", () => new Dictionary<int, int>((IDictionary<int, int>)null, null));
+            Assert.Throws<ArgumentNullException>("dictionary", () => new Dictionary<int, int>((IDictionary<int, int>)null, EqualityComparer<int>.Default));
+
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Dictionary<int, int>(new NegativeCountDictionary<int, int>()));
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Dictionary<int, int>(new NegativeCountDictionary<int, int>(), null));
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Dictionary<int, int>(new NegativeCountDictionary<int, int>(), EqualityComparer<int>.Default));
+        }
+
+        [Theory]
+        [MemberData("CopyConstructorInt32Data")]
+        public void CopyConstructorInt32(int size, Func<int, int> keyValueSelector, Func<IDictionary<int, int>, IDictionary<int, int>> dictionarySelector)
+        {
+            TestCopyConstructor(size, keyValueSelector, dictionarySelector);
+        }
+
+        public static IEnumerable<object[]> CopyConstructorInt32Data
+        {
+            get { return GetCopyConstructorData(i => i); }
+        }
+
+        [Theory]
+        [MemberData("CopyConstructorStringData")]
+        public void CopyConstructorString(int size, Func<int, string> keyValueSelector, Func<IDictionary<string, string>, IDictionary<string, string>> dictionarySelector)
+        {
+            TestCopyConstructor(size, keyValueSelector, dictionarySelector);
+        }
+
+        public static IEnumerable<object[]> CopyConstructorStringData
+        {
+            get { return GetCopyConstructorData(i => i.ToString()); }
+        }
+
+        private static void TestCopyConstructor<T>(int size, Func<int, T> keyValueSelector, Func<IDictionary<T, T>, IDictionary<T, T>> dictionarySelector)
+        {
+            IDictionary<T, T> expected = CreateDictionary(size, keyValueSelector);
+            IDictionary<T, T> input = dictionarySelector(CreateDictionary(size, keyValueSelector));
+
+            Assert.Equal(expected, new Dictionary<T, T>(input));
+        }
+
+        [Theory]
+        [MemberData("CopyConstructorInt32ComparerData")]
+        public void CopyConstructorInt32Comparer(int size, Func<int, int> keyValueSelector, Func<IDictionary<int, int>, IDictionary<int, int>> dictionarySelector, IEqualityComparer<int> comparer)
+        {
+            TestCopyConstructor(size, keyValueSelector, dictionarySelector, comparer);
+        }
+
+        public static IEnumerable<object[]> CopyConstructorInt32ComparerData
+        {
+            get
+            {
+                var comparers = new IEqualityComparer<int>[]
+                {
+                    null,
+                    EqualityComparer<int>.Default
+                };
+
+                return GetCopyConstructorData(i => i, comparers);
+            }
+        }
+
+        [Theory]
+        [MemberData("CopyConstructorStringComparerData")]
+        public void CopyConstructorStringComparer(int size, Func<int, string> keyValueSelector, Func<IDictionary<string, string>, IDictionary<string, string>> dictionarySelector, IEqualityComparer<string> comparer)
+        {
+            TestCopyConstructor(size, keyValueSelector, dictionarySelector, comparer);
+        }
+
+        public static IEnumerable<object[]> CopyConstructorStringComparerData
+        {
+            get
+            {
+                var comparers = new IEqualityComparer<string>[]
+                {
+                    null,
+                    EqualityComparer<string>.Default,
+                    StringComparer.Ordinal,
+                    StringComparer.OrdinalIgnoreCase
+                };
+
+                return GetCopyConstructorData(i => i.ToString(), comparers);
+            }
+        }
+
+        private static void TestCopyConstructor<T>(int size, Func<int, T> keyValueSelector, Func<IDictionary<T, T>, IDictionary<T, T>> dictionarySelector, IEqualityComparer<T> comparer)
+        {
+            IDictionary<T, T> expected = CreateDictionary(size, keyValueSelector, comparer);
+            IDictionary<T, T> input = dictionarySelector(CreateDictionary(size, keyValueSelector, comparer));
+
+            Assert.Equal(expected, new Dictionary<T, T>(input, comparer));
+        }
+
+        private static IEnumerable<object[]> GetCopyConstructorData<T>(Func<int, T> keyValueSelector, IEqualityComparer<T>[] comparers = null)
+        {
+            var dictionarySelectors = new Func<IDictionary<T, T>, IDictionary<T, T>>[]
+            {
+                d => d,
+                d => new DictionarySubclass<T, T>(d),
+                d => new ReadOnlyDictionary<T, T>(d)
+            };
+
+            var sizes = new int[] { 0, 1, 2, 3 };
+
+            foreach (Func<IDictionary<T, T>, IDictionary<T, T>> dictionarySelector in dictionarySelectors)
+            {
+                foreach (int size in sizes)
+                {
+                    if (comparers != null)
+                    {
+                        foreach (IEqualityComparer<T> comparer in comparers)
+                        {
+                            yield return new object[] { size, keyValueSelector, dictionarySelector, comparer };
+                        }
+                    }
+                    else
+                    {
+                        yield return new object[] { size, keyValueSelector, dictionarySelector };
+                    }
+                }
+            }
+        }
+
+        private static IDictionary<T, T> CreateDictionary<T>(int size, Func<int, T> keyValueSelector, IEqualityComparer<T> comparer = null)
+        {
+            return Enumerable.Range(1, size).ToDictionary(keyValueSelector, keyValueSelector, comparer);
+        }
+
+        private sealed class DictionarySubclass<TKey, TValue> : Dictionary<TKey, TValue>
+        {
+            public DictionarySubclass(IDictionary<TKey, TValue> dictionary)
+            {
+                foreach (var pair in dictionary)
+                {
+                    Add(pair.Key, pair.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// An incorrectly implemented dictionary that returns -1 from Count.
+        /// </summary>
+        private sealed class NegativeCountDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+        {
+            public int Count { get { return -1; } }
+
+            public TValue this[TKey key] { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+            public bool IsReadOnly { get { throw new NotImplementedException(); } }
+            public ICollection<TKey> Keys { get { throw new NotImplementedException(); } }
+            public ICollection<TValue> Values { get { throw new NotImplementedException(); } }
+            public void Add(KeyValuePair<TKey, TValue> item) { throw new NotImplementedException(); }
+            public void Add(TKey key, TValue value) { throw new NotImplementedException(); }
+            public void Clear() { throw new NotImplementedException(); }
+            public bool Contains(KeyValuePair<TKey, TValue> item) { throw new NotImplementedException(); }
+            public bool ContainsKey(TKey key) { throw new NotImplementedException(); }
+            public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) { throw new NotImplementedException(); }
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() { throw new NotImplementedException(); }
+            public bool Remove(KeyValuePair<TKey, TValue> item) { throw new NotImplementedException(); }
+            public bool Remove(TKey key) { throw new NotImplementedException(); }
+            public bool TryGetValue(TKey key, out TValue value) { throw new NotImplementedException(); }
+            IEnumerator IEnumerable.GetEnumerator() { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Generic\Common\GenericIListTest.cs" />
     <Compile Include="Generic\Common\IEnumerableTest.cs" />
     <Compile Include="Generic\Common\TestSupport.cs" />
+    <Compile Include="Generic\Dictionary\DictionaryTests.cs" />
     <Compile Include="Generic\Dictionary\HashCollisionScenarios\InputData.cs" />
     <Compile Include="Generic\Dictionary\HashCollisionScenarios\OutOfBoundsRegression.cs" />
     <Compile Include="Generic\HashSet\HashSetTestSupport.cs" />


### PR DESCRIPTION
Tests for the `Dictionary<TKey, TValue>` constructors that accept an `IDictionary<TKey, TValue>` parameter.