### PR TITLE
Update test namespaces in some System.Text.* assemblies

### DIFF
--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using Xunit;
 
-namespace Test
+namespace System.Text.Tests
 {
     public class EncodingTest : IClassFixture<CultureSetup>
     {

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetByteCount1.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetByteCount1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Calculates the number of bytes produced by encoding the characters in the specified String. 
     public class ASCIIEncodingGetByteCount1

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetByteCount2.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetByteCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Calculates the number of bytes produced 
     // by encoding the characters in the specified character array. 

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes1.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Encodes a set of characters from the specified String into the specified byte array. 
     public class ASCIIEncodingGetBytes1

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Encodes a set of characters from the specified character array into the specified byte array. 
     // for method: ASCIIEncoding.GetBytes(char[], Int32, Int32, Byte[], Int32)

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetCharCount.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Calculates the number of characters produced 
     // by decoding a sequence of bytes from the specified byte array.   

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetChars.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetChars.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Decodes a sequence of bytes from the specified byte array into the specified character array.   
     // ASCIIEncoding.GetChars(byte[], int, int, char[], int)

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetDecoder.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetDecoder.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // ASCIIEncoding.GetDecoder() 
     public class ASCIIEncodingGetDecoder

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetEncoder.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetEncoder.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // ASCIIEncoding.GetEncoder() 
     public class ASCIIEncodingGetEncoder

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetMaxByteCount.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetMaxByteCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Calculates the maximum number of bytes produced by encoding the specified number of characters.  
     // ASCIIEncoding.GetMaxByteCount(int)

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetMaxCharCount.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetMaxCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Calculates the maximum number of characters produced by decoding the specified number of bytes.  
     // ASCIIEncoding.GetMaxCharCount(int)

--- a/src/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class DecoderConvert2Decoder : Decoder
     {

--- a/src/System.Text.Encoding/tests/Decoder/DecoderCtor.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderCtor.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class DecoderCtorDecoder : Decoder
     {

--- a/src/System.Text.Encoding/tests/Decoder/DecoderGetCharCount2.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderGetCharCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetCharCount(System.Byte[],System.Int32,System.Int32,System.Boolean)
     public class DecoderGetCharCount2

--- a/src/System.Text.Encoding/tests/Decoder/DecoderGetCharCount3.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderGetCharCount3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetCharCount(System.Byte[],System.Int32,System.Int32)
     public class DecoderGetCharCount3

--- a/src/System.Text.Encoding/tests/Decoder/DecoderGetChars2.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderGetChars2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetChars(System.Byte[],System.Int32,System.Int32,System.Char[],System.Int32,System.Boolean)
     public class DecoderGetChars2

--- a/src/System.Text.Encoding/tests/Decoder/DecoderGetChars3.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderGetChars3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetChars(System.Byte[],System.Int32,System.Int32,System.Char[],System.Int32)
     public class DecoderGetChars3

--- a/src/System.Text.Encoding/tests/Decoder/DecoderReset.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderReset.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class DecoderReset
     {

--- a/src/System.Text.Encoding/tests/DecoderFallbackException/DecoderFallbackExceptionTests.cs
+++ b/src/System.Text.Encoding/tests/DecoderFallbackException/DecoderFallbackExceptionTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Text;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Tests the DecoderFallbackException class.
     public class DecoderFallbackExceptionTests

--- a/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncoderConvert2Encoder : Encoder
     {

--- a/src/System.Text.Encoding/tests/Encoder/EncoderCtor.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderCtor.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class TestEncoder : Encoder
     {

--- a/src/System.Text.Encoding/tests/Encoder/EncoderGetByteCount2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderGetByteCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetByteCount(System.Char[],System.Int32,System.Int32,System.Boolean)
     public class EncoderGetByteCount2

--- a/src/System.Text.Encoding/tests/Encoder/EncoderGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderGetBytes2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.Char[],System.Int32,System.Int32,System.Byte[],System.Int32,System.Boolean)
     public class EncoderGetBytes2

--- a/src/System.Text.Encoding/tests/EncoderFallbackException/EncoderFallbackExceptionTests.cs
+++ b/src/System.Text.Encoding/tests/EncoderFallbackException/EncoderFallbackExceptionTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Text;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Tests the EncoderFallbackException class.
     public class EncoderFallbackExceptionTests

--- a/src/System.Text.Encoding/tests/Encoding/ConvertUnicodeEncodings.cs
+++ b/src/System.Text.Encoding/tests/Encoding/ConvertUnicodeEncodings.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class ConvertUnicodeEncodings
     {

--- a/src/System.Text.Encoding/tests/Encoding/Encoding.cs
+++ b/src/System.Text.Encoding/tests/Encoding/Encoding.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Globalization;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingTest
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingBigEndianUnicode.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingBigEndianUnicode.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // BigEndianUnicode
     public class EncodingBigEndianUnicode

--- a/src/System.Text.Encoding/tests/Encoding/EncodingConvert1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingConvert1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Convert(System.Text.Encoding,System.Text.Encoding,System.Byte[])
     public class EncodingConvert1

--- a/src/System.Text.Encoding/tests/Encoding/EncodingConvert2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingConvert2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingConvert2
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingCtor1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingCtor1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingCtor1
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingEquals.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingEquals.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingEquals
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetByteCount
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetByteCount1
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetByteCount2
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount3.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetByteCount3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetByteCount(System.String)
     public class EncodingGetByteCount3

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetBytes1
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.Char[],System.Int32,System.Int32)
     public class EncodingGetBytes2

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes3.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.Char[],System.Int32,System.Int32,System.Byte[],System.Int32)
     public class EncodingGetBytes3

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes4.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes4.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.String)
     public class EncodingGetBytes4

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes5.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetBytes5.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.String,System.Int32,System.Int32,System.Byte[],System.Int32)
     public class EncodingGetBytes5

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetCharCount.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetCharCount
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetCharCount1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetCharCount1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Encoding.GetCharCount(Byte[])
     public class EncodingGetCharCount1

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetCharCount2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetCharCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Encoding.GetCharCount(Byte[],Int32,Int32)
     public class EncodingGetCharCount2

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetChars1.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetChars1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetChars1
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetChars2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetChars2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Encoding.GetChars(Byte[],Int32,Int32)
     public class EncodingGetChars2

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetChars3.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetChars3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Encoding.GetChars(byte[],Int32,Int32,char[],Int32)
     public class EncodingGetChars3

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetEncoding2.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetEncoding2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetEncoding2
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetMaxByteCount.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetMaxByteCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetMaxByteCount
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetMaxCharCount.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetMaxCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetMaxCharCount
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetPreamble.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetPreamble.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetPreamble
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetString.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetString.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingGetString
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingUTF8.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingUTF8.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingUTF8
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingUnicode.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingUnicode.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingUnicode
     {

--- a/src/System.Text.Encoding/tests/Encoding/EncodingWebName.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingWebName.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class EncodingWebName
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingCtor1.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingCtor1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingCtor1
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingCtor2.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingCtor2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingCtor2
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEquals.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEquals.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingEquals
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetByteCount1.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetByteCount1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetByteCount
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetByteCount2.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetByteCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetByteCount2
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetBytes1.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetBytes1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetBytes1
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetBytes2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetBytes2
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetCharCount.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetCharCount
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetChars.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetChars.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetChars
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetDecoder.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetDecoder.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetDecoder
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetEncoder.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetEncoder.cs
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-public class UTF7EncodingGetEncoder
+namespace System.Text.Tests
 {
-    // PosTest1: Verify method GetEncoder
-    [Fact]
-    public void PosTest1()
+    public class UTF7EncodingGetEncoder
     {
-        UTF7Encoding utf7 = new UTF7Encoding();
-        Encoder encoder = utf7.GetEncoder();
+        // PosTest1: Verify method GetEncoder
+        [Fact]
+        public void PosTest1()
+        {
+            UTF7Encoding utf7 = new UTF7Encoding();
+            Encoder encoder = utf7.GetEncoder();
+        }
     }
 }

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetHashCode.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetHashCode.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetHashCode
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetMaxByteCount.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetMaxByteCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetMaxByteCount
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetMaxCharCount.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetMaxCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetMaxCharCount
     {

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetString.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingGetString.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF7EncodingGetString
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingCtor.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingCtor.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF8EncodingCtor
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingCtor2.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingCtor2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF8EncodingCtor2
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingCtor3.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingCtor3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // ctor(System.Boolean,System.Boolean)
     public class UTF8EncodingCtor3

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingEquals.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingEquals.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // Equals(System.Object)
     public class UTF8EncodingEquals

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetByteCount1.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetByteCount1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetByteCount(System.Char[],System.Int32,System.Int32)
     public class UTF8EncodingGetByteCount1

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetByteCount2.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetByteCount2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetByteCount(System.String)
     public class UTF8EncodingGetByteCount2

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetBytes1.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetBytes1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.Char[],System.Int32,System.Int32,System.Byte[],System.Int32)
     public class UTF8EncodingGetBytes1

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetBytes2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetBytes(System.String,System.Int32,System.Int32,System.Byte[],System.Int32)
     public class UTF8EncodingGetBytes2

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetCharCount.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetByteCount(System.Char[],System.Int32,System.Int32)
     public class UTF8EncodingGetCharCount

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetChars.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetChars.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetChars(System.Byte[],System.Int32,System.Int32,System.Char[],System.Int32)
     public class UTF8EncodingGetChars

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetDecoder.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetDecoder.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF8EncodingGetDecoder
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetEncoder.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetEncoder.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF8EncodingGetEncoder
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetHashCode.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetHashCode.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF8EncodingGetHashCode
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxByteCount.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxByteCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetMaxByteCount(System.Int32)
     public class UTF8EncodingGetMaxByteCount

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxCharCount.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxCharCount.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetMaxCharCount(System.Int32)
     public class UTF8EncodingGetMaxCharCount

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetPreamble.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetPreamble.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UTF8EncodingGetPreamble
     {

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetString.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetString.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     // GetString(System.Byte[],System.Int32,System.Int32)
     public class UTF8EncodingGetString

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingCtor1.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingCtor1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UnicodeEncodingCtor
     {

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingEquals.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingEquals.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UnicodeEncodingEquals
     {

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetByteCount1.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetByteCount1.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UnicodeEncodingGetByteCount1
     {

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetByteCount2.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetByteCount2.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     public class UnicodeEncodingGetByteCount2
     {

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes1.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes1.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Test.UnicodeEncoding.GetBytes(System.Char[],System.Int32,System.Int32,System.Byte[],System.Int32)
     public class UnicodeEncodingGetBytes1

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes2.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Test.UnicodeEncoding.GetBytes(System.String,System.Int32,System.Int32,System.Byte[],System.Int32) [v-zuolan]
     public class UnicodeEncodingGetBytes2

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetCharCount.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetCharCount.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Test.UnicodeEncoding.GetCharCount(System.Byte[],System.Int32,System.Int32) [v-zuolan]
     public class UnicodeEncodingGetCharCount

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetChars.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetChars.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Test.UnicodeEncoding.GetChars(System.Byte[],System.Int32,System.Int32,System.Char[],System.Int32)
     public class UnicodeEncodingGetChars

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetDecoder.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetDecoder.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Test.UnicodeEncoding.GetDecoder()
     public class UnicodeEncodingGetDecoder

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetEncoder.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetEncoder.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Text.UnicodeEncoding.GetEncoder() [v-zuolan]
     public class UnicodeEncodingGetEncoder

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetHashCode.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetHashCode.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Text.UnicodeEncoding.GetHashCode()
     public class UnicodeEncodingGetHashCode

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetMaxByteCount.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetMaxByteCount.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Text.UnicodeEncoding.GetMaxByteCount(int)
     public class UnicodeEncodingGetMaxByteCount

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetMaxCharCount.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetMaxCharCount.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Text.UnicodeEncoding.GetMaxCharCount(int)
     public class UnicodeEncodingGetMaxCharCount

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetPreamble.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetPreamble.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Text.UnicodeEncoding.GetPreamble()
     public class UnicodeEncodingGetPreamble

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetString.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetString.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Xunit;
 
-namespace System.Text.EncodingTests
+namespace System.Text.Tests
 {
     //System.Test.UnicodeEncoding.GetString(System.Byte[],System.Int32,System.Int32)
     public class UnicodeEncodingGetString


### PR DESCRIPTION
Update test namespaces in some System.Text.* assemblies, per #2898 .
`using`s were also cleaned up.

One small (~18 line) file had the namespace added: `UTF7EncodingGetEncoder` (System.Text.Encoding).

@stephentoub 