### PR TITLE
Fix a bug in the Socket constructor.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -96,7 +96,13 @@ namespace System.Net.Sockets
             }
 
             InitializeSockets();
+
             _handle = SocketPal.CreateSocket(addressFamily, socketType, protocolType);
+            if (_handle.IsInvalid)
+            {
+                // Failed to create the socket, throw.
+                throw new SocketException((int)SocketPal.GetLastSocketError());
+            }
 
             _addressFamily = addressFamily;
             _socketType = socketType;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -37,13 +37,7 @@ namespace System.Net.Sockets
 
         public static SafeCloseSocket CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
-            SafeCloseSocket handle = SafeCloseSocket.CreateWSASocket(addressFamily, socketType, protocolType);
-            if (handle.IsInvalid)
-            {
-                // Failed to create the win32 socket, throw.
-                throw new SocketException();
-            }
-            return handle;
+            return SafeCloseSocket.CreateWSASocket(addressFamily, socketType, protocolType);
         }
 
         public static unsafe SafeCloseSocket CreateSocket(SocketInformation socketInformation, out AddressFamily addressFamily, out SocketType socketType, out ProtocolType protocolType)

--- a/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class CreateSocket
+    {
+        public static object[][] DualModeSuccessInputs = {
+            new object[] { SocketType.Stream, ProtocolType.Tcp },
+            new object[] { SocketType.Dgram, ProtocolType.Udp },
+        };
+
+        public static object[][] DualModeFailureInputs = {
+            new object[] { SocketType.Dgram, ProtocolType.Tcp },
+            new object[] { SocketType.Raw, ProtocolType.Tcp },
+            new object[] { SocketType.Rdm, ProtocolType.Tcp },
+            new object[] { SocketType.Seqpacket, ProtocolType.Tcp },
+            new object[] { SocketType.Unknown, ProtocolType.Tcp },
+            new object[] { SocketType.Raw, ProtocolType.Udp },
+            new object[] { SocketType.Rdm, ProtocolType.Udp },
+            new object[] { SocketType.Seqpacket, ProtocolType.Udp },
+            new object[] { SocketType.Stream, ProtocolType.Udp },
+            new object[] { SocketType.Unknown, ProtocolType.Udp },
+        };
+
+        [Theory, MemberData("DualModeSuccessInputs")]
+        public void DualMode_Success(SocketType socketType, ProtocolType protocolType)
+        {
+            using (new Socket(socketType, protocolType))
+            {
+            }
+        }
+
+        [Theory, MemberData("DualModeFailureInputs")]
+        public void DualMode_Failure(SocketType socketType, ProtocolType protocolType)
+        {
+            Assert.Throws<SocketException>(() => new Socket(socketType, protocolType));
+        }
+
+        public static object[][] CtorSuccessInputs = {
+            new object[] { AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp },
+            new object[] { AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp },
+        };
+
+        [Theory, MemberData("CtorSuccessInputs")]
+        public void Ctor_Success(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        {
+            using (new Socket(addressFamily, socketType, protocolType))
+            {
+            }
+        }
+
+        public static object[][] CtorFailureInputs = {
+            new object[] { AddressFamily.Unknown, SocketType.Stream, ProtocolType.Tcp },
+            new object[] { AddressFamily.Unknown, SocketType.Dgram, ProtocolType.Udp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Raw, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Rdm, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Seqpacket, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Unknown, ProtocolType.Tcp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Raw, ProtocolType.Udp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Rdm, ProtocolType.Udp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Seqpacket, ProtocolType.Udp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Udp },
+            new object[] { AddressFamily.InterNetwork, SocketType.Unknown, ProtocolType.Udp },
+        };
+
+        [Theory, MemberData("CtorFailureInputs")]
+        public void Ctor_Failure(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        {
+            Assert.Throws<SocketException>(() => new Socket(addressFamily, socketType, protocolType));
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -15,6 +15,7 @@
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="ConnectAsync.cs" />
     <Compile Include="ConnectExTest.cs" />
+    <Compile Include="CreateSocketTests.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
     <Compile Include="SendReceive.cs" />


### PR DESCRIPTION
Only the Windows constuctor was throwing the appropriate exceptions due
to misplacement of the `throw` behind the PAL. The `throw` has been
moved into the platform-independent code and tests have been added.