### PR TITLE
Add explicit 0 index args to Array.Copy usage

### DIFF
--- a/src/Common/src/Interop/Windows/BCrypt/BCryptAlgorithmCache.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/BCryptAlgorithmCache.cs
@@ -39,7 +39,7 @@ internal partial class Interop
     
                 Entry[] newCache = new Entry[cache.Length + 1];
                 Entry newEntry = new Entry(hashAlgorithmId, flags, safeBCryptAlgorithmHandle);
-                Array.Copy(cache, newCache, cache.Length);
+                Array.Copy(cache, 0, newCache, 0, cache.Length);
                 newCache[newCache.Length - 1] = newEntry;
     
                 // Atomically overwrite the cache with our new cache. It's possible some other thread raced to add a new entry with us - if so, one of the new entries

--- a/src/Common/src/System/Xml/XmlTextWriter.cs
+++ b/src/Common/src/System/Xml/XmlTextWriter.cs
@@ -1461,7 +1461,7 @@ namespace System.Xml
             if (nsIndex == nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[nsIndex * 2];
-                Array.Copy(nsStack, newStack, nsIndex);
+                Array.Copy(nsStack, 0, newStack, 0, nsIndex);
                 nsStack = newStack;
             }
             nsStack[nsIndex].Set(prefix, ns, declared);
@@ -1721,7 +1721,7 @@ namespace System.Xml
             if (top == stack.Length - 1)
             {
                 TagInfo[] na = new TagInfo[stack.Length + 10];
-                if (top > 0) Array.Copy(stack, na, top + 1);
+                if (top > 0) Array.Copy(stack, 0, na, 0, top + 1);
                 stack = na;
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
@@ -941,7 +941,7 @@ namespace Microsoft.SqlServer.Server
                     {
                         byte[] rgbValue = value.Value;
                         byte[] rgbNewValue = new byte[MaxLength];
-                        Array.Copy(rgbValue, rgbNewValue, rgbValue.Length);
+                        Array.Copy(rgbValue, 0, rgbNewValue, 0, rgbValue.Length);
                         Array.Clear(rgbNewValue, rgbValue.Length, rgbNewValue.Length - rgbValue.Length);
                         return new SqlBinary(rgbNewValue);
                     }
@@ -962,7 +962,7 @@ namespace Microsoft.SqlServer.Server
             {
                 byte[] rgbValue = value.Value;
                 byte[] rgbNewValue = new byte[MaxLength];
-                Array.Copy(rgbValue, rgbNewValue, (int)MaxLength);
+                Array.Copy(rgbValue, 0, rgbNewValue, 0, (int)MaxLength);
                 value = new SqlBinary(rgbNewValue);
             }
 
@@ -992,7 +992,7 @@ namespace Microsoft.SqlServer.Server
                         if (value.MaxLength < MaxLength)
                         {
                             char[] rgchNew = new char[(int)MaxLength];
-                            Array.Copy(value.Buffer, rgchNew, (int)oldLength);
+                            Array.Copy(value.Buffer, 0, rgchNew, 0, (int)oldLength);
                             value = new SqlChars(rgchNew);
                         }
 
@@ -1039,7 +1039,7 @@ namespace Microsoft.SqlServer.Server
                         if (value.MaxLength < MaxLength)
                         {
                             byte[] rgbNew = new byte[MaxLength];
-                            Array.Copy(value.Buffer, rgbNew, (int)oldLength);
+                            Array.Copy(value.Buffer, 0, rgbNew, 0, (int)oldLength);
                             value = new SqlBytes(rgbNew);
                         }
 
@@ -1379,7 +1379,7 @@ namespace Microsoft.SqlServer.Server
                     if (value.Length < MaxLength)
                     {
                         byte[] rgbNewValue = new byte[MaxLength];
-                        Array.Copy(value, rgbNewValue, value.Length);
+                        Array.Copy(value, 0, rgbNewValue, 0, value.Length);
                         Array.Clear(rgbNewValue, value.Length, (int)rgbNewValue.Length - value.Length);
                         return rgbNewValue;
                     }
@@ -1399,7 +1399,7 @@ namespace Microsoft.SqlServer.Server
             if (value.Length > MaxLength && Max != MaxLength)
             {
                 byte[] rgbNewValue = new byte[MaxLength];
-                Array.Copy(value, rgbNewValue, (int)MaxLength);
+                Array.Copy(value, 0, rgbNewValue, 0, (int)MaxLength);
                 value = rgbNewValue;
             }
 
@@ -1435,7 +1435,7 @@ namespace Microsoft.SqlServer.Server
                     if (oldLength < MaxLength)
                     {
                         char[] rgchNew = new char[(int)MaxLength];
-                        Array.Copy(value, rgchNew, (int)oldLength);
+                        Array.Copy(value, 0, rgchNew, 0, (int)oldLength);
 
                         // pad extra space
                         for (long i = oldLength; i < rgchNew.Length; i++)
@@ -1459,7 +1459,7 @@ namespace Microsoft.SqlServer.Server
             if (value.Length > MaxLength && Max != MaxLength)
             {
                 char[] rgchNewValue = new char[MaxLength];
-                Array.Copy(value, rgchNewValue, (int)MaxLength);
+                Array.Copy(value, 0, rgchNewValue, 0, (int)MaxLength);
                 value = rgchNewValue;
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
@@ -370,7 +370,7 @@ namespace System.Data.SqlClient
                     {
                         // Otherwise, copy over the leftover buffer
                         byteBuffer = new byte[byteBufferSize];
-                        Array.Copy(_leftOverBytes, byteBuffer, _leftOverBytes.Length);
+                        Array.Copy(_leftOverBytes, 0, byteBuffer, 0, _leftOverBytes.Length);
                         byteBufferUsed = _leftOverBytes.Length;
                     }
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
@@ -193,7 +193,7 @@ namespace System.Data.SqlTypes
 
                     default:
                         buffer = new byte[_lCurLen];
-                        Array.Copy(m_rgbBuf, buffer, (int)_lCurLen);
+                        Array.Copy(m_rgbBuf, 0, buffer, 0, (int)_lCurLen);
                         break;
                 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
@@ -185,7 +185,7 @@ namespace System.Data.SqlTypes
 
                     default:
                         buffer = new char[_lCurLen];
-                        Array.Copy(m_rgchBuf, buffer, (int)_lCurLen);
+                        Array.Copy(m_rgchBuf, 0, buffer, 0, (int)_lCurLen);
                         break;
                 }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -284,7 +284,7 @@ namespace System.Diagnostics
                 break;
             }
             int[] ids = new int[size / 4];
-            Array.Copy(processIds, ids, ids.Length);
+            Array.Copy(processIds, 0, ids, 0, ids.Length);
             return ids;
         }
 

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/ExpandoClass.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/ExpandoClass.cs
@@ -74,7 +74,7 @@ namespace System.Dynamic
 
                 // no applicable transition, create a new one
                 string[] keys = new string[_keys.Length + 1];
-                Array.Copy(_keys, keys, _keys.Length);
+                Array.Copy(_keys, 0, keys, 0, _keys.Length);
                 keys[_keys.Length] = newKey;
                 ExpandoClass ec = new ExpandoClass(keys, hashCode);
 

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/ExpandoObject.cs
@@ -1123,7 +1123,7 @@ namespace System.Dynamic
                     // we've grown too much - we need a new object array
                     int oldLength = _dataArray.Length;
                     object[] arr = new object[GetAlignedSize(newClass.Keys.Length)];
-                    Array.Copy(_dataArray, arr, _dataArray.Length);
+                    Array.Copy(_dataArray, 0, arr, 0, _dataArray.Length);
                     ExpandoData newData = new ExpandoData(newClass, arr, _version);
                     newData[oldLength] = ExpandoObject.Uninitialized;
                     return newData;

--- a/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
@@ -728,7 +728,7 @@ namespace System.IO.Compression
             byte[] distanceTreeCodeLength = new byte[HuffmanTree.MaxDistTreeElements];
 
             // Create literal and distance tables
-            Array.Copy(_codeList, literalTreeCodeLength, _literalLengthCodeCount);
+            Array.Copy(_codeList, 0, literalTreeCodeLength, 0, _literalLengthCodeCount);
             Array.Copy(_codeList, _literalLengthCodeCount, distanceTreeCodeLength, 0, _distanceCodeCount);
 
             // Make sure there is an end-of-block code, otherwise how could we ever end?

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/PatternMatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/PatternMatcher.cs
@@ -299,11 +299,11 @@ namespace System.IO
                         {
                             int newSize = currentMatches.Length * 2;
                             int[] tmp = new int[newSize];
-                            Array.Copy(currentMatches, tmp, currentMatches.Length);
+                            Array.Copy(currentMatches, 0, tmp, 0, currentMatches.Length);
                             currentMatches = tmp;
 
                             tmp = new int[newSize];
-                            Array.Copy(previousMatches, tmp, previousMatches.Length);
+                            Array.Copy(previousMatches, 0, tmp, 0, previousMatches.Length);
                             previousMatches = tmp;
                         }
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace System.Dynamic.Utils
         public static T[] Copy<T>(this T[] array)
         {
             T[] copy = new T[array.Length];
-            Array.Copy(array, copy, array.Length);
+            Array.Copy(array, 0, copy, 0, array.Length);
             return copy;
         }
     }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
@@ -380,7 +380,7 @@ namespace System.Linq.Parallel
                 // Trim the partially-full chunk to an array just big enough to hold it.
                 Debug.Assert(1 <= _producerChunkIndex && _producerChunkIndex <= _chunkSize);
                 T[] leftOverChunk = new T[_producerChunkIndex];
-                Array.Copy(_producerChunk, leftOverChunk, _producerChunkIndex);
+                Array.Copy(_producerChunk, 0, leftOverChunk, 0, _producerChunkIndex);
 
                 // And enqueue the right-sized temporary chunk, possibly blocking if it's full.
                 EnqueueChunk(leftOverChunk);

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1203,7 +1203,7 @@ namespace System.Net.Http.Headers
                 if (currentIndex < length)
                 {
                     string[] trimmedValues = new string[currentIndex];
-                    Array.Copy(values, trimmedValues, currentIndex);
+                    Array.Copy(values, 0, trimmedValues, 0, currentIndex);
                     values = trimmedValues;
                 }
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -458,7 +458,7 @@ namespace System.Net.Http.Functional.Tests
             byte[] rawBytes = encoding.GetBytes(str);
             byte[] preamble = encoding.GetPreamble(); // Get the correct BOM characters
             byte[] contentBytes = new byte[preamble.Length + rawBytes.Length];
-            Array.Copy(preamble, contentBytes, preamble.Length);
+            Array.Copy(preamble, 0, contentBytes, 0, preamble.Length);
             Array.Copy(rawBytes, 0, contentBytes, preamble.Length, rawBytes.Length);
             return contentBytes;
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4344,7 +4344,7 @@ namespace System.Net.Sockets
 
             Socket socket = EndAccept(out innerBuffer, out bytesTransferred, asyncResult);
             buffer = new byte[bytesTransferred];
-            Array.Copy(innerBuffer, buffer, bytesTransferred);
+            Array.Copy(innerBuffer, 0, buffer, 0, bytesTransferred);
             return socket;
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -821,12 +821,12 @@ namespace System.Runtime.Serialization
                     {
                         baseMemberCount = BaseContract.MemberNames.Length;
                         MemberNames = new XmlDictionaryString[Members.Count + baseMemberCount];
-                        Array.Copy(BaseContract.MemberNames, MemberNames, baseMemberCount);
+                        Array.Copy(BaseContract.MemberNames, 0, MemberNames, 0, baseMemberCount);
                         MemberNamespaces = new XmlDictionaryString[Members.Count + baseMemberCount];
-                        Array.Copy(BaseContract.MemberNamespaces, MemberNamespaces, baseMemberCount);
+                        Array.Copy(BaseContract.MemberNamespaces, 0, MemberNamespaces, 0, baseMemberCount);
                         baseContractCount = BaseContract.ContractNamespaces.Length;
                         ContractNamespaces = new XmlDictionaryString[1 + baseContractCount];
-                        Array.Copy(BaseContract.ContractNamespaces, ContractNamespaces, baseContractCount);
+                        Array.Copy(BaseContract.ContractNamespaces, 0, ContractNamespaces, 0, baseContractCount);
                     }
                     ContractNamespaces[baseContractCount] = Namespace;
                     for (int i = 0; i < Members.Count; i++)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExceptionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExceptionDataContract.cs
@@ -181,7 +181,7 @@ namespace System.Runtime.Serialization
                     _memberNamespaces = new XmlDictionaryString[Members.Count];
                     baseContractCount = BaseContract._contractNamespaces.Length;
                     _contractNamespaces = new XmlDictionaryString[1 + baseContractCount];
-                    Array.Copy(BaseContract._contractNamespaces, _contractNamespaces, baseContractCount);
+                    Array.Copy(BaseContract._contractNamespaces, 0, _contractNamespaces, 0, baseContractCount);
                 }
                 _contractNamespaces[baseContractCount] = Namespace;
                 for (int i = 0; i < Members.Count; i++)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
@@ -135,7 +135,7 @@ namespace System.Runtime.Serialization.Json
                 properResizeMethod.Invoke(null, new object[] { array, srcArray.Length });
 
                 // Copy
-                Array.Copy(srcArray, array, srcArray.Length);
+                Array.Copy(srcArray, 0, array, 0, srcArray.Length);
                 return;
             }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
@@ -1076,7 +1076,7 @@ namespace System.Runtime.Serialization.Json
             else if (_scopes.Length == _scopeDepth)
             {
                 JsonNodeType[] newScopes = new JsonNodeType[_scopeDepth * 2];
-                Array.Copy(_scopes, newScopes, _scopeDepth);
+                Array.Copy(_scopes, 0, newScopes, 0, _scopeDepth);
                 _scopes = newScopes;
             }
             _scopes[_scopeDepth] = currentNodeType;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -1215,7 +1215,7 @@ namespace System.Runtime.Serialization.Json
             else if (_scopes.Length == _depth)
             {
                 JsonNodeType[] newScopes = new JsonNodeType[_depth * 2];
-                Array.Copy(_scopes, newScopes, _depth);
+                Array.Copy(_scopes, 0, newScopes, 0, _depth);
                 _scopes = newScopes;
             }
             _scopes[_depth] = currentNodeType;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -283,7 +283,7 @@ namespace System.Xml
             else if (_elementNodes.Length == _depth)
             {
                 XmlElementNode[] newElementNodes = new XmlElementNode[_depth * 2];
-                Array.Copy(_elementNodes, newElementNodes, _depth);
+                Array.Copy(_elementNodes, 0, newElementNodes, 0, _depth);
                 _elementNodes = newElementNodes;
             }
             XmlElementNode elementNode = _elementNodes[_depth];
@@ -317,7 +317,7 @@ namespace System.Xml
             else if (_attributeNodes.Length == attributeIndex)
             {
                 XmlAttributeNode[] newAttributeNodes = new XmlAttributeNode[attributeIndex * 2];
-                Array.Copy(_attributeNodes, newAttributeNodes, attributeIndex);
+                Array.Copy(_attributeNodes, 0, newAttributeNodes, 0, attributeIndex);
                 _attributeNodes = newAttributeNodes;
             }
             XmlAttributeNode attributeNode = _attributeNodes[attributeIndex];
@@ -2678,7 +2678,7 @@ namespace System.Xml
                 else if (_attributes.Length == _attributeCount)
                 {
                     XmlAttribute[] newAttributes = new XmlAttribute[_attributeCount * 2];
-                    Array.Copy(_attributes, newAttributes, _attributeCount);
+                    Array.Copy(_attributes, 0, newAttributes, 0, _attributeCount);
                     _attributes = newAttributes;
                 }
                 XmlAttribute attribute = _attributes[_attributeCount];
@@ -2716,7 +2716,7 @@ namespace System.Xml
                 else if (_namespaces.Length == _nsCount)
                 {
                     Namespace[] newNamespaces = new Namespace[_nsCount * 2];
-                    Array.Copy(_namespaces, newNamespaces, _nsCount);
+                    Array.Copy(_namespaces, 0, newNamespaces, 0, _nsCount);
                     _namespaces = newNamespaces;
                 }
                 Namespace nameSpace = _namespaces[_nsCount];

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -672,7 +672,7 @@ namespace System.Xml
             else if (_elements.Length == _depth)
             {
                 Element[] newElementNodes = new Element[_depth * 2];
-                Array.Copy(_elements, newElementNodes, _depth);
+                Array.Copy(_elements, 0, newElementNodes, 0, _depth);
                 _elements = newElementNodes;
             }
             Element element = _elements[_depth];
@@ -1980,7 +1980,7 @@ namespace System.Xml
                 else if (_attributes.Length == _attributeCount)
                 {
                     XmlAttribute[] newAttributes = new XmlAttribute[_attributeCount * 2];
-                    Array.Copy(_attributes, newAttributes, _attributeCount);
+                    Array.Copy(_attributes, 0, newAttributes, 0, _attributeCount);
                     _attributes = newAttributes;
                 }
                 XmlAttribute attribute = _attributes[_attributeCount];
@@ -2074,7 +2074,7 @@ namespace System.Xml
                 if (_namespaces.Length == _nsCount)
                 {
                     Namespace[] newNamespaces = new Namespace[_nsCount * 2];
-                    Array.Copy(_namespaces, newNamespaces, _nsCount);
+                    Array.Copy(_namespaces, 0, newNamespaces, 0, _nsCount);
                     _namespaces = newNamespaces;
                 }
                 nameSpace = _namespaces[_nsCount];

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
@@ -48,7 +48,7 @@ namespace System.Xml
                 else if (id >= _strings.Length)
                 {
                     XmlDictionaryString[] newStrings = new XmlDictionaryString[Math.Min(Math.Max(id + 1, _strings.Length * 2), MaxArrayEntries)];
-                    Array.Copy(_strings, newStrings, _strings.Length);
+                    Array.Copy(_strings, 0, newStrings, 0, _strings.Length);
                     _strings = newStrings;
                 }
                 _strings[id] = xmlString;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriterSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriterSession.cs
@@ -251,7 +251,7 @@ namespace System.Xml
                     if (index >= _array.Length)
                     {
                         int[] newArray = new int[Math.Max(index + 1, _array.Length * 2)];
-                        Array.Copy(_array, newArray, _array.Length);
+                        Array.Copy(_array, 0, newArray, 0, _array.Length);
                         _array = newArray;
                     }
 

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -324,7 +324,7 @@ namespace System.Numerics
             bool needExtraByte = (bytes[msb] & 0x80) != (highByte & 0x80);
 
             byte[] trimmedBytes = new byte[msb + 1 + (needExtraByte ? 1 : 0)];
-            Array.Copy(bytes, trimmedBytes, msb + 1);
+            Array.Copy(bytes, 0, trimmedBytes, 0, msb + 1);
 
             if (needExtraByte) trimmedBytes[trimmedBytes.Length - 1] = highByte;
             return trimmedBytes;
@@ -368,7 +368,7 @@ namespace System.Numerics
             bool needExtraByte = (dwords[msb] & 0x80000000) != (highDWord & 0x80000000);
 
             uint[] trimmed = new uint[msb + 1 + (needExtraByte ? 1 : 0)];
-            Array.Copy(dwords, trimmed, msb + 1);
+            Array.Copy(dwords, 0, trimmed, 0, msb + 1);
 
             if (needExtraByte) trimmed[trimmed.Length - 1] = highDWord;
             return trimmed;
@@ -676,7 +676,7 @@ namespace System.Numerics
                     {
                         _sign = -1;
                         _bits = new uint[len];
-                        Array.Copy(val, _bits, len);
+                        Array.Copy(val, 0, _bits, 0, len);
                     }
                     else
                     {
@@ -737,7 +737,7 @@ namespace System.Numerics
             {
                 _sign = negative ? -1 : +1;
                 _bits = new uint[len];
-                Array.Copy(value, _bits, len);
+                Array.Copy(value, 0, _bits, 0, len);
             }
             AssertValid();
         }
@@ -795,7 +795,7 @@ namespace System.Numerics
                 {
                     _sign = +1;
                     _bits = new uint[dwordCount];
-                    Array.Copy(value, _bits, dwordCount);
+                    Array.Copy(value, 0, _bits, 0, dwordCount);
                 }
                 // no trimming is possible.  Assign value directly to _bits.  
                 else
@@ -838,7 +838,7 @@ namespace System.Numerics
             {
                 _sign = -1;
                 _bits = new uint[len];
-                Array.Copy(value, _bits, len);
+                Array.Copy(value, 0, _bits, 0, len);
             }
             // no trimming is possible.  Assign value directly to _bits.  
             else
@@ -1506,7 +1506,7 @@ namespace System.Numerics
                     return BigInteger.MinusOne;
                 }
                 uint[] temp = new uint[xl];
-                Array.Copy(xd /* sourceArray */, temp /* destinationArray */, xl /* length */);  // make a copy of immutable value._bits
+                Array.Copy(xd /* sourceArray */, 0 /* sourceIndex */, temp /* destinationArray */, 0 /* destinationIndex */, xl /* length */);  // make a copy of immutable value._bits
                 xd = temp;
                 NumericsHelpers.DangerousMakeTwosComplement(xd); // mutates xd
             }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -779,7 +779,7 @@ namespace Internal.NativeCrypto
                 throw new CryptographicException(SR.Format(SR.Argument_InvalidValue, "Encrypted data length is less than 0"));
             }
             byte[] dataTobeDecrypted = new byte[encryptedDataLength];
-            Array.Copy(encryptedData, dataTobeDecrypted, encryptedDataLength);
+            Array.Copy(encryptedData, 0, dataTobeDecrypted, 0, encryptedDataLength);
             Array.Reverse(dataTobeDecrypted); //ToDO: Check is this is really needed? To be confirmed with tests
 
             int dwFlags = fOAEP ? (int)CryptDecryptFlags.CRYPT_OAEP : 0;
@@ -855,7 +855,7 @@ namespace Internal.NativeCrypto
             // key should always be larger than the plaintext key, so use that to determine the buffer size.
             Debug.Assert(cbEncryptedKey >= cbKey);
             pbEncryptedKey = new byte[cbEncryptedKey];
-            Array.Copy(pbKey, pbEncryptedKey, cbKey);
+            Array.Copy(pbKey, 0, pbEncryptedKey, 0, cbKey);
 
             // Encrypt for real - the last parameter is the total size of the in/out buffer, while the second to last
             // parameter specifies the size of the plaintext to encrypt.

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -203,7 +203,7 @@ namespace System.Security.Cryptography
             }
 
             byte[] plainBytes = new byte[returnValue];
-            Array.Copy(buf, plainBytes, returnValue);
+            Array.Copy(buf, 0, plainBytes, 0, returnValue);
             return plainBytes;
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
@@ -233,7 +233,7 @@ namespace Internal.Cryptography.Pal
                             if (cb < buffer.Length)
                             {
                                 byte[] newBuffer = new byte[cb];
-                                Array.Copy(buffer, newBuffer, cb);
+                                Array.Copy(buffer, 0, newBuffer, 0, cb);
                                 buffer = newBuffer;
                             }
                             return buffer;

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -73,7 +73,7 @@ namespace System.Security.Principal
                 if (!Interop.SecurityBase.AllocateLocallyUniqueId(out sourceContext.SourceIdentifier))
                     throw new SecurityException(Interop.mincore.GetMessage(Marshal.GetLastWin32Error()));
                 sourceContext.SourceName = new byte[TOKEN_SOURCE.TOKEN_SOURCE_LENGTH];
-                Array.Copy(sourceName, sourceContext.SourceName, sourceName.Length);
+                Array.Copy(sourceName, 0, sourceContext.SourceName, 0, sourceName.Length);
 
                 // Desktop compat: Desktop never null-checks sUserPrincipalName. Actual behavior is that the null makes it down to Encoding.Unicode.GetBytes() which then throws
                 // the ArgumentNullException (provided that the prior LSA calls didn't fail first.) To make this compat decision explicit, we'll null check ourselves 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -205,7 +205,7 @@ namespace System.Text.RegularExpressions
 
                         if (i == 0)
                         {
-                            System.Array.Copy(_negativeASCII, newarray, 128);
+                            System.Array.Copy(_negativeASCII, 0, newarray, 0, 128);
                             _negativeASCII = newarray;
                         }
 

--- a/src/System.Xml.ReaderWriter/src/System/Xml/BitStack.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/BitStack.cs
@@ -96,7 +96,7 @@ namespace System.Xml
             if (_stackPos >= len)
             {
                 uint[] bitStackNew = new uint[2 * len];
-                Array.Copy(_bitStack, bitStackNew, len);
+                Array.Copy(_bitStack, 0, bitStackNew, 0, len);
                 _bitStack = bitStackNew;
             }
         }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -1538,7 +1538,7 @@ namespace System.Xml
         {
             Debug.Assert(_lastMarkPos + 1 == _textContentMarks.Length);
             int[] newTextContentMarks = new int[_textContentMarks.Length * 2];
-            Array.Copy(_textContentMarks, newTextContentMarks, _textContentMarks.Length);
+            Array.Copy(_textContentMarks, 0, newTextContentMarks, 0, _textContentMarks.Length);
             _textContentMarks = newTextContentMarks;
         }
 

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriter.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriter.cs
@@ -522,7 +522,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, newStack, top);
+                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);
@@ -1845,7 +1845,7 @@ namespace System.Xml
             if (top == _nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[top * 2];
-                Array.Copy(_nsStack, newStack, top);
+                Array.Copy(_nsStack, 0, newStack, 0, top);
                 _nsStack = newStack;
             }
             _nsStack[top].Set(prefix, ns, kind);
@@ -2219,7 +2219,7 @@ namespace System.Xml
             if (top == _attrStack.Length)
             {
                 AttrName[] newStack = new AttrName[top * 2];
-                Array.Copy(_attrStack, newStack, top);
+                Array.Copy(_attrStack, 0, newStack, 0, top);
                 _attrStack = newStack;
             }
             _attrStack[top].Set(prefix, localName, namespaceName);

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriterAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriterAsync.cs
@@ -291,7 +291,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, newStack, top);
+                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriterHelpers.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWellformedWriterHelpers.cs
@@ -510,7 +510,7 @@ namespace System.Xml
                 else if (_items.Length == newItemIndex)
                 {
                     Item[] newItems = new Item[newItemIndex * 2];
-                    Array.Copy(_items, newItems, newItemIndex);
+                    Array.Copy(_items, 0, newItems, 0, newItemIndex);
                     _items = newItems;
                 }
                 if (_items[newItemIndex] == null)

--- a/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriter.cs
+++ b/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriter.cs
@@ -488,7 +488,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, newStack, top);
+                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);
@@ -1826,7 +1826,7 @@ namespace System.Xml
             if (top == _nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[top * 2];
-                Array.Copy(_nsStack, newStack, top);
+                Array.Copy(_nsStack, 0, newStack, 0, top);
                 _nsStack = newStack;
             }
             _nsStack[top].Set(prefix, ns, kind);
@@ -2200,7 +2200,7 @@ namespace System.Xml
             if (top == _attrStack.Length)
             {
                 AttrName[] newStack = new AttrName[top * 2];
-                Array.Copy(_attrStack, newStack, top);
+                Array.Copy(_attrStack, 0, newStack, 0, top);
                 _attrStack = newStack;
             }
             _attrStack[top].Set(prefix, localName, namespaceName);

--- a/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriterHelpers.cs
+++ b/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriterHelpers.cs
@@ -509,7 +509,7 @@ namespace System.Xml
                 else if (_items.Length == newItemIndex)
                 {
                     Item[] newItems = new Item[newItemIndex * 2];
-                    Array.Copy(_items, newItems, newItemIndex);
+                    Array.Copy(_items, 0, newItems, 0, newItemIndex);
                     _items = newItems;
                 }
                 if (_items[newItemIndex] == null)

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationILGen.cs
@@ -139,7 +139,7 @@ namespace System.Xml.Serialization
             if (a == null) return new TypeMapping[32];
             if (index < a.Length) return a;
             TypeMapping[] b = new TypeMapping[a.Length + 32];
-            Array.Copy(a, b, index);
+            Array.Copy(a, 0, b, 0, index);
             return b;
         }
 


### PR DESCRIPTION
```Array.Copy``` is implemented to work with any ```System.Array```, not just ```T[]```.  When ```Array.Copy(sourceArr, destArray, length)``` is used, it delegates to ```Array.Copy(sourceArr, sourceIndex, destArray, destIndex, length)```, and as such needs to query for the lower-bound of the supplied arrays, since although a ```T[]``` in C# always has a lower bound of 0, an arbitrary ```Array``` may not.  Given this, instead of calling ```Array.Copy(src, dest, length)``` where ```src``` and ```dest``` are both known to be ```T[]```, it's slightly more efficient to just call ```Array.Copy(src, 0, dest, 0, length)```, avoiding the need for the ```Array.GetLowerBound``` calls made while delegating to the 5-arg version.

I noticed one occurrence of this in some code I was looking at, and while fixing that, I fixed all of them across corefx\src.