### PR TITLE
Update test namespaces in System.Threading.Tasks.Parallel

### DIFF
--- a/src/System.Threading.Tasks.Parallel/tests/BreakTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/BreakTests.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
 
     public static class BreakTests

--- a/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
@@ -4,10 +4,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Threading;
 using Xunit;
 
-namespace System.Threading.Tasks.Test.Unit
+namespace System.Threading.Tasks.Tests
 {
     public class EtwTests
     {

--- a/src/System.Threading.Tasks.Parallel/tests/Logger.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/Logger.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace CoreFXTestLibrary
+namespace System.Threading.Tasks.Tests
 {
     // A dummy class for passing through System.Console calls until the System.Console contract is available.
     // To-do: Remove this workaround when possible.

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelFor.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelFor.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using CoreFXTestLibrary;
 
-using System;
-
-namespace System.Threading.Tasks.Test.Unit
+namespace System.Threading.Tasks.Tests
 {
 
     public sealed class ParallelForUnitTests

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForBoundary.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForBoundary.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using CoreFXTestLibrary;
 
-using System;
-
-namespace System.Threading.Tasks.Test.Unit
+namespace System.Threading.Tasks.Tests
 {
     public sealed class ParallelForBoundary
     {

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForTest.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForTest.cs
@@ -9,18 +9,12 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test.Unit
+namespace System.Threading.Tasks.Tests
 {
     public sealed class ParallelForTest
     {

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -1,17 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security;
-using System.Threading;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
 
     public class ParallelForTests

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForeachPartitioner.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForeachPartitioner.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using CoreFXTestLibrary;
 
-using System;
-
-namespace System.Threading.Tasks.Test.Unit
+namespace System.Threading.Tasks.Tests
 {
 
     public sealed class ParallelForeachPartitioner

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelInvokeTest.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelInvokeTest.cs
@@ -9,12 +9,8 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-
 
 using Xunit;
-using CoreFXTestLibrary;
 
-using System;
-using System.Threading.Tasks;
-
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
     public sealed class ParallelInvokeTest
     {

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelLoopResultTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelLoopResultTests.cs
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
 
     public static class ParallelLoopResultTests

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelStateTest.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelStateTest.cs
@@ -8,13 +8,9 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using Xunit;
+using Logger = System.Threading.Tasks.Tests.Logger;
 
 namespace System.Threading.Tasks.Test
 {

--- a/src/System.Threading.Tasks.Parallel/tests/RangePartitioner1Chunk.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/RangePartitioner1Chunk.cs
@@ -18,17 +18,11 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
 
     public class Partitioner1Chunk

--- a/src/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
 using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
 
     public class RangePartitionerTests

--- a/src/System.Threading.Tasks.Parallel/tests/RangePartitionerThreadSafetyTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/RangePartitionerThreadSafetyTests.cs
@@ -12,16 +12,11 @@
 // 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using Xunit;
-using CoreFXTestLibrary;
-
-using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using Xunit;
 
-namespace System.Threading.Tasks.Test
+namespace System.Threading.Tasks.Tests
 {
 
     public class RangePartitionerThreadSafetyTests

--- a/src/System.Threading.Tasks.Parallel/tests/RespectParentCancellationTest.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/RespectParentCancellationTest.cs
@@ -11,15 +11,13 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-
 
-using Xunit;
-using CoreFXTestLibrary;
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
-namespace Microsoft.Test.PCP
+namespace Sytem.Threading.Tasks.Tests
 {
 
     public sealed class RespectParentCancellationTest
@@ -85,35 +83,36 @@ namespace Microsoft.Test.PCP
                 yield return 0;
             }
         }
-       
-    }
 
-    public enum API
-    {
-        For,      // Parallel.For
-        For64,    // Parallel.For64
-        Foreach,  // Parallel.Foreach
-    }
+        public enum API
+        {
+            For,      // Parallel.For
+            For64,    // Parallel.For64
+            Foreach,  // Parallel.Foreach
+        }
 
-    public static class TestMethods
-    {
-        [Fact]
-        public static void RespectParentCancellation1()
+        public static class TestMethods
         {
-            RespectParentCancellationTest test = new RespectParentCancellationTest(API.For);
-            test.RealRun();
-        }
-        [Fact]
-        public static void RespectParentCancellation2()
-        {
-            RespectParentCancellationTest test = new RespectParentCancellationTest(API.For64);
-            test.RealRun();
-        }
-        [Fact]
-        public static void RespectParentCancellation3()
-        {
-            RespectParentCancellationTest test = new RespectParentCancellationTest(API.Foreach);
-            test.RealRun();
+            [Fact]
+            public static void RespectParentCancellation1()
+            {
+                RespectParentCancellationTest test = new RespectParentCancellationTest(API.For);
+                test.RealRun();
+            }
+
+            [Fact]
+            public static void RespectParentCancellation2()
+            {
+                RespectParentCancellationTest test = new RespectParentCancellationTest(API.For64);
+                test.RealRun();
+            }
+
+            [Fact]
+            public static void RespectParentCancellation3()
+            {
+                RespectParentCancellationTest test = new RespectParentCancellationTest(API.Foreach);
+                test.RealRun();
+            }
         }
     }
 }


### PR DESCRIPTION
Update test namespaces in System.Threading.Tasks.Parallel, per #2898 . 
 - Clean up `using`s.
 - Some types moved inside existing namespace.
 - ParallelStateTest only updated to reference moved logger (indentation changes too large).