### PR TITLE
Increasing the positive case timeout for an unreliable Timer test

### DIFF
--- a/src/System.Threading.Timer/tests/TimerChangeTests.cs
+++ b/src/System.Threading.Timer/tests/TimerChangeTests.cs
@@ -91,7 +91,7 @@ public class TimerChangeTests
         {
             Assert.False(are.WaitOne(TimeSpan.FromMilliseconds(100)), "The reset event should not have been set yet");
             t.Change(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(-1));
-            Assert.True(are.WaitOne(TimeSpan.FromMilliseconds(500)), "Should have received a timer event after this new duration");
+            Assert.True(are.WaitOne(TimeSpan.FromMilliseconds(TimerFiringTests.MaxPositiveTimeoutInMs)), "Should have received a timer event after this new duration");
         }
     }
 }

--- a/src/System.Threading.Timer/tests/TimerFiringTests.cs
+++ b/src/System.Threading.Timer/tests/TimerFiringTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 public class TimerFiringTests
 {
-    private const int MaxPositiveTimeoutInMs = 30000;
+    internal const int MaxPositiveTimeoutInMs = 30000;
 
     [Fact]
     public void Timer_Fires_After_DueTime_Ellapses()


### PR DESCRIPTION
This test fails randomly and unreliably; it looks to be a timing issue so increasing the positive-case timeout should add some buffer time for the timer to fire. Since this is the positive case, if the timer fires quickly then the wait will be cut short and not slow down the run. This fixes #3533

/cc: @stephentoub 