### PR TITLE
Updated perf tests and documentation

### DIFF
--- a/Documentation/project-docs/performance-tests.md
+++ b/Documentation/project-docs/performance-tests.md
@@ -5,16 +5,89 @@ This document contains instructions for building, running, and adding Performanc
 
 Requirements
 --------------------
-
-To run performance tests, .NET portable v5.0 is required. This library is included in [the Visual Studio Community 2015 download](https://www.visualstudio.com/products/visual-studio-community-vs). To get the correct packages during installation, follow these steps after opening the installer:
+### Windows
+To run performance tests on Windows, .NET portable v5.0 is required. This library is included in [the Visual Studio Community 2015 download](https://www.visualstudio.com/products/visual-studio-community-vs). To get the correct packages during installation, follow these steps after opening the installer:
 1. Select "Custom Installation" if no installation is present, or "Modify" otherwise
 2. Check the "Universal Windows App Development Tools" box under the "Windows and Web Development" menu
 3. Install
+### Linux
+Performance tests on Linux require all of the same steps as they do for regular xunit tests - check out the linux instructions [here](https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md). Once you can have a directory on your Linux machine with a working corerun and xunit.console.netcore.exe (as well as the test dll containing your perf tests!), you only need to run the following command:
+
+`dnu commands install Microsoft.DotNet.xunit.performance.runner.dnx 1.0.0-alpha-build0021 -f https://www.myget.org/F/dotnet-buildtools/`
+
+Be careful that your mscorlib and test dlls were compiled using the "/p:Configuration=Release" property. Otherwise you may get skewed results.
 
 Running the tests
 -----------
+### Windows
 Performance test files (if present) are stored within a library's ```tests/Performance``` directory and contain test methods that are all marked with a perf-specific *Benchmark* attribute. The performance tests will only be run if the ```performance``` property is set to ```true```.
 
-To build and run the tests using msbuild for only one project, run ```msbuild /t:BuildAndTest /p:Performance=true``` from the tests directory. If the v5.0 assemblies aren't installed on your system, an error will be raised and no tests will be run.
+To build and run the tests using msbuild for a project, run ```msbuild /t:BuildAndTest /p:Performance=true /p:Configuration=Release``` from the tests directory. If the v5.0 assemblies aren't installed on your system, an error will be raised and no tests will be run.
 
-Performance tests for all libraries can also be run using the build script in ```corefx```: ```./build.cmd /p:Performance=true```
+Note: Because build.cmd runs tests concurrently, it's not recommended that you execute the perf tests using it.
+
+results will be in: corefx/bin/tests/Windows_NT.AnyCPU.Release/TESTNAME/dnxcore50
+### Linux
+From your tests directory, run:
+```
+xunit.performance System.Collections.Tests.dll -trait Benchmark=true -verbose -runner ./xunit.console.netcore.exe -runnerhost ./corerun -runid System.Collections.Tests.dll-Linux -outdir results
+```
+
+This will run the perf tests for System.Collections.Tests.dll and output the results in results/System.Collections.Tests.dll-Linux.xml and results/System.Collections.Tests.dll-Linux.csv
+
+Adding new Performance tests
+-----------
+Performance tests for CoreFX are built on top of xunit and [the Microsoft xunit-performance runner](https://github.com/Microsoft/xunit-performance/). 
+
+For the time being, perf tests should reside within their own "Performance" folder within the tests directory of a library (e.g. [corefx/src/System.IO.FileSystem/tests/Performance](https://github.com/dotnet/corefx/tree/master/src/System.IO.FileSystem/tests/Performance) contains perf tests for FileSystem).
+
+Start by adding the following lines to the tests csproj:
+```
+  <!-- Performance tests require v5.0 portable tools -->  
+  <PropertyGroup Condition="'$(RunPerfTestsForProject)' == 'true'">  
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>  
+    <TargetFrameworkProfile />  
+  </PropertyGroup>  
+
+ <!-- Performance Tests -->  
+  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">  
+    <Compile Include="Performance\Perf.Dictionary.cs" />  
+    <Compile Include="Performance\Perf.List.cs" />  
+    <Compile Include="$(CommonTestPath)\Performance\PerfUtils.cs">  
+      <Link>Common\Performance\PerfUtils.cs</Link>  
+    </Compile>  
+  </ItemGroup>  
+```
+(Replace Dictionary/List with whatever class you’re testing.)
+
+Next, the project.json for the tests directory also needs to import the perf stuff:
+
+```
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0022",  
+    "xunit": "2.1.0",  
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"  
+```
+Once that’s all done, you can actually add tests to the file. The basic structure of a perf test file with file name Perf.Dictionary.cs should be like so:
+```
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Collections.Tests
+{
+    public class Perf_Dictionary
+    {
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 20000; i++)
+                    {
+                        new Dictionary<int, string>();
+                    }
+        }
+    }
+}
+```
+The perf-test runner handles a lot of the specifics of the testing for you like iteration control. You won't need to add any Asserts or anything generally used in functional testing to get perf measurements, just make sure the thing within the “using” is big enough to avoid timer resolution errors.
+

--- a/Documentation/project-docs/performance-tests.md
+++ b/Documentation/project-docs/performance-tests.md
@@ -11,11 +11,11 @@ To run performance tests on Windows, .NET portable v5.0 is required. This librar
 2. Check the "Universal Windows App Development Tools" box under the "Windows and Web Development" menu
 3. Install
 ### Linux
-Performance tests on Linux require all of the same steps as they do for regular xunit tests - check out the linux instructions [here](https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md). Once you can have a directory on your Linux machine with a working corerun and xunit.console.netcore.exe (as well as the test dll containing your perf tests!), you only need to run the following command:
+Performance tests on Linux require all of the same steps as they do for regular xunit tests - see the linux instructions [here](https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md). Once you can have a directory on your Linux machine with a working corerun and xunit.console.netcore.exe (as well as the test dll containing your perf tests!), you only need to run the following command:
 
 `dnu commands install Microsoft.DotNet.xunit.performance.runner.dnx 1.0.0-alpha-build0021 -f https://www.myget.org/F/dotnet-buildtools/`
 
-Be careful that your mscorlib and test dlls were compiled using the "/p:Configuration=Release" property. Otherwise you may get skewed results.
+Be careful that your mscorlib, libcoreclr, and test dlls were compiled using the "/p:Configuration=Release" property. Otherwise you may get skewed results.
 
 Running the tests
 -----------

--- a/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
+++ b/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
@@ -9,19 +9,6 @@ namespace System.Collections.Tests
 {
     public class Perf_HashTable
     {
-        private static List<object[]> _testData;
-
-        public static IEnumerable<object[]> TestData()
-        {
-            if (_testData == null)
-            {
-                _testData = new List<object[]>();
-                _testData.Add(new object[] { CreateHashtable(10000) });
-                _testData.Add(new object[] { CreateHashtable(1000000) });
-            }
-            return _testData;
-        }
-
         public static Hashtable CreateHashtable(int size)
         {
             Hashtable ht = new Hashtable();
@@ -48,9 +35,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void GetItem(Hashtable table)
+        [InlineData(10000)]
+        [InlineData(1000000)]
+        public void GetItem(int size)
         {
+            Hashtable table = CreateHashtable(size);
+
             // Setup - utils needs a specific seed to prevent key collision with TestData
             object result;
             PerfUtils utils = new PerfUtils(983452);
@@ -69,13 +59,14 @@ namespace System.Collections.Tests
                     }
                 }
             }
-            table.Remove(key);
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void Add(Hashtable table)
+        [InlineData(10000)]
+        [InlineData(1000000)]
+        public void Add(int size)
         {
+            Hashtable table = CreateHashtable(size);
             foreach (var iteration in Benchmark.Iterations)
             {
                 Hashtable tableCopy = new Hashtable(table);

--- a/src/System.Collections/tests/Performance/Perf.Dictionary.cs
+++ b/src/System.Collections/tests/Performance/Perf.Dictionary.cs
@@ -9,41 +9,12 @@ namespace System.Collections.Tests
 {
     public class Perf_Dictionary
     {
-        private static List<object[]> _testData;
-
-        /// <summary>
-        /// Yields several Dictionaries containing increasing amounts of string-string
-        /// pairs can be used as MemberData input to performance tests for Dictionary
-        /// </summary>
-        /// <remarks>Any changes made to the returned collections MUST be undone. Collections
-        /// used as MemberData are cached and reused in other perf tests.
-        /// </remarks>
-        public static List<object[]> TestData()
-        {
-            if (_testData == null)
-            {
-                PerfUtils utils = new PerfUtils();
-                _testData = new List<object[]>();
-                _testData.Add(new object[] { CreateDictionary(utils, 1000) });
-                _testData.Add(new object[] { CreateDictionary(utils, 10000) });
-                _testData.Add(new object[] { CreateDictionary(utils, 100000) });
-            }
-            return _testData;
-        }
-
-        public static IEnumerable<object[]> TestDataIntString()
-        {
-            Random rand = new Random(12);
-            yield return new object[] { CreateDictionaryIntInt(rand, 1000) };
-            yield return new object[] { CreateDictionaryIntInt(rand, 10000) };
-            yield return new object[] { CreateDictionaryIntInt(rand, 100000) };
-        }
-
         /// <summary>
         /// Creates a Dictionary of string-string with the specified number of pairs
         /// </summary>
-        public static Dictionary<string, string> CreateDictionary(PerfUtils utils, int size)
+        public static Dictionary<string, string> CreateDictionary(int size)
         {
+            PerfUtils utils = new PerfUtils(837322);
             Dictionary<string, string> dict = new Dictionary<string, string>();
             while (dict.Count < size)
             {
@@ -58,8 +29,9 @@ namespace System.Collections.Tests
         /// <summary>
         /// Creates a Dictionary of int-int with the specified number of pairs
         /// </summary>
-        public static Dictionary<int, int> CreateDictionaryIntInt(Random rand, int size)
+        public static Dictionary<int, int> CreateDictionaryIntInt(int size)
         {
+            Random rand = new Random(837322);
             Dictionary<int, int> dict = new Dictionary<int, int>();
             while (dict.Count < size)
             {
@@ -67,13 +39,16 @@ namespace System.Collections.Tests
                 if (!dict.ContainsKey(key))
                     dict.Add(key, 0);
             }
-           return dict1;
+           return dict;
         }
 
         [Benchmark]
-        [MemberData("TestDataIntString")]
-        public void Add(Dictionary<int, int> dict)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Add(int size)
         {
+            Dictionary<int, int> dict = CreateDictionaryIntInt(size);
             foreach (var iteration in Benchmark.Iterations)
             {
                 Dictionary<int, int> copyDict = new Dictionary<int, int>(dict);
@@ -118,9 +93,13 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void GetItem(Dictionary<string, string> dict)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void GetItem(int size)
         {
+            Dictionary<string, string> dict = CreateDictionary(size);
+
             // Setup
             string retrieved;
             for (int i = 1; i <= 9; i++)
@@ -137,16 +116,15 @@ namespace System.Collections.Tests
                         retrieved = dict["key7"]; retrieved = dict["key8"]; retrieved = dict["key9"];
                     }
             }
-
-            // Teardown
-            for (int i = 1; i <= 9; i++)
-                dict.Remove("key" + i);
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void SetItem(Dictionary<string, string> dict)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void SetItem(int size)
         {
+            Dictionary<string, string> dict = CreateDictionary(size);
             // Setup
             for (int i = 1; i <= 9; i++)
                 dict.Add("key" + i, "value");
@@ -162,16 +140,15 @@ namespace System.Collections.Tests
                         dict["key7"] = "string"; dict["key8"] = "string"; dict["key9"] = "string";
                     }
             }
-
-            // Teardown
-            for (int i = 1; i <= 9; i++)
-                dict.Remove("key" + i);
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void GetKeys(Dictionary<string, string> dict)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void GetKeys(int size)
         {
+            Dictionary<string, string> dict = CreateDictionary(size);
             IEnumerable<string> result;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
@@ -184,9 +161,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void TryGetValue(Dictionary<string, string> dict)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void TryGetValue(int size)
         {
+            Dictionary<string, string> dict = CreateDictionary(size);
             // Setup - utils needs a specific seed to prevent key collision with TestData
             string retrieved;
             PerfUtils utils = new PerfUtils(56334);
@@ -203,15 +183,16 @@ namespace System.Collections.Tests
                         dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
                         dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
                     }
-
-            // Teardown
-            dict.Remove(key);
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void ContainsKey(Dictionary<string, string> dict)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void ContainsKey(int size)
         {
+            Dictionary<string, string> dict = CreateDictionary(size);
+
             // Setup - utils needs a specific seed to prevent key collision with TestData
             PerfUtils utils = new PerfUtils(152891);
             string key = utils.CreateString(50);
@@ -227,7 +208,6 @@ namespace System.Collections.Tests
                         dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
                         dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
                     }
-            dict.Remove(key);
         }
     }
 }

--- a/src/System.Collections/tests/Performance/Perf.List.cs
+++ b/src/System.Collections/tests/Performance/Perf.List.cs
@@ -9,33 +9,12 @@ namespace System.Collections.Tests
 {
     public class Perf_List
     {
-        private static List<object[]> _testData;
-
-        /// <summary>
-        /// Yields several Lists containing increasing amounts of strings
-       ///  can be used as MemberData input to performance tests for Dictionary
-        /// </summary>
-        /// <remarks>Any changes made to the returned collections MUST be undone. Collections
-        /// used as MemberData are cached and reused in other perf tests.
-        /// </remarks>
-        public static List<object[]> TestData()
-        {
-            if (_testData == null)
-            {
-                PerfUtils utils = new PerfUtils();
-                _testData = new List<object[]>();
-                _testData.Add(new object[] { CreateList(utils, 1000) });
-                _testData.Add(new object[] { CreateList(utils, 10000) });
-                _testData.Add(new object[] { CreateList(utils, 100000) });
-            }
-            return _testData;
-        }
-
         /// <summary>
         /// Creates a list containing a number of elements equal to the specified size
         /// </summary>
-        public static List<object> CreateList(PerfUtils utils, int size)
+        public static List<object> CreateList(int size)
         {
+            PerfUtils utils = new PerfUtils(24565653);
             List<object> list = new List<object>();
             for (int i = 0; i < size; i++)
                 list.Add(utils.CreateString(100));
@@ -43,9 +22,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void Add(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Add(int size)
         {
+            List<object> list = CreateList(size);
             foreach (var iteration in Benchmark.Iterations)
             {
                 List<object> copyList = new List<object>(list);
@@ -61,9 +43,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void AddRange(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void AddRange(int size)
         {
+            List<object> list = CreateList(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 5000; i++)
@@ -74,9 +59,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void Clear(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Clear(int size)
         {
+            List<object> list = CreateList(size);
             foreach (var iteration in Benchmark.Iterations)
             {
                 // Setup lists to clear
@@ -92,9 +80,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void Contains(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Contains(int size)
         {
+            List<object> list = CreateList(size);
             object contained = list[list.Count / 2];
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
@@ -114,7 +105,7 @@ namespace System.Collections.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < 10000; i++)
+                    for (int i = 0; i < 20000; i++)
                     {
                         new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
                         new List<object>(); new List<object>(); new List<object>(); new List<object>(); new List<object>();
@@ -124,9 +115,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void ctor_IEnumerable(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void ctor_IEnumerable(int size)
         {
+            List<object> list = CreateList(size);
             var array = list.ToArray();
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
@@ -135,9 +129,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void GetCount(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void GetCount(int size)
         {
+            List<object> list = CreateList(size);
             int temp;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
@@ -152,9 +149,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void GetItem(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void GetItem(int size)
         {
+            List<object> list = CreateList(size);
             object temp;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
@@ -170,9 +170,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void Enumerator(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Enumerator(int size)
         {
+            List<object> list = CreateList(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)
@@ -180,9 +183,12 @@ namespace System.Collections.Tests
         }
 
         [Benchmark]
-        [MemberData("TestData")]
-        public void ToArray(List<object> list)
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void ToArray(int size)
         {
+            List<object> list = CreateList(size);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)

--- a/src/System.Console/tests/Performance/Perf.Console.cs
+++ b/src/System.Console/tests/Performance/Perf.Console.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.ConsoleTests
+{
+    /// <summary>
+    /// Perf tests for Console are chosen based on which functions have PAL code. They are:
+    /// 
+    /// - OpenStandardInput, OpenStandardOutput, OpenStandardError
+    /// - InputEncoding, OutputEncoding
+    /// - ForegroundColor, BackgroundColor, ResetColor
+    /// </summary>
+    public class Perf_Console
+    {
+        [Benchmark]
+        public void OpenStandardInput()
+        {
+            // We preserve copies of each opened Stream so that the perf area doesn't 
+            // cover the disposal of those streams.
+            const int innerIterations = 50;
+            Stream[] streams = new Stream[innerIterations * 4];
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        streams[0 + i * 4] = Console.OpenStandardInput(); streams[1 + i * 4] = Console.OpenStandardInput();
+                        streams[2 + i * 4] = Console.OpenStandardInput(); streams[3 + i * 4] = Console.OpenStandardInput();
+                    }
+                }
+                foreach (Stream s in streams)
+                {
+                    Assert.NotNull(s);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void OpenStandardOutput()
+        {
+            // We preserve copies of each opened Stream so that the perf area doesn't 
+            // cover the disposal of those streams.
+            const int innerIterations = 50;
+            Stream[] streams = new Stream[innerIterations * 4];
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        streams[0 + i * 4] = Console.OpenStandardOutput(); streams[1 + i * 4] = Console.OpenStandardOutput();
+                        streams[2 + i * 4] = Console.OpenStandardOutput(); streams[3 + i * 4] = Console.OpenStandardOutput();
+                    }
+                }
+                foreach (Stream s in streams)
+                    s.Dispose();
+            }
+        }
+
+        [Benchmark]
+        public void OpenStandardError()
+        {
+            // We preserve copies of each opened Stream so that the perf area doesn't 
+            // cover the disposal of those streams.
+            const int innerIterations = 50;
+            Stream[] streams = new Stream[innerIterations * 4];
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        streams[0 + i * 4] = Console.OpenStandardError(); streams[1 + i * 4] = Console.OpenStandardError();
+                        streams[2 + i * 4] = Console.OpenStandardError(); streams[3 + i * 4] = Console.OpenStandardError();
+                    }
+                }
+                foreach (Stream s in streams)
+                    s.Dispose();
+            }
+        }
+    }
+}

--- a/src/System.Console/tests/Performance/Perf.Console.cs
+++ b/src/System.Console/tests/Performance/Perf.Console.cs
@@ -38,9 +38,7 @@ namespace System.ConsoleTests
                     }
                 }
                 foreach (Stream s in streams)
-                {
-                    Assert.NotNull(s);
-                }
+                    s.Dispose();
             }
         }
 

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -10,6 +10,11 @@
     <RootNamespace>System.Console.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <!-- Performance tests require v5.0 portable tools -->
+  <PropertyGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
@@ -28,6 +33,13 @@
     <Compile Include="ThreadSafety.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="TermInfo.cs" />
+  </ItemGroup>
+  <!-- Performance Tests -->
+  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <Compile Include="Performance\Perf.Console.cs" />
+    <Compile Include="$(CommonTestPath)\Performance\PerfUtils.cs">
+      <Link>Common\Performance\PerfUtils.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Console.csproj">

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Collections": "4.0.10",
     "System.Collections.Concurrent": "4.0.10",
     "System.IO": "4.0.10",

--- a/src/System.Console/tests/project.lock.json
+++ b/src/System.Console/tests/project.lock.json
@@ -3,6 +3,36 @@
   "version": 1,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0022": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "xunit.abstractions": "2.0.0",
+          "xunit.extensibility.core": "2.1.0",
+          "xunit.extensibility.execution": "2.1.0"
+        },
+        "compile": {
+          "lib/dotnet/xunit.performance.core.dll": {},
+          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.performance.core.dll": {},
+          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
+        }
+      },
       "System.Collections/4.0.10": {
         "type": "package",
         "dependencies": {
@@ -517,6 +547,25 @@
     }
   },
   "libraries": {
+    "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0022": {
+      "type": "package",
+      "sha512": "uh4WpDAs7mW9aiMqcHojn1MEGNUND03qmSsWFyVApAcRQQ0ppCJvQ2sUGBdL1/8DB12NGzKizaGg0Tnd4PCnfA==",
+      "files": [
+        "lib/dotnet/xunit.performance.core.dll",
+        "lib/dotnet/xunit.performance.core.pdb",
+        "lib/dotnet/xunit.performance.core.XML",
+        "lib/dotnet/xunit.performance.execution.dotnet.dll",
+        "lib/dotnet/xunit.performance.execution.dotnet.pdb",
+        "lib/net46/xunit.performance.core.dll",
+        "lib/net46/xunit.performance.core.pdb",
+        "lib/net46/xunit.performance.core.XML",
+        "lib/net46/xunit.performance.execution.desktop.dll",
+        "lib/net46/xunit.performance.execution.desktop.pdb",
+        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0022.nupkg",
+        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0022.nupkg.sha512",
+        "Microsoft.DotNet.xunit.performance.nuspec"
+      ]
+    },
     "System.Collections/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1631,6 +1680,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "Microsoft.DotNet.xunit.performance >= 1.0.0-*",
       "System.Collections >= 4.0.10",
       "System.Collections.Concurrent >= 4.0.10",
       "System.IO >= 4.0.10",

--- a/src/System.IO.FileSystem/tests/Performance/Perf.Directory.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.Directory.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Xunit.Performance;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Perf_Directory : FileSystemTest
     {
@@ -55,6 +55,4 @@ namespace System.IO.FileSystem.Tests
             Directory.Delete(testFile);
         }
     }
-
-
 }

--- a/src/System.IO.FileSystem/tests/Performance/Perf.File.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.File.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Xunit.Performance;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Perf_File : FileSystemTest
     {

--- a/src/System.IO.FileSystem/tests/Performance/Perf.FileInfo.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.FileInfo.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Xunit.Performance;
 
-namespace System.IO.FileSystem.Tests
+namespace System.IO.Tests
 {
     public class Perf_FileInfo : FileSystemTest
     {


### PR DESCRIPTION
- Updated getting started perf docs
- Removed caching of collections for tests; my results found the caching of negligible benefit
- Changed from MemberData to InlineData where possible to simplify matching method signatures for the perf analysis tools.
- Fixed the namespace for FileSystem tests to be the same as the other FS tests

Note: Will also include new build tools version after merging of https://github.com/dotnet/buildtools/pull/299