### PR TITLE
Fix DecodeHexString parsing to match .net 4.6 behavior

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -33,8 +33,8 @@ namespace Internal.Cryptography
             return new string(ToHexArrayUpper(bytes));
         }
 
-        // Decode a hex string-encoded byte array passed to various X509 crypto api. The parsing rules are overly forgiving but for compat reasons,
-        // they cannot be tightened.
+        // Decode a hex string-encoded byte array passed to various X509 crypto api.
+        // The parsing rules are overly forgiving but for compat reasons, they cannot be tightened.
         public static byte[] DecodeHexString(this string s)
         {
             int whitespaceCount = 0;
@@ -47,19 +47,40 @@ namespace Internal.Cryptography
 
             uint cbHex = (uint)(s.Length - whitespaceCount) / 2;
             byte[] hex = new byte[cbHex];
+            byte accum = 0;
+            bool byteInProgress = false;
+            int index = 0;
 
-            for (int index = 0, i = 0; index < cbHex; index++)
+            for (int i = 0; i < s.Length; i++)
             {
-                if (char.IsWhiteSpace(s[i]))
+                char c = s[i];
+
+                if (char.IsWhiteSpace(c))
                 {
-                    i++;
+                    continue;
                 }
-                else
+
+                accum <<= 4;
+                accum |= HexToByte(c);
+
+                byteInProgress = !byteInProgress;
+
+                // If we've flipped from 0 to 1, back to 0, we have a whole byte
+                // so add it to the buffer.
+                if (!byteInProgress)
                 {
-                    hex[index] = (byte)((HexToByte(s[i]) << 4) | HexToByte(s[i + 1]));
-                    i += 2;
+                    Debug.Assert(index < cbHex, "index < cbHex");
+
+                    hex[index] = accum;
+                    index++;
                 }
             }
+
+            // Desktop compat:
+            // The desktop algorithm removed all whitespace before the loop, then went up to length/2
+            // of what was left.  This means that in the event of odd-length input the last char is
+            // ignored, no exception should be raised.
+            Debug.Assert(index == cbHex, "index == cbHex");
 
             return hex;
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -369,13 +369,33 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "B4D738B2D4978AFF290A0B02987BABD114FEE9C7");
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("5971A65A334DDA980780FF841EBE87F9723241F2")]
+        // Whitespace is allowed
+        [InlineData("59 71\tA6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
+        // Non-byte-aligned whitespace is allowed
+        [InlineData("597 1A6 5A3 34D DA9 807 80F F84 1EB E87 F97 232 41F 2")]
+        // Non-symmetric whitespace is allowed
+        [InlineData("    5971A65   A334DDA980780FF84  1EBE87F97           23241F   2")]
         [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void TestBySubjectKeyIdentifier_MatchB()
+        public static void TestBySubjectKeyIdentifier_MatchB(string subjectKeyIdentifier)
         {
-            RunSingleMatchTest_MsCer(
-                X509FindType.FindBySubjectKeyIdentifier,
-                "5971A65A334DDA980780FF841EBE87F9723241F2");
+            RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
+        }
+
+        [Theory]
+        // Compat: Lone trailing nybbles are ignored
+        [InlineData("59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2 3")]
+        // Compat: Lone trailing nybbles are ignored, even if not hex
+        [InlineData("59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2 p")]
+        // Compat: A non-hex character as the high nybble makes that nybble be F
+        [InlineData("59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 p9 72 32 41 F2")]
+        // Compat: A non-hex character as the low nybble makes the whole byte FF.
+        [InlineData("59 71 A6 5A 33 4D DA 98 07 80 0p 84 1E BE 87 F9 72 32 41 F2")]
+        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        public static void TestBySubjectKeyIdentifier_MatchB_Compat(string subjectKeyIdentifier)
+        {
+            RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -373,6 +373,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("5971A65A334DDA980780FF841EBE87F9723241F2")]
         // Whitespace is allowed
         [InlineData("59 71\tA6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
+        // Lots of kinds of whitespace (does not include \u000b or \u000c, because those
+        // produce a build warning (which becomes an error):
+        //     EXEC : warning : '(not included here)', hexadecimal value 0x0C, is an invalid character.
+        [InlineData(
+            "59\u000971\u000aA6\u30005A\u205f33\u000d4D\u0020DA\u008598\u00a007\u1680" +
+            "80\u2000FF\u200184\u20021E\u2003BE\u200487\u2005F9\u200672\u200732\u2008" +
+            "4\u20091\u200aF\u20282\u2029\u202f")]
         // Non-byte-aligned whitespace is allowed
         [InlineData("597 1A6 5A3 34D DA9 807 80F F84 1EB E87 F97 232 41F 2")]
         // Non-symmetric whitespace is allowed


### PR DESCRIPTION
During the port to CoreFX DecodeHexString gained some interesting new quirks.

"010305"   => {0x01, 0x03, 0x05} (OK)
"01 03 05" => {0x01, 0x00, 0x03} (no)
"0 10305"  => {0xFF, 0x10, 0x30} (no)
" 010305"  => {0x00, 0x01, 0x03} (no)
"  010305" => {0x00, 0x00, 0x01} (no)

This change restores the behavior to be functionally equivalent to the parsing logic in .NET (Full Framework) 4.6, but still without creating the intermediate string.

Because one of the existing test certificates has both an 0xFF byte and a 0xFx byte (other than 0xFF) in its subject key identifier field, the behavior of this method is most optimally tested with the subject key identifier tests.

Test cases have been added to prevent future regressions.