### PR TITLE
Make X509FindType.FindBySubjectKeyIdentifier correctly check for equality

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -91,7 +91,7 @@ namespace Internal.Cryptography
 
             for (int i = 0; i < a1.Length; i++)
             {
-                if (a1[0] != a2[0])
+                if (a1[i] != a2[i])
                     return false;
             }
             return true;

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -387,6 +387,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [ActiveIssue(1993, PlatformID.AnyUnix)]
+        public static void TestBySubjectKeyIdentifier_NoMatch_RightLength()
+        {
+            RunZeroMatchTest(
+                X509FindType.FindBySubjectKeyIdentifier,
+                "5971A65A334DDA980780FF841EBE87F9723241F0");
+        }
+
+        [Fact]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestByApplicationPolicy_MatchAll()
         {
             RunTest(


### PR DESCRIPTION
FindBySubjectKeyIdentifier only checked the byte[].Length and the value of the first byte; it returned false matches for an incremented key value.

Added a test that fails without this change to keep it from regressing.