### PR TITLE
Extract the whole cert chain during SSL handshake.

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -225,6 +225,14 @@ internal static partial class Interop
             return certPtr;
         }
 
+        internal static SafeSharedX509StackHandle GetPeerCertificateChain(IntPtr sslContextPtr)
+        {
+            SslContext context = Marshal.PtrToStructure<SslContext>(sslContextPtr);
+            IntPtr sslPtr = context.sslPtr;
+
+            return libssl.SSL_get_peer_cert_chain(sslPtr);
+        }
+
         internal static libssl.SSL_CIPHER GetConnectionInfo(IntPtr sslContextPtr)
         {
             SslContext context = Marshal.PtrToStructure<SslContext>(sslContextPtr);

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
@@ -86,6 +86,9 @@ internal static partial class Interop
         internal static extern IntPtr SSL_get_peer_certificate(IntPtr ssl);
 
         [DllImport(Interop.Libraries.LibSsl)]
+        internal static extern SafeSharedX509StackHandle SSL_get_peer_cert_chain(IntPtr ssl);
+
+        [DllImport(Interop.Libraries.LibSsl)]
         internal static extern IntPtr SSL_get_current_cipher(IntPtr ssl);
 
         [DllImport(Interop.Libraries.LibSsl)]


### PR DESCRIPTION
When the server sends the whole cert chain, extract the elements after the leaf/EE certificate to be passed into X509Chain.ChainPolicy.ExtraStore; this will prevent failures due to unknown intermediate CAs (and may also prevent the need to download that intermediate).

This is a partial fix for #3362 (GetRemoteCertificate - Fetch remoteCertificateStore, if applicable for unix. (CertModule.cs)).