### PR TITLE
Improve Process.GetProcesses* performance on Linux

### DIFF
--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -182,12 +182,16 @@ internal static partial class Interop
 
         internal static bool TryReadStatFile(int pid, out ParsedStat result)
         {
-            return TryParseStatFile(GetStatFilePathForProcess(pid), out result);
+            bool b = TryParseStatFile(GetStatFilePathForProcess(pid), out result);
+            Debug.Assert(!b || result.pid == pid, "Expected process ID from stat file to match supplied pid");
+            return b;
         }
 
         internal static bool TryReadStatFile(int pid, int tid, out ParsedStat result)
         {
-            return TryParseStatFile(GetStatFilePathForThread(pid, tid), out result);
+            bool b = TryParseStatFile(GetStatFilePathForThread(pid, tid), out result);
+            Debug.Assert(!b || result.pid == tid, "Expected thread ID from stat file to match supplied tid");
+            return b;
         }
 
         private static bool TryParseStatFile(string statFilePath, out ParsedStat result)

--- a/src/Common/src/System/Text/ReusableTextReader.cs
+++ b/src/Common/src/System/Text/ReusableTextReader.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace System.Text
+{
+    /// <summary>Provides a reusable reader for reading all of the text from streams.</summary>
+    internal sealed class ReusableTextReader
+    {
+        /// <summary>StringBuilder used to store intermediate text results.</summary>
+        private readonly StringBuilder _builder = new StringBuilder();
+        /// <summary>Decoder used to decode data read from the stream.</summary>
+        private readonly Decoder _decoder;
+        /// <summary>Bytes read from the stream.</summary>
+        private readonly byte[] _bytes;
+        /// <summary>Temporary storage from characters converted from the bytes then written to the builder.</summary>
+        private readonly char[] _chars;
+
+        /// <summary>Initializes a new reusable reader.</summary>
+        /// <param name="encoding">The Encoding to use.  Defaults to UTF8.</param>
+        /// <param name="bufferSize">The size of the buffer to use when reading from the stream.</param>
+        public ReusableTextReader(Encoding encoding = null, int bufferSize = 1024)
+        {
+            if (encoding == null)
+            {
+                encoding = Encoding.UTF8;
+            }
+
+            _decoder = encoding.GetDecoder();
+            _bytes = new byte[bufferSize];
+            _chars = new char[encoding.GetMaxCharCount(_bytes.Length)];
+        }
+
+        /// <summary>Read all of the text from the current position of the stream.</summary>
+        public unsafe string ReadAllText(Stream source)
+        {
+            int bytesRead;
+            while ((bytesRead = source.Read(_bytes, 0, _bytes.Length)) != 0)
+            {
+                int charCount = _decoder.GetChars(_bytes, 0, bytesRead, _chars, 0);
+                _builder.Append(_chars, 0, charCount);
+            }
+
+            string s = _builder.ToString();
+
+            _builder.Clear();
+            _decoder.Reset();
+
+            return s;
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -211,7 +211,7 @@
     <value>StandardError has not been redirected.</value>
   </data>
   <data name="CantMixSyncAsyncOperation" xml:space="preserve">
-    <value> Cannot mix synchronous and asynchronous operation on process stream.</value>
+    <value>Cannot mix synchronous and asynchronous operation on process stream.</value>
   </data>
   <data name="CantRedirectStreams" xml:space="preserve">
     <value>The Process object must have the UseShellExecute property set to false in order to redirect IO streams.</value>
@@ -226,7 +226,7 @@
     <value>An async read operation has already been started on the stream.</value>
   </data>
   <data name="UseShellExecute" xml:space="preserve">
-    <value> UseShellExecute must always be set to false.</value>
+    <value>UseShellExecute must always be set to false.</value>
   </data>
   <data name="InvalidParameter" xml:space="preserve">
     <value>Invalid value '{1}' for parameter '{0}'.</value>
@@ -259,7 +259,7 @@
     <value>Process IDs cannot be negative.</value>
   </data>
   <data name="ProcessorAffinityNotSupported" xml:space="preserve">
-    <value>OS X does not support deterministic Process or Thread Processor Affinity.</value>
+    <value>Processor affinity for processes or threads is not supported.</value>
   </data>
   <data name="ResourceLimitQueryFailure" xml:space="preserve">
     <value>Failed to retrieve process resource limits for the current process. See the error code for OS-specific error information.</value>
@@ -268,9 +268,12 @@
     <value>Failed to set or retrieve rusage information. See the error code for OS-specific error information.</value>
   </data>
   <data name="MinimumWorkingSetNotSupported" xml:space="preserve">
-    <value>OS X does not support setting the minimum working set.</value>
+    <value>Setting the minimum working set is not supported.</value>
   </data>
   <data name="OsxExternalProcessWorkingSetNotSupported" xml:space="preserve">
-    <value>Getting or Setting the Working Set limits on other processes is not supported on OS X.</value>
+    <value>Getting or setting the working set limits on other processes is not supported.</value>
+  </data>
+  <data name="ProcessInformationUnavailable" xml:space="preserve">
+    <value>Unable to retrieve the specified information about the process or thread.  It may have exited or may be privileged.</value>
   </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -271,6 +271,9 @@
     <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.sched_getsetaffinity.cs">
       <Link>Common\Interop\Linux\Interop.sched_getsetaffinity.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+      <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="System\Diagnostics\Process.OSX.cs" />

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -274,6 +274,9 @@
     <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
       <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Text\ReusableTextReader.cs">
+      <Link>Common\System\Text\ReusableTextReader.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="System\Diagnostics\Process.OSX.cs" />

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -1,15 +1,42 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.Diagnostics
 {
     public partial class Process : IDisposable
     {
+        /// <summary>
+        /// Creates an array of <see cref="Process"/> components that are associated with process resources on a
+        /// remote computer. These process resources share the specified process name.
+        /// </summary>
+        public static Process[] GetProcessesByName(string processName, string machineName)
+        {
+            ProcessManager.ThrowIfRemoteMachine(machineName);
+            if (processName == null)
+            {
+                processName = string.Empty;
+            }
+
+            var processes = new List<Process>();
+            foreach (int pid in ProcessManager.EnumerateProcessIds())
+            {
+                Interop.procfs.ParsedStat parsedStat;
+                if (Interop.procfs.TryReadStatFile(pid, out parsedStat) &&
+                    string.Equals(processName, parsedStat.comm, StringComparison.OrdinalIgnoreCase))
+                {
+                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(parsedStat);
+                    processes.Add(new Process(machineName, false, processInfo.ProcessId, processInfo));
+                }
+            }
+
+            return processes.ToArray();
+        }
+
         /// <summary>Gets the amount of time the process has spent running code inside the operating system core.</summary>
         public TimeSpan PrivilegedProcessorTime
         {
@@ -207,7 +234,12 @@ namespace System.Diagnostics
         private Interop.procfs.ParsedStat GetStat()
         {
             EnsureState(State.HaveId);
-            return Interop.procfs.ReadStatFile(_processId);
+            Interop.procfs.ParsedStat stat;
+            if (!Interop.procfs.TryReadStatFile(_processId, result: out stat))
+            {
+                throw new Win32Exception(SR.ProcessInformationUnavailable);
+            }
+            return stat;
         }
 
     }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -1,15 +1,41 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace System.Diagnostics
 {
     public partial class Process
     {
-        // The ri_proc_start_abstime needs to be converted to milliseconds to determine
-        // the actual start time of the process.
-        private const ulong MillisecondFactor = 100000000000;
+        /// <summary>
+        /// Creates an array of <see cref="Process"/> components that are associated with process resources on a
+        /// remote computer. These process resources share the specified process name.
+        /// </summary>
+        public static Process[] GetProcessesByName(string processName, string machineName)
+        {
+            if (processName == null)
+            {
+                processName = string.Empty;
+            }
+
+            Process[] procs = GetProcesses(machineName);
+            var list = new List<Process>();
+
+            for (int i = 0; i < procs.Length; i++)
+            {
+                if (string.Equals(processName, procs[i].ProcessName, StringComparison.OrdinalIgnoreCase))
+                {
+                    list.Add(procs[i]);
+                }
+                else
+                {
+                    procs[i].Dispose();
+                }
+            }
+
+            return list.ToArray();
+        }
 
         /// <summary>Gets the amount of time the process has spent running code inside the operating system core.</summary>
         public TimeSpan PrivilegedProcessorTime
@@ -157,6 +183,10 @@ namespace System.Diagnostics
         // ----------------------------------
         // ---- Unix PAL layer ends here ----
         // ----------------------------------
+
+        // The ri_proc_start_abstime needs to be converted to milliseconds to determine
+        // the actual start time of the process.
+        private const ulong MillisecondFactor = 100000000000;
 
         private Interop.libproc.rusage_info_v3 GetCurrentProcessRUsage()
         {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -16,6 +16,35 @@ namespace System.Diagnostics
     public partial class Process : IDisposable
     {
         /// <summary>
+        /// Creates an array of <see cref="Process"/> components that are associated with process resources on a
+        /// remote computer. These process resources share the specified process name.
+        /// </summary>
+        public static Process[] GetProcessesByName(string processName, string machineName)
+        {
+            if (processName == null)
+            {
+                processName = string.Empty;
+            }
+
+            Process[] procs = GetProcesses(machineName);
+            var list = new List<Process>();
+
+            for (int i = 0; i < procs.Length; i++)
+            {
+                if (string.Equals(processName, procs[i].ProcessName, StringComparison.OrdinalIgnoreCase))
+                {
+                    list.Add(procs[i]);
+                }
+                else
+                {
+                    procs[i].Dispose();
+                }
+            }
+
+            return list.ToArray();
+        }
+
+        /// <summary>
         /// Puts a Process component in state to interact with operating system processes that run in a 
         /// special mode by enabling the native property SeDebugPrivilege on the current thread.
         /// </summary>
@@ -664,7 +693,7 @@ namespace System.Diagnostics
                 commandLine.Append("\"");
             }
 
-            if (!String.IsNullOrEmpty(arguments))
+            if (!string.IsNullOrEmpty(arguments))
             {
                 commandLine.Append(" ");
                 commandLine.Append(arguments);

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -894,33 +894,6 @@ namespace System.Diagnostics
 
         /// <devdoc>
         ///    <para>
-        ///       Creates an array of <see cref='System.Diagnostics.Process'/> components that are associated with process resources on a
-        ///       remote computer. These process resources share the specified process name.
-        ///    </para>
-        /// </devdoc>
-        public static Process[] GetProcessesByName(string processName, string machineName)
-        {
-            if (processName == null) processName = String.Empty;
-            Process[] procs = GetProcesses(machineName);
-            List<Process> list = new List<Process>();
-
-            for (int i = 0; i < procs.Length; i++)
-            {
-                if (String.Equals(processName, procs[i].ProcessName, StringComparison.OrdinalIgnoreCase))
-                {
-                    list.Add(procs[i]);
-                }
-                else
-                {
-                    procs[i].Dispose();
-                }
-            }
-
-            return list.ToArray();
-        }
-
-        /// <devdoc>
-        ///    <para>
         ///       Creates a new <see cref='System.Diagnostics.Process'/>
         ///       component for each process resource on the local computer.
         ///    </para>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -13,20 +13,7 @@ namespace System.Diagnostics
         /// <summary>Gets the IDs of all processes on the current machine.</summary>
         public static int[] GetProcessIds()
         {
-            // Parse /proc for any directory that's named with a number.  Each such
-            // directory represents a process.
-            var pids = new List<int>();
-            foreach (string procDir in Directory.EnumerateDirectories(Interop.procfs.RootPath))
-            {
-                string dirName = Path.GetFileName(procDir);
-                int pid;
-                if (int.TryParse(dirName, NumberStyles.Integer, CultureInfo.InvariantCulture, out pid))
-                {
-                    Debug.Assert(pid >= 0);
-                    pids.Add(pid);
-                }
-            }
-            return pids.ToArray();
+            return EnumerableHelpers.ToArray(EnumerateProcessIds());
         }
 
         /// <summary>Gets an array of module infos for the specified process.</summary>
@@ -74,61 +61,62 @@ namespace System.Diagnostics
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        private static ProcessInfo CreateProcessInfo(int pid)
+        /// <summary>
+        /// Creates a ProcessInfo from the specified process ID.
+        /// </summary>
+        internal static ProcessInfo CreateProcessInfo(int pid)
         {
-            // Read /proc/pid/stat to get information about the process, and churn that into a ProcessInfo
-            ProcessInfo pi;
-            try
-            {
-                Interop.procfs.ParsedStat procFsStat = Interop.procfs.ReadStatFile(pid);
-                pi = new ProcessInfo
-                {
-                    ProcessId = pid,
-                    ProcessName = procFsStat.comm,
-                    BasePriority = (int)procFsStat.nice,
-                    VirtualBytes = (long)procFsStat.vsize,
-                    WorkingSet = procFsStat.rss,
-                    SessionId = procFsStat.session,
+            Interop.procfs.ParsedStat stat;
+            return Interop.procfs.TryReadStatFile(pid, out stat) ?
+                CreateProcessInfo(stat) :
+                null;
+        }
 
-                    // We don't currently fill in the other values.
-                    // A few of these could probably be filled in from getrusage,
-                    // but only for the current process or its children, not for
-                    // arbitrary other processes.
-                };
-            }
-            catch (IOException)
+        /// <summary>
+        /// Creates a ProcessInfo from the data parsed from a /proc/pid/stat file and the associated tasks directory.
+        /// </summary>
+        internal static ProcessInfo CreateProcessInfo(Interop.procfs.ParsedStat procFsStat)
+        {
+            int pid = procFsStat.pid;
+
+            ProcessInfo pi = new ProcessInfo()
             {
-                // Between the time that we get an ID and the time that we try to read the associated stat
-                // file(s), the process could be gone.
-                return null;
-            }
+                ProcessId = pid,
+                ProcessName = procFsStat.comm,
+                BasePriority = (int)procFsStat.nice,
+                VirtualBytes = (long)procFsStat.vsize,
+                WorkingSet = procFsStat.rss,
+                SessionId = procFsStat.session,
+
+                // We don't currently fill in the other values.
+                // A few of these could probably be filled in from getrusage,
+                // but only for the current process or its children, not for
+                // arbitrary other processes.
+            };
 
             // Then read through /proc/pid/task/ to find each thread in the process...
-            try
+            string tasksDir = Interop.procfs.GetTaskDirectoryPathForProcess(pid);
+            foreach (string taskDir in Directory.EnumerateDirectories(tasksDir))
             {
-                string tasksDir = Interop.procfs.GetTaskDirectoryPathForProcess(pid);
-                foreach (string taskDir in Directory.EnumerateDirectories(tasksDir))
+                // ...and read its associated /proc/pid/task/tid/stat file to create a ThreadInfo
+                string dirName = Path.GetFileName(taskDir);
+                int tid;
+                Interop.procfs.ParsedStat stat;
+                if (int.TryParse(dirName, NumberStyles.Integer, CultureInfo.InvariantCulture, out tid) &&
+                    Interop.procfs.TryReadStatFile(pid, tid, out stat))
                 {
-                    string dirName = Path.GetFileName(taskDir);
-                    int tid;
-                    if (int.TryParse(dirName, NumberStyles.Integer, CultureInfo.InvariantCulture, out tid))
+                    pi._threadInfoList.Add(new ThreadInfo
                     {
-                        // ...and read its associated /proc/pid/task/tid/stat file to create a ThreadInfo
-                        Interop.procfs.ParsedStat stat = Interop.procfs.ReadStatFile(pid, tid);
-                        pi._threadInfoList.Add(new ThreadInfo
-                        {
-                            _processId = pid,
-                            _threadId = (ulong)tid,
-                            _basePriority = pi.BasePriority,
-                            _currentPriority = (int)stat.nice,
-                            _startAddress = (IntPtr)stat.startstack,
-                            _threadState = ProcFsStateToThreadState(stat.state),
-                            _threadWaitReason = ThreadWaitReason.Unknown
-                        });
-                    }
+                        _processId = pid,
+                        _threadId = (ulong)tid,
+                        _basePriority = pi.BasePriority,
+                        _currentPriority = (int)stat.nice,
+                        _startAddress = (IntPtr)stat.startstack,
+                        _threadState = ProcFsStateToThreadState(stat.state),
+                        _threadWaitReason = ThreadWaitReason.Unknown
+                    });
                 }
             }
-            catch (IOException) { } // process and/or threads may go away by the time we try to read from them
 
             // Finally return what we've built up
             return pi;
@@ -137,6 +125,23 @@ namespace System.Diagnostics
         // ----------------------------------
         // ---- Unix PAL layer ends here ----
         // ----------------------------------
+
+        /// <summary>Enumerates the IDs of all processes on the current machine.</summary>
+        internal static IEnumerable<int> EnumerateProcessIds()
+        {
+            // Parse /proc for any directory that's named with a number.  Each such
+            // directory represents a process.
+            foreach (string procDir in Directory.EnumerateDirectories(Interop.procfs.RootPath))
+            {
+                string dirName = Path.GetFileName(procDir);
+                int pid;
+                if (int.TryParse(dirName, NumberStyles.Integer, CultureInfo.InvariantCulture, out pid))
+                {
+                    Debug.Assert(pid >= 0);
+                    yield return pid;
+                }
+            }
+        }
 
         /// <summary>Gets a ThreadState to represent the value returned from the status field of /proc/pid/stat.</summary>
         /// <param name="c">The status field value.</param>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -14,6 +14,28 @@ namespace System.Diagnostics
             return Interop.libproc.proc_listallpids();
         }
 
+        /// <summary>Gets process infos for each process on the specified machine.</summary>
+        /// <param name="machineName">The target machine.</param>
+        /// <returns>An array of process infos, one per found process.</returns>
+        public static ProcessInfo[] GetProcessInfos(string machineName)
+        {
+            ThrowIfRemoteMachine(machineName);
+            int[] procIds = GetProcessIds(machineName);
+
+            // Iterate through all process IDs to load information about each process
+            var processes = new List<ProcessInfo>(procIds.Length);
+            foreach (int pid in procIds)
+            {
+                ProcessInfo pi = CreateProcessInfo(pid);
+                if (pi != null)
+                {
+                    processes.Add(pi);
+                }
+            }
+
+            return processes.ToArray();
+        }
+
         // -----------------------------
         // ---- PAL layer ends here ----
         // -----------------------------

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -91,7 +91,7 @@ namespace System.Diagnostics
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        private static void ThrowIfRemoteMachine(string machineName)
+        internal static void ThrowIfRemoteMachine(string machineName)
         {
             if (IsRemoteMachine(machineName))
             {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
+using System.Text;
 
 namespace System.Diagnostics
 {
@@ -36,28 +37,6 @@ namespace System.Diagnostics
         {
             ThrowIfRemoteMachine(machineName);
             return CreateProcessInfo(processId);
-        }
-
-        /// <summary>Gets process infos for each process on the specified machine.</summary>
-        /// <param name="machineName">The target machine.</param>
-        /// <returns>An array of process infos, one per found process.</returns>
-        public static ProcessInfo[] GetProcessInfos(string machineName)
-        {
-            ThrowIfRemoteMachine(machineName);
-            int[] procIds = GetProcessIds(machineName);
-
-            // Iterate through all process IDs to load information about each process
-            var processes = new List<ProcessInfo>(procIds.Length);
-            foreach (int pid in procIds)
-            {
-                ProcessInfo pi = CreateProcessInfo(pid);
-                if (pi != null)
-                {
-                    processes.Add(pi);
-                }
-            }
-
-            return processes.ToArray();
         }
 
         /// <summary>Gets the IDs of all processes on the specified machine.</summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 namespace System.Diagnostics
 {
     public partial class ProcessThread
@@ -77,7 +79,12 @@ namespace System.Diagnostics
 
         private Interop.procfs.ParsedStat GetStat()
         {
-            return Interop.procfs.ReadStatFile(pid: _processId, tid: Id);
+            Interop.procfs.ParsedStat stat;
+            if (!Interop.procfs.TryReadStatFile(pid: _processId, tid: Id, result: out stat))
+            {
+                throw new Win32Exception(SR.ProcessInformationUnavailable);
+            }
+            return stat;
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Text;
 
 namespace System.Diagnostics
 {
@@ -80,7 +81,7 @@ namespace System.Diagnostics
         private Interop.procfs.ParsedStat GetStat()
         {
             Interop.procfs.ParsedStat stat;
-            if (!Interop.procfs.TryReadStatFile(pid: _processId, tid: Id, result: out stat))
+            if (!Interop.procfs.TryReadStatFile(pid: _processId, tid: Id, result: out stat, reusableReader: new ReusableTextReader(Encoding.UTF8)))
             {
                 throw new Win32Exception(SR.ProcessInformationUnavailable);
             }


### PR DESCRIPTION
On Linux we parse procfs to get information about the various processes on the system.  With our current implementation, this is significantly slower for an operation like Process.GetProcessesByName than that same operation on Windows.

Some of this is due to the core source of the information and needing to enumerate directories and open/read/close procfs files to get at the information for the processes; not much we can do about that.  However, a large chunk of it is due simply to the implementation, which we can fix.  This PR fixes the implementation to significantly lessen the gap.  For a test that does Process.GetProcessesByName and that will return just a couple of processes, this improves throughput by ~6x and reduces gen0 GCs by ~24x.  It's still ~2x slower on my Linux VM than it is on my Windows host, but my Linux VM also has about 50% more active processes than does my Windows host.

Three primary sets of changes divided into three commits:
- We previously enumerated all of the threads for a process prior to filtering by the specified name.  Now we delay doing that enumeration and associated processing until we know the process is going to match the filter.
- We use a StringParser type to parse the files in procfs.  We currently extract primitive types by first getting a substring and then parsing that substring; with this change, we do the parsing without first extracting the string.
- We currently read each file from procfs using File.ReadAllText.  Since we're doing this many times as part of the same operaiton, I added a simple reusable stream reader that lets us cache and reuse most of the objects involved in ReadAllText.

Fixes #3505
cc: @ianhays, @pallavit, @mellinoe, @ellismg