### PR TITLE
Use a fixed dictionary for common OIDs to remove platform differences.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LookupFriendlyNameByOid.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LookupFriendlyNameByOid.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int LookupFriendlyNameByOid(string oidValue, ref IntPtr friendlyNamePtr);
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Unix.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Unix.cs
@@ -2,33 +2,37 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Internal.Cryptography
 {
     internal static partial class OidLookup
     {
+        private static bool ShouldUseCache(OidGroup oidGroup)
+        {
+            return true;
+        }
+
         private static string NativeOidToFriendlyName(string oid, OidGroup oidGroup, bool fallBackToAllGroups)
         {
-            // We're going to call OBJ_txt2nid, then OBJ_nid2obj. Anyone proficient in factor/label reduction
-            // would see that this should be equivalent to OBJ_txt2obj, but it isn't.
-            //
-            // OBJ_txt2obj, when given an OID value dotted string will decode the dotted string and return
-            // a blank(ish) object (which would need to be freed).  We could then pass that to OBJ_obj2nid to
-            // look up the internal identifier.  Then, if we got a NID which wasn't NID_undef we would know
-            // there was a match, and could call OBJ_nid2obj to get the shared pointer to the definition.
-            //
-            // In this case, the composition of functions that we want is OBJ_obj2nid(OBJ_txt2obj) => OBJ_txt2nid.
+            IntPtr friendlyNamePtr = IntPtr.Zero;
+            int result = Interop.Crypto.LookupFriendlyNameByOid(oid, ref friendlyNamePtr);
 
-            int nid = Interop.libcrypto.OBJ_txt2nid(oid);
-
-            if (nid == Interop.libcrypto.NID_undef)
+            switch (result)
             {
-                return null;
-            }
+                case 1: /* Success */
+                    Debug.Assert(friendlyNamePtr != IntPtr.Zero, "friendlyNamePtr != IntPtr.Zero");
 
-            return Interop.libcrypto.OBJ_nid2ln(nid);
+                    // The pointer is to a shared string, so marshalling it out is all that's required.
+                    return Marshal.PtrToStringAnsi(friendlyNamePtr);
+                case -1: /* OpenSSL internal error */
+                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                default:
+                    Debug.Assert(result == 0, "LookupFriendlyNameByOid returned unexpected result " + result);
+                    return null;
+            }
         }
 
         private static string NativeFriendlyNameToOid(string friendlyName, OidGroup oidGroup, bool fallBackToAllGroups)
@@ -53,19 +57,6 @@ namespace Internal.Cryptography
             }
 
             return Interop.libcrypto.OBJ_obj2txt_helper(sharedObject);
-        }
-
-        private static string FindFriendlyNameAlias(string userValue)
-        {
-            foreach (FriendlyNameAlias alias in s_friendlyNameAliases)
-            {
-                if (userValue.Equals(alias.Windows, StringComparison.OrdinalIgnoreCase))
-                {
-                    return alias.OpenSsl;
-                }
-            }
-
-            return null;
         }
 
         // -----------------------------

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Windows.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Windows.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Security.Cryptography;
 
 using Internal.NativeCrypto;
@@ -10,6 +9,11 @@ namespace Internal.Cryptography
 {
     internal static partial class OidLookup
     {
+        private static bool ShouldUseCache(OidGroup oidGroup)
+        {
+            return oidGroup == OidGroup.All;
+        }
+
         private static string NativeOidToFriendlyName(string oid, OidGroup oidGroup, bool fallBackToAllGroups)
         {
             CRYPT_OID_INFO oidInfo = OidInfo.FindOidInfo(CryptOidInfoKeyType.CRYPT_OID_INFO_OID_KEY, oid, oidGroup, fallBackToAllGroups);
@@ -20,19 +24,6 @@ namespace Internal.Cryptography
         {
             CRYPT_OID_INFO oidInfo = OidInfo.FindOidInfo(CryptOidInfoKeyType.CRYPT_OID_INFO_NAME_KEY, friendlyName, oidGroup, fallBackToAllGroups);
             return oidInfo.OID;
-        }
-
-        private static string FindFriendlyNameAlias(string userValue)
-        {
-            foreach (FriendlyNameAlias alias in s_friendlyNameAliases)
-            {
-                if (userValue.Equals(alias.OpenSsl, StringComparison.OrdinalIgnoreCase))
-                {
-                    return alias.Windows;
-                }
-            }
-
-            return null;
         }
 
         // -----------------------------

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
@@ -2,39 +2,20 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
 {
     internal static partial class OidLookup
     {
-        private struct FriendlyNameAlias
-        {
-            internal string Windows { get; set; }
-            internal string OpenSsl { get; set; }
-        }
+        private static readonly ConcurrentDictionary<string, string> s_lateBoundOidToFriendlyName =
+            new ConcurrentDictionary<string, string>();
 
-        // The Windows cryptography API "Friendly Names" don't use the same name as the OIDs were given
-        // in their declaring RFCs.  If a .NET developer learned to call the algorithm "sha1RSA" then we
-        // want to understand that it should be called "sha1WithRSAEncryption" when calling into OpenSSL.
-        //
-        // The canonical form of the Windows versions come from https://msdn.microsoft.com/en-us/library/ff635603.aspx
-        private static readonly FriendlyNameAlias[] s_friendlyNameAliases =
-        {
-            new FriendlyNameAlias { Windows = "RSA", OpenSsl = "rsaEncryption" }, // RFC 2313
-            new FriendlyNameAlias { Windows = "md2RSA", OpenSsl = "md2WithRSAEncryption" }, // RFC 2313
-            new FriendlyNameAlias { Windows = "md4RSA", OpenSsl = "md4WithRSAEncryption" }, // RFC 2313
-            new FriendlyNameAlias { Windows = "md5RSA", OpenSsl = "md5WithRSAEncryption" }, // RFC 2313
-            new FriendlyNameAlias { Windows = "sha1RSA", OpenSsl = "sha1WithRSAEncryption" }, // RFC 3447
-            new FriendlyNameAlias { Windows = "sha256RSA", OpenSsl = "sha256WithRSAEncryption" }, // RFC 3447
-            new FriendlyNameAlias { Windows = "sha384RSA", OpenSsl = "sha384WithRSAEncryption" }, // RFC 3447
-            new FriendlyNameAlias { Windows = "sha512RSA", OpenSsl = "sha512WithRSAEncryption" }, // RFC 3447
-
-            new FriendlyNameAlias { Windows = "DSA", OpenSsl = "dsaEncryption" }, // RFC 3370 calls this "id-dsa"
-            new FriendlyNameAlias { Windows = "sha1DSA", OpenSsl = "dsaWithSHA1" }, // RFC 3370 calls this "id-dsa-with-sha1"
-
-            // We can keep going for as many things as we want to support.
-        };
+        private static readonly ConcurrentDictionary<string, string> s_lateBoundFriendlyNameToOid =
+            new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         //
         // Attempts to map a friendly name to an OID. Returns null if not a known name.
@@ -44,7 +25,35 @@ namespace Internal.Cryptography
             if (oid == null)
                 throw new ArgumentNullException("oid");
 
-            return NativeOidToFriendlyName(oid, oidGroup, fallBackToAllGroups);
+            string mappedName;
+            bool shouldUseCache = ShouldUseCache(oidGroup);
+
+            // On Unix shouldUseCache is always true, so no matter what OidGroup is passed in the Windows
+            // friendly name will be returned.
+            //
+            // On Windows shouldUseCache is only true for OidGroup.All, because otherwise the OS may filter
+            // out the answer based on the group criteria.
+            if (shouldUseCache)
+            {
+                if (s_oidToFriendlyName.TryGetValue(oid, out mappedName) ||
+                    s_compatOids.TryGetValue(oid, out mappedName) ||
+                    s_lateBoundOidToFriendlyName.TryGetValue(oid, out mappedName))
+                {
+                    return mappedName;
+                }
+            }
+
+            mappedName = NativeOidToFriendlyName(oid, oidGroup, fallBackToAllGroups);
+
+            if (shouldUseCache && mappedName != null)
+            {
+                s_lateBoundOidToFriendlyName.TryAdd(oid, mappedName);
+
+                // Don't add the reverse here.  Just because oid => name doesn't mean name => oid.
+                // And don't bother doing the reverse lookup proactively, just wait until they ask for it.
+            }
+
+            return mappedName;
         }
 
         //
@@ -55,19 +64,168 @@ namespace Internal.Cryptography
             if (friendlyName == null)
                 throw new ArgumentNullException("friendlyName");
 
-            string oid = NativeFriendlyNameToOid(friendlyName, oidGroup, fallBackToAllGroups);
+            string mappedOid;
+            bool shouldUseCache = ShouldUseCache(oidGroup);
 
-            if (oid == null)
+            if (shouldUseCache)
             {
-                string alias = FindFriendlyNameAlias(friendlyName);
-
-                if (alias != null)
+                if (s_friendlyNameToOid.TryGetValue(friendlyName, out mappedOid) ||
+                    s_lateBoundFriendlyNameToOid.TryGetValue(friendlyName, out mappedOid))
                 {
-                    oid = NativeFriendlyNameToOid(alias, oidGroup, fallBackToAllGroups);
+                    return mappedOid;
                 }
             }
 
-            return oid;
+            mappedOid = NativeFriendlyNameToOid(friendlyName, oidGroup, fallBackToAllGroups);
+
+            if (shouldUseCache && mappedOid != null)
+            {
+                s_lateBoundFriendlyNameToOid.TryAdd(friendlyName, mappedOid);
+
+                // Don't add the reverse here.  Friendly Name => OID is a case insensitive search,
+                // so the casing provided as input here may not be the 'correct' one.  Just let
+                // ToFriendlyName capture the response and cache it itself.
+            }
+
+            return mappedOid;
         }
+
+        // This table was originally built by extracting every szOID #define out of wincrypt.h,
+        // and running them through new Oid(string) on Windows 10.  Then, take the list of everything
+        // which produced a FriendlyName value, and run it through two other languages. If all 3 agree
+        // on the mapping, consider the value to be non-localized.
+        //
+        // This original list was produced on English (Win10), cross-checked with Spanish (Win8.1) and
+        // Japanese (Win10).
+        //
+        // Sometimes wincrypt.h has more than one OID which results in the same name.  The OIDs whose value
+        // doesn't roundtrip (new Oid(new Oid(value).FriendlyName).Value) are contained in s_compatOids.
+        //
+        // X-Plat: The names (and casing) in this table come from Windows. Part of the intent of this table
+        // is to prevent issues wherein an identifier is different between CoreFX\Windows and CoreFX\Unix;
+        // since any existing code would be using the Windows identifier, it is the de facto standard.
+        private static readonly Dictionary<string, string> s_friendlyNameToOid =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "3des", "1.2.840.113549.3.7" },
+                { "aes128", "2.16.840.1.101.3.4.1.2" },
+                { "aes128wrap", "2.16.840.1.101.3.4.1.5" },
+                { "aes192", "2.16.840.1.101.3.4.1.22" },
+                { "aes192wrap", "2.16.840.1.101.3.4.1.25" },
+                { "aes256", "2.16.840.1.101.3.4.1.42" },
+                { "aes256wrap", "2.16.840.1.101.3.4.1.45" },
+                { "brainpoolP160r1", "1.3.36.3.3.2.8.1.1.1" },
+                { "brainpoolP160t1", "1.3.36.3.3.2.8.1.1.2" },
+                { "brainpoolP192r1", "1.3.36.3.3.2.8.1.1.3" },
+                { "brainpoolP192t1", "1.3.36.3.3.2.8.1.1.4" },
+                { "brainpoolP224r1", "1.3.36.3.3.2.8.1.1.5" },
+                { "brainpoolP224t1", "1.3.36.3.3.2.8.1.1.6" },
+                { "brainpoolP256r1", "1.3.36.3.3.2.8.1.1.7" },
+                { "brainpoolP256t1", "1.3.36.3.3.2.8.1.1.8" },
+                { "brainpoolP320r1", "1.3.36.3.3.2.8.1.1.9" },
+                { "brainpoolP320t1", "1.3.36.3.3.2.8.1.1.10" },
+                { "brainpoolP384r1", "1.3.36.3.3.2.8.1.1.11" },
+                { "brainpoolP384t1", "1.3.36.3.3.2.8.1.1.12" },
+                { "brainpoolP512r1", "1.3.36.3.3.2.8.1.1.13" },
+                { "brainpoolP512t1", "1.3.36.3.3.2.8.1.1.14" },
+                { "C", "2.5.4.6" },
+                { "CMS3DESwrap", "1.2.840.113549.1.9.16.3.6" },
+                { "CMSRC2wrap", "1.2.840.113549.1.9.16.3.7" },
+                { "CN", "2.5.4.3" },
+                { "CPS", "1.3.6.1.5.5.7.2.1" },
+                { "DC", "0.9.2342.19200300.100.1.25" },
+                { "des", "1.3.14.3.2.7" },
+                { "Description", "2.5.4.13" },
+                { "DH", "1.2.840.10046.2.1" },
+                { "dnQualifier", "2.5.4.46" },
+                { "DSA", "1.2.840.10040.4.1" },
+                { "dsaSHA1", "1.3.14.3.2.27" },
+                { "E", "1.2.840.113549.1.9.1" },
+                { "ec192wapi", "1.2.156.11235.1.1.2.1" },
+                { "ECC", "1.2.840.10045.2.1" },
+                { "ECDH_STD_SHA1_KDF", "1.3.133.16.840.63.0.2" },
+                { "ECDH_STD_SHA256_KDF", "1.3.132.1.11.1" },
+                { "ECDH_STD_SHA384_KDF", "1.3.132.1.11.2" },
+                { "ECDSA_P256", "1.2.840.10045.3.1.7" },
+                { "ECDSA_P384", "1.3.132.0.34" },
+                { "ECDSA_P521", "1.3.132.0.35" },
+                { "ESDH", "1.2.840.113549.1.9.16.3.5" },
+                { "G", "2.5.4.42" },
+                { "I", "2.5.4.43" },
+                { "L", "2.5.4.7" },
+                { "md2", "1.2.840.113549.2.2" },
+                { "md2RSA", "1.2.840.113549.1.1.2" },
+                { "md4", "1.2.840.113549.2.4" },
+                { "md4RSA", "1.2.840.113549.1.1.3" },
+                { "md5", "1.2.840.113549.2.5" },
+                { "md5RSA", "1.2.840.113549.1.1.4" },
+                { "mgf1", "1.2.840.113549.1.1.8" },
+                { "mosaicKMandUpdSig", "2.16.840.1.101.2.1.1.20" },
+                { "mosaicUpdatedSig", "2.16.840.1.101.2.1.1.19" },
+                { "nistP192", "1.2.840.10045.3.1.1" },
+                { "nistP224", "1.3.132.0.33" },
+                { "NO_SIGN", "1.3.6.1.5.5.7.6.2" },
+                { "O", "2.5.4.10" },
+                { "OU", "2.5.4.11" },
+                { "Phone", "2.5.4.20" },
+                { "POBox", "2.5.4.18" },
+                { "PostalCode", "2.5.4.17" },
+                { "rc2", "1.2.840.113549.3.2" },
+                { "rc4", "1.2.840.113549.3.4" },
+                { "RSA", "1.2.840.113549.1.1.1" },
+                { "RSAES_OAEP", "1.2.840.113549.1.1.7" },
+                { "RSASSA-PSS", "1.2.840.113549.1.1.10" },
+                { "S", "2.5.4.8" },
+                { "secP160k1", "1.3.132.0.9" },
+                { "secP160r1", "1.3.132.0.8" },
+                { "secP160r2", "1.3.132.0.30" },
+                { "secP192k1", "1.3.132.0.31" },
+                { "secP224k1", "1.3.132.0.32" },
+                { "secP256k1", "1.3.132.0.10" },
+                { "SERIALNUMBER", "2.5.4.5" },
+                { "sha1", "1.3.14.3.2.26" },
+                { "sha1DSA", "1.2.840.10040.4.3" },
+                { "sha1ECDSA", "1.2.840.10045.4.1" },
+                { "sha1RSA", "1.2.840.113549.1.1.5" },
+                { "sha256", "2.16.840.1.101.3.4.2.1" },
+                { "sha256ECDSA", "1.2.840.10045.4.3.2" },
+                { "sha256RSA", "1.2.840.113549.1.1.11" },
+                { "sha384", "2.16.840.1.101.3.4.2.2" },
+                { "sha384ECDSA", "1.2.840.10045.4.3.3" },
+                { "sha384RSA", "1.2.840.113549.1.1.12" },
+                { "sha512", "2.16.840.1.101.3.4.2.3" },
+                { "sha512ECDSA", "1.2.840.10045.4.3.4" },
+                { "sha512RSA", "1.2.840.113549.1.1.13" },
+                { "SN", "2.5.4.4" },
+                { "specifiedECDSA", "1.2.840.10045.4.3" },
+                { "STREET", "2.5.4.9" },
+                { "T", "2.5.4.12" },
+                { "wtls9", "2.23.43.1.4.9" },
+                { "X21Address", "2.5.4.24" },
+                { "x962P192v2", "1.2.840.10045.3.1.2" },
+                { "x962P192v3", "1.2.840.10045.3.1.3" },
+                { "x962P239v1", "1.2.840.10045.3.1.4" },
+                { "x962P239v2", "1.2.840.10045.3.1.5" },
+                { "x962P239v3", "1.2.840.10045.3.1.6" },
+            };
+
+        private static readonly Dictionary<string, string> s_oidToFriendlyName =
+            s_friendlyNameToOid.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+        private static readonly Dictionary<string, string> s_compatOids =
+            new Dictionary<string, string>
+            {
+                { "1.2.840.113549.1.3.1", "DH" },
+                { "1.3.14.3.2.12", "DSA" },
+                { "1.3.14.3.2.13", "sha1DSA" },
+                { "1.3.14.3.2.15", "shaRSA" },
+                { "1.3.14.3.2.18", "sha" },
+                { "1.3.14.3.2.2", "md4RSA" },
+                { "1.3.14.3.2.22", "RSA_KEYX" },
+                { "1.3.14.3.2.29", "sha1RSA" },
+                { "1.3.14.3.2.3", "md5RSA" },
+                { "1.3.14.3.2.4", "md4RSA" },
+                { "1.3.14.7.2.3.1", "md2RSA" },
+            };
     }
 }

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -76,11 +76,14 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.X509Ext.cs">
+      <Link>Common\Interop\Unix\libcrypto\Interop.X509Ext.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.X509Ext.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.X509Ext.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.LookupFriendlyNameByOid.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.LookupFriendlyNameByOid.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>

--- a/src/System.Security.Cryptography.Encoding/src/project.json
+++ b/src/System.Security.Cryptography.Encoding/src/project.json
@@ -1,8 +1,11 @@
 {
   "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Collections.Concurrent": "4.0.0",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
+    "System.Linq": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime": "4.0.20",
     "System.Runtime.InteropServices": "4.0.20"

--- a/src/System.Security.Cryptography.Encoding/src/project.lock.json
+++ b/src/System.Security.Cryptography.Encoding/src/project.lock.json
@@ -3,6 +3,25 @@
   "version": 1,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Concurrent.dll": {}
+        }
+      },
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -48,6 +67,22 @@
         },
         "runtime": {
           "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
         }
       },
       "System.Private.Uri/4.0.0": {
@@ -108,6 +143,18 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
       "System.Runtime.Handles/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -156,6 +203,100 @@
     }
   },
   "libraries": {
+    "System.Collections/4.0.0": {
+      "type": "package",
+      "sha512": "i2vsGDIEbWdHcUSNDPKZP/ZWod6o740el7mGTCy0dqbCxQh74W4QoC+klUwPEtGEFuvzJ7bJgvwJqscosVNyZQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Collections.xml",
+        "ref/netcore50/es/System.Collections.xml",
+        "ref/netcore50/fr/System.Collections.xml",
+        "ref/netcore50/it/System.Collections.xml",
+        "ref/netcore50/ja/System.Collections.xml",
+        "ref/netcore50/ko/System.Collections.xml",
+        "ref/netcore50/ru/System.Collections.xml",
+        "ref/netcore50/System.Collections.dll",
+        "ref/netcore50/System.Collections.xml",
+        "ref/netcore50/zh-hans/System.Collections.xml",
+        "ref/netcore50/zh-hant/System.Collections.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.4.0.0.nupkg",
+        "System.Collections.4.0.0.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
+    "System.Collections.Concurrent/4.0.0": {
+      "type": "package",
+      "sha512": "1f5SWoX7UlFkvUt7A8JoG5lXgZDw4cRAcKG8Eaxa+3Sq6e/UgVWl2YWew1evJv+p+edNNlIIorDfREKcoEDHGw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/fr/System.Collections.Concurrent.xml",
+        "ref/dotnet/it/System.Collections.Concurrent.xml",
+        "ref/dotnet/ja/System.Collections.Concurrent.xml",
+        "ref/dotnet/ko/System.Collections.Concurrent.xml",
+        "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Collections.Concurrent.xml",
+        "ref/netcore50/es/System.Collections.Concurrent.xml",
+        "ref/netcore50/fr/System.Collections.Concurrent.xml",
+        "ref/netcore50/it/System.Collections.Concurrent.xml",
+        "ref/netcore50/ja/System.Collections.Concurrent.xml",
+        "ref/netcore50/ko/System.Collections.Concurrent.xml",
+        "ref/netcore50/ru/System.Collections.Concurrent.xml",
+        "ref/netcore50/System.Collections.Concurrent.dll",
+        "ref/netcore50/System.Collections.Concurrent.xml",
+        "ref/netcore50/zh-hans/System.Collections.Concurrent.xml",
+        "ref/netcore50/zh-hant/System.Collections.Concurrent.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.Concurrent.4.0.0.nupkg",
+        "System.Collections.Concurrent.4.0.0.nupkg.sha512",
+        "System.Collections.Concurrent.nuspec"
+      ]
+    },
     "System.Diagnostics.Contracts/4.0.0": {
       "type": "package",
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
@@ -303,6 +444,39 @@
         "System.IO.4.0.10.nupkg",
         "System.IO.4.0.10.nupkg.sha512",
         "System.IO.nuspec"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.4.0.0.nupkg",
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
@@ -468,6 +642,40 @@
         "System.Runtime.4.0.20.nupkg",
         "System.Runtime.4.0.20.nupkg.sha512",
         "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
@@ -637,9 +845,12 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "System.Collections >= 4.0.0",
+      "System.Collections.Concurrent >= 4.0.0",
       "System.Diagnostics.Contracts >= 4.0.0",
       "System.Diagnostics.Debug >= 4.0.10",
       "System.IO >= 4.0.10",
+      "System.Linq >= 4.0.0",
       "System.Resources.ResourceManager >= 4.0.0",
       "System.Runtime >= 4.0.20",
       "System.Runtime.InteropServices >= 4.0.20"


### PR DESCRIPTION
Use a classic Dictionary for the most common OID values, then a ConcurrentDictionary for on-the-fly memoization to save on p/invoke and repeated parsing.

The "common values" dictionaries ensure that Windows FriendlyName values resolve on Unix, and that OID -> FriendlyName gives a consistent result for those cases where someone is likely to have tried writing matching logic.

The Oid class tests were refactored and spruced up a bit as a part of this change.

Fixes #1813.
Fixes #1863.