### PR TITLE
CURL Handler redirect fixes

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -32,6 +32,8 @@ internal static partial class Interop
             internal const int CURLOPT_NOSIGNAL = CurlOptionLongBase + 99;
             internal const int CURLOPT_PROXYTYPE = CurlOptionLongBase + 101;
             internal const int CURLOPT_HTTPAUTH = CurlOptionLongBase + 107;
+            internal const int CURLOPT_PROTOCOLS = CurlOptionLongBase + 181;
+            internal const int CURLOPT_REDIR_PROTOCOLS = CurlOptionLongBase + 182;
 
             internal const int CURLOPT_WRITEDATA = CurlOptionObjectPointBase + 1;
             internal const int CURLOPT_URL = CurlOptionObjectPointBase + 2;
@@ -131,6 +133,12 @@ internal static partial class Interop
             internal const int CURL_VERSION_GSSAPI       = (1<<17);
             internal const int CURL_VERSION_KERBEROS5    = (1<<18);
             internal const int CURL_VERSION_UNIX_SOCKETS = (1<<19);
+        }
+
+        internal static partial class CURLPROTO_Definitions
+        {
+            internal const int CURLPROTO_HTTP  =  (1<<0);
+            internal const int CURLPROTO_HTTPS =  (1<<1);
         }
 
         // Type definition of CURLMsg from multi.h

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -665,7 +665,15 @@ namespace System.Net.Http
             if (Uri.TryCreate(location, UriKind.RelativeOrAbsolute, out forwardUri) && forwardUri.IsAbsoluteUri)
             {
                 NetworkCredential newCredential = GetCredentials(state._handler.Credentials as CredentialCache, forwardUri);
-                state.SetCredentialsOptions(newCredential);
+                if (newCredential != null)
+                {
+                    state.SetCredentialsOptions(newCredential);
+                }
+                else
+                {
+                    state.SetCurlOption(CURLoption.CURLOPT_USERNAME, IntPtr.Zero);
+                    state.SetCurlOption(CURLoption.CURLOPT_PASSWORD, IntPtr.Zero);
+                }
 
                 // reset proxy - it is possible that the proxy has different credentials for the new URI
                 state.SetProxyOptions(forwardUri);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -205,7 +205,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(3555, PlatformID.AnyUnix)]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpsToHttp_StatusCodeRedirect()
         {
             var handler = new HttpClientHandler();
@@ -245,7 +244,6 @@ namespace System.Net.Http.Functional.Tests
        }
 
         [Fact]
-        [ActiveIssue(3557, PlatformID.AnyUnix)]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK()
         {
             Uri uri = HttpTestServers.BasicAuthUriForCreds(Username, Password);


### PR DESCRIPTION
This commit fixes the following issues  in CurlHandler w.r.t following URI redirection
* Ensure that the credentials are nullified at the right place. We should not set username and/or password to null unnecessarily.
* Ensure that libcurl follows only HTTPS uri if the original request was for a HTTPS URL.
* Ensure that libcurl follows only a HTTPS or a HTTP uri if the original request was for a HTTP URL.
