### PR TITLE
Fix a bug in Windows async sockets.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -836,6 +836,15 @@ namespace System.Net.Sockets
                 {
                     _ptrNativeOverlapped.Dispose();
                     _ptrNativeOverlapped = null;
+                }
+
+                // Free the preallocated overlapped object. This in turn will unpin
+                // any pinned buffers.
+                if (_preAllocatedOverlapped != null)
+                {
+                    _preAllocatedOverlapped.Dispose();
+                    _preAllocatedOverlapped = null;
+
                     _pinState = PinState.None;
                     _pinnedAcceptBuffer = null;
                     _pinnedSingleBuffer = null;
@@ -843,25 +852,22 @@ namespace System.Net.Sockets
                     _pinnedSingleBufferCount = 0;
                 }
 
-                if (_preAllocatedOverlapped != null)
-                {
-                    _preAllocatedOverlapped.Dispose();
-                    _preAllocatedOverlapped = null;
-                }
-
-                // Free any alloc'd GCHandles.
+                // Free any allocated GCHandles.
                 if (_socketAddressGCHandle.IsAllocated)
                 {
                     _socketAddressGCHandle.Free();
                 }
+
                 if (_wsaMessageBufferGCHandle.IsAllocated)
                 {
                     _wsaMessageBufferGCHandle.Free();
                 }
+
                 if (_wsaRecvMsgWSABufferArrayGCHandle.IsAllocated)
                 {
                     _wsaRecvMsgWSABufferArrayGCHandle.Free();
                 }
+
                 if (_controlBufferGCHandle.IsAllocated)
                 {
                     _controlBufferGCHandle.Free();


### PR DESCRIPTION
Consider the following sequence of events for a SocketAsyncEventArgs `args`
and a non-null `byte` buffer `buf`:
1. `args._buffer` is set to `buf` via `args.SetBuffer(buf, 0, buf.Length)`
2. Some asychronous call is made using `args` (e.g. `socket.SendAsync(args)`)
3. The asynchronous call completed
4. `args._buffer` is set to `null` via `args.SetBuffer(null, 0, 0)`
5. A GC occurs that relocates `buf`.
6. `args._buffer` is reset to `buf` via `args.SetBuffer(buf, 0, buf.Length)`
7. Another asynchronous call is made using `args` (e.g.
   `socket.SendAsync(args)`)

- (2) will pin `buf` via a `PreAllocatedOverlapped` instance, store the
  instance in `args._preAllocatedOverlapped`, set `args._pinState` to
  `PinState.SingleBuffer`, set up a native overlapped object, and finally set
  `args._ptrNativeOverlapped` to a safe handle that wraps the overlapped
  object.
- (3) will dispose the handle stored in `args._ptrNativeOverlapped` and set
  `args._ptrNativeOverlapped` to `null`.
- (4) will call `args.FreeOverlapped`, which will dispose
  `args._preAllocatedOverlapped` (thus unpinning `buf`) and set
  `args._preAllocatedOverlapped` to `null`. `args._pinState` and related
  fields will not be updated: the code that does so is conditional upon
  `args._ptrNativeOverlapped` being non-`null`, and (3) already set the
  same to `null`.
- (6) will call `args.CheckPinSingleBuffer`, which will observe that
  `args._pinState` is `PinState.SingleBuffer` and `_pinnedSingleBuffer`
  is the same as `_buffer` and consider the buffer already pinned. As a
  result, the call will not re-pin `buf`.
- Because (6) did not re-pin `buf`, the asynchronous call made in (7) will
  reuse the address at which the buffer was located the last time it was
  pinned. At best, this address is no longer mapped and the call results in
  an AV; at worst, this address contains unknown (and potentially sensitive)
  data.

The fix is to reset `_pinState` and related fields when `_preAllocatedOverlapped`
is disposed.