### PR TITLE
Fix assembly load context InitializeDefaultContext test

### DIFF
--- a/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -109,16 +109,22 @@ namespace System.Runtime.Loader.Tests
             Assert.NotNull(context);
         }
 
-        [ActiveIssue(3569, PlatformID.AnyUnix)]
+        [ActiveIssue(3569, PlatformID.Windows)]
         [Fact]
         public static void InitializeDefaultContextTest()
         {
-            var loadContext = new ResourceAssemblyLoadContext();
+            // The coreclr binding model will become locked upon loading the first assembly that is not on the TPA list, or
+            // upon initializing the default context for the first time. For this test, test assemblies are located alongside
+            // corerun, and hence will be on the TPA list. So, we should be able to set the default context once successfully,
+            // and fail on the second try.
 
-            // because the coreclr binding model is already locked for the appdomain
-            // and cannot be reset
+            var loadContext = new ResourceAssemblyLoadContext();
+            AssemblyLoadContext.InitializeDefaultContext(loadContext);
+            Assert.Equal(loadContext, AssemblyLoadContext.Default);
+
+            loadContext = new ResourceAssemblyLoadContext();
             Assert.Throws(typeof(InvalidOperationException), 
                 () => AssemblyLoadContext.InitializeDefaultContext(loadContext));
-        }        
+        }
     }
 }


### PR DESCRIPTION
Updated the test and enabled it on Unixes. Disabled it on Windows, as the CoreCLR binaries being used to run the tests on Windows appear to be old. Once the repo starts pulling a more recent version of CoreCLR binaries, I'll re-enable the test on Windows.

Related to #3569