### PR TITLE
Prevent stack overflow from EnumerableQuery of null enumerable

### DIFF
--- a/src/System.Linq.Queryable/src/Resources/Strings.resx
+++ b/src/System.Linq.Queryable/src/Resources/Strings.resx
@@ -135,4 +135,7 @@
   <data name="NoMethodOnTypeMatchingArguments" xml:space="preserve">
     <value>There is no method '{0}' on type '{1}' that matches the specified arguments</value>
   </data>
+  <data name="EnumeratingNullEnumerableExpression" xml:space="preserve">
+    <value>Cannot enumerate a query created from a null IEnumerable&lt;&gt;</value>
+  </data>
 </root>

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -135,7 +135,10 @@ namespace System.Linq
                 EnumerableRewriter rewriter = new EnumerableRewriter();
                 Expression body = rewriter.Visit(_expression);
                 Expression<Func<IEnumerable<T>>> f = Expression.Lambda<Func<IEnumerable<T>>>(body, (IEnumerable<ParameterExpression>)null);
-                _enumerable = f.Compile()();
+                IEnumerable<T> enumerable = f.Compile()();
+                if (enumerable == this)
+                    throw Error.EnumeratingNullEnumerableExpression();
+                _enumerable = enumerable;
             }
             return _enumerable.GetEnumerator();
         }

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -144,7 +144,9 @@ namespace System.Linq
                     Type t = GetPublicType(sq.Enumerable.GetType());
                     return Expression.Constant(sq.Enumerable, t);
                 }
-                return this.Visit(sq.Expression);
+                Expression exp = sq.Expression;
+                if (exp != c)
+                    return Visit(exp);
             }
             return c;
         }

--- a/src/System.Linq.Queryable/src/System/Linq/Error.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Error.cs
@@ -44,5 +44,10 @@ namespace System.Linq
         {
             return new InvalidOperationException(Strings.NoMethodOnTypeMatchingArguments(name, type));
         }
+
+        internal static Exception EnumeratingNullEnumerableExpression()
+        {
+            return new InvalidOperationException(Strings.EnumeratingNullEnumerableExpression());
+        }
     }
 }

--- a/src/System.Linq.Queryable/src/System/Linq/Strings.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Strings.cs
@@ -37,5 +37,10 @@ namespace System.Linq
         {
             return SR.Format(SR.NoMethodOnTypeMatchingArguments, name, type);
         }
+
+        internal static string EnumeratingNullEnumerableExpression()
+        {
+            return SR.EnumeratingNullEnumerableExpression;
+        }
     }
 }

--- a/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
+++ b/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
@@ -25,8 +25,7 @@ namespace System.Linq.Tests
             IQueryable<int> query = new EnumerableQuery<int>((IEnumerable<int>)null);
             var exp = (ConstantExpression)query.Expression;
             Assert.Same(query, exp.Value);
-            //FIXME: query.GetEnumerator() will now throw StackOverflowException which cannot be usefully caught.
-            //Issue #3546
+            Assert.Throws<InvalidOperationException>(() => query.GetEnumerator());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #3546

If an EnumerableQuery is created from a null IEnumerable<T>, calling
GetEnumerator() will cause infinite recursion. Change this to throw
immediately.