### PR TITLE
Don't copy WP8 aseemblies to test overlay

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -148,7 +148,7 @@ create_test_overlay()
 	echo "Corefx binaries not found at $CoreFxBins"
 	exit 1
   fi
-  find $CoreFxBins -path "*ToolRuntime*" -prune -o -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
+  find $CoreFxBins \( -path "*ToolRuntime*" -or -path "*System.Threading.Tasks.Dataflow.WP8*" \) -prune -o -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
 
   # Then the native CoreFX binaries
   if [ ! -d $CoreFxNativeBins ]

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
@@ -9,7 +9,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
     public class EtwTests
     {
         [Fact]
-        [ActiveIssue(3520, PlatformID.OSX)]
         public void TestEtw()
         {
             using (var listener = new TestEventListener(new Guid("16F53577-E41D-43D4-B47E-C17025BF4025"), EventLevel.Verbose))


### PR DESCRIPTION
Before we moved to using packer to slim down our test drop, we had
Jenkins exclude the System.Threading.Tasks.Dataflow.WP8 assemblies when
uploading build artifacts. This meant that the OSX and Linux jobs would
never copy them down and hence they could not be picked up by
run-test.sh (and overwrite the correct version of
System.Threading.Tasks.Dataflow when building the test overlay).

With packer, we now archive everything, so depending on the order in
which find discovered files, we may have copied over the WP8 version,
which does not have ETW support.

For now, update run-test.sh to exclude this folder when copying stuff
over. The correct long term fix is to just do what we do on
Windows (have the build produce the correct test layouts and get out of
this run-test.sh test overlay game).

Fixes #3520