### PR TITLE
Fix seg faults due to incorrect crypto DllImport signatures

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -94,8 +94,16 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative)]
         internal static extern void RecursiveFreeX509Stack(IntPtr stack);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
-        internal static extern string GetX509RootStorePath();
+        internal static string GetX509RootStorePath()
+        {
+            IntPtr ptr = GetX509RootStorePath_private();
+            return ptr != null ?
+                Marshal.PtrToStringAnsi(ptr) :
+                null;
+        }
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509RootStorePath")]
+        private static extern IntPtr GetX509RootStorePath_private();
 
         [DllImport(Libraries.CryptoNative)]
         private static extern int GetPkcs7Certificates(SafePkcs7Handle p7, out SafeSharedX509StackHandle certs);

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
@@ -41,8 +41,16 @@ internal static partial class Interop
         [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
         internal static extern int OBJ_sn2nid(string sn);
 
-        [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
-        internal static extern string OBJ_nid2ln(int n);
+        internal static string OBJ_nid2ln(int n)
+        {
+            IntPtr ptr = OBJ_nid2ln_private(n);
+            return ptr != null ?
+                Marshal.PtrToStringAnsi(ptr) :
+                null;
+        }
+
+        [DllImport(Libraries.LibCrypto, EntryPoint = "OBJ_nid2ln")]
+        private static extern IntPtr OBJ_nid2ln_private(int n);
 
         // Returns shared pointers, should not be tracked as a SafeHandle.
         [DllImport(Libraries.LibCrypto)]

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.X509.cs
@@ -119,8 +119,16 @@ internal static partial class Interop
         [DllImport(Libraries.LibCrypto)]
         internal static extern int X509_STORE_CTX_get_error_depth(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.LibCrypto)]
-        internal static extern string X509_verify_cert_error_string(X509VerifyStatusCode n);
+        internal static string X509_verify_cert_error_string(X509VerifyStatusCode n)
+        {
+            IntPtr ptr = X509_verify_cert_error_string_private(n);
+            return ptr != null ?
+                Marshal.PtrToStringAnsi(ptr) :
+                null;
+        }
+
+        [DllImport(Libraries.LibCrypto, EntryPoint = "X509_verify_cert_error_string")]
+        private static extern IntPtr X509_verify_cert_error_string_private(X509VerifyStatusCode n);
         
         [DllImport(Libraries.LibCrypto)]
         internal static extern void X509_CRL_free(IntPtr a);


### PR DESCRIPTION
Three DllImports were declared to return strings rather than IntPtr.  Returning a string like this should only be done when the native code is allocating a ```char*``` that must be freed by the consumer, and the CLR dutifully attempts to do so after marshaling the ```char*``` to the managed string.  However, these three DllImports all return ```const char*```s that shouldn't be freed, which was resulting in seg faults.

The fix is simply to declare the DllImports to return IntPtr, and then use Marshal.PtrToStringAnsi to do the marshaling.

Fix #3581
cc: @bartonjs, @nguerrera 