### PR TITLE
Rename System.Diagnostics.Tracing.Telemetry.TelemetrySource -> System…

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
+++ b/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23103.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.DiagnosticSource", "src\System.Diagnostics.DiagnosticSource.csproj", "{F24D3391-2928-4E83-AADE-B34423498750}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.DiagnosticSource.Tests", "tests\System.Diagnostics.DiagnosticSource.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -1,0 +1,20 @@
+namespace System.Diagnostics {
+  public partial class DiagnosticListener : System.Diagnostics.DiagnosticSource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>> {
+    public DiagnosticListener(string name) { }
+    public static System.Diagnostics.DiagnosticListener DefaultListener { get { return default(System.Diagnostics.DiagnosticListener); } }
+    public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { return default(string); } }
+    public static IObservable<DiagnosticListener> AllListeners { get; } 
+    public virtual void Dispose() { }
+    public override bool IsEnabled(string name) { return default(bool); }
+    public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { return default(System.IDisposable); }
+    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { return default(System.IDisposable); }
+    public override void Write(string name, object parameters) { }
+  }
+  public abstract partial class DiagnosticSource {
+    protected DiagnosticSource() { }
+    public static System.Diagnostics.DiagnosticSource DefaultSource { get { return default(System.Diagnostics.DiagnosticSource); } }
+    public abstract bool IsEnabled(string name);
+    public abstract void Write(string name, object value);
+  }
+}
+

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Diagnostics.DiagnosticSource.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.DiagnosticSource/ref/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/ref/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/System.Diagnostics.DiagnosticSource/ref/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/ref/project.lock.json
@@ -1,0 +1,68 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    ".NETPlatform,Version=v5.0": {
+      "System.Runtime/4.0.0": {
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Runtime/4.0.0": {
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
+      "files": [
+        "License.rtf",
+        "System.Runtime.4.0.0.nupkg",
+        "System.Runtime.4.0.0.nupkg.sha512",
+        "System.Runtime.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Runtime >= 4.0.0"
+    ],
+    ".NETPlatform,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <ProjectGuid>{F24D3391-2928-4E83-AADE-B34423498750}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Diagnostics.DiagnosticSource</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <NoWarn>0420</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <NoWarn>0420</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
+    <Compile Include="System\Diagnostics\DiagnosticListener.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+// TODO when we upgrade to C# V6 you can remove this.  
+// warning CS0420: ‘P.x': a reference to a volatile field will not be treated as volatile
+// This happens when you pass a _subcribers (a volatile field) to interlocked operations (which are byref). 
+// This was fixed in C# V6.  
+#pragma warning disable 0420
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// A DiagnosticListener is something that forwards on events written with DiagnosticSource.
+    /// It is an IObservable (has Subscribe method), and it also has a Subscribe overload that
+    /// lets you specify a 'IsEnabled' predicate that users of DiagnosticSource will use for 
+    /// 'quick checks'.   
+    /// 
+    /// The item in the stream is a KeyValuePair[string, object] where the string is the name
+    /// of the diagnostic item and the object is the payload (typically an anonymous type).  
+    /// 
+    /// There may be many DiagnosticListeners in the system, but we encourage the use of
+    /// The DiagnosticSource.DefaultSource which goes to the DiagnosticListener.DefaultListener.
+    /// 
+    /// If you need to see 'everything' you can subscribe to the 'AllListeners' event that
+    /// will fire for every live DiagnosticListener in the appdomain (past or present). 
+    /// </summary>
+    public class DiagnosticListener : DiagnosticSource, IObservable<KeyValuePair<string, object>>, IDisposable
+    {
+#if false
+        /// <summary>
+        /// This is the DiagnosticListener that is used by default by the class library.   
+        /// Generally you don't want to make your own but rather have everyone use this one, which
+        /// ensures that everyone who wished to subscribe gets the callbacks.  
+        /// The main reason not to us this one is that you WANT isolation from other 
+        /// events in the system (e.g. multi-tenancy).  
+        /// </summary>
+        public static DiagnosticListener DefaultListener { get { return s_default; } }
+#endif 
+        /// <summary>
+        /// When you subscribe to this you get callbacks for all NotificationListeners in the appdomain
+        /// as well as those that occurred in the past, and all future Listeners created in the future. 
+        /// </summary>
+        public static IObservable<DiagnosticListener> AllListeners
+        {
+            get
+            {
+                if (s_allListenerObservable == null)
+                {
+                    s_allListenerObservable = new AllListenerObservable();
+                }
+                return s_allListenerObservable;
+            }
+        }
+
+        // Subscription implementation 
+        /// <summary>
+        /// Add a subscriber (Observer).  If 'IsEnabled' == null (or not present), then the Source's IsEnabled 
+        /// will always return true.  
+        /// </summary>
+        virtual public IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<string> isEnabled)
+        {
+            // If we have been disposed, we silently ignore any subscriptions.  
+            if (_disposed)
+            {
+                return new DiagnosticSubscription() { Owner = this };
+            }
+            DiagnosticSubscription newSubscription = new DiagnosticSubscription() { Observer = observer, IsEnabled = isEnabled, Owner = this, Next = _subscriptions };
+            while (Interlocked.CompareExchange(ref _subscriptions, newSubscription, newSubscription.Next) != newSubscription.Next)
+                newSubscription.Next = _subscriptions;
+            return newSubscription;
+        }
+        /// <summary>
+        /// Same as other Subscribe overload where the predicate is assumed to always return true.  
+        /// </summary>
+        public IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer)
+        {
+            return Subscribe(observer, null);
+        }
+
+        /// <summary>
+        /// Make a new DiagnosticListener, it is a NotificationSource, which means the returned result can be used to 
+        /// log notifications, but it also has a Subscribe method so notifications can be forwarded
+        /// arbitrarily.  Thus its job is to forward things from the producer to all the listeners
+        /// (multi-casting).    Generally you should not be making your own DiagnosticListener but use the
+        /// DiagnosticListener.Default, so that notifications are as 'public' as possible.  
+        /// </summary>
+        public DiagnosticListener(string name)
+        {
+            Name = name;
+
+            // Insert myself into the list of all Listeners.   
+            lock (s_lock)
+            {
+                // Issue the callback for this new diagnostic listener.
+                var allListenerObservable = s_allListenerObservable;
+                if (allListenerObservable != null)
+                    allListenerObservable.OnNewDiagnosticListener(this);
+
+                // And add it to the list of all past listeners.  
+                _next = s_allListeners;
+                s_allListeners = this;
+            }
+        }
+
+        /// <summary>
+        /// Clean up the NotificationListeners.   Notification listeners do NOT DIE ON THEIR OWN
+        /// because they are in a global list (for discoverability).  You must dispose them explicitly. 
+        /// Note that we do not do the Dispose(bool) pattern because we frankly don't want to support
+        /// subclasses that have non-managed state.   
+        /// </summary>
+        virtual public void Dispose()
+        {
+            // Remove myself from the list of all listeners.  
+            lock (s_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+                if (s_allListeners == this)
+                    s_allListeners = s_allListeners._next;
+                else
+                {
+                    var cur = s_allListeners;
+                    while (cur != null)
+                    {
+                        if (cur._next == this)
+                        {
+                            cur._next = _next;
+                            break;
+                        }
+                        cur = cur._next;
+                    }
+                }
+                _next = null;
+            }
+
+            // Indicate completion to all subscribers.  
+            DiagnosticSubscription subscriber = null;
+            Interlocked.Exchange(ref subscriber, _subscriptions);
+            while (subscriber != null)
+            {
+                subscriber.Observer.OnCompleted();
+                subscriber = subscriber.Next;
+            }
+            // The code above also nulled out all subscriptions. 
+        }
+
+        /// <summary>
+        /// When a DiagnosticListener is created it is given a name.   Return this.  
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Return the name for the ToString() to aid in debugging.  
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        #region private
+
+        // NotificationSource implementation
+        /// <summary>
+        /// Override abstract method
+        /// </summary>
+        public override bool IsEnabled(string name)
+        {
+            for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
+            {
+                if (curSubscription.IsEnabled == null || curSubscription.IsEnabled(name))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Override abstract method
+        /// </summary>
+        public override void Write(string name, object value)
+        {
+            for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
+                curSubscription.Observer.OnNext(new KeyValuePair<string, object>(name, value));
+        }
+
+        // Note that Subscriptions are READ ONLY.   This means you never update any fields (even on removal!)
+        private class DiagnosticSubscription : IDisposable
+        {
+            internal IObserver<KeyValuePair<string, object>> Observer;
+            internal Predicate<string> IsEnabled;
+            internal DiagnosticListener Owner;          // The DiagnosticListener this is a subscription for.  
+            internal DiagnosticSubscription Next;                // Linked list of subscribers
+
+            public void Dispose()
+            {
+                // TO keep this lock free and easy to analyze, the linked list is READ ONLY.   Thus we copy
+                for (;;)
+                {
+                    DiagnosticSubscription subscriptions = Owner._subscriptions;
+                    DiagnosticSubscription newSubscriptions = Remove(subscriptions, this);    // Make a new list, with myself removed.  
+
+                    // try to update, but if someone beat us to it, then retry.  
+                    if (Interlocked.CompareExchange(ref Owner._subscriptions, newSubscriptions, subscriptions) == subscriptions)
+                    {
+#if DEBUG
+                        var cur = newSubscriptions;
+                        while (cur != null)
+                        {
+                            Debug.Assert(!(cur.Observer == Observer && cur.IsEnabled == IsEnabled), "Did not remove subscription!");
+                            cur = cur.Next;
+                        }
+#endif
+                        break;
+                    }
+                }
+            }
+
+            // Create a new linked list where 'subscription has been removed from the linked list of 'subscriptions'. 
+            private static DiagnosticSubscription Remove(DiagnosticSubscription subscriptions, DiagnosticSubscription subscription)
+            {
+                if (subscriptions == null)
+                {
+                    // May happen if the IDisposable returned from Subscribe is Dispose'd again
+                    return null;
+                }
+
+                if (subscriptions.Observer == subscription.Observer && subscriptions.IsEnabled == subscription.IsEnabled)
+                    return subscriptions.Next;
+#if DEBUG
+                // Delay a bit.  This makes it more likely that races will happen. 
+                for (int i = 0; i < 100; i++)
+                    GC.KeepAlive("");
+#endif
+                return new DiagnosticSubscription() { Observer = subscriptions.Observer, Owner = subscriptions.Owner, IsEnabled = subscriptions.IsEnabled, Next = Remove(subscriptions.Next, subscription) };
+            }
+        }
+
+        #region AllListenerObservable 
+        /// <summary>
+        /// Logically AllListenerObservable has a very simple task.  It has a linked list of subscribers that want
+        /// a callback when a new listener gets created.   When a new DiagnosticListener gets created it should call 
+        /// OnNewDiagnosticListener so that AllListenerObservable can forward it on to all the subscribers.   
+        /// </summary>
+        private class AllListenerObservable : IObservable<DiagnosticListener>
+        {
+            public IDisposable Subscribe(IObserver<DiagnosticListener> observer)
+            {
+                lock (s_lock)
+                {
+                    // Call back for each existing listener on the new callback (catch-up).   
+                    for (DiagnosticListener cur = s_allListeners; cur != null; cur = cur._next)
+                        observer.OnNext(cur);
+
+                    // Add the observer to the list of subscribers.   
+                    _subscriptions = new AllListenerSubscription(this, observer, _subscriptions);
+                    return _subscriptions;
+                }
+            }
+
+            /// <summary>
+            /// Called when a new DiagnosticListener gets created to tell anyone who subscribed that this happened.  
+            /// </summary>
+            /// <param name="diagnosticListener"></param>
+            internal void OnNewDiagnosticListener(DiagnosticListener diagnosticListener)
+            {
+                Debug.Assert(Monitor.IsEntered(s_lock));     // We should only be called when we hold this lock
+
+                // Simply send a callback to every subscriber that we have a new listener
+                for (var cur = _subscriptions; cur != null; cur = cur.Next)
+                    cur.Subscriber.OnNext(diagnosticListener);
+            }
+
+            #region private 
+            /// <summary>
+            /// Remove 'subscription from the list of subscriptions that the observable has.   Called when
+            /// subscriptions are disposed.   Returns true if the subscription was removed.  
+            /// </summary>
+            private bool Remove(AllListenerSubscription subscription)
+            {
+                lock (s_lock)
+                {
+                    if (_subscriptions == subscription)
+                    {
+                        _subscriptions = subscription.Next;
+                        return true;
+                    }
+                    else if (_subscriptions != null)
+                    {
+                        for (var cur = _subscriptions; cur.Next != null; cur = cur.Next)
+                        {
+                            if (cur.Next == subscription)
+                            {
+                                cur.Next = cur.Next.Next;
+                                return true;
+                            }
+                        }
+                    }
+
+                    // Subscriber likely disposed multiple times
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// One node in the linked list of subscriptions that AllListenerObservable keeps.   It is
+            /// IDisposable, and when that is called it removes itself from the list.  
+            /// </summary>
+            internal class AllListenerSubscription : IDisposable
+            {
+                internal AllListenerSubscription(AllListenerObservable owner, IObserver<DiagnosticListener> subscriber, AllListenerSubscription next)
+                {
+                    this._owner = owner;
+                    this.Subscriber = subscriber;
+                    this.Next = next;
+                }
+
+                public void Dispose()
+                {
+                    if (_owner.Remove(this))
+                    {
+                        Subscriber.OnCompleted();           // Called outside of a lock
+                    }
+                }
+
+                private readonly AllListenerObservable _owner;               // the list this is a member of.  
+                internal readonly IObserver<DiagnosticListener> Subscriber;
+                internal AllListenerSubscription Next;
+            }
+
+            private AllListenerSubscription _subscriptions;
+            #endregion
+        }
+        #endregion
+
+        private volatile DiagnosticSubscription _subscriptions;
+        private DiagnosticListener _next;               // We keep a linked list of all NotificationListeners (s_allListeners)
+        private bool _disposed;                        // Has Dispose been called?
+
+        private static DiagnosticListener s_allListeners;               // linked list of all instances of DiagnosticListeners.  
+        private static AllListenerObservable s_allListenerObservable;   // to make callbacks to this object when listeners come into existence. 
+        private static object s_lock = new object();                    // A lock for  
+#if false
+        private static readonly DiagnosticListener s_default = new DiagnosticListener("DiagnosticListener.DefaultListener");
+#endif
+
+        #endregion
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// This is the basic API to 'hook' parts of the framework.   It is like an EventSource
+    /// (which can also write object), but is intended to log complex objects that can't be serialized.
+    /// </summary>
+    public abstract class DiagnosticSource
+    {
+#if false
+        /// <summary>
+        /// The NotificationSource that you should be writing to by default.  This is what
+        /// most of the class library does.   Data written here goes to DefaultListener
+        /// which dispatches to all its subscribers.  
+        /// </summary>
+        // public static DiagnosticSource DefaultSource { get { return DiagnosticListener.DefaultListener; } }
+#endif 
+
+        /// <summary>
+        /// Write is a generic way of logging complex payloads.  Each notification
+        /// is given a name, which identifies it as well as a object (typically an anonymous type)
+        /// that gives the information to pass to the notification, which is arbitrary.  
+        /// 
+        /// The name should be short (so don't use fully qualified names unless you have to
+        /// to avoid ambiguity), but you want the name to be globally unique.  Typically your componentName.eventName
+        /// where componentName and eventName are strings less than 10 characters are a good compromise.  
+        /// notification names should NOT have '.' in them because component names have dots and for them both
+        /// to have dots would lead to ambiguity.   The suggestion is to use _ instead.  It is assumed 
+        /// that listeners will use string prefixing to filter groups, thus having hierarchy in component 
+        /// names is good.  
+        /// </summary>
+        /// <param name="name">The name of the event being written.</param>
+        /// <param name="value">An object that represent the value being passed as a payload for the event.
+        /// This is often a anonymous type which contains several sub-values.</param>
+        public abstract void Write(string name, object value);
+
+        /// <summary>
+        /// Optional: if there is expensive setup for the notification, you can call IsEnabled
+        /// before doing this setup.   Consumers should not be assuming that they only get notifications
+        /// for which IsEnabled is true however, it is optional for producers to call this API. 
+        /// The name should be the same as what is passed to Write.   
+        /// </summary>
+        /// <param name="name">The name of the event being written.</param>
+        public abstract bool IsEnabled(string name);
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/src/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "dependencies": {
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Runtime": "4.0.0",
+    "System.Threading": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/src/project.lock.json
@@ -1,0 +1,244 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Diagnostics.Debug/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Runtime/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      },
+      "System.Threading/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Diagnostics.Debug/4.0.0": {
+      "type": "package",
+      "sha512": "AYJsLLGDVTC/nyURjgAo7Lpye0+HuSkcQujUf+NgQVdC/C/ky5NyamQHCforHJzgqspitMMtBe8B4UBdGXy1zQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Diagnostics.Debug.xml",
+        "ref/netcore50/es/System.Diagnostics.Debug.xml",
+        "ref/netcore50/fr/System.Diagnostics.Debug.xml",
+        "ref/netcore50/it/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ja/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ko/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ru/System.Diagnostics.Debug.xml",
+        "ref/netcore50/System.Diagnostics.Debug.dll",
+        "ref/netcore50/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Diagnostics.Debug.4.0.0.nupkg",
+        "System.Diagnostics.Debug.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.0": {
+      "type": "package",
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.4.0.0.nupkg",
+        "System.Runtime.4.0.0.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Threading/4.0.0": {
+      "type": "package",
+      "sha512": "H6O/9gUrjPDNYanh/7OFGAZHjVXvEuITD0RcnjfvIV04HOGrOPqUBU0kmz9RIX/7YGgCQn1o1S2DX6Cuv8kVGQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.xml",
+        "ref/netcore50/es/System.Threading.xml",
+        "ref/netcore50/fr/System.Threading.xml",
+        "ref/netcore50/it/System.Threading.xml",
+        "ref/netcore50/ja/System.Threading.xml",
+        "ref/netcore50/ko/System.Threading.xml",
+        "ref/netcore50/ru/System.Threading.xml",
+        "ref/netcore50/System.Threading.dll",
+        "ref/netcore50/System.Threading.xml",
+        "ref/netcore50/zh-hans/System.Threading.xml",
+        "ref/netcore50/zh-hant/System.Threading.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.4.0.0.nupkg",
+        "System.Threading.4.0.0.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0": {
+      "type": "package",
+      "sha512": "dA3y1B6Pc8mNt9obhEWWGGpvEakS51+nafXpmM/Z8IF847GErLXGTjdfA+AYEKszfFbH7SVLWUklXhYeeSQ1lw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.Tasks.xml",
+        "ref/netcore50/es/System.Threading.Tasks.xml",
+        "ref/netcore50/fr/System.Threading.Tasks.xml",
+        "ref/netcore50/it/System.Threading.Tasks.xml",
+        "ref/netcore50/ja/System.Threading.Tasks.xml",
+        "ref/netcore50/ko/System.Threading.Tasks.xml",
+        "ref/netcore50/ru/System.Threading.Tasks.xml",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Tasks.4.0.0.nupkg",
+        "System.Threading.Tasks.4.0.0.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Diagnostics.Debug >= 4.0.0",
+      "System.Runtime >= 4.0.0",
+      "System.Threading >= 4.0.0"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -1,0 +1,667 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using System.Threading.Tasks;
+using TelemData = System.Collections.Generic.KeyValuePair<string, object>;
+
+namespace System.Diagnostics.Diagnostic.Tests
+{
+    /// <summary>
+    /// Tests for DiagnosticSource and DiagnosticListener
+    /// </summary>
+    public class DiagnosticSourceTest
+    {
+        /// <summary>
+        /// Trivial example of passing an integer
+        /// </summary>
+        [Fact]
+        public void IntPayload()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+                var result = new List<KeyValuePair<string, object>>();
+                var observer = new ObserverToList<TelemData>(result);
+
+                using (listener.Subscribe(new ObserverToList<TelemData>(result)))
+                {
+                    listener.Write("IntPayload", 5);
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("IntPayload", result[0].Key);
+                    Assert.Equal(5, result[0].Value);
+                }   // unsubscribe
+
+                // Make sure that after unsubscribing, we don't get more events. 
+                source.Write("IntPayload", 5);
+                Assert.Equal(1, result.Count);
+            }
+        }
+
+        /// <summary>
+        /// slightly less trivial of passing a structure with a couple of fields 
+        /// </summary>
+        [Fact]
+        public void StructPayload()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+                var result = new List<KeyValuePair<string, object>>();
+                using (listener.Subscribe(new ObserverToList<TelemData>(result)))
+                {
+                    source.Write("StructPayload", new Payload() { Name = "Hi", Id = 67 });
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("StructPayload", result[0].Key);
+                    var payload = (Payload)result[0].Value;
+
+                    Assert.Equal(67, payload.Id);
+                    Assert.Equal("Hi", payload.Name);
+                }
+
+                source.Write("StructPayload", new Payload() { Name = "Hi", Id = 67 });
+                Assert.Equal(1, result.Count);
+            }
+        }
+
+        /// <summary>
+        /// Tests the IObserver OnCompleted callback. 
+        /// </summary>
+        [Fact]
+        public void Completed()
+        {
+            var result = new List<KeyValuePair<string, object>>();
+            var observer = new ObserverToList<TelemData>(result);
+            var listener = new DiagnosticListener("MyListener");
+            var subscription = listener.Subscribe(observer);
+
+            listener.Write("IntPayload", 5);
+            Assert.Equal(1, result.Count);
+            Assert.Equal("IntPayload", result[0].Key);
+            Assert.Equal(5, result[0].Value);
+            Assert.False(observer.Completed);
+
+            // The listener dies
+            listener.Dispose();
+            Assert.True(observer.Completed);
+
+            // confirm that we can unsubscribe without crashing 
+            subscription.Dispose();
+
+            // If we resubscribe after dispose, but it does not do anything.  
+            subscription = listener.Subscribe(observer);
+
+            listener.Write("IntPayload", 5);
+            Assert.Equal(1, result.Count);
+        }
+
+        /// <summary>
+        /// Simple tests for the IsEnabled method.
+        /// </summary>
+        [Fact]
+        public void BasicIsEnabled()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+                var result = new List<KeyValuePair<string, object>>();
+
+                bool seenUninteresting = false;
+                bool seenStructPayload = false;
+                Predicate<string> predicate = delegate (string name)
+                {
+                    if (name == "Uninteresting")
+                        seenUninteresting = true;
+                    if (name == "StructPayload")
+                        seenStructPayload = true;
+
+                    return name == "StructPayload";
+                };
+
+                using (listener.Subscribe(new ObserverToList<TelemData>(result), predicate))
+                {
+                    Assert.False(source.IsEnabled("Uninteresting"));
+                    Assert.True(source.IsEnabled("StructPayload"));
+
+                    Assert.True(seenUninteresting);
+                    Assert.True(seenStructPayload);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test if it works when you have two subscribers active simultaneously
+        /// </summary>
+        [Fact]
+        public void MultiSubscriber()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+                var subscriber1Result = new List<KeyValuePair<string, object>>();
+                Predicate<string> subscriber1Predicate = name => (name == "DataForSubscriber1");
+                var subscriber1Oberserver = new ObserverToList<TelemData>(subscriber1Result);
+
+                var subscriber2Result = new List<KeyValuePair<string, object>>();
+                Predicate<string> subscriber2Predicate = name => (name == "DataForSubscriber2");
+                var subscriber2Oberserver = new ObserverToList<TelemData>(subscriber2Result);
+
+                // Get two subscribers going. 
+                using (var subscription1 = listener.Subscribe(subscriber1Oberserver, subscriber1Predicate))
+                {
+                    using (var subscription2 = listener.Subscribe(subscriber2Oberserver, subscriber2Predicate))
+                    {
+                        // Things that neither subscribe to get filtered out. 
+                        if (listener.IsEnabled("DataToFilterOut"))
+                            listener.Write("DataToFilterOut", -1);
+
+                        Assert.Equal(0, subscriber1Result.Count);
+                        Assert.Equal(0, subscriber2Result.Count);
+
+                        /****************************************************/
+                        // If a Source does not use the IsEnabled, then every subscriber gets it.  
+                        subscriber1Result.Clear();
+                        subscriber2Result.Clear();
+                        listener.Write("UnfilteredData", 3);
+
+                        Assert.Equal(1, subscriber1Result.Count);
+                        Assert.Equal("UnfilteredData", subscriber1Result[0].Key);
+                        Assert.Equal(3, (int)subscriber1Result[0].Value);
+
+                        Assert.Equal(1, subscriber2Result.Count);
+                        Assert.Equal("UnfilteredData", subscriber2Result[0].Key);
+                        Assert.Equal(3, (int)subscriber2Result[0].Value);
+
+                        /****************************************************/
+                        // Filters not filter out everything, they are just a performance optimization.  
+                        // Here you actually get more than you want even though you use a filter 
+                        subscriber1Result.Clear();
+                        subscriber2Result.Clear();
+                        if (listener.IsEnabled("DataForSubscriber1"))
+                            listener.Write("DataForSubscriber1", 1);
+
+                        Assert.Equal(1, subscriber1Result.Count);
+                        Assert.Equal("DataForSubscriber1", subscriber1Result[0].Key);
+                        Assert.Equal(1, (int)subscriber1Result[0].Value);
+
+                        // Subscriber 2 happens to get it 
+                        Assert.Equal(1, subscriber2Result.Count);
+                        Assert.Equal("DataForSubscriber1", subscriber2Result[0].Key);
+                        Assert.Equal(1, (int)subscriber2Result[0].Value);
+
+                        /****************************************************/
+                        subscriber1Result.Clear();
+                        subscriber2Result.Clear();
+                        if (listener.IsEnabled("DataForSubscriber2"))
+                            listener.Write("DataForSubscriber2", 2);
+
+                        // Subscriber 1 happens to get it 
+                        Assert.Equal(1, subscriber1Result.Count);
+                        Assert.Equal("DataForSubscriber2", subscriber1Result[0].Key);
+                        Assert.Equal(2, (int)subscriber1Result[0].Value);
+
+                        Assert.Equal(1, subscriber2Result.Count);
+                        Assert.Equal("DataForSubscriber2", subscriber2Result[0].Key);
+                        Assert.Equal(2, (int)subscriber2Result[0].Value);
+                    }   // subscriber2 drops out
+
+                    /*********************************************************************/
+                    /* Only Subscriber 1 is left */
+                    /*********************************************************************/
+
+                    // Things that neither subscribe to get filtered out. 
+                    subscriber1Result.Clear();
+                    subscriber2Result.Clear();
+                    if (listener.IsEnabled("DataToFilterOut"))
+                        listener.Write("DataToFilterOut", -1);
+
+                    Assert.Equal(0, subscriber1Result.Count);
+                    Assert.Equal(0, subscriber2Result.Count);
+
+                    /****************************************************/
+                    // If a Source does not use the IsEnabled, then every subscriber gets it.  
+                    subscriber1Result.Clear();
+                    listener.Write("UnfilteredData", 3);
+
+                    Assert.Equal(1, subscriber1Result.Count);
+                    Assert.Equal("UnfilteredData", subscriber1Result[0].Key);
+                    Assert.Equal(3, (int)subscriber1Result[0].Value);
+
+                    // Subscriber 2 has dropped out.
+                    Assert.Equal(0, subscriber2Result.Count);
+
+                    /****************************************************/
+                    // Filters not filter out everything, they are just a performance optimization.  
+                    // Here you actually get more than you want even though you use a filter 
+                    subscriber1Result.Clear();
+                    if (listener.IsEnabled("DataForSubscriber1"))
+                        listener.Write("DataForSubscriber1", 1);
+
+                    Assert.Equal(1, subscriber1Result.Count);
+                    Assert.Equal("DataForSubscriber1", subscriber1Result[0].Key);
+                    Assert.Equal(1, (int)subscriber1Result[0].Value);
+
+                    // Subscriber 2 has dropped out.
+                    Assert.Equal(0, subscriber2Result.Count);
+
+                    /****************************************************/
+                    subscriber1Result.Clear();
+                    if (listener.IsEnabled("DataForSubscriber2"))
+                        listener.Write("DataForSubscriber2", 2);
+
+                    // Subscriber 1 filters
+                    Assert.Equal(0, subscriber1Result.Count);
+                    // Subscriber 2 has dropped out
+                    Assert.Equal(0, subscriber2Result.Count);
+                } // subscriber1 drops out  
+
+                /*********************************************************************/
+                /* No Subscribers are left */
+                /*********************************************************************/
+
+                // Things that neither subscribe to get filtered out. 
+                subscriber1Result.Clear();
+                subscriber2Result.Clear();
+                if (listener.IsEnabled("DataToFilterOut"))
+                    listener.Write("DataToFilterOut", -1);
+
+                Assert.Equal(0, subscriber1Result.Count);
+                Assert.Equal(0, subscriber2Result.Count);
+
+                /****************************************************/
+                // If a Source does not use the IsEnabled, then every subscriber gets it.  
+
+                listener.Write("UnfilteredData", 3);
+
+                // No one subscribing
+                Assert.Equal(0, subscriber1Result.Count);
+                Assert.Equal(0, subscriber2Result.Count);
+
+                /****************************************************/
+                // Filters not filter out everything, they are just a performance optimization.  
+                // Here you actually get more than you want even though you use a filter 
+                if (listener.IsEnabled("DataForSubscriber1"))
+                    listener.Write("DataForSubscriber1", 1);
+
+                // No one subscribing
+                Assert.Equal(0, subscriber1Result.Count);
+                Assert.Equal(0, subscriber2Result.Count);
+
+                /****************************************************/
+                if (listener.IsEnabled("DataForSubscriber2"))
+                    listener.Write("DataForSubscriber2", 2);
+
+                // No one subscribing
+                Assert.Equal(0, subscriber1Result.Count);
+                Assert.Equal(0, subscriber2Result.Count);
+            }
+        }
+
+        /// <summary>
+        /// Stresses the Subscription routine by having many threads subscribe and
+        /// unsubscribe concurrently
+        /// </summary>
+        [Fact]
+        public void MultiSubscriberStress()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+
+                var random = new Random();
+                //  Beat on the default listener by subscribing and unsubscribing on many threads simultaneously. 
+                var factory = new TaskFactory();
+
+                // To the whole stress test 10 times.  This keeps the task array size needed down while still
+                // having lots of concurrency.   
+                for (int j = 0; j < 20; j++)
+                {
+                    // Spawn off lots of concurrent activity
+                    var tasks = new Task[1000];
+                    for (int i = 0; i < tasks.Length; i++)
+                    {
+                        tasks[i] = factory.StartNew(delegate (object taskData)
+                        {
+                            int taskNum = (int)taskData;
+                            var taskName = "Task" + taskNum;
+                            var result = new List<KeyValuePair<string, object>>();
+                            Predicate<string> predicate = (name) => name == taskName;
+                            Predicate<KeyValuePair<string, object>> filter = (keyValue) => keyValue.Key == taskName;
+
+                        // set up the observer to only see events set with the task name as the nname.  
+                        var observer = new ObserverToList<TelemData>(result, filter, taskName);
+                            using (listener.Subscribe(observer, predicate))
+                            {
+                                source.Write(taskName, taskNum);
+
+                                Assert.Equal(1, result.Count);
+                                Assert.Equal(taskName, result[0].Key);
+                                Assert.Equal(taskNum, result[0].Value);
+
+                            // Spin a bit randomly.  This mixes of the lifetimes of the subscriptions and makes it 
+                            // more stressful 
+                            var cnt = random.Next(10, 100) * 1000;
+                                while (0 < --cnt)
+                                    GC.KeepAlive("");
+                            }   // Unsubscribe
+
+                        // Send the notification again, to see if it now does NOT come through (count remains unchanged). 
+                        source.Write(taskName, -1);
+                            Assert.Equal(1, result.Count);
+                        }, i);
+                    }
+                    Task.WaitAll(tasks);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests if as we create new DiagnosticListerns, we get callbacks for them 
+        /// </summary>
+        [Fact]
+        public void AllListenersAddRemove()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+
+                // This callback will return the listener that happens on the callback  
+                DiagnosticListener returnedListener = null;
+                Action<DiagnosticListener> onNewListener = delegate (DiagnosticListener listen)
+                {
+                    Assert.Null(returnedListener);
+                    Assert.NotNull(listen);
+                    returnedListener = listen;
+                };
+
+                // Subscribe, which delivers catch-up event for the Default listener 
+                using (var allListenerSubscription = DiagnosticListener.AllListeners.Subscribe(MakeObserver(onNewListener)))
+                {
+                    Assert.Equal(listener, returnedListener);
+                    returnedListener = null;
+                }   // Now we unsubscribe
+
+                // Create an dispose a listener, but we won't get a callback for it.  
+                using (new DiagnosticListener("TestListen"))
+                { }
+
+                Assert.Null(returnedListener);          // No callback was made 
+
+                // Resubscribe  
+                using (var allListenerSubscription = DiagnosticListener.AllListeners.Subscribe(MakeObserver(onNewListener)))
+                {
+
+                    Assert.Equal(listener, returnedListener);
+                    returnedListener = null;
+
+                    // add two new subscribers
+                    using (var listener1 = new DiagnosticListener("TestListen1"))
+                    {
+                        Assert.Equal(listener1.Name, "TestListen1");
+                        Assert.Equal(listener1, returnedListener);
+                        returnedListener = null;
+
+                        using (var listener2 = new DiagnosticListener("TestListen2"))
+                        {
+                            Assert.Equal(listener2.Name, "TestListen2");
+                            Assert.Equal(listener2, returnedListener);
+                            returnedListener = null;
+                        }   // Dispose of listener2
+                    }   // Dispose of listener1
+
+                } // Unsubscribe 
+
+                // Check that we are back to just the DefaultListener. 
+                using (var allListenerSubscription = DiagnosticListener.AllListeners.Subscribe(MakeObserver(onNewListener)))
+                {
+                    Assert.Equal(listener, returnedListener);
+                    returnedListener = null;
+                }   // cleanup 
+            }
+        }
+
+        /// <summary>
+        /// Tests that the 'catchupList' of active listeners is accurate even as we 
+        /// add and remove DiagnosticListeners randomly.  
+        /// </summary>
+        [Fact]
+        public void AllListenersCheckCatchupList()
+        {
+            var expected = new List<DiagnosticListener>();
+            var list = GetActiveNonDefaultListeners();
+            Assert.Equal(list, expected);
+
+            for (int i = 0; i < 50; i++)
+            {
+                expected.Insert(0, (new DiagnosticListener("TestListener" + i)));
+                list = GetActiveNonDefaultListeners();
+                Assert.Equal(list, expected);
+            }
+
+            // Remove the element randomly.  
+            var random = new Random(0);
+            while (0 < expected.Count)
+            {
+                var toRemoveIdx = random.Next(0, expected.Count - 1);     // Always leave the Default listener.  
+                var toRemoveListener = expected[toRemoveIdx];
+                toRemoveListener.Dispose();     // Kill it (which removes it from the list)
+                expected.RemoveAt(toRemoveIdx);
+                list = GetActiveNonDefaultListeners();
+                Assert.Equal(list.Count, expected.Count);
+                Assert.Equal(list, expected);
+            }
+        }
+
+        /// <summary>
+        /// Stresses the AllListeners by having many threads be added and removed.
+        /// </summary>
+        [Fact]
+        public void AllSubscriberStress()
+        {
+            var list = GetActiveNonDefaultListeners();
+            Assert.Equal(0, list.Count);
+
+            var factory = new TaskFactory();
+
+            // To the whole stress test 10 times.  This keeps the task array size needed down while still
+            // having lots of concurrency.   
+            for (int k = 0; k < 10; k++)
+            {
+                // TODO FIX NOW:  Task[1] should be Task[100] but it fails.  
+                var tasks = new Task[1];
+                for (int i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = (factory.StartNew(delegate ()
+                    {
+                        // Create a set of DiagnosticListeners (which add themselves to the AllListeners list. 
+                        var listeners = new List<DiagnosticListener>();
+                        for (int j = 0; j < 100; j++)
+                            listeners.Insert(0, (new DiagnosticListener("Task " + i + " TestListener" + j)));
+
+                        // They are all in the list
+                        list = GetActiveNonDefaultListeners();
+                        foreach (var listener in listeners)
+                            Assert.Contains(listener, list);
+
+                        // Dispose them all, first the even then the odd, just to mix it up and be more stressful.  
+                        for (int j = 0; j < listeners.Count; j += 2)      // Even
+                            listeners[j].Dispose();
+                        for (int j = 1; j < listeners.Count; j += 2)      // odd
+                            listeners[j].Dispose();
+
+
+                        // And now they are not in the list.  
+                        list = GetActiveNonDefaultListeners();
+                        foreach (var listener in listeners)
+                            Assert.DoesNotContain(listener, list);
+                    }));
+                }
+                // Wait for all the tasks to finish.  
+                Task.WaitAll(tasks);
+            }
+
+            // There should be no listeners left.  
+            list = GetActiveNonDefaultListeners();
+            Assert.Equal(0, list.Count);
+        }
+
+        [Fact]
+        public void DoubleDisposeOfListener()
+        {
+            var listener = new DiagnosticListener("MyListener");
+            int completionCount = 0;
+
+            IDisposable subscription = listener.Subscribe(MakeObserver<KeyValuePair<string, object>>(_ => { }, () => completionCount++));
+
+            listener.Dispose();
+            listener.Dispose();
+
+            subscription.Dispose();
+            subscription.Dispose();
+
+            Assert.Equal(1, completionCount);
+        }
+
+        [Fact]
+        public void ListenerToString()
+        {
+            string name = Guid.NewGuid().ToString();
+            using (var listener = new DiagnosticListener(name))
+            {
+                Assert.Equal(name, listener.ToString());
+            }
+        }
+
+        [Fact]
+        public void DisposeAllListenerSubscriptionInSameOrderSubscribed()
+        {
+            int count1 = 0, count2 = 0, count3 = 0;
+            IDisposable sub1 = DiagnosticListener.AllListeners.Subscribe(MakeObserver<DiagnosticListener>(onCompleted: () => count1++));
+            IDisposable sub2 = DiagnosticListener.AllListeners.Subscribe(MakeObserver<DiagnosticListener>(onCompleted: () => count2++));
+            IDisposable sub3 = DiagnosticListener.AllListeners.Subscribe(MakeObserver<DiagnosticListener>(onCompleted: () => count3++));
+
+            Assert.Equal(0, count1);
+            Assert.Equal(0, count2);
+            Assert.Equal(0, count3);
+
+            sub1.Dispose();
+            Assert.Equal(1, count1);
+            Assert.Equal(0, count2);
+            Assert.Equal(0, count3);
+            sub1.Dispose(); // dispose again just to make sure nothing bad happens
+
+            sub2.Dispose();
+            Assert.Equal(1, count1);
+            Assert.Equal(1, count2);
+            Assert.Equal(0, count3);
+            sub2.Dispose();
+
+            sub3.Dispose();
+            Assert.Equal(1, count1);
+            Assert.Equal(1, count2);
+            Assert.Equal(1, count3);
+            sub3.Dispose();
+        }
+
+        #region Helpers 
+        /// <summary>
+        /// Returns the list of active diagnostic listeners.  
+        /// </summary>
+        /// <returns></returns>
+        private static List<DiagnosticListener> GetActiveNonDefaultListeners()
+        {
+            var ret = new List<DiagnosticListener>();
+            Action<DiagnosticListener> onNewListener = delegate (DiagnosticListener listen)
+            {
+                ret.Add(listen);
+            };
+
+            // Subscribe, which gives you the list
+            using (var allListenerSubscription = DiagnosticListener.AllListeners.Subscribe(MakeObserver(onNewListener)))
+            {
+            } // Unsubscribe to remove side effects.  
+            return ret;
+        }
+
+        /// <summary>
+        /// Used to make an observer out of a action delegate. 
+        /// </summary>
+        private static IObserver<T> MakeObserver<T>(
+            Action<T> onNext = null, Action onCompleted = null)
+        {
+            return new Observer<T>(onNext, onCompleted);
+        }
+
+        /// <summary>
+        /// Used in the implementation of MakeObserver.  
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        private class Observer<T> : IObserver<T>
+        {
+            public Observer(Action<T> onNext, Action onCompleted)
+            {
+                _onNext = onNext ?? new Action<T>(_ => { });
+                _onCompleted = onCompleted ?? new Action(() => { });
+            }
+
+            public void OnCompleted() { _onCompleted(); }
+            public void OnError(Exception error) { }
+            public void OnNext(T value) { _onNext(value); }
+
+            private Action<T> _onNext;
+            private Action _onCompleted;
+        }
+        #endregion 
+    }
+
+    // Takes an IObserver and returns a List<T> that are the elements observed.
+    // Will assert on error and 'Completed' is set if the 'OnCompleted' callback
+    // is issued.  
+    internal class ObserverToList<T> : IObserver<T>
+    {
+        public ObserverToList(List<T> output, Predicate<T> filter = null, string name = null)
+        {
+            _output = output;
+            _output.Clear();
+            _filter = filter;
+            _name = name;
+        }
+
+        public bool Completed { get; private set; }
+
+        #region private
+
+        public void OnCompleted()
+        {
+            Completed = true;
+        }
+
+        public void OnError(Exception error)
+        {
+            Assert.True(false, "Error happened on IObserver");
+        }
+
+        public void OnNext(T value)
+        {
+            Assert.False(Completed);
+            if (_filter == null || _filter(value))
+                _output.Add(value);
+        }
+
+        private List<T> _output;
+        private Predicate<T> _filter;
+        private string _name;  // for debugging 
+        #endregion
+    }
+
+    /// <summary>
+    /// Trivial class used for payloads.  (Usually anonymous types are used.  
+    /// </summary>
+    internal class Payload
+    {
+        public string Name { get; set; }
+        public int Id { get; set; }
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Diagnostics.DiagnosticSource.Tests</AssemblyName>
+    <RootNamespace>System.Diagnostics.DiagnosticSource.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DiagnosticSourceTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.csproj">
+      <Project>{F24D3391-2928-4E83-AADE-B34423498750}</Project>
+      <Name>System.Diagnostics.DiagnosticSource</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Globalization": "4.0.10",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0-beta3-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
@@ -1,0 +1,983 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "xunit/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.assert": "[2.1.0-beta3-build3029]",
+          "xunit.core": "[2.1.0-beta3-build3029]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-beta3-build3029": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-beta3-build3029]",
+          "xunit.extensibility.execution": "[2.1.0-beta3-build3029]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0]"
+        },
+        "compile": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll": {},
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.tdnet.dll": {},
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-beta3-build3029]"
+        },
+        "compile": {
+          "lib/dnxcore50/xunit.execution.dnx.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/xunit.execution.dnx.dll": {}
+        }
+      },
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "xunit": "2.1.0-beta3-build3029"
+        },
+        "compile": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Collections/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
+      "files": [
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.4.0.10.nupkg",
+        "System.Collections.4.0.10.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.4.0.10.nupkg",
+        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Globalization/4.0.10": {
+      "type": "package",
+      "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.4.0.10.nupkg",
+        "System.Globalization.4.0.10.nupkg.sha512",
+        "System.Globalization.nuspec"
+      ]
+    },
+    "System.IO/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
+      "files": [
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.4.0.10.nupkg",
+        "System.IO.4.0.10.nupkg.sha512",
+        "System.IO.nuspec"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.4.0.0.nupkg",
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0.nupkg",
+        "System.Private.Uri.4.0.0.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.10": {
+      "type": "package",
+      "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.4.0.10.nupkg",
+        "System.Reflection.4.0.10.nupkg.sha512",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.4.0.0.nupkg",
+        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.4.0.0.nupkg",
+        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20.nupkg",
+        "System.Runtime.4.0.20.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.4.0.0.nupkg",
+        "System.Runtime.Handles.4.0.0.nupkg.sha512",
+        "System.Runtime.Handles.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.4.0.20.nupkg",
+        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
+      "files": [
+        "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23213.nupkg",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23213.nupkg.sha512",
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "type": "package",
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Threading/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.4.0.10.nupkg",
+        "System.Threading.4.0.10.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.4.0.10.nupkg",
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    },
+    "xunit/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "NMFXV0ePe/GrfhMSPGAlWmiUZCzjaatpdAGcavf2B6vYTRyMTpyJT01LI6jemMV/VSDXLrtHp0Ov9xZyR1cLLg==",
+      "files": [
+        "xunit.2.1.0-beta3-build3029.nupkg",
+        "xunit.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.nuspec"
+      ]
+    },
+    "xunit.abstractions/2.0.0": {
+      "type": "package",
+      "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
+      "files": [
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
+        "xunit.abstractions.2.0.0.nupkg",
+        "xunit.abstractions.2.0.0.nupkg.sha512",
+        "xunit.abstractions.nuspec"
+      ]
+    },
+    "xunit.assert/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "AMS7Fv77DayXVRCBMmVEDwOXPcbxk8dCBA/iACsve+6+UQqopMtNyAynyIcXPFRK/peeitUKID4ChOXWisJmUw==",
+      "files": [
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.pdb",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.xml",
+        "xunit.assert.2.1.0-beta3-build3029.nupkg",
+        "xunit.assert.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.assert.nuspec"
+      ]
+    },
+    "xunit.core/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "uDUBbwZSRx226BMwj6VylzXQPVpEIelNIulT+LxbSEH52y2a4btR9d5ptQmkSVjmJXP5/hGCc4cu1DSCu0pgUA==",
+      "files": [
+        "build/_Desktop/xunit.execution.desktop.dll",
+        "build/monoandroid/xunit.core.props",
+        "build/monoandroid/xunit.execution.MonoAndroid.dll",
+        "build/monotouch/xunit.core.props",
+        "build/monotouch/xunit.execution.MonoTouch.dll",
+        "build/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.props",
+        "build/portable-win81+wpa81/xunit.core.props",
+        "build/portable-win81+wpa81/xunit.core.targets",
+        "build/portable-win81+wpa81/xunit.execution.universal.dll",
+        "build/portable-win81+wpa81/xunit.execution.universal.pri",
+        "build/wp8/xunit.core.props",
+        "build/wp8/xunit.core.targets",
+        "build/wp8/xunit.execution.wp8.dll",
+        "build/Xamarin.iOS/xunit.core.props",
+        "build/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
+        "xunit.core.2.1.0-beta3-build3029.nupkg",
+        "xunit.core.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.core.nuspec"
+      ]
+    },
+    "xunit.extensibility.core/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "lsPro5U3NLasHI/RwqjKzXiRlh9N0IOlR3cluwXYVtihXbGtySeSnU/Fh5MTcWYxh+MVpoNop5zDD0/A2nrHsA==",
+      "files": [
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll.tdnet",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.pdb",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.xml",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.tdnet.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll",
+        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg",
+        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.extensibility.core.nuspec"
+      ]
+    },
+    "xunit.extensibility.execution/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "WuUYamK4RHrHxihvNuX7NkryMhQrpH1+ziJ/mPIQbm18zevSgre8BwUuVZvmLZa8uVob3xS4dvAah2+HCgLiXg==",
+      "files": [
+        "lib/dnx451/xunit.execution.dnx.dll",
+        "lib/dnx451/xunit.execution.dnx.pdb",
+        "lib/dnx451/xunit.execution.dnx.xml",
+        "lib/dnxcore50/xunit.execution.dnx.dll",
+        "lib/dnxcore50/xunit.execution.dnx.pdb",
+        "lib/dnxcore50/xunit.execution.dnx.xml",
+        "lib/monoandroid/xunit.execution.MonoAndroid.dll",
+        "lib/monoandroid/xunit.execution.MonoAndroid.pdb",
+        "lib/monoandroid/xunit.execution.MonoAndroid.xml",
+        "lib/monotouch/xunit.execution.MonoTouch.dll",
+        "lib/monotouch/xunit.execution.MonoTouch.pdb",
+        "lib/monotouch/xunit.execution.MonoTouch.xml",
+        "lib/net45/xunit.execution.desktop.dll",
+        "lib/net45/xunit.execution.desktop.pdb",
+        "lib/net45/xunit.execution.desktop.xml",
+        "lib/portable-wpa81+win81/xunit.execution.universal.dll",
+        "lib/portable-wpa81+win81/xunit.execution.universal.pdb",
+        "lib/portable-wpa81+win81/xunit.execution.universal.pri",
+        "lib/portable-wpa81+win81/xunit.execution.universal.xml",
+        "lib/wp8/xunit.execution.wp8.dll",
+        "lib/wp8/xunit.execution.wp8.pdb",
+        "lib/wp8/xunit.execution.wp8.xml",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.pdb",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.xml",
+        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg",
+        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.extensibility.execution.nuspec"
+      ]
+    },
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
+      "files": [
+        "lib/dotnet/Xunit.NetCore.Extensions.dll",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
+        "xunit.netcore.extensions.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Collections >= 4.0.10",
+      "System.Diagnostics.Debug >= 4.0.10",
+      "System.Globalization >= 4.0.10",
+      "System.Reflection >= 4.0.10",
+      "System.Runtime >= 4.0.20",
+      "System.Runtime.Extensions >= 4.0.10",
+      "System.Threading >= 4.0.10",
+      "System.Threading.Tasks >= 4.0.10",
+      "xunit >= 2.1.0-beta3-*",
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
@@ -277,7 +277,7 @@
           "lib/dnxcore50/xunit.execution.dnx.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00099": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -953,14 +953,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00099": {
       "type": "package",
       "serviceable": true,
-      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
+      "sha512": "wb9DcRxzCE2T8pBsBFbGONg739pvsoZKFOxL6GhWR217MzMopKPAdw+VqmCPabIRRDJSnGdktUaB5+neNmmOrA==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00099.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00099.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
Rename System.Diagnostics.Tracing.Telemetry.TelemetrySource -> System.Diagnostics.DiagnosticSource
Rename the DLL from System.Diagnostics.Tracing.Telemetry -> System.Diagnostics.DiagnosticSource
Rename WriteTelemetry -> Write

The basic reason for this is that what this calls is for is detailed information that is more like a debugger than a monitoring agent.  When people think Telemetry, they think monitoring, and that simply leads to inappropriate use 

This code is essentially a rename of TelemetrySource.  In another pull request I Will obsolete TelemetrySource and later still simply remove it.  