### PR TITLE
Add test coverage for ReadOnlyDictionary

### DIFF
--- a/src/Common/tests/Collections/ICollectionTest.cs
+++ b/src/Common/tests/Collections/ICollectionTest.cs
@@ -307,10 +307,7 @@ namespace Tests.Collections
             ICollection<T> collection = GetCollection(items) as ICollection<T>;
             if (collection == null)
                 return;
-            foreach (var item in items)
-            {
-                Assert.True(collection.Contains((T)item));
-            }
+            Assert.All(items, item => Assert.True(collection.Contains((T) item)));
         }
 
         internal class MyInvalidReferenceType

--- a/src/Common/tests/Collections/ICollectionTest.cs
+++ b/src/Common/tests/Collections/ICollectionTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Sdk;
@@ -296,6 +297,19 @@ namespace Tests.Collections
                     collection.Count);
                 collection.CopyTo(itemArray, 0);
                 CollectionAssert.Equal(items, itemArray);
+            }
+        }
+
+        [Fact]
+        public void CollectionShouldContainAllItems()
+        {
+            object[] items = GenerateItems(16);
+            ICollection<T> collection = GetCollection(items) as ICollection<T>;
+            if (collection == null)
+                return;
+            foreach (var item in items)
+            {
+                Assert.True(collection.Contains((T)item));
             }
         }
 

--- a/src/Common/tests/Collections/IDictionaryTest.cs
+++ b/src/Common/tests/Collections/IDictionaryTest.cs
@@ -28,12 +28,13 @@ namespace Tests.Collections
         public void KeysShouldBeCorrect(int count)
         {
             object[] items = GenerateItems(count);
-            IDictionary<TKey, TValue> dict = GetDictionary(items);
             var expectedKeys = new TKey[items.Length];
             for (int i = 0; i < items.Length; ++i)
             {
                 expectedKeys[i] = ((KeyValuePair<TKey, TValue>)items[i]).Key;
             }
+
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
 
             CollectionAssert.Equal(expectedKeys, dict.Keys);
 
@@ -51,12 +52,13 @@ namespace Tests.Collections
         public void ValuesShouldBeCorrect(int count)
         {
             object[] items = GenerateItems(count);
-            IDictionary<TKey, TValue> dict = GetDictionary(items);
             var expectedValues = new TValue[items.Length];
             for (int i = 0; i < items.Length; ++i)
             {
                 expectedValues[i] = ((KeyValuePair<TKey, TValue>)items[i]).Value;
             }
+
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
 
             CollectionAssert.Equal(expectedValues, dict.Values);
 
@@ -175,6 +177,7 @@ namespace Tests.Collections
                         Assert.Equal(pair.Key, entry.Key);
                         Assert.Equal(pair.Value, entry.Value);
                     }
+                    Assert.False(dictEnumerator.MoveNext());
                     dictEnumerator.Reset();
                     enumerator.Reset();
                 }

--- a/src/Common/tests/Collections/IDictionaryTest.cs
+++ b/src/Common/tests/Collections/IDictionaryTest.cs
@@ -1,0 +1,266 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Tests.Collections
+{
+    public abstract class IDictionaryTest<TKey, TValue> : ICollectionTest<KeyValuePair<TKey, TValue>>
+    {
+        protected IDictionaryTest(bool isSynchronized)
+            : base(isSynchronized)
+        {
+        }
+
+        protected IDictionary<TKey, TValue> GetDictionary(object[] items)
+        {
+            return (IDictionary<TKey, TValue>)GetCollection(items);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(16)]
+        [InlineData(100)]
+        public void KeysShouldBeCorrect(int count)
+        {
+            object[] items = GenerateItems(count);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var expectedKeys = new TKey[items.Length];
+            for (int i = 0; i < items.Length; ++i)
+            {
+                expectedKeys[i] = ((KeyValuePair<TKey, TValue>)items[i]).Key;
+            }
+
+            CollectionAssert.Equal(expectedKeys, dict.Keys);
+
+            IDictionary dict2 = dict as IDictionary;
+            if (dict2 != null)
+            {
+                CollectionAssert.Equal(expectedKeys, dict2.Keys);
+            }
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(16)]
+        [InlineData(100)]
+        public void ValuesShouldBeCorrect(int count)
+        {
+            object[] items = GenerateItems(count);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var expectedValues = new TValue[items.Length];
+            for (int i = 0; i < items.Length; ++i)
+            {
+                expectedValues[i] = ((KeyValuePair<TKey, TValue>)items[i]).Value;
+            }
+
+            CollectionAssert.Equal(expectedValues, dict.Values);
+
+            IDictionary dict2 = dict as IDictionary;
+            if (dict2 != null)
+            {
+                CollectionAssert.Equal(expectedValues, dict2.Values);
+            }
+        }
+
+        [Fact]
+        public void ItemShouldBeCorrect()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var isReadOnly = dict.IsReadOnly;
+            for (int i = 0; i < items.Length; ++i)
+            {
+                var pair = (KeyValuePair<TKey, TValue>)items[i];
+                Assert.Equal(pair.Value, dict[pair.Key]);
+                if (isReadOnly)
+                {
+                    Assert.Throws<NotSupportedException>(() => dict[pair.Key] = pair.Value);
+                }
+                else
+                {
+                    dict[pair.Key] = pair.Value;
+                }
+            }
+
+            IDictionary dict2 = dict as IDictionary;
+            if (dict2 != null)
+            {
+                for (int i = 0; i < items.Length; ++i)
+                {
+                    var pair = (KeyValuePair<TKey, TValue>)items[i];
+                    Assert.Equal(pair.Value, dict2[pair.Key]);
+                    if (isReadOnly)
+                    {
+                        Assert.Throws<NotSupportedException>(() => dict2[pair.Key] = pair.Value);
+                    }
+                    else
+                    {
+                        dict2[pair.Key] = pair.Value;
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void IDictionaryShouldContainAllKeys()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary dict = GetDictionary(items) as IDictionary;
+            foreach (KeyValuePair<TKey, TValue> item in items)
+            {
+                Assert.True(dict.Contains(item.Key));
+            }
+        }
+
+        [Fact]
+        public void WhenDictionaryIsReadOnlyAddShouldThrow()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary dict = GetDictionary(items) as IDictionary;
+            if (dict.IsReadOnly)
+            {
+                var pair = (KeyValuePair<TKey, TValue>)GenerateItem();
+                Assert.Throws<NotSupportedException>(() => dict.Add(pair.Key, pair.Value));
+            }
+        }
+
+        [Fact]
+        public void WhenDictionaryIsReadOnlyClearShouldThrow()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary dict = GetDictionary(items) as IDictionary;
+            if (dict.IsReadOnly)
+            {
+                Assert.Throws<NotSupportedException>(() => dict.Clear());
+            }
+        }
+
+        [Fact]
+        public void WhenDictionaryIsReadOnlyRemoveShouldThrow()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary dict = GetDictionary(items) as IDictionary;
+            if (dict != null && dict.IsReadOnly)
+            {
+                var key = ((KeyValuePair<TKey, TValue>)GenerateItem()).Key;
+                Assert.Throws<NotSupportedException>(() => dict.Remove(key));
+            }
+        }
+
+        [Fact]
+        public void IDictionaryGetEnumeratorShouldEnumerateSameItemsAsIEnumerableGetEnumerator()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary dict = GetDictionary(items) as IDictionary;
+            if (dict != null)
+            {
+                IEnumerator enumerator = ((IEnumerable)dict).GetEnumerator();
+                IDictionaryEnumerator dictEnumerator = dict.GetEnumerator();
+                int i = 0;
+                while (i++ < 2)
+                {
+                    while (enumerator.MoveNext())
+                    {
+                        Assert.True(dictEnumerator.MoveNext());
+                        var pair = (KeyValuePair<TKey, TValue>) enumerator.Current;
+                        Assert.Equal(dictEnumerator.Current, dictEnumerator.Entry);
+                        var entry = dictEnumerator.Entry;
+                        Assert.Equal(pair.Key, dictEnumerator.Key);
+                        Assert.Equal(pair.Value, dictEnumerator.Value);
+                        Assert.Equal(pair.Key, entry.Key);
+                        Assert.Equal(pair.Value, entry.Value);
+                    }
+                    dictEnumerator.Reset();
+                    enumerator.Reset();
+                }
+            }
+        }
+
+        [Fact]
+        public void KeyCollectionIsReadOnly()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var item = (KeyValuePair<TKey, TValue>)GenerateItem();
+            var keys = dict.Keys;
+            Assert.True(keys.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => keys.Add(item.Key));
+            Assert.Throws<NotSupportedException>(() => keys.Clear());
+            Assert.Throws<NotSupportedException>(() => keys.Remove(item.Key));
+        }
+
+        [Fact]
+        public void KeyCollectionShouldContainAllKeys()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var keys = dict.Keys;
+            foreach (KeyValuePair<TKey, TValue> item in items)
+                Assert.True(keys.Contains(item.Key));
+        }
+
+        [Fact]
+        public void KeyCollectionShouldNotBeSynchronized()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var keys = (ICollection)dict.Keys;
+            Assert.False(keys.IsSynchronized);
+        }
+
+        [Fact]
+        public void KeyCollectionSyncRootShouldNotBeNull()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var keys = (ICollection)dict.Keys;
+            Assert.NotNull(keys.SyncRoot);
+        }
+
+        [Fact]
+        public void ValueCollectionIsReadOnly()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var item = (KeyValuePair<TKey, TValue>)GenerateItem();
+            var values = dict.Values;
+            Assert.True(values.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => values.Add(item.Value));
+            Assert.Throws<NotSupportedException>(() => values.Clear());
+            Assert.Throws<NotSupportedException>(() => values.Remove(item.Value));
+        }
+
+        [Fact]
+        public void ValueCollectionShouldContainAllValues()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var values = dict.Values;
+            foreach (KeyValuePair<TKey, TValue> item in items)
+                Assert.True(values.Contains(item.Value));
+        }
+
+        [Fact]
+        public void ValueCollectionShouldNotBeSynchronized()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var values = (ICollection)dict.Values;
+            Assert.False(values.IsSynchronized);
+        }
+
+        [Fact]
+        public void ValueCollectionSyncRootShouldNotBeNull()
+        {
+            object[] items = GenerateItems(16);
+            IDictionary<TKey, TValue> dict = GetDictionary(items);
+            var values = (ICollection)dict.Values;
+            Assert.NotNull(values.SyncRoot);
+        }
+    }
+}

--- a/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
+using Tests.Collections;
 
 namespace System.Collections.ObjectModel.Tests
 {
@@ -214,6 +215,186 @@ namespace System.Collections.ObjectModel.Tests
 
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ReadOnlyDictionary<int, int>(new Dictionary<int, int>()).Keys);
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ReadOnlyDictionary<int, int>(new Dictionary<int, int>()).Values);
+        }
+    }
+
+    public class TestReadOnlyDictionary<TKey, TValue> : ReadOnlyDictionary<TKey, TValue>
+    {
+        public TestReadOnlyDictionary(IDictionary<TKey, TValue> dict)
+            : base(dict)
+        {
+        }
+
+        public IDictionary<TKey, TValue> GetDictionary()
+        {
+            return Dictionary;
+        }
+    }
+
+    public class DictionaryThatDoesntImplementNonGeneric<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> _inner;
+        
+        public DictionaryThatDoesntImplementNonGeneric(IDictionary<TKey, TValue> inner)
+        {
+            _inner = inner;
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return _inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) _inner).GetEnumerator();
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            _inner.Add(item);
+        }
+
+        public void Clear()
+        {
+            _inner.Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return _inner.Contains(item);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            _inner.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return _inner.Remove(item);
+        }
+
+        public int Count
+        {
+            get { return _inner.Count; }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return _inner.IsReadOnly; }
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            _inner.Add(key, value);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return _inner.ContainsKey(key);
+        }
+
+        public bool Remove(TKey key)
+        {
+            return _inner.Remove(key);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return _inner.TryGetValue(key, out value);
+        }
+
+        public TValue this[TKey key]
+        {
+            get { return _inner[key]; }
+            set { _inner[key] = value; }
+        }
+
+        public ICollection<TKey> Keys
+        {
+            get { return _inner.Keys; }
+        }
+
+        public ICollection<TValue> Values
+        {
+            get { return _inner.Values; }
+        }
+    }
+
+    public class ReadOnlyDictionaryOverNonGenericTests
+        : IDictionaryTest<string, int>
+    {
+        public ReadOnlyDictionaryOverNonGenericTests()
+            : base(false)
+        {
+        }
+
+        private int m_next_item = 1;
+        protected override bool IsResetNotSupported { get { return false; } }
+        protected override bool IsGenericCompatibility { get { return false; } }
+        protected override bool ItemsMustBeUnique { get { return true; } }
+        protected override bool ItemsMustBeNonNull { get { return true; } }
+        protected override object GenerateItem()
+        {
+            return new KeyValuePair<string, int>(m_next_item.ToString(), m_next_item++);
+        }
+
+        protected override IEnumerable GetEnumerable(object[] items)
+        {
+            var dict = new DictionaryThatDoesntImplementNonGeneric<string, int>(new Dictionary<string, int>());
+            foreach (KeyValuePair<string, int> p in items)
+                dict[p.Key] = p.Value;
+            return new TestReadOnlyDictionary<string, int>(dict);
+        }
+
+        protected override object[] InvalidateEnumerator(IEnumerable enumerable)
+        {
+            var roDict = (TestReadOnlyDictionary<string, int>)enumerable;
+            var dict = roDict.GetDictionary();
+            var item = (KeyValuePair<string, int>)GenerateItem();
+            dict.Add(item.Key, item.Value);
+            var arr = new object[dict.Count];
+            ((ICollection)roDict).CopyTo(arr, 0);
+            return arr;
+        }
+    }
+
+    public class ReadOnlyDictionaryTestsStringInt
+        : IDictionaryTest<string, int>
+    {
+        public ReadOnlyDictionaryTestsStringInt()
+            : base(false)
+        {
+        }
+
+        private int m_next_item = 1;
+        protected override bool IsResetNotSupported { get { return false; } }
+        protected override bool IsGenericCompatibility { get { return false; } }
+        protected override bool ItemsMustBeUnique { get { return true; } }
+        protected override bool ItemsMustBeNonNull { get { return true; } }
+        protected override object GenerateItem()
+        {
+            return new KeyValuePair<string, int>(m_next_item.ToString(), m_next_item++);
+        }
+
+        protected override IEnumerable GetEnumerable(object[] items)
+        {
+            var dict = new Dictionary<string, int>();
+            foreach (KeyValuePair<string, int> p in items)
+                dict[p.Key] = p.Value;
+            return new TestReadOnlyDictionary<string, int>(dict);
+        }
+
+        protected override object[] InvalidateEnumerator(IEnumerable enumerable)
+        {
+            var roDict = (TestReadOnlyDictionary<string, int>)enumerable;
+            var dict = roDict.GetDictionary();
+            var item = (KeyValuePair<string, int>)GenerateItem();
+            dict.Add(item.Key, item.Value);
+            var arr = new object[dict.Count];
+            ((ICollection)roDict).CopyTo(arr, 0);
+            return arr;
         }
     }
 

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -29,6 +29,9 @@
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Collections\IDictionaryTest.cs">
+      <Link>Common\Collections\IDictionaryTest.cs</Link>
+    </Compile>
     <Compile Include="ComponentModel\INotifyPropertyChangingTests.cs" />
     <Compile Include="ComponentModel\PropertyChangingEventArgsTests.cs" />
     <Compile Include="KeyedCollection\TestMethods.cs" />


### PR DESCRIPTION
Add additional test coverage for ReadOnlyDictionary improving System.ObjectModel assembly coverage from 54% to 73%.

Fix #990