### PR TITLE
Make signature and attribute decoders instances

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -79,6 +79,7 @@
     <Compile Include="System\Reflection\Metadata\Decoding\ISignatureTypeProvider.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\ITypeProvider.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\SignatureDecoder.cs" />
+    <Compile Include="System\Reflection\Metadata\Decoding\SignatureDecoderOptions.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\StringComparers.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeNamedArgument.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeTypedArgument.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
@@ -74,15 +74,15 @@ namespace System.Reflection.Metadata.Decoding
                 return ImmutableArray<CustomAttributeTypedArgument<TType>>.Empty;
             }
 
-            var arguments = new CustomAttributeTypedArgument<TType>[count];
+            var arguments = ImmutableArray.CreateBuilder<CustomAttributeTypedArgument<TType>>(count);
 
             for (int i = 0; i < count; i++)
             {
                 ArgumentTypeInfo info = DecodeFixedArgumentType(metadataReader, ref signatureReader);
-                arguments[i] = DecodeArgument(ref valueReader, info);
+                arguments.Add(DecodeArgument(ref valueReader, info));
             }
 
-            return ImmutableArray.Create(arguments);
+            return arguments.MoveToImmutable();
         }
 
         private ImmutableArray<CustomAttributeNamedArgument<TType>> DecodeNamedArguments(ref BlobReader valueReader)
@@ -93,7 +93,7 @@ namespace System.Reflection.Metadata.Decoding
                 return ImmutableArray<CustomAttributeNamedArgument<TType>>.Empty;
             }
 
-            var arguments = new CustomAttributeNamedArgument<TType>[count];
+            var arguments = ImmutableArray.CreateBuilder<CustomAttributeNamedArgument<TType>>(count);
             for (int i = 0; i < count; i++)
             {
                 CustomAttributeNamedArgumentKind kind = (CustomAttributeNamedArgumentKind)valueReader.ReadSerializationTypeCode();
@@ -105,10 +105,10 @@ namespace System.Reflection.Metadata.Decoding
                 ArgumentTypeInfo info = DecodeNamedArgumentType(ref valueReader);
                 string name = valueReader.ReadSerializedString();
                 CustomAttributeTypedArgument<TType> argument = DecodeArgument(ref valueReader, info);
-                arguments[i] = new CustomAttributeNamedArgument<TType>(name, kind, argument.Type, argument.Value);
+                arguments.Add(new CustomAttributeNamedArgument<TType>(name, kind, argument.Type, argument.Value));
             }
 
-            return ImmutableArray.Create(arguments);
+            return arguments.MoveToImmutable();
         }
 
         private struct ArgumentTypeInfo
@@ -347,14 +347,14 @@ namespace System.Reflection.Metadata.Decoding
                 TypeCode = info.ElementTypeCode,
             };
 
-            var array = new CustomAttributeTypedArgument<TType>[count];
+            var arguments = ImmutableArray.CreateBuilder<CustomAttributeTypedArgument<TType>>(count);
 
             for (int i = 0; i < count; i++)
             {
-                array[i] = DecodeArgument(ref blobReader, elementInfo);
+                arguments.Add(DecodeArgument(ref blobReader, elementInfo));
             }
 
-            return ImmutableArray.Create(array);
+            return arguments.MoveToImmutable();
         }
 
         private TType GetTypeFromReferenceOrDefinition(MetadataReader metadataReader, EntityHandle typeRefOrDefHandle)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
@@ -9,23 +9,30 @@ namespace System.Reflection.Metadata.Decoding
     /// <summary>
     /// Decodes custom attribute blobs.
     /// </summary>
-    public static class CustomAttributeDecoder
+    public struct CustomAttributeDecoder<TProvider, TType> where TProvider : ICustomAttributeTypeProvider<TType>
     {
-        public static CustomAttributeValue<TType> DecodeCustomAttribute<TType>(CustomAttributeHandle handle, ICustomAttributeTypeProvider<TType> provider)
+        private readonly TProvider _provider;
+
+        public CustomAttributeDecoder(TProvider provider)
         {
-            CustomAttribute attribute = provider.Reader.GetCustomAttribute(handle);
+            _provider = provider;
+        }
+
+        public CustomAttributeValue<TType> DecodeCustomAttribute(MetadataReader metadataReader, CustomAttributeHandle handle)
+        {
+            CustomAttribute attribute = metadataReader.GetCustomAttribute(handle);
             EntityHandle constructor = attribute.Constructor;
             BlobHandle signature;
 
             switch (constructor.Kind)
             {
                 case HandleKind.MethodDefinition:
-                    MethodDefinition definition = provider.Reader.GetMethodDefinition((MethodDefinitionHandle)constructor);
+                    MethodDefinition definition = metadataReader.GetMethodDefinition((MethodDefinitionHandle)constructor);
                     signature = definition.Signature;
                     break;
 
                 case HandleKind.MemberReference:
-                    MemberReference reference = provider.Reader.GetMemberReference((MemberReferenceHandle)constructor);
+                    MemberReference reference = metadataReader.GetMemberReference((MemberReferenceHandle)constructor);
                     signature = reference.Signature;
                     break;
 
@@ -33,8 +40,8 @@ namespace System.Reflection.Metadata.Decoding
                     throw new BadImageFormatException();
             }
 
-            BlobReader signatureReader = provider.Reader.GetBlobReader(signature);
-            BlobReader valueReader = provider.Reader.GetBlobReader(attribute.Value);
+            BlobReader signatureReader = metadataReader.GetBlobReader(signature);
+            BlobReader valueReader = metadataReader.GetBlobReader(attribute.Value);
 
             ushort prolog = valueReader.ReadUInt16();
             if (prolog != 1)
@@ -55,12 +62,12 @@ namespace System.Reflection.Metadata.Decoding
                 throw new BadImageFormatException();
             }
 
-            ImmutableArray<CustomAttributeTypedArgument<TType>> fixedArguments = DecodeFixedArguments(ref signatureReader, ref valueReader, parameterCount, provider);
-            ImmutableArray<CustomAttributeNamedArgument<TType>> namedArguments = DecodeNamedArguments(ref valueReader, provider);
+            ImmutableArray<CustomAttributeTypedArgument<TType>> fixedArguments = DecodeFixedArguments(metadataReader, ref signatureReader, ref valueReader, parameterCount);
+            ImmutableArray<CustomAttributeNamedArgument<TType>> namedArguments = DecodeNamedArguments(ref valueReader);
             return new CustomAttributeValue<TType>(fixedArguments, namedArguments);
         }
 
-        private static ImmutableArray<CustomAttributeTypedArgument<TType>> DecodeFixedArguments<TType>(ref BlobReader signatureReader, ref BlobReader valueReader, int count, ICustomAttributeTypeProvider<TType> provider)
+        private ImmutableArray<CustomAttributeTypedArgument<TType>> DecodeFixedArguments(MetadataReader metadataReader, ref BlobReader signatureReader, ref BlobReader valueReader, int count)
         {
             if (count == 0)
             {
@@ -71,14 +78,14 @@ namespace System.Reflection.Metadata.Decoding
 
             for (int i = 0; i < count; i++)
             {
-                ArgumentTypeInfo<TType> info = DecodeFixedArgumentType(ref signatureReader, provider);
-                arguments[i] = DecodeArgument(ref valueReader, info, provider);
+                ArgumentTypeInfo info = DecodeFixedArgumentType(metadataReader, ref signatureReader);
+                arguments[i] = DecodeArgument(ref valueReader, info);
             }
 
             return ImmutableArray.Create(arguments);
         }
 
-        private static ImmutableArray<CustomAttributeNamedArgument<TType>> DecodeNamedArguments<TType>(ref BlobReader valueReader, ICustomAttributeTypeProvider<TType> provider)
+        private ImmutableArray<CustomAttributeNamedArgument<TType>> DecodeNamedArguments(ref BlobReader valueReader)
         {
             int count = valueReader.ReadUInt16();
             if (count == 0)
@@ -95,16 +102,16 @@ namespace System.Reflection.Metadata.Decoding
                     throw new BadImageFormatException();
                 }
 
-                ArgumentTypeInfo<TType> info = DecodeNamedArgumentType(ref valueReader, provider);
+                ArgumentTypeInfo info = DecodeNamedArgumentType(ref valueReader);
                 string name = valueReader.ReadSerializedString();
-                CustomAttributeTypedArgument<TType> argument = DecodeArgument(ref valueReader, info, provider);
+                CustomAttributeTypedArgument<TType> argument = DecodeArgument(ref valueReader, info);
                 arguments[i] = new CustomAttributeNamedArgument<TType>(name, kind, argument.Type, argument.Value);
             }
 
             return ImmutableArray.Create(arguments);
         }
 
-        private struct ArgumentTypeInfo<TType>
+        private struct ArgumentTypeInfo
         {
             public TType Type;
             public TType ElementType;
@@ -118,12 +125,12 @@ namespace System.Reflection.Metadata.Decoding
         // but instead decode one parameter at a time as we read the value blob. This is both
         // better perf-wise, but even more important is that we can't actually reason about
         // a method signature with opaque TType values without adding some unecessary chatter
-        // with the concrete subclass.
-        private static ArgumentTypeInfo<TType> DecodeFixedArgumentType<TType>(ref BlobReader signatureReader, ICustomAttributeTypeProvider<TType> provider, bool isElementType = false)
+        // with the provider.
+        private ArgumentTypeInfo DecodeFixedArgumentType(MetadataReader metadataReader, ref BlobReader signatureReader, bool isElementType = false)
         {
             SignatureTypeCode signatureTypeCode = signatureReader.ReadSignatureTypeCode();
 
-            var info = new ArgumentTypeInfo<TType>
+            var info = new ArgumentTypeInfo
             {
                 TypeCode = (SerializationTypeCode)signatureTypeCode,
             };
@@ -143,19 +150,19 @@ namespace System.Reflection.Metadata.Decoding
                 case SignatureTypeCode.UInt16:
                 case SignatureTypeCode.UInt32:
                 case SignatureTypeCode.UInt64:
-                    info.Type = provider.GetPrimitiveType((PrimitiveTypeCode)signatureTypeCode);
+                    info.Type = _provider.GetPrimitiveType((PrimitiveTypeCode)signatureTypeCode);
                     break;
 
                 case SignatureTypeCode.Object:
                     info.TypeCode = SerializationTypeCode.TaggedObject;
-                    info.Type = provider.GetPrimitiveType(PrimitiveTypeCode.Object);
+                    info.Type = _provider.GetPrimitiveType(PrimitiveTypeCode.Object);
                     break;
 
                 case SignatureTypeCode.TypeHandle:
                     // Parameter is type def or ref and is only allowed to be System.Type or Enum.
                     EntityHandle handle = signatureReader.ReadTypeHandle();
-                    info.Type = GetTypeFromReferenceOrDefinition(handle, provider);
-                    info.TypeCode = provider.IsSystemType(info.Type) ? SerializationTypeCode.Type : (SerializationTypeCode)provider.GetUnderlyingEnumType(info.Type);
+                    info.Type = GetTypeFromReferenceOrDefinition(metadataReader, handle);
+                    info.TypeCode = _provider.IsSystemType(info.Type) ? SerializationTypeCode.Type : (SerializationTypeCode)_provider.GetUnderlyingEnumType(info.Type);
                     break;
 
                 case SignatureTypeCode.SZArray:
@@ -165,10 +172,10 @@ namespace System.Reflection.Metadata.Decoding
                         throw new BadImageFormatException();
                     }
 
-                    var elementInfo = DecodeFixedArgumentType(ref signatureReader, provider, isElementType: true);
+                    var elementInfo = DecodeFixedArgumentType(metadataReader, ref signatureReader, isElementType: true);
                     info.ElementType = elementInfo.Type;
                     info.ElementTypeCode = elementInfo.TypeCode;
-                    info.Type = provider.GetSZArrayType(info.ElementType);
+                    info.Type = _provider.GetSZArrayType(info.ElementType);
                     break;
 
                 default:
@@ -178,9 +185,9 @@ namespace System.Reflection.Metadata.Decoding
             return info;
         }
 
-        private static ArgumentTypeInfo<TType> DecodeNamedArgumentType<TType>(ref BlobReader valueReader, ICustomAttributeTypeProvider<TType> provider, bool isElementType = false)
+        private ArgumentTypeInfo DecodeNamedArgumentType(ref BlobReader valueReader, bool isElementType = false)
         {
-            var info = new ArgumentTypeInfo<TType>
+            var info = new ArgumentTypeInfo
             {
                 TypeCode = valueReader.ReadSerializationTypeCode(),
             };
@@ -200,15 +207,15 @@ namespace System.Reflection.Metadata.Decoding
                 case SerializationTypeCode.UInt16:
                 case SerializationTypeCode.UInt32:
                 case SerializationTypeCode.UInt64:
-                    info.Type = provider.GetPrimitiveType((PrimitiveTypeCode)info.TypeCode);
+                    info.Type = _provider.GetPrimitiveType((PrimitiveTypeCode)info.TypeCode);
                     break;
 
                 case SerializationTypeCode.Type:
-                    info.Type = provider.GetSystemType();
+                    info.Type = _provider.GetSystemType();
                     break;
 
                 case SerializationTypeCode.TaggedObject:
-                    info.Type = provider.GetPrimitiveType(PrimitiveTypeCode.Object);
+                    info.Type = _provider.GetPrimitiveType(PrimitiveTypeCode.Object);
                     break;
 
                 case SerializationTypeCode.SZArray:
@@ -218,16 +225,16 @@ namespace System.Reflection.Metadata.Decoding
                         throw new BadImageFormatException();
                     }
 
-                    var elementInfo = DecodeNamedArgumentType(ref valueReader, provider, isElementType: true);
+                    var elementInfo = DecodeNamedArgumentType(ref valueReader, isElementType: true);
                     info.ElementType = elementInfo.Type;
                     info.ElementTypeCode = elementInfo.TypeCode;
-                    info.Type = provider.GetSZArrayType(info.ElementType);
+                    info.Type = _provider.GetSZArrayType(info.ElementType);
                     break;
 
                 case SerializationTypeCode.Enum:
                     string typeName = valueReader.ReadSerializedString();
-                    info.Type = provider.GetTypeFromSerializedName(typeName);
-                    info.TypeCode = (SerializationTypeCode)provider.GetUnderlyingEnumType(info.Type);
+                    info.Type = _provider.GetTypeFromSerializedName(typeName);
+                    info.TypeCode = (SerializationTypeCode)_provider.GetUnderlyingEnumType(info.Type);
                     break;
 
                 default:
@@ -237,11 +244,11 @@ namespace System.Reflection.Metadata.Decoding
             return info;
         }
 
-        private static CustomAttributeTypedArgument<TType> DecodeArgument<TType>(ref BlobReader valueReader, ArgumentTypeInfo<TType> info, ICustomAttributeTypeProvider<TType> provider)
+        private CustomAttributeTypedArgument<TType> DecodeArgument(ref BlobReader valueReader, ArgumentTypeInfo info)
         {
             if (info.TypeCode == SerializationTypeCode.TaggedObject)
             {
-                info = DecodeNamedArgumentType(ref valueReader, provider);
+                info = DecodeNamedArgumentType(ref valueReader);
             }
 
             object value;
@@ -302,11 +309,11 @@ namespace System.Reflection.Metadata.Decoding
 
                 case SerializationTypeCode.Type:
                     string typeName = valueReader.ReadSerializedString();
-                    value = provider.GetTypeFromSerializedName(typeName);
+                    value = _provider.GetTypeFromSerializedName(typeName);
                     break;
 
                 case SerializationTypeCode.SZArray:
-                    value = DecodeArrayArgument(ref valueReader, info, provider);
+                    value = DecodeArrayArgument(ref valueReader, info);
                     break;
 
                 default:
@@ -316,7 +323,7 @@ namespace System.Reflection.Metadata.Decoding
             return new CustomAttributeTypedArgument<TType>(info.Type, value);
         }
 
-        private static ImmutableArray<CustomAttributeTypedArgument<TType>>? DecodeArrayArgument<TType>(ref BlobReader blobReader, ArgumentTypeInfo<TType> info, ICustomAttributeTypeProvider<TType> provider)
+        private ImmutableArray<CustomAttributeTypedArgument<TType>>? DecodeArrayArgument(ref BlobReader blobReader, ArgumentTypeInfo info)
         {
             int count = blobReader.ReadInt32();
             if (count == -1)
@@ -334,7 +341,7 @@ namespace System.Reflection.Metadata.Decoding
                 throw new BadImageFormatException();
             }
 
-            var elementInfo = new ArgumentTypeInfo<TType>
+            var elementInfo = new ArgumentTypeInfo
             {
                 Type = info.ElementType,
                 TypeCode = info.ElementTypeCode,
@@ -344,23 +351,23 @@ namespace System.Reflection.Metadata.Decoding
 
             for (int i = 0; i < count; i++)
             {
-                array[i] = DecodeArgument(ref blobReader, elementInfo, provider);
+                array[i] = DecodeArgument(ref blobReader, elementInfo);
             }
 
             return ImmutableArray.Create(array);
         }
 
-        private static TType GetTypeFromReferenceOrDefinition<TType>(EntityHandle typeRefOrDefHandle, ICustomAttributeTypeProvider<TType> provider)
+        private TType GetTypeFromReferenceOrDefinition(MetadataReader metadataReader, EntityHandle typeRefOrDefHandle)
         {
             switch (typeRefOrDefHandle.Kind)
             {
                 case HandleKind.TypeDefinition:
                     TypeDefinitionHandle typeDefHandle = (TypeDefinitionHandle)typeRefOrDefHandle;
-                    return provider.GetTypeFromDefinition(typeDefHandle, null);
+                    return _provider.GetTypeFromDefinition(metadataReader, typeDefHandle, isValueType: null);
 
                 case HandleKind.TypeReference:
                     TypeReferenceHandle typeRefHandle = (TypeReferenceHandle)typeRefOrDefHandle;
-                    return provider.GetTypeFromReference(typeRefHandle, null);
+                    return _provider.GetTypeFromReference(metadataReader, typeRefHandle, isValueType: null);
 
                 default:
                     throw new BadImageFormatException();

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ICustomAttributeTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ICustomAttributeTypeProvider.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-// -----------------------------------------------------------------------
 
 using System;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
@@ -6,14 +6,13 @@ namespace System.Reflection.Metadata.Decoding
 {
     public interface ISignatureTypeProvider<TType> : ITypeProvider<TType>
     {
-        MetadataReader Reader { get; }
         TType GetFunctionPointerType(MethodSignature<TType> signature);
         TType GetGenericMethodParameter(int index);
         TType GetGenericTypeParameter(int index);
         TType GetModifiedType(TType unmodifiedType, ImmutableArray<CustomModifier<TType>> customModifiers);
         TType GetPinnedType(TType elementType);
         TType GetPrimitiveType(PrimitiveTypeCode typeCode);
-        TType GetTypeFromDefinition(TypeDefinitionHandle handle, bool? isValueType);
-        TType GetTypeFromReference(TypeReferenceHandle handle, bool? isValueType);
+        TType GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, bool? isValueType);
+        TType GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, bool? isValueType);
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -176,14 +176,14 @@ namespace System.Reflection.Metadata.Decoding
                 return ImmutableArray<TType>.Empty;
             }
 
-            var types = new TType[count];
+            var types = ImmutableArray.CreateBuilder<TType>(count);
 
             for (int i = 0; i < count; i++)
             {
-                types[i] = DecodeType(metadataReader, ref blobReader);
+                types.Add(DecodeType(metadataReader, ref blobReader));
             }
 
-            return ImmutableArray.Create(types);
+            return types.MoveToImmutable();
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace System.Reflection.Metadata.Decoding
                 return new MethodSignature<TType>(header, returnType, 0, genericParameterCount, ImmutableArray<TType>.Empty);
             }
 
-            var parameterTypes = new TType[parameterCount];
+            var parameterTypes = ImmutableArray.CreateBuilder<TType>(parameterCount);
             SignatureTypeCode typeCode;
             int parameterIndex;
 
@@ -242,17 +242,17 @@ namespace System.Reflection.Metadata.Decoding
                 {
                     break;
                 }
-                parameterTypes[parameterIndex] = DecodeType(metadataReader, ref blobReader);
+                parameterTypes.Add(DecodeType(metadataReader, ref blobReader));
             }
 
             int requiredParameterCount = parameterIndex;
 
             for (; parameterIndex < parameterCount; parameterIndex++)
             {
-                parameterTypes[parameterIndex] = DecodeType(metadataReader, ref blobReader);
+                parameterTypes.Add(DecodeType(metadataReader, ref blobReader));
             }
 
-            return new MethodSignature<TType>(header, returnType, requiredParameterCount, genericParameterCount, ImmutableArray.Create(parameterTypes));
+            return new MethodSignature<TType>(header, returnType, requiredParameterCount, genericParameterCount, parameterTypes.MoveToImmutable());
         }
 
         /// <summary>
@@ -360,23 +360,23 @@ namespace System.Reflection.Metadata.Decoding
             int sizesCount = blobReader.ReadCompressedInteger();
             if (sizesCount > 0)
             {
-                var array = new int[sizesCount];
+                var builder = ImmutableArray.CreateBuilder<int>(sizesCount);
                 for (int i = 0; i < sizesCount; i++)
                 {
-                    array[i] = blobReader.ReadCompressedInteger();
+                    builder.Add(blobReader.ReadCompressedInteger());
                 }
-                sizes = ImmutableArray.Create(array);
+                sizes = builder.MoveToImmutable();
             }
 
             int lowerBoundsCount = blobReader.ReadCompressedInteger();
             if (lowerBoundsCount > 0)
             {
-                var array = new int[lowerBoundsCount];
+                var builder = ImmutableArray.CreateBuilder<int>(lowerBoundsCount);
                 for (int i = 0; i < lowerBoundsCount; i++)
                 {
-                    array[i] = blobReader.ReadCompressedSignedInteger();
+                    builder.Add(blobReader.ReadCompressedSignedInteger());
                 }
-                lowerBounds = ImmutableArray.Create(array);
+                lowerBounds = builder.MoveToImmutable();
             }
 
             var arrayShape = new ArrayShape(rank, sizes, lowerBounds);

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata.Decoding
@@ -9,27 +9,60 @@ namespace System.Reflection.Metadata.Decoding
     /// <summary>
     /// Decodes signature blobs.
     /// </summary>
-    public static class SignatureDecoder
+    public struct SignatureDecoder<TProvider, TType> where TProvider : ISignatureTypeProvider<TType>
     {
+        private readonly TProvider _provider;
+        private readonly SignatureDecoderOptions _options;
+
+        public SignatureDecoder(TProvider provider)
+            : this(provider, SignatureDecoderOptions.None)
+        {
+
+        }
+
+        public SignatureDecoder(TProvider provider, SignatureDecoderOptions options)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException("provider");
+            }
+
+            _provider = provider;
+            _options = options;
+        }
+
         /// <summary>
         /// Decodes a type definition, reference or specification to its representation as TType.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="handle">A type definition, reference, or specification handle.</param>
-        /// <param name="provider">The type provider.</param>
+        /// <exception cref="System.BadImageFormatException">The handle does not represent a valid type reference, definition, or specification.</exception>
+        public TType DecodeType(MetadataReader metadataReader, EntityHandle handle)
+        {
+            return DecodeType(metadataReader, handle, isValueType: null);
+        }
+
+        /// <summary>
+        /// Decodes a type definition, reference or specification to its representation as TType.
+        /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
+        /// <param name="handle">A type definition, reference, or specification handle.</param>
         /// <param name="isValueType">Is the type a class or a value type. Null signifies that the current type signature does not have the prefix</param>
         /// <exception cref="System.BadImageFormatException">The handle does not represent a valid type reference, definition, or specification.</exception>
-        public static TType DecodeType<TType>(Handle handle, ISignatureTypeProvider<TType> provider, bool? isValueType)
+        public TType DecodeType(MetadataReader metadataReader, EntityHandle handle, bool? isValueType)
         {
             switch (handle.Kind)
             {
                 case HandleKind.TypeReference:
-                    return provider.GetTypeFromReference((TypeReferenceHandle)handle, isValueType);
+                    return _provider.GetTypeFromReference(metadataReader, (TypeReferenceHandle)handle, isValueType);
 
                 case HandleKind.TypeDefinition:
-                    return provider.GetTypeFromDefinition((TypeDefinitionHandle)handle, isValueType);
+                    return _provider.GetTypeFromDefinition(metadataReader, (TypeDefinitionHandle)handle, isValueType);
 
                 case HandleKind.TypeSpecification:
-                    return DecodeTypeSpecification((TypeSpecificationHandle)handle, provider);
+                    BlobHandle blobHandle = metadataReader.GetTypeSpecification((TypeSpecificationHandle)handle).Signature;
+                    BlobReader blobReader = metadataReader.GetBlobReader(blobHandle);
+                    return DecodeType(metadataReader, ref blobReader);
 
                 default:
                     throw new BadImageFormatException();
@@ -37,47 +70,30 @@ namespace System.Reflection.Metadata.Decoding
         }
 
         /// <summary>
-        /// Decodes a type specification.
+        /// Decodes a type from within a signature from a BlobReader positioned at the leading SignatureTypeCode.
         /// </summary>
-        /// <param name="handle">The type specification handle.</param>
-        /// <param name="provider">The type provider.</param>
-        /// <returns>The decoded type.</returns>
-        /// <exception cref="System.BadImageFormatException">The type specification has an invalid signature.</exception>
-        private static TType DecodeTypeSpecification<TType>(TypeSpecificationHandle handle, ISignatureTypeProvider<TType> provider)
-        {
-            BlobHandle blobHandle = provider.Reader.GetTypeSpecification(handle).Signature;
-            BlobReader blobReader = provider.Reader.GetBlobReader(blobHandle);
-            return DecodeType(ref blobReader, provider);
-        }
-
-        /// <summary>
-        /// Decodes a type from within a signature from a BlobReader positioned at its leading SignatureTypeCode.
-        /// </summary>
-        /// <param name="blobReader">The blob reader.</param>
-        /// <param name="provider">The type provider.</param>
+        /// <param name="metadataReader">The metadata reader.</param>
+        /// <param name="blobReader">The blob reader positioned at the leading SignatureTypeCode</param>
         /// <returns>The decoded type.</returns>
         /// <exception cref="System.BadImageFormatException">The reader was not positioned at a valid signature type.</exception>
-        public static TType DecodeType<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        public TType DecodeType(MetadataReader metadataReader, ref BlobReader blobReader)
         {
-            return DecodeType(ref blobReader, blobReader.ReadCompressedInteger(), provider);
+            return DecodeType(metadataReader, ref blobReader, blobReader.ReadCompressedInteger());
         }
 
         /// <summary>
         /// Decodes a type from within a signature from a BlobReader positioned immediately past the given SignatureTypeCode.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="blobReader">The blob reader.</param>
         /// <param name="typeCode">The SignatureTypeCode that immediately preceded the reader's current position.</param>
-        /// <param name="provider">The type provider.</param>
         /// <returns>The decoded type.</returns>
         /// <exception cref="System.BadImageFormatException">The reader was not positioned at a valud signature type.</exception>
-        private static TType DecodeType<TType>(ref BlobReader blobReader, int typeCode, ISignatureTypeProvider<TType> provider)
+        private TType DecodeType(MetadataReader metadataReader, ref BlobReader blobReader, int typeCode)
         {
             TType elementType;
             int index;
-            if(typeCode > byte.MaxValue)
-            {
-                typeCode = (int)SignatureTypeCode.Invalid;
-            }
+
             switch (typeCode)
             {
                 case (int)SignatureTypeCode.Boolean:
@@ -98,53 +114,53 @@ namespace System.Reflection.Metadata.Decoding
                 case (int)SignatureTypeCode.String:
                 case (int)SignatureTypeCode.Void:
                 case (int)SignatureTypeCode.TypedReference:
-                    return provider.GetPrimitiveType((PrimitiveTypeCode)typeCode);
+                    return _provider.GetPrimitiveType((PrimitiveTypeCode)typeCode);
 
                 case (int)SignatureTypeCode.Pointer:
-                    elementType = DecodeType(ref blobReader, provider);
-                    return provider.GetPointerType(elementType);
+                    elementType = DecodeType(metadataReader, ref blobReader);
+                    return _provider.GetPointerType(elementType);
 
                 case (int)SignatureTypeCode.ByReference:
-                    elementType = DecodeType(ref blobReader, provider);
-                    return provider.GetByReferenceType(elementType);
+                    elementType = DecodeType(metadataReader, ref blobReader);
+                    return _provider.GetByReferenceType(elementType);
 
                 case (int)SignatureTypeCode.Pinned:
-                    elementType = DecodeType(ref blobReader, provider);
-                    return provider.GetPinnedType(elementType);
+                    elementType = DecodeType(metadataReader, ref blobReader);
+                    return _provider.GetPinnedType(elementType);
 
                 case (int)SignatureTypeCode.SZArray:
-                    elementType = DecodeType(ref blobReader, provider);
-                    return provider.GetSZArrayType(elementType);
+                    elementType = DecodeType(metadataReader, ref blobReader);
+                    return _provider.GetSZArrayType(elementType);
 
                 case (int)SignatureTypeCode.FunctionPointer:
-                    MethodSignature<TType> methodSignature = DecodeMethodSignature(ref blobReader, provider);
-                    return provider.GetFunctionPointerType(methodSignature);
+                    MethodSignature<TType> methodSignature = DecodeMethodSignature(metadataReader, ref blobReader);
+                    return _provider.GetFunctionPointerType(methodSignature);
 
                 case (int)SignatureTypeCode.Array:
-                    return DecodeArrayType(ref blobReader, provider);
+                    return DecodeArrayType(metadataReader, ref blobReader);
 
                 case (int)SignatureTypeCode.RequiredModifier:
-                    return DecodeModifiedType(ref blobReader, provider, isRequired: true);
+                    return DecodeModifiedType(metadataReader, ref blobReader, isRequired: true);
 
                 case (int)SignatureTypeCode.OptionalModifier:
-                    return DecodeModifiedType(ref blobReader, provider, isRequired: false);
+                    return DecodeModifiedType(metadataReader, ref blobReader, isRequired: false);
 
                 case (int)SignatureTypeCode.GenericTypeInstance:
-                    return DecodeGenericTypeInstance(ref blobReader, provider);
+                    return DecodeGenericTypeInstance(metadataReader, ref blobReader);
 
                 case (int)SignatureTypeCode.GenericTypeParameter:
                     index = blobReader.ReadCompressedInteger();
-                    return provider.GetGenericTypeParameter(index);
+                    return _provider.GetGenericTypeParameter(index);
 
                 case (int)SignatureTypeCode.GenericMethodParameter:
                     index = blobReader.ReadCompressedInteger();
-                    return provider.GetGenericMethodParameter(index);
+                    return _provider.GetGenericMethodParameter(index);
 
                 case (int)CorElementType.ELEMENT_TYPE_CLASS:
-                    return DecodeTypeHandle(ref blobReader, provider, false);
+                    return DecodeTypeHandle(metadataReader, ref blobReader, isValueType: false);
 
                 case (int)CorElementType.ELEMENT_TYPE_VALUETYPE:
-                    return DecodeTypeHandle(ref blobReader, provider, true);
+                    return DecodeTypeHandle(metadataReader, ref blobReader, isValueType: true);
 
                 default:
                     throw new BadImageFormatException();
@@ -152,7 +168,7 @@ namespace System.Reflection.Metadata.Decoding
         }
 
         // Decodes a list of types preceded by their count as a compressed integer.
-        private static ImmutableArray<TType> DecodeTypes<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        private ImmutableArray<TType> DecodeTypes(MetadataReader metadataReader, ref BlobReader blobReader)
         {
             int count = blobReader.ReadCompressedInteger();
             if (count == 0)
@@ -164,7 +180,7 @@ namespace System.Reflection.Metadata.Decoding
 
             for (int i = 0; i < count; i++)
             {
-                types[i] = DecodeType(ref blobReader, provider);
+                types[i] = DecodeType(metadataReader, ref blobReader);
             }
 
             return ImmutableArray.Create(types);
@@ -173,24 +189,24 @@ namespace System.Reflection.Metadata.Decoding
         /// <summary>
         /// Decodes a method signature blob.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="handle">Handle to the method signature.</param>
         /// <returns>The decoded method signature.</returns>
-        /// <param name="provider">The type provider.</param>
         /// <exception cref="System.BadImageFormatException">The method signature is invalid.</exception>
-        public static MethodSignature<TType> DecodeMethodSignature<TType>(BlobHandle handle, ISignatureTypeProvider<TType> provider)
+        public MethodSignature<TType> DecodeMethodSignature(MetadataReader metadataReader, BlobHandle handle)
         {
-            BlobReader blobReader = provider.Reader.GetBlobReader(handle);
-            return DecodeMethodSignature(ref blobReader, provider);
+            BlobReader blobReader = metadataReader.GetBlobReader(handle);
+            return DecodeMethodSignature(metadataReader, ref blobReader);
         }
 
         /// <summary>
         /// Decodes a method signature blob.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="blobReader">BlobReader positioned at a method signature.</param>
-        /// <param name="provider">The type provider.</param>
         /// <returns>The decoded method signature.</returns>
         /// <exception cref="System.BadImageFormatException">The method signature is invalid.</exception>
-        private static MethodSignature<TType> DecodeMethodSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        private MethodSignature<TType> DecodeMethodSignature(MetadataReader metadataReader, ref BlobReader blobReader)
         {
             SignatureHeader header = blobReader.ReadSignatureHeader();
 
@@ -206,7 +222,7 @@ namespace System.Reflection.Metadata.Decoding
             }
 
             int parameterCount = blobReader.ReadCompressedInteger();
-            TType returnType = DecodeType(ref blobReader, provider);
+            TType returnType = DecodeType(metadataReader, ref blobReader);
 
             if (parameterCount == 0)
             {
@@ -226,14 +242,14 @@ namespace System.Reflection.Metadata.Decoding
                 {
                     break;
                 }
-                parameterTypes[parameterIndex] = DecodeType(ref blobReader, provider);
+                parameterTypes[parameterIndex] = DecodeType(metadataReader, ref blobReader);
             }
 
             int requiredParameterCount = parameterIndex;
 
             for (; parameterIndex < parameterCount; parameterIndex++)
             {
-                parameterTypes[parameterIndex] = DecodeType(ref blobReader, provider);
+                parameterTypes[parameterIndex] = DecodeType(metadataReader, ref blobReader);
             }
 
             return new MethodSignature<TType>(header, returnType, requiredParameterCount, genericParameterCount, ImmutableArray.Create(parameterTypes));
@@ -242,23 +258,23 @@ namespace System.Reflection.Metadata.Decoding
         /// <summary>
         /// Decodes a method specification signature blob.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="handle">The handle to the method specification signature blob. See <see cref="MethodSpecification.Signature"/>.</param>
-        /// <param name="provider">The type provider.</param>
         /// <returns>The types used to instantiate a generic method via a method specification.</returns>
         /// <exception cref="System.BadImageFormatException">The method specification signature is invalid.</exception>
-        public static ImmutableArray<TType> DecodeMethodSpecificationSignature<TType>(BlobHandle handle, ISignatureTypeProvider<TType> provider)
+        public ImmutableArray<TType> DecodeMethodSpecificationSignature(MetadataReader metadataReader, BlobHandle handle)
         {
-            BlobReader blobReader = provider.Reader.GetBlobReader(handle);
-            return DecodeMethodSpecificationSignature(ref blobReader, provider);
+            BlobReader blobReader = metadataReader.GetBlobReader(handle);
+            return DecodeMethodSpecificationSignature(metadataReader, ref blobReader);
         }
 
         /// <summary>
         /// Decodes a method specification signature blob.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="blobReader">A BlobReader positioned at a valid method specification signature.</param>
-        /// <param name="provider">The type provider.</param>
         /// <returns>The types used to instantiate a generic method via the method specification.</returns>
-        public static ImmutableArray<TType> DecodeMethodSpecificationSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        public ImmutableArray<TType> DecodeMethodSpecificationSignature(MetadataReader metadataReader, ref BlobReader blobReader)
         {
             SignatureHeader header = blobReader.ReadSignatureHeader();
             if (header.Kind != SignatureKind.MethodSpecification)
@@ -266,31 +282,31 @@ namespace System.Reflection.Metadata.Decoding
                 throw new BadImageFormatException();
             }
 
-            return DecodeTypes(ref blobReader, provider);
+            return DecodeTypes(metadataReader, ref blobReader);
         }
 
         /// <summary>
         /// Decodes a local variable signature blob.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="handle">The local variable signature handle.</param>
-        /// <param name="provider">The type provider.</param>
         /// <returns>The local variable types.</returns>
         /// <exception cref="System.BadImageFormatException">The local variable signature is invalid.</exception>
-        public static ImmutableArray<TType> DecodeLocalSignature<TType>(StandaloneSignatureHandle handle, ISignatureTypeProvider<TType> provider)
+        public ImmutableArray<TType> DecodeLocalSignature(MetadataReader metadataReader, StandaloneSignatureHandle handle)
         {
-            BlobHandle blobHandle = provider.Reader.GetStandaloneSignature(handle).Signature;
-            BlobReader blobReader = provider.Reader.GetBlobReader(blobHandle);
-            return DecodeLocalSignature(ref blobReader, provider);
+            BlobHandle blobHandle = metadataReader.GetStandaloneSignature(handle).Signature;
+            BlobReader blobReader = metadataReader.GetBlobReader(blobHandle);
+            return DecodeLocalSignature(metadataReader, ref blobReader);
         }
 
         /// <summary>
         /// Decodes a local variable signature blob and advances the reader past the signature.
         /// </summary>
-        /// <param name="blobReader">The blob reader.</param>
-        /// <param name="provider">The type provider.</param>
+        /// <param name="metadataReader">The metadata reader.</param>
+        /// <param name="blobReader">The blob reader positioned at a local variable signature.</param>
         /// <returns>The local variable types.</returns>
         /// <exception cref="System.BadImageFormatException">The local variable signature is invalid.</exception>
-        public static ImmutableArray<TType> DecodeLocalSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        public ImmutableArray<TType> DecodeLocalSignature(MetadataReader metadataReader, ref BlobReader blobReader)
         {
             SignatureHeader header = blobReader.ReadSignatureHeader();
             if (header.Kind != SignatureKind.LocalVariables)
@@ -298,27 +314,29 @@ namespace System.Reflection.Metadata.Decoding
                 throw new BadImageFormatException();
             }
 
-            return DecodeTypes(ref blobReader, provider);
+            return DecodeTypes(metadataReader, ref blobReader);
         }
 
         /// <summary>
         /// Decodes a field signature.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
         /// <param name="handle">The field signature handle.</param>
-        /// <param name="provider">The type provider.</param>
         /// <returns>The decoded field type.</returns>
         /// <exception cref="System.BadImageFormatException">The field signature is invalid.</exception>
-        public static TType DecodeFieldSignature<TType>(BlobHandle handle, ISignatureTypeProvider<TType> provider)
+        public TType DecodeFieldSignature(MetadataReader metadataReader, BlobHandle handle)
         {
-            BlobReader blobReader = provider.Reader.GetBlobReader(handle);
-            return DecodeFieldSignature(ref blobReader, provider);
+            BlobReader blobReader = metadataReader.GetBlobReader(handle);
+            return DecodeFieldSignature(metadataReader, ref blobReader);
         }
 
         /// <summary>
         /// Decodes a field signature.
         /// </summary>
+        /// <param name="metadataReader">The metadata reader.</param>
+        /// <param name="blobReader">The blob reader positioned at a field signature.</param>
         /// <returns>The decoded field type.</returns>
-        public static TType DecodeFieldSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        public TType DecodeFieldSignature(MetadataReader metadataReader, ref BlobReader blobReader)
         {
             SignatureHeader header = blobReader.ReadSignatureHeader();
 
@@ -327,14 +345,14 @@ namespace System.Reflection.Metadata.Decoding
                 throw new BadImageFormatException();
             }
 
-            return DecodeType(ref blobReader, provider);
+            return DecodeType(metadataReader, ref blobReader);
         }
 
         // Decodes a generalized (non-SZ/vector) array type represented by the element type followed by
         // its rank and optional sizes and lower bounds.
-        private static TType DecodeArrayType<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        private TType DecodeArrayType(MetadataReader metadataReader, ref BlobReader blobReader)
         {
-            TType elementType = DecodeType(ref blobReader, provider);
+            TType elementType = DecodeType(metadataReader, ref blobReader);
             int rank = blobReader.ReadCompressedInteger();
             var sizes = ImmutableArray<int>.Empty;
             var lowerBounds = ImmutableArray<int>.Empty;
@@ -362,23 +380,23 @@ namespace System.Reflection.Metadata.Decoding
             }
 
             var arrayShape = new ArrayShape(rank, sizes, lowerBounds);
-            return provider.GetArrayType(elementType, arrayShape);
+            return _provider.GetArrayType(elementType, arrayShape);
         }
 
         // Decodes a generic type instantiation encoded as the generic type followed by the types used to instantiate it.
-        private static TType DecodeGenericTypeInstance<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        private TType DecodeGenericTypeInstance(MetadataReader metadataReader, ref BlobReader blobReader)
         {
-            TType genericType = DecodeType(ref blobReader, provider);
-            ImmutableArray<TType> types = DecodeTypes(ref blobReader, provider);
-            return provider.GetGenericInstance(genericType, types);
+            TType genericType = DecodeType(metadataReader, ref blobReader);
+            ImmutableArray<TType> types = DecodeTypes(metadataReader, ref blobReader);
+            return _provider.GetGenericInstance(genericType, types);
         }
 
-        // Decodes a type with custom modifiers starting with the first modifier type that is required iff isRequired is passed,\
+        // Decodes a type with custom modifiers starting with the first modifier type that is required iff isRequired is passed,
         // followed by an optional sequence of additional modifiers (<SignaureTypeCode.Required|OptionalModifier> <type>) and 
         // terminated by the unmodified type.
-        private static TType DecodeModifiedType<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider, bool isRequired)
+        private TType DecodeModifiedType(MetadataReader metadataReader, ref BlobReader blobReader, bool isRequired)
         {
-            TType type = DecodeTypeHandle(ref blobReader, provider, null);
+            TType type = DecodeTypeHandle(metadataReader, ref blobReader, isValueType: null);
             var modifier = new CustomModifier<TType>(type, isRequired);
 
             ImmutableArray<CustomModifier<TType>> modifiers;
@@ -398,7 +416,7 @@ namespace System.Reflection.Metadata.Decoding
 
                 do
                 {
-                    type = DecodeTypeHandle(ref blobReader, provider, null);
+                    type = DecodeTypeHandle(metadataReader, ref blobReader, isValueType: null);
                     modifier = new CustomModifier<TType>(type, isRequired);
                     builder.Add(modifier);
                     typeCode = blobReader.ReadCompressedInteger();
@@ -407,15 +425,15 @@ namespace System.Reflection.Metadata.Decoding
 
                 modifiers = builder.ToImmutable();
             }
-            TType unmodifiedType = DecodeType(ref blobReader, typeCode, provider);
-            return provider.GetModifiedType(unmodifiedType, modifiers);
+            TType unmodifiedType = DecodeType(metadataReader, ref blobReader, typeCode);
+            return _provider.GetModifiedType(unmodifiedType, modifiers);
         }
 
         // Decodes a type definition, reference, or specification from the type handle at the given blob reader's current position.
-        private static TType DecodeTypeHandle<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider, bool? isValueType)
+        private TType DecodeTypeHandle(MetadataReader metadataReader, ref BlobReader blobReader, bool? isValueType)
         {
-            Handle handle = blobReader.ReadTypeHandle();
-            return DecodeType(handle, provider, isValueType);
+            EntityHandle handle = blobReader.ReadTypeHandle();
+            return DecodeType(metadataReader, handle, isValueType);
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoderOptions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoderOptions.cs
@@ -1,0 +1,19 @@
+﻿namespace System.Reflection.Metadata.Decoding
+{
+    [Flags]
+    public enum SignatureDecoderOptions
+    {
+        /// <summary>
+        /// Disable all options (default when no options are passed).
+        /// </summary>
+        None = 0x0,
+
+        /// <summary>
+        /// Causes the decoder to pass non-null for <see cref="Nullable{Bool}"/> isValueType arguments.
+        /// </summary>
+        /// <remarks>
+        /// There is additional overhead for this case when dealing with .winmd files to handle projection.
+        /// </remarks>
+        DifferentiateValueTypes = 0x1
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/TypeNameParsing/ITypeNameParserTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/TypeNameParsing/ITypeNameParserTypeProvider.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-// -----------------------------------------------------------------------
 
 using System;
 using System.Collections.Immutable;


### PR DESCRIPTION
This is a new take based on the discussion on closed PR #1068.

There's also some small cleanup in the other two commits.

I'm going to merge this if it passes CI since dev/metadata is effectively a dead-end now. I'll resurface the 
SignatureDecoder with these changes in a new PR to master. Having this work captured in dev/metadata will just make it easier to reconcile things after the portable PDB and SignatureDecoder are merged to master. That will leave only CustomAttributeDecoder and TypeNameParser as features in dev but not master and we should cherry-pick those over to a new branch for v1.2 dev. 
