### PR TITLE
Update test namespaces in some System.Xml.* assmblies

### DIFF
--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/CharReaderTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/CharReaderTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
-using XmlReaderTest.Common;
 using Xunit;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     public partial class CharCheckingReaderTest : CGenericTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/InheritedCases.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/InheritedCases.cs
@@ -2,14 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
 using System.IO;
-using System.Text;
-using System.Xml;
 using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     [TestModule(Name = "XmlCharCheckingReader Test", Desc = "XmlCharCheckingReader Test")]
     public partial class CharCheckingReaderTest : CGenericTestModule

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/CReaderTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/CReaderTestModule.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 using Xunit;
 
-namespace XmlReaderTest.CustomReaderTest
+namespace System.Xml.Tests
 {
     public partial class CReaderTestModule : CGenericTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/InheritedCases.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/InheritedCases.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using System.IO;
-using XmlReaderTest.Common;
-using System.Collections;
 
-namespace XmlReaderTest.CustomReaderTest
+namespace System.Xml.Tests
 {
     [TestModule(Name = "CustomReader Test", Desc = "CustomReader Test")]
     public partial class CReaderTestModule : CGenericTestModule

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/FactoryReaderTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/FactoryReaderTests.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 using Xunit;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     public partial class FactoryReaderTest : CGenericTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/InheritedCases.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/InheritedCases.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
 using System.IO;
-using System.Xml;
 using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // Module: use CXMLTypeCoercionTestModule

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/Normalization.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/Normalization.cs
@@ -1,15 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase TCXML Normalization

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/TCNormalization.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/TCNormalization.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     public partial class TCNormalization : TCXMLReaderBaseGeneral
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/CNameTableTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/CNameTableTestModule.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
 using Xunit;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
     public partial class CNameTableTestModule : CTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/InheritNameTable.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/InheritNameTable.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections.Generic;
-
 using OLEDB.Test.ModuleCore;
+using System.Collections.Generic;
 using XmlCoreTest.Common;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase NameTable user scenario inheritance
@@ -21,7 +17,7 @@ namespace NameTableTest
         [Variation("Read xml file using custom name table")]
         public int v1()
         {
-            string strFile = TestFiles.GetTestFileName(EREADER_TYPE.GENERIC);
+            string strFile = NameTable_TestFiles.GetTestFileName(EREADER_TYPE.GENERIC);
 
             // create custom nametable
             MyXmlNameTable nt = new MyXmlNameTable();

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TCRecordNameTableAdd.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TCRecordNameTableAdd.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
     public partial class TCRecordNameTableAdd : TCBase
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TCRecordNameTableGet.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TCRecordNameTableGet.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
     public partial class TCRecordNameTableGet : TCBase
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TCUserNameTable.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TCUserNameTable.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
     public partial class TCUserNameTable : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TestFiles.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/TestFiles.cs
@@ -1,26 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
-using System.Xml;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
-    public enum EREADER_TYPE
-    {
-        GENERIC = 0,
-        BIG_ELEMENT_SIZE,
-    };
     ////////////////////////////////////////////////////////////////
     // TestFiles
     //
     ////////////////////////////////////////////////////////////////
-    public class TestFiles
+    public class NameTable_TestFiles
     {
         //Data
         private static string s_allNodeTypeDTD = "AllNodeTypes.dtd";

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/XmlNameTable.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/XmlNameTable.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace NameTableTest
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // Module
@@ -35,7 +32,7 @@ namespace NameTableTest
 
             // Create global usage test files
             string strFile = String.Empty;
-            TestFiles.CreateTestFile(ref strFile, EREADER_TYPE.GENERIC);
+            NameTable_TestFiles.CreateTestFile(ref strFile, EREADER_TYPE.GENERIC);
 
             return ret;
         }
@@ -117,7 +114,7 @@ namespace NameTableTest
                 DataReader.Dispose();
             }
 
-            string strFile = TestFiles.GetTestFileName(EREADER_TYPE.GENERIC);
+            string strFile = NameTable_TestFiles.GetTestFileName(EREADER_TYPE.GENERIC);
             DataReader = XmlReader.Create(FilePathUtil.getStream(strFile), new XmlReaderSettings() { DtdProcessing = DtdProcessing.Ignore });//new XmlTextReader(strFile);
         }
 
@@ -331,7 +328,7 @@ namespace NameTableTest
         public int Variation_10()
         {
             string filename = null;
-            TestFiles.CreateTestFile(ref filename, EREADER_TYPE.BIG_ELEMENT_SIZE);
+            NameTable_TestFiles.CreateTestFile(ref filename, EREADER_TYPE.BIG_ELEMENT_SIZE);
             XmlReader rDataReader = XmlReader.Create(FilePathUtil.getStream(filename));
 
             while (rDataReader.Read() == true) ;
@@ -776,7 +773,7 @@ namespace NameTableTest
             // Add strings again and verify
 
             string filename = null;
-            TestFiles.CreateTestFile(ref filename, EREADER_TYPE.BIG_ELEMENT_SIZE);
+            NameTable_TestFiles.CreateTestFile(ref filename, EREADER_TYPE.BIG_ELEMENT_SIZE);
             XmlReader rDataReader = XmlReader.Create(FilePathUtil.getStream(filename));
             while (rDataReader.Read() == true) ;
             XmlNameTable nt = rDataReader.NameTable;
@@ -792,7 +789,7 @@ namespace NameTableTest
             CError.Compare(objActual1, nt.Get(strTest), "Comparing objActual1 and GetString");
             CError.Compare(objActual1, nt.Add(strTest), "Comparing objActual1 and AddString");
 
-            TestFiles.RemoveDataReader(EREADER_TYPE.BIG_ELEMENT_SIZE);
+            NameTable_TestFiles.RemoveDataReader(EREADER_TYPE.BIG_ELEMENT_SIZE);
 
             return TEST_PASS;
         }

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/CReaderTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/CReaderTestModule.cs
@@ -1,15 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 using Xunit;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class CReaderTestModule : CGenericTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/ConformanceSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/ConformanceSettings.cs
@@ -1,17 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections.Generic;
-using System.Reflection;
-using XmlReaderTest.Common;
-using XmlCoreTest.Common;
 using OLEDB.Test.ModuleCore;
+using System.Collections.Generic;
+using System.IO;
 using WebData.BaseLib;
+using XmlCoreTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     [TestCase(Name = "Conformance Settings", Desc = "Conformance Settings")]
     public partial class TCConformanceSettings : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/CreateOverloads.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/CreateOverloads.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Xml.Schema;
-using System.Collections;
-using XmlReaderTest.Common;
-using XmlCoreTest.Common;
 using OLEDB.Test.ModuleCore;
-using WebData.BaseLib;
+using System.IO;
+using XmlCoreTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     [TestCase(Name = "Create Overloads", Desc = "Create Overloads")]
     public partial class TCCreateOverloads : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/FilterSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/FilterSettings.cs
@@ -1,37 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using OLEDB.Test.ModuleCore;
 using System.IO;
-using System.Xml;
-using System.Xml.Schema;
-using System.Collections;
-using XmlReaderTest.Common;
 using XmlCoreTest.Common;
 
-using OLEDB.Test.ModuleCore;
-
-/*
-
-<?xml version="1.0"?>
-<!DOCTYPE root [
-  <!ELEMENT root (elem)*>
-  <!ELEMENT elem (#PCDATA)>
-  <!ATTLIST elem num ID #REQUIRED>
-  <!ATTLIST elem link1 IDREF #IMPLIED>
-  <!ATTLIST elem link2 IDREFS #IMPLIED>
-]>
-<root>
-  <elem num="a">data1</elem>
-  <elem num="b">data2</elem>
-  <elem num="c" link1="a">data3</elem>
-  <elem num="d" link2="b">data4</elem>
-  <elem num="e" link1="c" link2="a b">data5</elem>
-</root>
-
-*/
-
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     [TestCase(Name = "Filter Settings", Desc = "Filter Settings")]
     public partial class TCFilterSettings : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/Interactions.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/Interactions.cs
@@ -1,16 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Xml.Schema;
-using System.Collections;
-using XmlReaderTest.Common;
-
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     [TestCase(Name = "LineInfo", Desc = "LineInfo")]
     public partial class TCLineInfo : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/MaxSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/MaxSettings.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using OLEDB.Test.ModuleCore;
 using System;
 using System.IO;
-using System.Text;
-using System.Xml;
-using System.Collections;
-using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     [TestCase(Name = "MaxCharacters Settings", Desc = "MaxCharacters Settings")]
     public partial class TCMaxSettings : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/ReaderSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/ReaderSettings.cs
@@ -1,17 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections;
-using System.Text;
-using XmlReaderTest.Common;
-using XmlCoreTest.Common;
 using OLEDB.Test.ModuleCore;
-using WebData.BaseLib;
+using System.IO;
+using System.Text;
+using XmlCoreTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     [TestModule(Name = "ReaderSettings Test", Desc = "ReaderSettings Test")]
     public partial class CReaderTestModule : CGenericTestModule

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCCloseInput.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCCloseInput.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCCloseInput : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCCloseInput
+        // Type is System.Xml.Tests.TCCloseInput
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCConformanceSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCConformanceSettings.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCConformanceSettings : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCConformanceSettings
+        // Type is System.Xml.Tests.TCConformanceSettings
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCCreateOverloads.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCCreateOverloads.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCCreateOverloads : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCCreateOverloads
+        // Type is System.Xml.Tests.TCCreateOverloads
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCDtdProcessingCoreReader.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCDtdProcessingCoreReader.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCDtdProcessingCoreReader : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCDtdProcessingCoreReader
+        // Type is System.Xml.Tests.TCDtdProcessingCoreReader
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCDtdProcessingNonCoreReader.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCDtdProcessingNonCoreReader.cs
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCDtdProcessingNonCoreReader : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCDtdProcessingNonCoreReader
+        // Type is System.Xml.Tests.TCDtdProcessingNonCoreReader
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCFilterSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCFilterSettings.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCFilterSettings : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCFilterSettings
+        // Type is System.Xml.Tests.TCFilterSettings
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCLineInfo.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCLineInfo.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCLineInfo : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCLineInfo
+        // Type is System.Xml.Tests.TCLineInfo
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCMaxSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCMaxSettings.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMaxSettings : TCXMLReaderBaseGeneral
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCOneByteStream.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCOneByteStream.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCOneByteStream : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCOneByteStream
+        // Type is System.Xml.Tests.TCOneByteStream
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCRSGeneric.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCRSGeneric.cs
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCRSGeneric : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCRSGeneric
+        // Type is System.Xml.Tests.TCRSGeneric
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCReaderSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/TCReaderSettings.cs
@@ -1,17 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest.ReaderSettingsTest
+namespace System.Xml.Tests
 {
     public partial class TCReaderSettings : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.ReaderSettingsTest.TCReaderSettings
+        // Type is System.Xml.Tests.TCReaderSettings
         // Test Case
         public override void DOTEST()
         {

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/InheritedCases.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/InheritedCases.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
 using System.IO;
-using System.Xml;
 using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     [TestModule(Name = "XmlSubtreeReader Test", Desc = "XmlSubtreeReader Test")]
     public partial class SubtreeReaderTest : CGenericTestModule

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/SubtreeReaderTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/SubtreeReaderTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using OLEDB.Test.ModuleCore;
-using System;
-using XmlReaderTest.Common;
+using Xunit;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     public partial class SubtreeReaderTest : CGenericTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/InheritedCases.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/InheritedCases.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
 using System.IO;
-using System.Xml;
 using XmlCoreTest.Common;
-using XmlReaderTest.Common;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     [TestModule(Name = "XmlWrappedReader Test", Desc = "XmlWrappedReader Test")]
     public partial class WrappedReaderTest : CGenericTestModule

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/WrappedReaderTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/WrappedReaderTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using OLEDB.Test.ModuleCore;
-using System;
-using XmlReaderTest.Common;
+using Xunit;
 
-namespace XmlReaderTest
+namespace System.Xml.Tests
 {
     public partial class WrappedReaderTest : CGenericTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CFactoryModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CFactoryModule.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using Webdata.Test.XmlDriver;
-using XmlCoreTest.Common;
 using Xunit;
 
-namespace RWFactory
+namespace System.Xml.Tests
 {
     public partial class CFactoryModule : CXmlDriverModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CModCmdLine.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CModCmdLine.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using OLEDB.Test.ModuleCore;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CModCmdLine

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CRWFactory.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CRWFactory.cs
@@ -1,18 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Xml.Linq;
-using System.Text;
-using System.IO;
 using OLEDB.Test.ModuleCore;
-using Webdata.Test.XmlDriver;
+using System.IO;
 using XmlCoreTest.Common;
 
 //This file loads the specified new control file and executes the variations.
 
-namespace RWFactory
+namespace System.Xml.Tests
 {
     /// <summary>
     /// This is the CXmlDriver related code.

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverEngine.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverEngine.cs
@@ -1,21 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.IO;
+using OLEDB.Test.ModuleCore;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Diagnostics;
 using System.Globalization;
-using RWFactory;
-using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using XmlCoreTest.Common;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CXmlDriverEngine

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverException.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverException.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using OLEDB.Test.ModuleCore;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CXmlDriverException.

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverModule.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
 using OLEDB.Test.ModuleCore;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CXmlDriverModule

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverParam.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverParam.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Xml.Linq;
-using System.Collections.Generic;
-using System.Diagnostics;
 using OLEDB.Test.ModuleCore;
+using System.Collections.Generic;
+using System.Xml.Linq;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CXmlDriverParam

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverScenario.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverScenario.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Globalization;
 using OLEDB.Test.ModuleCore;
+using System.Globalization;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CXmlDriverScenario 

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverVariation.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CXmlDriverVariation.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Globalization;
 using OLEDB.Test.ModuleCore;
 
-namespace Webdata.Test.XmlDriver
+namespace System.Xml.Tests
 {
     /// <summary>
     /// CXmlDriverVariation

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/ReaderFactory.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/ReaderFactory.cs
@@ -1,16 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using OLEDB.Test.ModuleCore;
 using System.IO;
 using System.Text;
-using System.Xml;
-using System.Xml.Schema;
-using OLEDB.Test.ModuleCore;
-using Webdata.Test.XmlDriver;
 using XmlCoreTest.Common;
 
-namespace RWFactory
+namespace System.Xml.Tests
 {
     public partial class CReaderFactory : CFactory
     {

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/WriterFactory.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/WriterFactory.cs
@@ -1,16 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using OLEDB.Test.ModuleCore;
 using System.IO;
 using System.Text;
-using System.Xml;
-using System.Xml.Schema;
-using OLEDB.Test.ModuleCore;
-using Webdata.Test.XmlDriver;
 using XmlCoreTest.Common;
 
-namespace RWFactory
+namespace System.Xml.Tests
 {
     /// <summary>
     /// Summary description for WriterFactory.

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/CommonTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/CommonTests.cs
@@ -1,19 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using OLEDB.Test.ModuleCore;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Globalization;
-using System.Xml;
-using System.Collections.Generic;
-using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
-using System.Reflection;
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestCase(Name = "Invalid State Combinations", Pri = 1)]
     public partial class TCErrorState : XmlWriterTestCaseBase

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.Xml;
-using System.Text;
-using System.IO;
 using OLEDB.Test.ModuleCore;
+using System.IO;
+using System.Text;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestCase(Name="XmlWriterSettings: NewLineHandling")]
     public partial class TCEOFHandling : XmlFactoryWriterTestCaseBase

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/ErrorCondition.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/ErrorCondition.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Xml;
-using System.Linq;
 using OLEDB.Test.ModuleCore;
+using System.IO;
+using System.Linq;
+using System.Text;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestCase(Name = "ErrorCondition")]
     public partial class TCErrorConditionWriter : XmlWriterTestCaseBase

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/NamespaceHandlingTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/NamespaceHandlingTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.Xml;
-using System.Text;
-using System.IO;
 using OLEDB.Test.ModuleCore;
+using System.IO;
+using System.Text;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestCase(Name = "XmlWriterSettings: NamespaceHandling")]
     public partial class TCNamespaceHandling : XmlFactoryWriterTestCaseBase

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/ReaderParamTestCase.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/ReaderParamTestCase.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
-using System.Reflection;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public enum ReaderType
     {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCAttribute.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCAttribute.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCAttribute : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCAttribute
+        // Type is System.Xml.Tests.TCAttribute
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCAutoCL.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCAutoCL.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCAutoCL : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCAutoCL
+        // Type is System.Xml.Tests.TCAutoCL
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCAutoComplete.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCAutoComplete.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCAutoComplete : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCAutoComplete
+        // Type is System.Xml.Tests.TCAutoComplete
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCCheckChars.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCCheckChars.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCCheckChars : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCCheckChars
+        // Type is System.Xml.Tests.TCCheckChars
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCCloseOutput.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCCloseOutput.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCCloseOutput : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCCloseOutput
+        // Type is System.Xml.Tests.TCCloseOutput
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCDefaultWriterSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCDefaultWriterSettings.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCDefaultWriterSettings : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCDefaultWriterSettings
+        // Type is System.Xml.Tests.TCDefaultWriterSettings
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCDocType.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCDocType.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCDocType : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCDocType
+        // Type is System.Xml.Tests.TCDocType
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCDocument.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCDocument.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCDocument : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCDocument
+        // Type is System.Xml.Tests.TCDocument
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCEOFHandling.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCEOFHandling.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCEOFHandling : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCEOFHandling
+        // Type is System.Xml.Tests.TCEOFHandling
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCElement.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCElement : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCElement
+        // Type is System.Xml.Tests.TCElement
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCErrorConditionWriter.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCErrorConditionWriter.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCErrorConditionWriter : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCErrorConditionWriter
+        // Type is System.Xml.Tests.TCErrorConditionWriter
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCErrorState.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCErrorState.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCErrorState : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCErrorState
+        // Type is System.Xml.Tests.TCErrorState
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCFlushClose.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCFlushClose.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCFlushClose : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCFlushClose
+        // Type is System.Xml.Tests.TCFlushClose
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCFragmentCL.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCFragmentCL.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCFragmentCL : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCFragmentCL
+        // Type is System.Xml.Tests.TCFragmentCL
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCFullEndElement : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCFullEndElement
+        // Type is System.Xml.Tests.TCFullEndElement
         // Test Case
         public override void AddChildren()
         {
@@ -49,70 +47,70 @@ namespace XmlWriterAPI.Test
             }
 
 
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCElemNamespace
+            // for class System.Xml.Tests.TCFullEndElement+TCElemNamespace
             {
                 this.AddChild(new TCElemNamespace() { Attribute = new TestCase() { Name = "Element Namespace" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCAttrNamespace
+            // for class System.Xml.Tests.TCFullEndElement+TCAttrNamespace
             {
                 this.AddChild(new TCAttrNamespace() { Attribute = new TestCase() { Name = "Attribute Namespace" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCCData
+            // for class System.Xml.Tests.TCFullEndElement+TCCData
             {
                 this.AddChild(new TCCData() { Attribute = new TestCase() { Name = "WriteCData" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCComment
+            // for class System.Xml.Tests.TCFullEndElement+TCComment
             {
                 this.AddChild(new TCComment() { Attribute = new TestCase() { Name = "WriteComment" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCEntityRef
+            // for class System.Xml.Tests.TCFullEndElement+TCEntityRef
             {
                 this.AddChild(new TCEntityRef() { Attribute = new TestCase() { Name = "WriteEntityRef" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCCharEntity
+            // for class System.Xml.Tests.TCFullEndElement+TCCharEntity
             {
                 this.AddChild(new TCCharEntity() { Attribute = new TestCase() { Name = "WriteCharEntity" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCSurrogateCharEntity
+            // for class System.Xml.Tests.TCFullEndElement+TCSurrogateCharEntity
             {
                 this.AddChild(new TCSurrogateCharEntity() { Attribute = new TestCase() { Name = "WriteSurrogateCharEntity" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCPI
+            // for class System.Xml.Tests.TCFullEndElement+TCPI
             {
                 this.AddChild(new TCPI() { Attribute = new TestCase() { Name = "WriteProcessingInstruction" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteNmToken
+            // for class System.Xml.Tests.TCFullEndElement+TCWriteNmToken
             {
                 this.AddChild(new TCWriteNmToken() { Attribute = new TestCase() { Name = "WriteNmToken" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteName
+            // for class System.Xml.Tests.TCFullEndElement+TCWriteName
             {
                 this.AddChild(new TCWriteName() { Attribute = new TestCase() { Name = "WriteName" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteQName
+            // for class System.Xml.Tests.TCFullEndElement+TCWriteQName
             {
                 this.AddChild(new TCWriteQName() { Attribute = new TestCase() { Name = "WriteQualifiedName" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteChars
+            // for class System.Xml.Tests.TCFullEndElement+TCWriteChars
             {
                 this.AddChild(new TCWriteChars() { Attribute = new TestCase() { Name = "WriteChars" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteString
+            // for class System.Xml.Tests.TCFullEndElement+TCWriteString
             {
                 this.AddChild(new TCWriteString() { Attribute = new TestCase() { Name = "WriteString" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWhiteSpace
+            // for class System.Xml.Tests.TCFullEndElement+TCWhiteSpace
             {
                 this.AddChild(new TCWhiteSpace() { Attribute = new TestCase() { Name = "WriteWhitespace" } });
             }
-            // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue
+            // for class System.Xml.Tests.TCFullEndElement+TCWriteValue
             {
                 this.AddChild(new TCWriteValue() { Attribute = new TestCase() { Name = "WriteValue" } });
             }
         }
         public partial class TCElemNamespace : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCElemNamespace
+            // Type is System.Xml.Tests.TCFullEndElement+TCElemNamespace
             // Test Case
             public override void AddChildren()
             {
@@ -310,7 +308,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCAttrNamespace : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCAttrNamespace
+            // Type is System.Xml.Tests.TCFullEndElement+TCAttrNamespace
             // Test Case
             public override void AddChildren()
             {
@@ -562,7 +560,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCCData : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCCData
+            // Type is System.Xml.Tests.TCFullEndElement+TCCData
             // Test Case
             public override void AddChildren()
             {
@@ -651,7 +649,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCComment : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCComment
+            // Type is System.Xml.Tests.TCFullEndElement+TCComment
             // Test Case
             public override void AddChildren()
             {
@@ -693,7 +691,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCEntityRef : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCEntityRef
+            // Type is System.Xml.Tests.TCFullEndElement+TCEntityRef
             // Test Case
             public override void AddChildren()
             {
@@ -715,7 +713,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCCharEntity : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCCharEntity
+            // Type is System.Xml.Tests.TCFullEndElement+TCCharEntity
             // Test Case
             public override void AddChildren()
             {
@@ -769,7 +767,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCSurrogateCharEntity : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCSurrogateCharEntity
+            // Type is System.Xml.Tests.TCFullEndElement+TCSurrogateCharEntity
             // Test Case
             public override void AddChildren()
             {
@@ -823,7 +821,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCPI : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCPI
+            // Type is System.Xml.Tests.TCFullEndElement+TCPI
             // Test Case
             public override void AddChildren()
             {
@@ -907,7 +905,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWriteNmToken : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteNmToken
+            // Type is System.Xml.Tests.TCFullEndElement+TCWriteNmToken
             // Test Case
             public override void AddChildren()
             {
@@ -941,7 +939,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWriteName : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteName
+            // Type is System.Xml.Tests.TCFullEndElement+TCWriteName
             // Test Case
             public override void AddChildren()
             {
@@ -973,7 +971,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWriteQName : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteQName
+            // Type is System.Xml.Tests.TCFullEndElement+TCWriteQName
             // Test Case
             public override void AddChildren()
             {
@@ -1011,7 +1009,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWriteChars : TCWriteBuffer
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteChars
+            // Type is System.Xml.Tests.TCFullEndElement+TCWriteChars
             // Test Case
             public override void AddChildren()
             {
@@ -1083,7 +1081,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWriteString : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteString
+            // Type is System.Xml.Tests.TCFullEndElement+TCWriteString
             // Test Case
             public override void AddChildren()
             {
@@ -1173,7 +1171,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWhiteSpace : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWhiteSpace
+            // Type is System.Xml.Tests.TCFullEndElement+TCWhiteSpace
             // Test Case
             public override void AddChildren()
             {
@@ -1214,7 +1212,7 @@ namespace XmlWriterAPI.Test
         }
         public partial class TCWriteValue : XmlWriterTestCaseBase
         {
-            // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue
+            // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue
             // Test Case
             public override void AddChildren()
             {
@@ -1982,50 +1980,50 @@ namespace XmlWriterAPI.Test
                 }
 
 
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCLookUpPrefix
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCLookUpPrefix
                 {
                     this.AddChild(new TCLookUpPrefix() { Attribute = new TestCase() { Name = "LookupPrefix" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCXmlSpace
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCXmlSpace
                 {
                     this.AddChild(new TCXmlSpace() { Attribute = new TestCase() { Name = "XmlSpace" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCXmlLang
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCXmlLang
                 {
                     this.AddChild(new TCXmlLang() { Attribute = new TestCase() { Name = "XmlLang" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteRaw
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteRaw
                 {
                     this.AddChild(new TCWriteRaw() { Attribute = new TestCase() { Name = "WriteRaw" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteBase64
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteBase64
                 {
                     this.AddChild(new TCWriteBase64() { Attribute = new TestCase() { Name = "WriteBase64" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteBinHex
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteBinHex
                 {
                     this.AddChild(new TCWriteBinHex() { Attribute = new TestCase() { Name = "WriteBinHex" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteState
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteState
                 {
                     this.AddChild(new TCWriteState() { Attribute = new TestCase() { Name = "WriteState" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TC_NDP20_NewMethods
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TC_NDP20_NewMethods
                 {
                     this.AddChild(new TC_NDP20_NewMethods() { Attribute = new TestCase() { Name = "NDP20_NewMethods" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCGlobalization
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCGlobalization
                 {
                     this.AddChild(new TCGlobalization() { Attribute = new TestCase() { Name = "Globalization" } });
                 }
-                // for class XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCClose
+                // for class System.Xml.Tests.TCFullEndElement+TCWriteValue+TCClose
                 {
                     this.AddChild(new TCClose() { Attribute = new TestCase() { Name = "Close()" } });
                 }
             }
             public partial class TCLookUpPrefix : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCLookUpPrefix
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCLookUpPrefix
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2091,7 +2089,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCXmlSpace : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCXmlSpace
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCXmlSpace
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2151,7 +2149,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCXmlLang : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCXmlLang
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCXmlLang
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2205,7 +2203,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCWriteRaw : TCWriteBuffer
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteRaw
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteRaw
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2295,7 +2293,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCWriteBase64 : TCWriteBuffer
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteBase64
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteBase64
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2379,7 +2377,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCWriteBinHex : TCWriteBuffer
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteBinHex
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteBinHex
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2445,7 +2443,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCWriteState : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCWriteState
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCWriteState
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2554,7 +2552,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TC_NDP20_NewMethods : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TC_NDP20_NewMethods
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TC_NDP20_NewMethods
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2603,7 +2601,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCGlobalization : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCGlobalization
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCGlobalization
                 // Test Case
                 public override void AddChildren()
                 {
@@ -2621,7 +2619,7 @@ namespace XmlWriterAPI.Test
             }
             public partial class TCClose : XmlWriterTestCaseBase
             {
-                // Type is XmlWriterAPI.Test.TCFullEndElement+TCWriteValue+TCClose
+                // Type is System.Xml.Tests.TCFullEndElement+TCWriteValue+TCClose
                 // Test Case
                 public override void AddChildren()
                 {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCIndent.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCIndent.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCIndent : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCIndent
+        // Type is System.Xml.Tests.TCIndent
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCIndentChars.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCIndentChars.cs
@@ -2,15 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCIndentChars : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCIndentChars
+        // Type is System.Xml.Tests.TCIndentChars
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNamespaceHandling.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNamespaceHandling.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCNamespaceHandling : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCNamespaceHandling
+        // Type is System.Xml.Tests.TCNamespaceHandling
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNewLineChars.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNewLineChars.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCNewLineChars : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCNewLineChars
+        // Type is System.Xml.Tests.TCNewLineChars
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNewLineHandling.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNewLineHandling.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCNewLineHandling : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCNewLineHandling
+        // Type is System.Xml.Tests.TCNewLineHandling
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNewLineOnAttributes.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCNewLineOnAttributes.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCNewLineOnAttributes : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCNewLineOnAttributes
+        // Type is System.Xml.Tests.TCNewLineOnAttributes
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCOmitXmlDecl.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCOmitXmlDecl.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCOmitXmlDecl : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCOmitXmlDecl
+        // Type is System.Xml.Tests.TCOmitXmlDecl
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCStandAlone.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCStandAlone.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCStandAlone : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCStandAlone
+        // Type is System.Xml.Tests.TCStandAlone
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriteAttributes.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriteAttributes.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCWriteAttributes : ReaderParamTestCase
     {
-        // Type is XmlWriterAPI.Test.TCWriteAttributes
+        // Type is System.Xml.Tests.TCWriteAttributes
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriteEndDocumentOnCloseTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriteEndDocumentOnCloseTest.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCWriteEndDocumentOnCloseTest : XmlWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCWriteEndDocumentOnCloseTest
+        // Type is System.Xml.Tests.TCWriteEndDocumentOnCloseTest
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriteNode_XmlReader.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriteNode_XmlReader.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCWriteNode_XmlReader : ReaderParamTestCase
     {
-        // Type is XmlWriterAPI.Test.TCWriteNode_XmlReader
+        // Type is System.Xml.Tests.TCWriteNode_XmlReader
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriterSettingsMisc.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriterSettingsMisc.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCWriterSettingsMisc : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCWriterSettingsMisc
+        // Type is System.Xml.Tests.TCWriterSettingsMisc
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriterWithMemoryStream.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCWriterWithMemoryStream.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class TCWriterWithMemoryStream : XmlFactoryWriterTestCaseBase
     {
-        // Type is XmlWriterAPI.Test.TCWriterWithMemoryStream
+        // Type is System.Xml.Tests.TCWriterWithMemoryStream
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
 using Xunit;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public partial class XmlWriterTestModule : CTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/WriteEndDocumentOnCloseTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/WriteEndDocumentOnCloseTest.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestCase(Name = "XmlWriterSettings: WriteEndDocumentOnClose")]
     public partial class TCWriteEndDocumentOnCloseTest : XmlWriterTestCaseBase

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlFactoryWriterTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlFactoryWriterTests.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.Xml;
-using System.Text;
-using System.IO;
 using OLEDB.Test.ModuleCore;
+using System.IO;
+using System.Text;
 using XmlCoreTest.Common;
-using System.Reflection;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestCase(Name="XmlWriterSettings: Default Values", Pri=0)]
     public partial class TCDefaultWriterSettings : XmlFactoryWriterTestCaseBase

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlWriterTestCaseBase.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlWriterTestCaseBase.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
 using System.IO;
-using System.Xml;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     public abstract partial class XmlWriterTestCaseBase : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlWriterTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlWriterTestModule.cs
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlWriterAPI.Test
+namespace System.Xml.Tests
 {
     //[TestModule(Name="XmlWriter API")]
     public partial class XmlWriterTestModule : CTestModule

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/EncodeDecodeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/EncodeDecodeTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class EncodeDecodeTests : SqlXmlConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/MiscellaneousTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/MiscellaneousTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class MiscellaneousTests : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase: XmlConvert 

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests0.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests0.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class SqlXmlConvertTests0 : SqlXmlConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class SqlXmlConvertTests1 : SqlXmlConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class SqlXmlConvertTests2 : SqlXmlConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/SqlXmlConvertTests3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class SqlXmlConvertTests3 : SqlXmlConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/ToTypeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/ToTypeTests.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
+using System.Globalization;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     /// <summary>
     ///     XmlConvert type conversion functions

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests1.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
-using System.Xml;
 using XmlCoreTest.Common;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class VerifyNameTests1 : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests2.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
-using System.Xml;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class VerifyNameTests2 : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class VerifyNameTests3 : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests4.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests4.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class VerifyNameTests4 : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests5.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/VerifyNameTests5.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OLEDB.Test.ModuleCore;
-using System;
-using System.Xml;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class VerifyNameTests5 : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests.cs
@@ -3,7 +3,7 @@
 
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal abstract class XmlBaseCharConvertTests : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlBaseCharConvertTests1 : XmlBaseCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests2.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlBaseCharConvertTests2 : XmlBaseCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlBaseCharConvertTests3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlBaseCharConvertTests3 : XmlBaseCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests.cs
@@ -3,7 +3,7 @@
 
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal abstract class XmlCombiningCharConvertTests : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests1.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlCombiningCharConvertTests1 : XmlCombiningCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlCombiningCharConvertTests2 : XmlCombiningCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlCombiningCharConvertTests3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlCombiningCharConvertTests3 : XmlCombiningCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlConvertTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using OLEDB.Test.ModuleCore;
+using Xunit;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     public class XmlConvertTests : CTestModule
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests.cs
@@ -3,7 +3,7 @@
 
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal abstract class XmlDigitCharConvertTests : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests1.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlDigitCharConvertTests1 : XmlDigitCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlDigitCharConvertTests2 : XmlDigitCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlDigitCharConvertTests3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlDigitCharConvertTests3 : XmlDigitCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests.cs
@@ -3,7 +3,7 @@
 
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal abstract class XmlEmbeddedNullCharConvertTests : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests1.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlEmbeddedNullCharConvertTests1 : XmlEmbeddedNullCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlEmbeddedNullCharConvertTests2 : XmlEmbeddedNullCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlEmbeddedNullCharConvertTests3.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlEmbeddedNullCharConvertTests3 : XmlEmbeddedNullCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests.cs
@@ -3,7 +3,7 @@
 
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal abstract class XmlIdeographicCharConvertTests : CTestCase
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests1.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests1.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlIdeographicCharConvertTests1 : XmlIdeographicCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests2.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlIdeographicCharConvertTests2 : XmlIdeographicCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests3.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlIdeographicCharConvertTests3.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlConvertTests
+namespace System.Xml.Tests
 {
     internal class XmlIdeographicCharConvertTests3 : XmlIdeographicCharConvertTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsArrayTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsArrayTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ArrayTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsBooleanAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsBooleanAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class BooleanAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsBooleanElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsBooleanElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class BooleanElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsBooleanTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsBooleanTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class BooleanTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsByteAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsByteAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ByteAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsByteElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsByteElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ByteElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsByteTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsByteTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ByteTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsCharElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsCharElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class CharElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsCharTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsCharTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class CharTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DateTimeAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DateTimeElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeOffsetAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeOffsetAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DateTimeOffsetAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeOffsetElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeOffsetElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DateTimeOffsetElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeOffsetTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeOffsetTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DateTimeOffsetTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDateTimeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DateTimeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDayOfWeekElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDayOfWeekElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DayOfWeekElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDayOfWeekTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDayOfWeekTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DayOfWeekTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDecimalAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDecimalAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DecimalAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDecimalElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDecimalElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DecimalElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDecimalTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDecimalTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DecimalTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDoubleAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDoubleAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DoubleAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDoubleElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDoubleElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DoubleElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDoubleTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsDoubleTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class DoubleTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExceptionElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExceptionElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ExceptionElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExceptionTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExceptionTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ExceptionTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExtendedDateTimeElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExtendedDateTimeElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ExtendedDateTimeElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExtendedDateTimeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsExtendedDateTimeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ExtendedDateTimeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsFloatAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsFloatAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class FloatAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsFloatElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsFloatElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class FloatElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsFloatTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsFloatTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class FloatTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsIntegerAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsIntegerAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class IntegerAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsIntegerElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsIntegerElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class IntegerElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsIntegerTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsIntegerTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class IntegerTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsLongAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsLongAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class LongAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsLongElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsLongElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class LongElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsLongTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsLongTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class LongTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsObjectAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsObjectAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ObjectAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsObjectElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsObjectElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ObjectElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsObjectTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsObjectTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class ObjectTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsStringAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsStringAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class StringAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsStringElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsStringElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class StringElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsStringTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsStringTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class StringTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeSpanAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeSpanAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class TimeSpanAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeSpanElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeSpanElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class TimeSpanElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeSpanTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeSpanTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class TimeSpanTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeZoneInfoElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeZoneInfoElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class TimeZoneInfoElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeZoneInfoTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsTimeZoneInfoTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class TimeZoneInfoTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsUriAttributeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsUriAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class UriAttributeTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsUriElementContentTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsUriElementContentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class UriElementContentTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsUriTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/ReadAsUriTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter.ReadContentTests
+namespace System.Xml.Tests
 {
     public class UriTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/Utils.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/Utils.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Xml;
 
-namespace XMLTests.ReaderWriter
+namespace System.Xml.Tests
 {
     public static class Utils
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Xml;
 using System.IO;
+using System.Text;
 using Xunit;
-using Xunit.Extensions;
 
-namespace XMLTests.ReaderWriter
+namespace System.Xml.Tests
 {
     public static class AsyncReaderLateInitTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/DisposeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/DisposeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.IO;
 using System.Text;
-using System.Xml;
+using Xunit;
 
-namespace XMLTests.ReaderWriter.DisposeTests
+namespace System.Xml.Tests
 {
     public class MyXmlReader : XmlReader
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Xml;
+using Xunit;
 
-namespace XMLTests.ReaderWriter.XmlResolverTests
+namespace System.Xml.Tests
 {
     public class XmlSystemPathResolverTests
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CDataReader.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CDataReader.cs
@@ -1,16 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Xml.Schema;
-using System.IO;
-using System.Collections;
-using System.Text;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public enum EREADER_TYPE
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CDataReaderTestCase.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CDataReaderTestCase.cs
@@ -1,14 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Reflection;
-
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CGenericTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CGenericTestModule.cs
@@ -1,17 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Xml;
-using System.IO;
-using System.Xml.Schema;
 using OLEDB.Test.ModuleCore;
-using System.Security;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // All test module cases should inherit from CUniTestModule

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CReader.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CReader.cs
@@ -1,16 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.Xml.Schema;
-using OLEDB.Test.ModuleCore;
 using System.IO;
-using XmlReaderTest.Common;
-using System.Collections;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public class XmlCustomReader : XmlReader
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLGeneralTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLGeneralTest.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using System.Collections.Generic;
-using XmlCoreTest.Common;
+using System.IO;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase TCXML BaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLReaderAttrTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLReaderAttrTest.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase TCXML AttributeAccess

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXmlReaderEntityTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXmlReaderEntityTest.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-
 using OLEDB.Test.ModuleCore;
+using System.IO;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase TCXML ResolveEntity and ReadAttributeValue

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXmlReaderReadEtc.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXmlReaderReadEtc.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase TCXML ReadState

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CommonTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CommonTest.cs
@@ -1,18 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Collections;
-using System.IO;
-using System.Xml;
-using System.Text;
-using XmlCoreTest.Common;
 using OLEDB.Test.ModuleCore;
+using System.IO;
+using XmlCoreTest.Common;
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestCase TCXML Dispose

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ErrorCondition.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ErrorCondition.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.IO;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     [InheritRequired()]
     public abstract partial class TCErrorCondition : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/IntegrityTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/IntegrityTest.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
-using System.IO;
-using System.Collections;
-
 using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public enum EINTEGRITY
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/LineNumber.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/LineNumber.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     [InheritRequired()]
     public abstract partial class TCLinePos : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBase64.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBase64.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using OLEDB.Test.ModuleCore;
 using System.IO;
-using System.Xml;
 using System.Text;
 using XmlCoreTest.Common;
-using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     [InheritRequired()]
     public abstract partial class TCReadContentAsBase64 : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBinHex.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBinHex.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Text;
 using OLEDB.Test.ModuleCore;
+using System.IO;
+using System.Text;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     [InheritRequired()]
     public abstract partial class TCReadContentAsBinHex : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadOuterXml.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadOuterXml.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     /////////////////////////////////////////////////////////////////////////
     // TestCase ReadOuterXml

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadSubTree.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadSubTree.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections.Generic;
 using OLEDB.Test.ModuleCore;
+using System.Collections.Generic;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     /////////////////////////////////////////////////////////////////////////
     // TestCase ReadOuterXml

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadToDescendant.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadToDescendant.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     /////////////////////////////////////////////////////////////////////////
     // TestCase ReadOuterXml

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadToFollowing.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadToFollowing.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
+using System.IO;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     /////////////////////////////////////////////////////////////////////////
     // TestCase ReadOuterXml

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadToNextSibling.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadToNextSibling.cs
@@ -1,17 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections.Generic;
-using System.Threading;
-
 using OLEDB.Test.ModuleCore;
-
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     /////////////////////////////////////////////////////////////////////////
     // TestCase ReadOuterXml

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadValue.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadValue.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Xml;
-using System.Collections;
 using OLEDB.Test.ModuleCore;
+using System.IO;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     /////////////////////////////////////////////////////////////////////////
     // TestCase ReadValue

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCAttributeAccess.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCAttributeAccess.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCAttributeAccess : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCAttributeAccess
+        // Type is System.Xml.Tests.TCAttributeAccess
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCAttributeTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCAttributeTest.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCAttributeTest : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCAttributeTest
+        // Type is System.Xml.Tests.TCAttributeTest
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCAttributeXmlDeclaration.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCAttributeXmlDeclaration.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCAttributeXmlDeclaration : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCAttributeXmlDeclaration
+        // Type is System.Xml.Tests.TCAttributeXmlDeclaration
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCBufferBoundaries.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCBufferBoundaries.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCBufferBoundaries : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCBufferBoundaries
+        // Type is System.Xml.Tests.TCBufferBoundaries
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCDepth.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCDepth.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCDepth : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCDepth
+        // Type is System.Xml.Tests.TCDepth
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCDispose.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCDispose.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCDispose : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCDispose
+        // Type is System.Xml.Tests.TCDispose
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCErrorCondition.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCErrorCondition.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCErrorCondition : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCErrorCondition
+        // Type is System.Xml.Tests.TCErrorCondition
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCGetAttributeName.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCGetAttributeName.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCGetAttributeName : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCGetAttributeName
+        // Type is System.Xml.Tests.TCGetAttributeName
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCGetAttributeOrdinal.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCGetAttributeOrdinal.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCGetAttributeOrdinal : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCGetAttributeOrdinal
+        // Type is System.Xml.Tests.TCGetAttributeOrdinal
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCHasValue.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCHasValue.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCHasValue : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCHasValue
+        // Type is System.Xml.Tests.TCHasValue
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCInvalidXML.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCInvalidXML.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCInvalidXML : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCInvalidXML
+        // Type is System.Xml.Tests.TCInvalidXML
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCIsEmptyElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCIsEmptyElement.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCIsEmptyElement : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCIsEmptyElement
+        // Type is System.Xml.Tests.TCIsEmptyElement
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCIsStartElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCIsStartElement.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCIsStartElement : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCIsStartElement
+        // Type is System.Xml.Tests.TCIsStartElement
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCLinePos.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCLinePos.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCLinePos : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCLinePos
+        // Type is System.Xml.Tests.TCLinePos
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToAttribute.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToAttribute.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMoveToAttribute : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCMoveToAttribute
+        // Type is System.Xml.Tests.TCMoveToAttribute
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToAttributeOrdinal.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToAttributeOrdinal.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMoveToAttributeOrdinal : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCMoveToAttributeOrdinal
+        // Type is System.Xml.Tests.TCMoveToAttributeOrdinal
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToContent.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToContent.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMoveToContent : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCMoveToContent
+        // Type is System.Xml.Tests.TCMoveToContent
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToElement.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMoveToElement : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCMoveToElement
+        // Type is System.Xml.Tests.TCMoveToElement
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToFirstAttribute.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToFirstAttribute.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMoveToFirstAttribute : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCMoveToFirstAttribute
+        // Type is System.Xml.Tests.TCMoveToFirstAttribute
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToNextAttribute.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCMoveToNextAttribute.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCMoveToNextAttribute : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCMoveToNextAttribute
+        // Type is System.Xml.Tests.TCMoveToNextAttribute
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCNamespace.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCNamespace.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCNamespace : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCNamespace
+        // Type is System.Xml.Tests.TCNamespace
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCRead2.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCRead2.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCRead2 : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCRead2
+        // Type is System.Xml.Tests.TCRead2
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadAttributeValue.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadAttributeValue.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadAttributeValue : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadAttributeValue
+        // Type is System.Xml.Tests.TCReadAttributeValue
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadContentAsBase64.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadContentAsBase64.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadContentAsBase64 : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadContentAsBase64
+        // Type is System.Xml.Tests.TCReadContentAsBase64
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadContentAsBinHex.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadContentAsBinHex.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadContentAsBinHex : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadContentAsBinHex
+        // Type is System.Xml.Tests.TCReadContentAsBinHex
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadElementContentAsBase64.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadElementContentAsBase64.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadElementContentAsBase64 : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadElementContentAsBase64
+        // Type is System.Xml.Tests.TCReadElementContentAsBase64
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadElementContentAsBinHex.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadElementContentAsBinHex.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadElementContentAsBinHex : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadElementContentAsBinHex
+        // Type is System.Xml.Tests.TCReadElementContentAsBinHex
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadEndElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadEndElement.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadEndElement : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadEndElement
+        // Type is System.Xml.Tests.TCReadEndElement
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadOuterXml.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadOuterXml.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadOuterXml : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadOuterXml
+        // Type is System.Xml.Tests.TCReadOuterXml
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadStartElement.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadStartElement.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadStartElement : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadStartElement
+        // Type is System.Xml.Tests.TCReadStartElement
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadSubtree.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadSubtree.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadSubtree : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadSubtree
+        // Type is System.Xml.Tests.TCReadSubtree
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadToDescendant.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadToDescendant.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadToDescendant : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadToDescendant
+        // Type is System.Xml.Tests.TCReadToDescendant
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadToFollowing.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadToFollowing.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadToFollowing : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadToFollowing
+        // Type is System.Xml.Tests.TCReadToFollowing
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadToNextSibling.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadToNextSibling.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadToNextSibling : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadToNextSibling
+        // Type is System.Xml.Tests.TCReadToNextSibling
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadValue.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCReadValue.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCReadValue : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCReadValue
+        // Type is System.Xml.Tests.TCReadValue
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCResolveEntity.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCResolveEntity.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCResolveEntity : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCResolveEntity
+        // Type is System.Xml.Tests.TCResolveEntity
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCSkip.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCSkip.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCSkip : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCSkip
+        // Type is System.Xml.Tests.TCSkip
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCThisName.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCThisName.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCThisName : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCThisName
+        // Type is System.Xml.Tests.TCThisName
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCThisOrdinal.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCThisOrdinal.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCThisOrdinal : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCThisOrdinal
+        // Type is System.Xml.Tests.TCThisOrdinal
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXMLException.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXMLException.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCXMLException : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCXMLException
+        // Type is System.Xml.Tests.TCXMLException
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXMLIntegrityBase.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXMLIntegrityBase.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCXMLIntegrityBase : CDataReaderTestCase
     {
-        // Type is XmlReaderTest.Common.TCXMLIntegrityBase
+        // Type is System.Xml.Tests.TCXMLIntegrityBase
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlLang.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlLang.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCXmlLang : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCXmlLang
+        // Type is System.Xml.Tests.TCXmlLang
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlSpace.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlSpace.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCXmlSpace : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCXmlSpace
+        // Type is System.Xml.Tests.TCXmlSpace
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlns.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlns.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCXmlns : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCXmlns
+        // Type is System.Xml.Tests.TCXmlns
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlnsPrefix.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TCXmlnsPrefix.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     public partial class TCXmlnsPrefix : TCXMLReaderBaseGeneral
     {
-        // Type is XmlReaderTest.Common.TCXmlnsPrefix
+        // Type is System.Xml.Tests.TCXmlnsPrefix
         // Test Case
         public override void AddChildren()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TestFiles.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/TestFiles.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.IO;
 using System.Text;
-using System.Xml;
-using OLEDB.Test.ModuleCore;
 using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     ////////////////////////////////////////////////////////////////
     // TestFiles

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/XmlException.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/XmlException.cs
@@ -1,14 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.IO;
-using System.Xml;
 using OLEDB.Test.ModuleCore;
-using XmlCoreTest.Common;
 
-namespace XmlReaderTest.Common
+namespace System.Xml.Tests
 {
     [InheritRequired()]
     public abstract partial class TCXMLException : TCXMLReaderBaseGeneral

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/DisposeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/DisposeTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.IO;
 using System.Text;
-using System.Xml;
+using Xunit;
 
-namespace XMLTests.ReaderWriter.DisposeTests
+namespace System.Xml.Tests
 {
     public class MyXmlWriter : XmlWriter
     {

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithEncoding.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithEncoding.cs
@@ -1,38 +1,39 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Text;
-using System.Xml;
 using Xunit;
 
-public class XmlWriterTests
+namespace System.Xml.Tests
 {
-    [Fact]
-    public static void WriteWithEncoding()
+    public class XmlWriterTests_Encoding
     {
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
-        XmlWriterSettings settings = new XmlWriterSettings();
-        settings.OmitXmlDeclaration = true;
-        settings.ConformanceLevel = ConformanceLevel.Fragment;
-        settings.CloseOutput = false;
-        settings.Encoding = Encoding.GetEncoding("Windows-1252");
-        MemoryStream strm = new MemoryStream();
-
-        using (XmlWriter writer = XmlWriter.Create(strm, settings))
+        [Fact]
+        public static void WriteWithEncoding()
         {
-            writer.WriteElementString("orderID", "1-456-ab\u0661");
-            writer.WriteElementString("orderID", "2-36-00a\uD800\uDC00\uD801\uDC01");
-            writer.Flush();
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            XmlWriterSettings settings = new XmlWriterSettings();
+            settings.OmitXmlDeclaration = true;
+            settings.ConformanceLevel = ConformanceLevel.Fragment;
+            settings.CloseOutput = false;
+            settings.Encoding = Encoding.GetEncoding("Windows-1252");
+            MemoryStream strm = new MemoryStream();
+
+            using (XmlWriter writer = XmlWriter.Create(strm, settings))
+            {
+                writer.WriteElementString("orderID", "1-456-ab\u0661");
+                writer.WriteElementString("orderID", "2-36-00a\uD800\uDC00\uD801\uDC01");
+                writer.Flush();
+            }
+
+            strm.Seek(0, SeekOrigin.Begin);
+            byte[] bytes = new byte[strm.Length];
+            int bytesCount = strm.Read(bytes, 0, (int)strm.Length);
+            string s = settings.Encoding.GetString(bytes, 0, bytesCount);
+
+            Assert.Equal("<orderID>1-456-ab&#x661;</orderID><orderID>2-36-00a&#x10000;&#x10401;</orderID>", s);
         }
-
-        strm.Seek(0, SeekOrigin.Begin);
-        byte[] bytes = new byte[strm.Length];
-        int bytesCount = strm.Read(bytes, 0, (int)strm.Length);
-        string s = settings.Encoding.GetString(bytes, 0, bytesCount);
-
-        Assert.Equal("<orderID>1-456-ab&#x661;</orderID><orderID>2-36-00a&#x10000;&#x10401;</orderID>", s);
     }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithEncodingWithFallback.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithEncodingWithFallback.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.IO;
 using System.Text;
-using System.Xml;
+using Xunit;
 
-namespace XMLTests.ReaderWriter.WriteWithEncodingWithFallback
+namespace System.Xml.Tests
 {
-    public class XmlWriterTests
+    public class XmlWriterTests_EncodingFallback
     {
         private const char SurHighStart = '\ud800';
         //const char SurHighEnd = '\udbff';

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithInvalidSurrogate.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithInvalidSurrogate.cs
@@ -1,22 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.IO;
 using System.Text;
-using System.Xml;
-using System.Reflection;
+using Xunit;
 
-namespace XMLTests.ReaderWriter.RegressionTests
+namespace System.Xml.Tests
 {
-    public class XmlWriterTests
+    public class XmlWriterTests_InvalidSurrogate
     {
         private const int SurHighStart = 0xd800;
         private const int SurLowStart = 0xdc00;
         private const int SurLowEnd = 0xdfff;
 
-        static XmlWriterTests()
+        static XmlWriterTests_InvalidSurrogate()
         {
             // Make sure that we don't cache the value of the switch to enable testing
             AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/AppendTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/AppendTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class AppendTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/CollectionInterfaceTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/CollectionInterfaceTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class CollectionInterfaceTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/CopyToTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/CopyToTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class CopyToTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/IndexerTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/IndexerTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class IndexerTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/InsertAfterTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/InsertAfterTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class InsertAfterTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/InsertBeforeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/InsertBeforeTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class InsertBeforeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/PrependTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/PrependTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class PrependTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/RemoveAllTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/RemoveAllTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class RemoveAllTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/RemoveAtTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/RemoveAtTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class RemoveAtTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/RemoveTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/RemoveTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class RemoveTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/SetNamedItemTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeCollectionTests/SetNamedItemTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeCollectionTests
+namespace System.Xml.Tests
 {
     public class SetNamedItemTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlAttributeTests/SpecifiedTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlAttributeTests/SpecifiedTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlAttributeTests
+namespace System.Xml.Tests
 {
     public static class SpecifiedTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/AppendDataTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/AppendDataTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
     public class AppendDataTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/DataTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/DataTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
-    public class DataTests
+    public class Character_DataTests
     {
         [Fact]
         public static void GetDataFromEmptyCdataNode()

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/DeleteDataTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/DeleteDataTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
     public class DeleteDataTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/InsertDataTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/InsertDataTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
     public class InsertDataTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/LengthTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/LengthTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
     public class LengthTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/ReplaceTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/ReplaceTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
     public class ReplaceTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/SubstringTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlCharacterDataTests/SubstringTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlCharacterDataTests
+namespace System.Xml.Tests
 {
     public class SubstringTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateAttributeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateAttributeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateAttributeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateCDataSectionTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateCDataSectionTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateCDataSectionTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateCommentTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateCommentTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateCommentTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateDocumentFragment.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateDocumentFragment.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateDocumentFragment
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateElementTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateElementTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateElementTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateProcessingInstruction.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateProcessingInstruction.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateProcessingInstruction
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateTextNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateTextNodeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateTextNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateXmlDeclarationTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateXmlDeclarationTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class CreateXmlDeclarationTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/GetElementsByTagNameTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/GetElementsByTagNameTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class GetElementsByTagNameTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/ImportNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/ImportNodeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class ImportNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeChangedTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeChangedTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class NodeChangedTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeChangingTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeChangingTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class NodeChangingTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeInsertedTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeInsertedTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class NodeInsertedTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeInsertingTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeInsertingTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class NodeInsertingTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeRemovedTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeRemovedTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class NodeRemovedTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeRemovingTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/NodeRemovingTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using System;
 using System.Xml;
 
-namespace XmlDocumentTests.XmlDocumentTests
+namespace System.Xml.Tests
 {
     public class NodeRemovingTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/GetAttributeNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/GetAttributeNodeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class GetAttributeNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/GetAttributeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/GetAttributeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class GetAttributeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/GetElementsByTagNameTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/GetElementsByTagNameTests.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
-    public class GetElementsByTagNameTests
+    public class DocumentElement_GetElementsByTagNameTests
     {
         [Fact]
         public static void GetElements()

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/HasAttributeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/HasAttributeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class HasAttributeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/RemoveAttributeNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/RemoveAttributeNodeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class RemoveAttributeNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/RemoveAttributeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/RemoveAttributeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class RemoveAttributeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/SetAttributeNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/SetAttributeNodeTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class SetAttributeNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlElementTests/SetAttributeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlElementTests/SetAttributeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlElementTests
+namespace System.Xml.Tests
 {
     public class SetAttributeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlImplementationTests/CreateDocumentTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlImplementationTests/CreateDocumentTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlImplementationTests
+namespace System.Xml.Tests
 {
     public class CreateDocumentTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlImplementationTests/HasFeatureTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlImplementationTests/HasFeatureTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlImplementationTests
+namespace System.Xml.Tests
 {
     public class HasFeatureTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/CountTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/CountTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNamedNodeMapTests
+namespace System.Xml.Tests
 {
     public static class CountTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/GetNameTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/GetNameTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNamedNodeMapTests
+namespace System.Xml.Tests
 {
     public static class GetNameTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/GetNamedItemTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/GetNamedItemTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNamedNodeMapTests
+namespace System.Xml.Tests
 {
     public static class GetNamedItemTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/ItemTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/ItemTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNamedNodeMapTests
+namespace System.Xml.Tests
 {
     public static class ItemTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/RemoveNamedItemTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/RemoveNamedItemTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNamedNodeMapTests
+namespace System.Xml.Tests
 {
     public static class RemoveNamedItemTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/SetNamedItemTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNamedNodeMapTests/SetNamedItemTests.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNamedNodeMapTests
+namespace System.Xml.Tests
 {
-    public static class SetNamedItemTests
+    public static class NodeMap_SetNamedItemTests
     {
         [Fact]
         public static void NamedItemDoesNotExist()

--- a/src/System.Xml.XmlDocument/tests/XmlNodeListTests/CountTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeListTests/CountTests.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeListTests
+namespace System.Xml.Tests
 {
-    public class CountTests
+    public class NodeList_CountTests
     {
         [Fact]
         public static void CountTest1()

--- a/src/System.Xml.XmlDocument/tests/XmlNodeListTests/ItemTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeListTests/ItemTests.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeListTests
+namespace System.Xml.Tests
 {
-    public static class ItemTests
+    public static class NodeList_ItemTests
     {
         [Fact]
         public static void ItemTest1()

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/AppendChildTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/AppendChildTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class AppendChildTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/AttributesTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/AttributesTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class AttributesTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/ChildNodesTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/ChildNodesTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class ChildNodesTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/CloneNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/CloneNodeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class CloneNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/FirstChildTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/FirstChildTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class FirstChildTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/HasChildNodesTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/HasChildNodesTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class HasChildNodesTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertBeforeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertBeforeTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
-    public class InsertBeforeTests
+    public class DocumentElement_InsertBeforeTests
     {
         [Fact]
         public static void NodeWithOneChild()

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/OneElementTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/OneElementTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests.InsertTests
+namespace System.Xml.Tests
 {
     public static class OneElementTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/TestHelper.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/TestHelper.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests.InsertTests
+namespace System.Xml.Tests
 {
     public enum InsertType { Prepend, Append, InsertBefore, InsertAfter }
 

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/ThreeElementTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/ThreeElementTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests.InsertTests
+namespace System.Xml.Tests
 {
     public static class ThreeElementTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/TwoElementTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/TwoElementTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests.InsertTests
+namespace System.Xml.Tests
 {
     public static class TwoElementTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/TwoTextNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/InsertTests/TwoTextNodeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests.InsertTests
+namespace System.Xml.Tests
 {
     public static class TwoTextNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/LastChildTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/LastChildTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class LastChildTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/LocalNameTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/LocalNameTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class LocalNameTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/NameTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/NameTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class NameTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/NamespaceURITests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/NamespaceURITests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class NamespaceURITests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/NextSiblingTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/NextSiblingTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml;
 using Xunit;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public static class NextSiblingTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/NodeTypeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/NodeTypeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class NodeTypeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/NormalizeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/NormalizeTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
-using System;
 using System.Text;
-using System.Xml;
+using Xunit;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class NormalizeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/OwnerDocumentTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/OwnerDocumentTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlAttributeTests
+namespace System.Xml.Tests
 {
     public static class OwnerDocumentTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/ParentNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/ParentNodeTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class ParentNodeTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/PrefixTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/PrefixTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class PrefixTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/PreviousSiblingTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/PreviousSiblingTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public static class PreviousSiblingTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/RemoveChildTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/RemoveChildTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class RemoveChildTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/ReplaceChildTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/ReplaceChildTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public static class ReplaceChildTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/SupportsTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/SupportsTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public class SupportsTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/ValueTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/ValueTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlNodeTests
+namespace System.Xml.Tests
 {
     public static class ValueTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlProcessingInstructionTests/DataTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlProcessingInstructionTests/DataTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlProcessingInstructionTests
+namespace System.Xml.Tests
 {
     public static class DataTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlProcessingInstructionTests/TargetTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlProcessingInstructionTests/TargetTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlProcessingInstructionTests
+namespace System.Xml.Tests
 {
     public static class TargetTests
     {

--- a/src/System.Xml.XmlDocument/tests/XmlTextTests/SplitTextTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlTextTests/SplitTextTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Xml;
 
-namespace XmlDocumentTests.XmlTextTests
+namespace System.Xml.Tests
 {
     public static class SplitTextTests
     {


### PR DESCRIPTION
Update test namespaces in some System.Xml.* assemblies, per #2898 .
Add namespace to lone (small-ish) file in System.Xml.ReaderWriter (XmlWriter/WriteWithEncoding).
Clean up `using`s.
Change some names to avoid conflicts.