### PR TITLE
Restore HandleKind.Namespace and HandleKind.String values

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Handles.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Handles.cs
@@ -123,7 +123,18 @@ namespace System.Reflection.Metadata
 
         public HandleKind Kind
         {
-            get { return HandleType.ToHandleKind(_vType & HandleType.TypeMask); }
+            get
+            {
+                uint type = Type;
+
+                // Do not surface extra non-virtual string type bits in public handle kind
+                if ((type & ~HandleType.NonVirtualStringTypeMask) == HandleType.String)
+                {
+                    return HandleKind.String;
+                }
+
+                return (HandleKind)type;
+            }
         }
 
         public bool IsNil
@@ -257,7 +268,12 @@ namespace System.Reflection.Metadata
 
         public HandleKind Kind
         {
-            get { return HandleType.ToHandleKind(Type >> TokenTypeIds.RowIdBitCount); }
+            get 
+            { 
+                // EntityHandles cannot be StringHandles and therefore we do not need
+                // to handle stripping the extra non-virtual string type bits here.
+                return (HandleKind)(Type >> TokenTypeIds.RowIdBitCount);
+            }
         }
 
         internal int Token
@@ -2578,10 +2594,10 @@ namespace System.Reflection.Metadata
 
         private StringHandle(uint value)
         {
-            Debug.Assert((value & HeapHandleType.TypeMask) == StringHandleType.String ||
-                         (value & HeapHandleType.TypeMask) == StringHandleType.VirtualString ||
-                         (value & HeapHandleType.TypeMask) == StringHandleType.WinRTPrefixedString ||
-                         (value & HeapHandleType.TypeMask) == StringHandleType.DotTerminatedString);
+            Debug.Assert((value & StringHandleType.TypeMask) == StringHandleType.String ||
+                         (value & StringHandleType.TypeMask) == StringHandleType.VirtualString ||
+                         (value & StringHandleType.TypeMask) == StringHandleType.WinRTPrefixedString ||
+                         (value & StringHandleType.TypeMask) == StringHandleType.DotTerminatedString);
 
             _value = value;
         }
@@ -2620,13 +2636,13 @@ namespace System.Reflection.Metadata
         {
             // VTT... -> V111 10TT
             return new Handle(
-                (byte)((handle._value & HeapHandleType.VirtualBit) >> 24 | HandleType.String | (handle._value & HeapHandleType.NonVirtualTypeMask) >> 26),
+                (byte)((handle._value & HeapHandleType.VirtualBit) >> 24 | HandleType.String | (handle._value & StringHandleType.NonVirtualTypeMask) >> 26),
                 (int)(handle._value & HeapHandleType.OffsetMask));
         }
 
         public static explicit operator StringHandle(Handle handle)
         {
-            if ((handle.VType & HandleType.StringOrNamespaceMask) != HandleType.String)
+            if ((handle.VType & ~(HandleType.VirtualBit | HandleType.NonVirtualStringTypeMask)) != HandleType.String)
             {
                 Throw.InvalidCast();
             }
@@ -2634,7 +2650,7 @@ namespace System.Reflection.Metadata
             // V111 10TT -> VTT...
             return new StringHandle(
                 (handle.VType & HandleType.VirtualBit) << 24 | 
-                (handle.VType & HandleType.StringHeapTypeMask) << HeapHandleType.OffsetBitCount | 
+                (handle.VType & HandleType.NonVirtualStringTypeMask) << HeapHandleType.OffsetBitCount | 
                 (uint)handle.Offset);
         }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
@@ -130,25 +130,31 @@ namespace System.Reflection.Metadata.Ecma335
 
     internal static class StringHandleType
     {
+        // The 3 high bits above the offset that specify the full string type (including virtual bit)
+        internal const uint TypeMask = ~(HeapHandleType.OffsetMask);
+
+        // The string type bits excluding the virtual bit.
+        internal const uint NonVirtualTypeMask = TypeMask & ~(HeapHandleType.VirtualBit);
+
         // NUL-terminated UTF8 string on a #String heap.
-        internal const uint String = 0;
+        internal const uint String = (0 << HeapHandleType.OffsetBitCount);
 
         // String on #String heap whose terminator is NUL and '.', whichever comes first.
-        internal const uint DotTerminatedString = String | (1 << HeapHandleType.OffsetBitCount);
+        internal const uint DotTerminatedString = (1 << HeapHandleType.OffsetBitCount);
 
         // Reserved values that can be used for future strings:
-        internal const uint ReservedString1 = String | (2 << HeapHandleType.OffsetBitCount);
-        internal const uint ReservedString2 = String | (3 << HeapHandleType.OffsetBitCount);
+        internal const uint ReservedString1 = (2 << HeapHandleType.OffsetBitCount);
+        internal const uint ReservedString2 = (3 << HeapHandleType.OffsetBitCount);
 
         // Virtual string identified by a virtual index
-        internal const uint VirtualString = HeapHandleType.VirtualBit | String;
+        internal const uint VirtualString = HeapHandleType.VirtualBit | (0 << HeapHandleType.OffsetBitCount);
 
-        // Virtual string whose value is a "<WinRT>" prefixed string found at the specified heap offset.          
-        internal const uint WinRTPrefixedString = HeapHandleType.VirtualBit | String | (1 << HeapHandleType.OffsetBitCount);
+        // Virtual string whose value is a "<WinRT>" prefixed string found at the specified heap offset.
+        internal const uint WinRTPrefixedString = HeapHandleType.VirtualBit | (1 << HeapHandleType.OffsetBitCount);
 
         // Reserved virtual strings that can be used in future:
-        internal const uint ReservedVirtualString1 = HeapHandleType.VirtualBit | String | (2 << HeapHandleType.OffsetBitCount);
-        internal const uint ReservedVirtualString2 = HeapHandleType.VirtualBit | String | (3 << HeapHandleType.OffsetBitCount);
+        internal const uint ReservedVirtualString1 = HeapHandleType.VirtualBit | (2 << HeapHandleType.OffsetBitCount);
+        internal const uint ReservedVirtualString2 = HeapHandleType.VirtualBit | (3 << HeapHandleType.OffsetBitCount);
     }
 
     internal static class HeapHandleType
@@ -157,8 +163,6 @@ namespace System.Reflection.Metadata.Ecma335
         internal const int OffsetBitCount = 29;
         internal const uint OffsetMask = (1 << OffsetBitCount) - 1;
         internal const uint VirtualBit = 0x80000000;
-        internal const uint NonVirtualTypeMask = 3u << OffsetBitCount;
-        internal const uint TypeMask = VirtualBit | NonVirtualTypeMask;
 
         internal static bool IsValidHeapOffset(uint offset)
         {
@@ -166,6 +170,9 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
+    /// <summary>
+    /// These contants are all in the byte range and apply to the interpretation of <see cref="Handle.VType"/>,
+    /// </summary>
     internal static class HandleType
     {
         internal const uint Module = 0x00;
@@ -202,23 +209,29 @@ namespace System.Reflection.Metadata.Ecma335
 
         // The following values never appear in a token stored in metadata, 
         // they are just helper values to identify the type of a handle.
+        // Note, however, that even though they do not come from the spec,
+        // they are surfaced as public constants via HandleKind enum and 
+        // therefore cannot change!
 
         internal const uint Blob = 0x71;        // #Blob heap
         internal const uint Guid = 0x72;        // #Guid heap
-        internal const uint Namespace = 0x73;   // #String heap but known to be the full name of a namespace
 
-        // #String heap and its modifications (up to 8 string kinds, virtual and non-virtual)
-        internal const uint String = 0x7c;
-        internal const uint DotTerminatedString = String | ((StringHandleType.DotTerminatedString & ~HeapHandleType.VirtualBit) >> HeapHandleType.OffsetBitCount);
-        internal const uint ReservedString1 = String | ((StringHandleType.ReservedString1 & ~HeapHandleType.VirtualBit) >> HeapHandleType.OffsetBitCount); 
-        internal const uint ReservedString2 = String | ((StringHandleType.ReservedString2 & ~HeapHandleType.VirtualBit) >> HeapHandleType.OffsetBitCount); 
-        internal const uint VirtualString = VirtualBit | String;
-        internal const uint WinRTPrefixedString = VirtualBit | String | ((StringHandleType.WinRTPrefixedString & ~HeapHandleType.VirtualBit) >> HeapHandleType.OffsetBitCount);
-        internal const uint ReservedVirtualString1 = VirtualBit | String | ((StringHandleType.ReservedString1 & ~HeapHandleType.VirtualBit) >> HeapHandleType.OffsetBitCount);
-        internal const uint ReservedVirtualString2 = VirtualBit | String | ((StringHandleType.ReservedString2 & ~HeapHandleType.VirtualBit) >> HeapHandleType.OffsetBitCount);
+        // #String heap and its modifications
+        //
+        // Multiple values are reserved for string handles so that we can encode special
+        // handling with more than just the virtual bit. See StringHandleType for how
+        // the two extra bits are actually interpreted. The extra String1,2,3 values here are 
+        // not used directly, but serve as a reminder that they are not available for use
+        // by another handle type.
+        internal const uint String  = 0x78;
+        internal const uint String1 = 0x79;
+        internal const uint String2 = 0x7a;
+        internal const uint String3 = 0x7b;
 
-        internal const uint StringHeapTypeMask = HeapHandleType.NonVirtualTypeMask >> HeapHandleType.OffsetBitCount;
-        internal const uint StringOrNamespaceMask = 0x7c;
+        // Namespace handles also have offsets into the #String heap (when non-virtual)
+        // to their full name. However, this is an implementation detail and they are
+        // surfaced with first-class HandleKind.Namespace and strongly-typed NamespaceHandle.
+        internal const uint Namespace = 0x7c;
 
         internal const uint HeapMask = 0x70;
         internal const uint TypeMask = 0x7F;
@@ -229,19 +242,11 @@ namespace System.Reflection.Metadata.Ecma335
         /// </summary>
         internal const uint VirtualBit = 0x80;
 
-        public static HandleKind ToHandleKind(uint handleType)
-        {
-            Debug.Assert((handleType & VirtualBit) == 0);
-
-            // Do not surface special string token sub-types (e.g. dot terminated, winrt prefixed) 
-            // in public-facing handle type. Pretend that all strings are just plain strings.
-            if (handleType > String)
-            {
-                return HandleKind.String;
-            }
-
-            return (HandleKind)handleType;
-        }
+        /// <summary>
+        /// In the case of string handles, the two lower bits that (in addition to the 
+        /// virtual bit not included in this mask) encode how to obtain the string value.
+        /// </summary>
+        internal const uint NonVirtualStringTypeMask = 0x03;
     }
 
     internal static class TokenTypeIds

--- a/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
@@ -10,6 +10,44 @@ namespace System.Reflection.Metadata.Tests
     public class HandleTests
     {
         [Fact]
+        public void HandleKindsMatchSpecAndDoNotChange()
+        {
+            // These are chosen to match their encoding in metadata tokens as specified by the CLI spec
+            Assert.Equal(0x00, (int)HandleKind.ModuleDefinition);
+            Assert.Equal(0x01, (int)HandleKind.TypeReference);
+            Assert.Equal(0x02, (int)HandleKind.TypeDefinition);
+            Assert.Equal(0x04, (int)HandleKind.FieldDefinition);
+            Assert.Equal(0x06, (int)HandleKind.MethodDefinition);
+            Assert.Equal(0x08, (int)HandleKind.Parameter);
+            Assert.Equal(0x09, (int)HandleKind.InterfaceImplementation);
+            Assert.Equal(0x0A, (int)HandleKind.MemberReference);
+            Assert.Equal(0x0B, (int)HandleKind.Constant);
+            Assert.Equal(0x0C, (int)HandleKind.CustomAttribute);
+            Assert.Equal(0x0E, (int)HandleKind.DeclarativeSecurityAttribute);
+            Assert.Equal(0x11, (int)HandleKind.StandaloneSignature);
+            Assert.Equal(0x14, (int)HandleKind.EventDefinition);
+            Assert.Equal(0x17, (int)HandleKind.PropertyDefinition);
+            Assert.Equal(0x19, (int)HandleKind.MethodImplementation);
+            Assert.Equal(0x1A, (int)HandleKind.ModuleReference);
+            Assert.Equal(0x1B, (int)HandleKind.TypeSpecification);
+            Assert.Equal(0x20, (int)HandleKind.AssemblyDefinition);
+            Assert.Equal(0x26, (int)HandleKind.AssemblyFile);
+            Assert.Equal(0x23, (int)HandleKind.AssemblyReference);
+            Assert.Equal(0x27, (int)HandleKind.ExportedType);
+            Assert.Equal(0x2A, (int)HandleKind.GenericParameter);
+            Assert.Equal(0x2B, (int)HandleKind.MethodSpecification);
+            Assert.Equal(0x2C, (int)HandleKind.GenericParameterConstraint);
+            Assert.Equal(0x28, (int)HandleKind.ManifestResource);
+            Assert.Equal(0x70, (int)HandleKind.UserString);
+
+            // These values were chosen arbitrarily, but must still never change
+            Assert.Equal(0x71, (int)HandleKind.Blob);
+            Assert.Equal(0x72, (int)HandleKind.Guid);
+            Assert.Equal(0x78, (int)HandleKind.String);
+            Assert.Equal(0x7c, (int)HandleKind.NamespaceDefinition);
+        }
+
+        [Fact]
         public void HandleConversionGivesCorrectKind()
         {
             var expectedKinds = new SortedSet<HandleKind>((HandleKind[])Enum.GetValues(typeof(HandleKind)));


### PR DESCRIPTION
Change a4ecef2c659586922512a9b6ce43e6091ebf6a94 inadvertently modified the values of these public facing enum members.

It has only affected pre-release builds so far and so this change restores the values from the stable release so that a binary built against one stable release can safely run against the next one.

The code has also been refactored to clarify the points of confusion that led to this mistake and a test has been added to check for specific numeric values for all HandleKinds.