### PR TITLE
Implement AesCng and TripleDESCng

### DIFF
--- a/src/Common/src/Internal/Cryptography/BasicSymmetricCipher.cs
+++ b/src/Common/src/Internal/Cryptography/BasicSymmetricCipher.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    // 
+    // Represents a symmetric reusable cipher encryptor or decryptor. Underlying technology may be CNG or OpenSSL or anything else.
+    // The key, IV, chaining mode, blocksize and direction of encryption are all locked in when the BasicSymmetricCipher is instantiated.
+    //
+    //  - Performs no padding. Padding is done by a higher-level layer.
+    //
+    //  - Transform and TransformFinal only accept blocks whose sizes are a multiple of the crypto algorithms block size.
+    //
+    //  - Transform() can do in-place encryption/decryption (input and output referencing the same array.) 
+    //
+    //  - TransformFinal() resets the object for reuse.
+    // 
+    internal abstract class BasicSymmetricCipher : IDisposable
+    {
+        protected BasicSymmetricCipher(byte[] iv, int blockSizeInBytes)
+        {
+            IV = iv;
+            BlockSizeInBytes = blockSizeInBytes;
+        }
+
+        public abstract int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset);
+
+        public abstract byte[] TransformFinal(byte[] input, int inputOffset, int count);
+
+        public int BlockSizeInBytes { get; private set; }
+
+        public virtual void Dispose()
+        {
+            if (IV != null)
+            {
+                Array.Clear(IV, 0, IV.Length);
+                IV = null;
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        protected byte[] IV { get; private set; }
+    }
+}

--- a/src/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    //
+    // A cross-platform ICryptoTransform implementation for decryption. 
+    //
+    //  - Implements the various padding algorithms (as we support padding algorithms that the underlying native apis don't.)
+    //
+    //  - Parameterized by a BasicSymmetricCipher which encapsulates the algorithm, key, IV, chaining mode, direction of encryption
+    //    and the underlying native apis implementing the encryption.
+    //
+    internal sealed class UniversalCryptoDecryptor : UniversalCryptoTransform
+    {
+        public UniversalCryptoDecryptor(PaddingMode paddingMode, BasicSymmetricCipher basicSymmetricCipher)
+            : base(paddingMode, basicSymmetricCipher)
+        {
+        }
+
+        protected sealed override int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            //
+            // If we're decrypting, it's possible to be called with the last blocks of the data, and then
+            // have TransformFinalBlock called with an empty array. Since we don't know if this is the case,
+            // we won't decrypt the last block of the input until either TransformBlock or
+            // TransformFinalBlock is next called.
+            //
+            // We don't need to do this for PaddingMode.None because there is no padding to strip, and
+            // we also don't do this for PaddingMode.Zeros since there is no way for us to tell if the
+            // zeros at the end of a block are part of the plaintext or the padding.
+            //
+            int decryptedBytes = 0;
+            if (DepaddingRequired)
+            {
+                // If we have data saved from a previous call, decrypt that into the output first
+                if (_heldoverCipher != null)
+                {
+                    int depadDecryptLength = BasicSymmetricCipher.Transform(_heldoverCipher, 0, _heldoverCipher.Length, outputBuffer, outputOffset);
+                    outputOffset += depadDecryptLength;
+                    decryptedBytes += depadDecryptLength;
+                }
+                else
+                {
+                    _heldoverCipher = new byte[InputBlockSize];
+                }
+
+                // Postpone the last block to the next round.
+                Debug.Assert(inputCount >= _heldoverCipher.Length, "inputCount >= _heldoverCipher.Length");
+                int startOfLastBlock = inputOffset + inputCount - _heldoverCipher.Length;
+                Buffer.BlockCopy(inputBuffer, startOfLastBlock, _heldoverCipher, 0, _heldoverCipher.Length);
+                inputCount -= _heldoverCipher.Length;
+                Debug.Assert(inputCount % InputBlockSize == 0, "Did not remove whole blocks for depadding");
+            }
+
+            if (inputCount > 0)
+            {
+                decryptedBytes += BasicSymmetricCipher.Transform(inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset);
+            }
+
+            return decryptedBytes;
+        }
+
+        protected sealed override byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            // We can't complete decryption on a partial block
+            if (inputCount % InputBlockSize != 0)
+                throw new CryptographicException(SR.Cryptography_PartialBlock);
+
+            //
+            // If we have postponed cipher bits from the prior round, copy that into the decryption buffer followed by the input data.
+            // Otherwise the decryption buffer is just the input data.
+            //
+
+            byte[] ciphertext = null;
+
+            if (_heldoverCipher == null)
+            {
+                ciphertext = new byte[inputCount];
+                Buffer.BlockCopy(inputBuffer, inputOffset, ciphertext, 0, inputCount);
+            }
+            else
+            {
+                ciphertext = new byte[_heldoverCipher.Length + inputCount];
+                Buffer.BlockCopy(_heldoverCipher, 0, ciphertext, 0, _heldoverCipher.Length);
+                Buffer.BlockCopy(inputBuffer, inputOffset, ciphertext, _heldoverCipher.Length, inputCount);
+            }
+
+            // Decrypt the data, then strip the padding to get the final decrypted data. Note that even if the cipherText length is 0, we must
+            // invoke TransformFinal() so that the cipher object knows to reset for the next cipher operation.
+            byte[] decryptedBytes = BasicSymmetricCipher.TransformFinal(ciphertext, 0, ciphertext.Length);
+            byte[] outputData;
+            if (ciphertext.Length > 0)
+            {
+                outputData = DepadBlock(decryptedBytes, 0, decryptedBytes.Length);
+            }
+            else
+            {
+                outputData = Array.Empty<byte>();
+            }
+
+            Reset();
+            return outputData;
+        }
+
+        protected sealed override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                byte[] heldoverCipher = _heldoverCipher;
+                _heldoverCipher = null;
+                if (heldoverCipher != null)
+                {
+                    Array.Clear(heldoverCipher, 0, heldoverCipher.Length);
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void Reset()
+        {
+            if (_heldoverCipher != null)
+            {
+                Array.Clear(_heldoverCipher, 0, _heldoverCipher.Length);
+                _heldoverCipher = null;
+            }
+        }
+
+        private bool DepaddingRequired
+        {
+            get
+            {
+                // Aes automatically strips padding after decryption when PKCS7 padding is in effect.
+                // It does not do so when PaddingMode.Zeroes in effect as that padding mode is not sufficiently
+                // self-describing to do the operation safely.
+                return PaddingMode == PaddingMode.PKCS7;
+            }
+        }
+
+        /// <summary>
+        ///     Remove the padding from the last blocks being decrypted
+        /// </summary>
+        private byte[] DepadBlock(byte[] block, int offset, int count)
+        {
+            Debug.Assert(block != null && count >= block.Length - offset);
+            Debug.Assert(0 <= offset);
+            Debug.Assert(0 <= count);
+
+            int padBytes = 0;
+
+            // See PadBlock for a description of the padding modes.
+            switch (PaddingMode)
+            {
+                case PaddingMode.PKCS7:
+                    padBytes = block[offset + count - 1];
+
+                    // Verify the amount of padding is reasonable
+                    if (padBytes <= 0 || padBytes > InputBlockSize)
+                        throw new CryptographicException(SR.Cryptography_InvalidPadding);
+
+                    // Verify all the padding bytes match the amount of padding
+                    for (int i = offset + count - padBytes; i < offset + count; i++)
+                    {
+                        if (block[i] != padBytes)
+                            throw new CryptographicException(SR.Cryptography_InvalidPadding);
+                    }
+
+                    break;
+
+                // We cannot remove Zeros padding because we don't know if the zeros at the end of the block
+                // belong to the padding or the plaintext itself.
+                case PaddingMode.Zeros:
+                case PaddingMode.None:
+                    padBytes = 0;
+                    break;
+
+                default:
+                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
+            }
+
+            // Copy everything but the padding to the output
+            byte[] depadded = new byte[count - padBytes];
+            Buffer.BlockCopy(block, offset, depadded, 0, depadded.Length);
+            return depadded;
+        }
+
+        //
+        // For padding modes that support automatic depadding, TransformBlock() leaves the last block it is given undone since it has no way of knowing
+        // whether this is the final block that needs depadding. This block is held (in encrypted form) in _heldoverCipher. The next call to TransformBlock
+        // or TransformFinalBlock must include the decryption of _heldoverCipher in the results.
+        //
+        private byte[] _heldoverCipher;
+    }
+}

--- a/src/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    //
+    // A cross-platform ICryptoTransform implementation for encryption. 
+    //
+    //  - Implements the various padding algorithms (as we support padding algorithms that the underlying native apis don't.)
+    //
+    //  - Parameterized by a BasicSymmetricCipher which encapsulates the algorithm, key, IV, chaining mode, direction of encryption
+    //    and the underlying native apis implementing the encryption.
+    //
+    internal sealed class UniversalCryptoEncryptor : UniversalCryptoTransform
+    {
+        public UniversalCryptoEncryptor(PaddingMode paddingMode, BasicSymmetricCipher basicSymmetricCipher)
+            : base(paddingMode, basicSymmetricCipher)
+        {
+        }
+
+        protected sealed override int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            return BasicSymmetricCipher.Transform(inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset);
+        }
+
+        protected sealed override byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            byte[] paddedBlock = PadBlock(inputBuffer, inputOffset, inputCount);
+            byte[] output = BasicSymmetricCipher.TransformFinal(paddedBlock, 0, paddedBlock.Length);
+            return output;
+        }
+
+        private byte[] PadBlock(byte[] block, int offset, int count)
+        {
+            byte[] result;
+            int padBytes = InputBlockSize - (count % InputBlockSize);
+
+            switch (PaddingMode)
+            {
+                case PaddingMode.None:
+                    if (count % InputBlockSize != 0)
+                        throw new CryptographicException(SR.Cryptography_PartialBlock);
+
+                    result = new byte[count];
+                    Buffer.BlockCopy(block, offset, result, 0, result.Length);
+                    break;
+
+                // PKCS padding fills the blocks up with bytes containing the total number of padding bytes
+                // used, adding an extra block if the last block is complete.
+                //
+                // xx xx 06 06 06 06 06 06
+                case PaddingMode.PKCS7:
+                    result = new byte[count + padBytes];
+                    Buffer.BlockCopy(block, offset, result, 0, count);
+
+                    for (int i = count; i < result.Length; i++)
+                    {
+                        result[i] = (byte)padBytes;
+                    }
+                    break;
+
+                // Zeros padding fills the last partial block with zeros, and does not add a new block to
+                // the end if the last block is already complete.
+                //
+                //  xx 00 00 00 00 00 00 00
+                case PaddingMode.Zeros:
+                    if (padBytes == InputBlockSize)
+                    {
+                        padBytes = 0;
+                    }
+
+                    result = new byte[count + padBytes];
+                    Buffer.BlockCopy(block, offset, result, 0, count);
+                    break;
+
+                default:
+                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
+++ b/src/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    //
+    // The common base class for the cross-platform CreateEncryptor()/CreateDecryptor() implementations. 
+    //
+    //  - Implements the various padding algorithms (as we support padding algorithms that the underlying native apis don't.)
+    //
+    //  - Parameterized by a BasicSymmetricCipher which encapsulates the algorithm, key, IV, chaining mode, direction of encryption
+    //    and the underlying native apis implementing the encryption.
+    //
+    internal abstract class UniversalCryptoTransform : ICryptoTransform
+    {
+        public static ICryptoTransform Create(PaddingMode paddingMode, BasicSymmetricCipher cipher, bool encrypting)
+        {
+            if (encrypting)
+                return new UniversalCryptoEncryptor(paddingMode, cipher);
+            else
+                return new UniversalCryptoDecryptor(paddingMode, cipher);
+        }
+
+        protected UniversalCryptoTransform(PaddingMode paddingMode, BasicSymmetricCipher basicSymmetricCipher)
+        {
+            PaddingMode = paddingMode;
+            BasicSymmetricCipher = basicSymmetricCipher;
+        }
+
+        public bool CanReuseTransform
+        {
+            get { return true; }
+        }
+
+        public bool CanTransformMultipleBlocks
+        {
+            get { return true; }
+        }
+
+        public int InputBlockSize
+        {
+            get { return BasicSymmetricCipher.BlockSizeInBytes; }
+        }
+
+        public int OutputBlockSize
+        {
+            get { return BasicSymmetricCipher.BlockSizeInBytes; }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            if (inputBuffer == null)
+                throw new ArgumentNullException("inputBuffer");
+            if (inputOffset < 0)
+                throw new ArgumentOutOfRangeException("inputOffset");
+            if (inputOffset > inputBuffer.Length)
+                throw new ArgumentOutOfRangeException("inputOffset");
+            if (inputCount <= 0)
+                throw new ArgumentOutOfRangeException("inputCount");
+            if (inputCount % InputBlockSize != 0)
+                throw new ArgumentOutOfRangeException("inputCount", SR.Cryptography_MustTransformWholeBlock);
+            if (inputCount > inputBuffer.Length - inputOffset)
+                throw new ArgumentOutOfRangeException("inputCount", SR.Cryptography_TransformBeyondEndOfBuffer);
+            if (outputBuffer == null)
+                throw new ArgumentNullException("outputBuffer");
+            if (outputOffset > outputBuffer.Length)
+                throw new ArgumentOutOfRangeException("outputOffset");
+            if (inputCount > outputBuffer.Length - outputOffset)
+                throw new ArgumentOutOfRangeException("outputOffset", SR.Cryptography_TransformBeyondEndOfBuffer);
+            
+            int numBytesWritten = UncheckedTransformBlock(inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset);
+            Debug.Assert(numBytesWritten >= 0 && numBytesWritten <= inputCount);
+            return numBytesWritten;
+        }
+
+        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            if (inputBuffer == null)
+                throw new ArgumentNullException("inputBuffer");
+            if (inputOffset < 0)
+                throw new ArgumentOutOfRangeException("inputOffset");
+            if (inputCount < 0)
+                throw new ArgumentOutOfRangeException("inputCount");
+            if (inputOffset > inputBuffer.Length)
+                throw new ArgumentOutOfRangeException("inputOffset");
+            if (inputCount > inputBuffer.Length - inputOffset)
+                throw new ArgumentOutOfRangeException("inputCount", SR.Cryptography_TransformBeyondEndOfBuffer);
+
+            byte[] output = UncheckedTransformFinalBlock(inputBuffer, inputOffset, inputCount);
+            return output;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                BasicSymmetricCipher.Dispose();
+            }
+        }
+
+        protected abstract int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset);
+        protected abstract byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount);
+
+        protected PaddingMode PaddingMode { get; private set; }
+        protected BasicSymmetricCipher BasicSymmetricCipher { get; private set; }
+    }
+}
+

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptChainingModes.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptChainingModes.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class BCrypt
+    {
+        internal const string BCRYPT_CHAIN_MODE_CBC = "ChainingModeCBC";
+        internal const string BCRYPT_CHAIN_MODE_ECB = "ChainingModeECB";
+    }
+}
+

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptKeyDataBlob.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptKeyDataBlob.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class BCrypt
+    {
+        internal const int BCRYPT_KEY_DATA_BLOB_MAGIC = 0x4d42444b; // 'KDBM'
+        internal const int BCRYPT_KEY_DATA_BLOB_VERSION1 = 1;
+    }
+}
+

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.NCryptAlgorithms.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.NCryptAlgorithms.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class NCrypt
+    {
+        internal const string NCRYPT_3DES_ALGORITHM = "3DES";
+        internal const string NCRYPT_AES_ALGORITHM = "AES";
+    }
+}
+

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.NCryptCipherKeyBlob.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.NCryptCipherKeyBlob.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class NCrypt
+    {
+        internal const string NCRYPT_CIPHER_KEY_BLOB = "CipherKeyBlob";
+        internal const int NCRYPT_CIPHER_KEY_BLOB_MAGIC = 0x52485043;  //'CPHR'
+    }
+}

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.NCryptPropertyNames.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.NCryptPropertyNames.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class NCrypt
+    {
+        internal const string NCRYPT_CHAINING_MODE_PROPERTY = "Chaining Mode";
+        internal const string NCRYPT_INITIALIZATION_VECTOR = "IV";
+    }
+}
+

--- a/src/Common/tests/Cryptography/AlgorithmImplementations/AES/AesCornerTests.cs
+++ b/src/Common/tests/Cryptography/AlgorithmImplementations/AES/AesCornerTests.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Aes.Tests
+{
+    using Aes = System.Security.Cryptography.Aes;
+
+    public static class AesCornerTests
+    {
+        [Fact]
+        public static void EncryptorReusability()
+        {
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "f238882f6530ae9191c294868feed0b0df4058b322377dec14690c3b6bbf6ad1dd5b7c063a28e2cca2a6dce8cc2e668ea6ce80cee4c1a1a955ff46c530f3801b".HexToByteArray();
+            // CBC, Padding.None
+            byte[] expectedCipher = "7c6e1bcd3c30d2fb2d92e3346048307dc6719a6b96a945b4d987af09469ec68f5ca535fab7f596fffa80f7cfaeb26eefaf8d4ca8be190393b2569249d673f042".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.None;
+
+                ICryptoTransform encryptor = a.CreateEncryptor();
+                Assert.True(encryptor.CanReuseTransform);
+
+                for (int i = 0; i < 4; i++)
+                {
+                    byte[] cipher = encryptor.Transform(plainText, 1);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+            }
+        }
+
+        [Fact]
+        [ActiveIssue(1965, PlatformID.AnyUnix)]
+        public static void TransformStateSeparation()
+        {
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "f238882f6530ae9191c294868feed0b0df4058b322377dec14690c3b6bbf6ad1dd5b7c063a28e2cca2a6dce8cc2e668ea6ce80cee4c1a1a955ff46c530f3801b".HexToByteArray();
+            // CBC, Padding.None
+            byte[] cipher = "7c6e1bcd3c30d2fb2d92e3346048307dc6719a6b96a945b4d987af09469ec68f5ca535fab7f596fffa80f7cfaeb26eefaf8d4ca8be190393b2569249d673f042".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.None;
+
+                // To ensure that each ICryptoTransform maintains an independent encryption state, we'll create two encryptors and two decryptors. 
+                // Then we'll feed them one block each in an interleaved fashion. At the end, they'd better still come up with the correct result.
+
+                MemoryStream plain1 = new MemoryStream(plainText);
+                MemoryStream plain2 = new MemoryStream(plainText);
+                MemoryStream cipher1 = new MemoryStream(cipher);
+                MemoryStream cipher2 = new MemoryStream(cipher);
+
+                ICryptoTransform encryptor1 = a.CreateEncryptor();
+                ICryptoTransform encryptor2 = a.CreateEncryptor();
+                ICryptoTransform decryptor1 = a.CreateDecryptor();
+                ICryptoTransform decryptor2 = a.CreateDecryptor();
+
+                List<byte> encryptionCollector1 = new List<byte>();
+                List<byte> encryptionCollector2 = new List<byte>();
+                List<byte> decryptionCollector1 = new List<byte>();
+                List<byte> decryptionCollector2 = new List<byte>();
+
+                int blockSize = a.BlockSize / 8;
+
+                encryptionCollector1.Collect(encryptor1, plain1, 1 * blockSize);
+                encryptionCollector2.Collect(encryptor2, plain2, 1 * blockSize);
+                encryptionCollector1.Collect(encryptor1, plain1, 1 * blockSize);
+                decryptionCollector1.Collect(decryptor1, cipher1, 1 * blockSize);
+                decryptionCollector2.Collect(decryptor2, cipher2, 1 * blockSize);
+                decryptionCollector2.Collect(decryptor2, cipher2, 1 * blockSize);
+                encryptionCollector1.Collect(encryptor1, plain1, 1 * blockSize);
+                decryptionCollector1.Collect(decryptor1, cipher1, 1 * blockSize);
+                decryptionCollector2.Collect(decryptor2, cipher2, 1 * blockSize);
+                decryptionCollector2.Collect(decryptor2, cipher2, 1 * blockSize);
+                encryptionCollector2.Collect(encryptor2, plain2, 1 * blockSize);
+                decryptionCollector1.Collect(decryptor1, cipher1, 1 * blockSize);
+                decryptionCollector2.AddRange(decryptor2.TransformFinalBlock(new byte[0], 0, 0));
+                decryptionCollector1.Collect(decryptor1, cipher1, 1 * blockSize);
+                encryptionCollector2.Collect(encryptor2, plain2, 1 * blockSize);
+                decryptionCollector1.AddRange(decryptor1.TransformFinalBlock(new byte[0], 0, 0));
+                encryptionCollector1.Collect(encryptor1, plain1, 1 * blockSize);
+                encryptionCollector1.AddRange(encryptor1.TransformFinalBlock(new byte[0], 0, 0));
+                encryptionCollector2.Collect(encryptor2, plain2, 1 * blockSize);
+                encryptionCollector2.AddRange(encryptor2.TransformFinalBlock(new byte[0], 0, 0));
+
+                Assert.Equal<byte>(cipher, encryptionCollector1.ToArray());
+                Assert.Equal<byte>(cipher, encryptionCollector2.ToArray());
+                Assert.Equal<byte>(plainText, decryptionCollector1.ToArray());
+                Assert.Equal<byte>(plainText, decryptionCollector2.ToArray());
+            }
+        }
+
+        private static void Collect(this List<byte> l, ICryptoTransform transform, Stream input, int count)
+        {
+            byte[] buffer = new byte[count];
+            int numRead = input.Read(buffer, 0, count);
+            Assert.Equal(count, numRead);
+            int numBytesWritten = transform.TransformBlock(buffer, 0, count, buffer, 0);
+            Array.Resize(ref buffer, numBytesWritten);
+            l.AddRange(buffer);
+            return;
+        }
+
+        [Fact]
+        public static void MultipleBlockTransformNoPad()
+        {
+            // Ensure that multiple blocks can be transformed with one call (the no padding code path)
+
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "f238882f6530ae9191c294868feed0b0df4058b322377dec14690c3b6bbf6ad1dd5b7c063a28e2cca2a6dce8cc2e668ea6ce80cee4c1a1a955ff46c530f3801b".HexToByteArray();
+            // CBC, Padding.None
+            byte[] expectedCipher = "7c6e1bcd3c30d2fb2d92e3346048307dc6719a6b96a945b4d987af09469ec68f5ca535fab7f596fffa80f7cfaeb26eefaf8d4ca8be190393b2569249d673f042".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.None;
+
+                using (ICryptoTransform encryptor = a.CreateEncryptor())
+                {
+                    Assert.True(encryptor.CanTransformMultipleBlocks);
+                    byte[] cipher = encryptor.Transform(plainText, blockSizeMultipler: 2);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+
+                using (ICryptoTransform decryptor = a.CreateDecryptor())
+                {
+                    Assert.True(decryptor.CanTransformMultipleBlocks);
+                    byte[] decrypted = decryptor.Transform(expectedCipher, blockSizeMultipler: 2);
+                    Assert.Equal<byte>(plainText, decrypted);
+                }
+            }
+        }
+
+        [Fact]
+        public static void MultipleBlockTransformPKCS7()
+        {
+            // Ensure that multiple blocks can be transformed with one call. (the PKCS7 code path)
+
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "f238882f6530ae9191c294868feed0b0df4058b322377dec14690c3b6bbf6ad1dd5b7c063a28e2cca2a6dce8cc2e668ea6ce80cee4c1a1a955ff46c530f3801b".HexToByteArray();
+            // CBC, Padding.PKCS7
+            byte[] expectedCipher = "7c6e1bcd3c30d2fb2d92e3346048307dc6719a6b96a945b4d987af09469ec68f5ca535fab7f596fffa80f7cfaeb26eefaf8d4ca8be190393b2569249d673f042a6a223f1c1069aa1d3c19d6bc454c205".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.PKCS7;
+
+                using (ICryptoTransform encryptor = a.CreateEncryptor())
+                {
+                    Assert.True(encryptor.CanTransformMultipleBlocks);
+                    byte[] cipher = encryptor.Transform(plainText, blockSizeMultipler: 2);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+
+                using (ICryptoTransform decryptor = a.CreateDecryptor())
+                {
+                    Assert.True(decryptor.CanTransformMultipleBlocks);
+                    byte[] decrypted = decryptor.Transform(expectedCipher, blockSizeMultipler: 2);
+                    Assert.Equal<byte>(plainText, decrypted);
+                }
+            }
+        }
+
+        [Fact]
+        public static void FinalOnlyTransformNoPad()
+        {
+            // Use no TransformBlock calls() - do the entire transform using only TransformFinalBlock().
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "f238882f6530ae9191c294868feed0b0df4058b322377dec14690c3b6bbf6ad1dd5b7c063a28e2cca2a6dce8cc2e668ea6ce80cee4c1a1a955ff46c530f3801b".HexToByteArray();
+            // CBC, Padding.None
+            byte[] expectedCipher = "7c6e1bcd3c30d2fb2d92e3346048307dc6719a6b96a945b4d987af09469ec68f5ca535fab7f596fffa80f7cfaeb26eefaf8d4ca8be190393b2569249d673f042".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.None;
+
+                using (ICryptoTransform encryptor = a.CreateEncryptor())
+                {
+                    Assert.True(encryptor.CanTransformMultipleBlocks);
+                    byte[] cipher = encryptor.TransformFinalBlock(plainText, 0, plainText.Length);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+
+                using (ICryptoTransform decryptor = a.CreateDecryptor())
+                {
+                    Assert.True(decryptor.CanTransformMultipleBlocks);
+                    byte[] decrypted = decryptor.TransformFinalBlock(expectedCipher, 0, expectedCipher.Length);
+                    Assert.Equal<byte>(plainText, decrypted);
+                }
+            }
+        }
+
+        [Fact]
+        public static void FinalOnlyTransformPKCS7()
+        {
+            // Use no TransformBlock calls() - do the entire transform using only TransformFinalBlock().
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "f238882f6530ae9191c294868feed0b0df4058b322377dec14690c3b6bbf6ad1dd5b7c063a28e2cca2a6dce8cc2e668ea6ce80cee4c1a1a955ff46c530f3801b".HexToByteArray();
+            // CBC, Padding.PKCS7
+            byte[] expectedCipher = "7c6e1bcd3c30d2fb2d92e3346048307dc6719a6b96a945b4d987af09469ec68f5ca535fab7f596fffa80f7cfaeb26eefaf8d4ca8be190393b2569249d673f042a6a223f1c1069aa1d3c19d6bc454c205".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.PKCS7;
+
+                using (ICryptoTransform encryptor = a.CreateEncryptor())
+                {
+                    Assert.True(encryptor.CanTransformMultipleBlocks);
+                    byte[] cipher = encryptor.TransformFinalBlock(plainText, 0, plainText.Length);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+
+                using (ICryptoTransform decryptor = a.CreateDecryptor())
+                {
+                    Assert.True(decryptor.CanTransformMultipleBlocks);
+                    byte[] decrypted = decryptor.TransformFinalBlock(expectedCipher, 0, expectedCipher.Length);
+                    Assert.Equal<byte>(plainText, decrypted);
+                }
+            }
+        }
+
+        [Fact]
+        public static void ZeroLengthTransformNoPad()
+        {
+            // Use no TransformBlock calls() - do the entire transform using only TransformFinalBlock().
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "".HexToByteArray();
+            // CBC, Padding.None
+            byte[] expectedCipher = "".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.None;
+
+                using (ICryptoTransform encryptor = a.CreateEncryptor())
+                {
+                    Assert.True(encryptor.CanTransformMultipleBlocks);
+                    byte[] cipher = encryptor.TransformFinalBlock(plainText, 0, plainText.Length);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+
+                using (ICryptoTransform decryptor = a.CreateDecryptor())
+                {
+                    Assert.True(decryptor.CanTransformMultipleBlocks);
+                    byte[] decrypted = decryptor.TransformFinalBlock(expectedCipher, 0, expectedCipher.Length);
+                    Assert.Equal<byte>(plainText, decrypted);
+                }
+            }
+        }
+
+        [Fact]
+        public static void ZeroLengthTransformPKCS7()
+        {
+            // Use no TransformBlock calls() - do the entire transform using only TransformFinalBlock().
+            byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();
+            byte[] iv = "47d1e060ba3c8643f9f8b65feeda4b30".HexToByteArray();
+
+            byte[] plainText = "".HexToByteArray();
+            // CBC, Padding.PKCS7
+            byte[] expectedCipher = "d5450767bcc31793fe5065251b96b715".HexToByteArray();
+
+            using (Aes a = Aes.Create())
+            {
+                a.Key = key;
+                a.IV = iv;
+                a.Mode = CipherMode.CBC;
+                a.Padding = PaddingMode.PKCS7;
+
+                using (ICryptoTransform encryptor = a.CreateEncryptor())
+                {
+                    Assert.True(encryptor.CanTransformMultipleBlocks);
+                    byte[] cipher = encryptor.TransformFinalBlock(plainText, 0, plainText.Length);
+                    Assert.Equal<byte>(expectedCipher, cipher);
+                }
+
+                using (ICryptoTransform decryptor = a.CreateDecryptor())
+                {
+                    Assert.True(decryptor.CanTransformMultipleBlocks);
+                    byte[] decrypted = decryptor.TransformFinalBlock(expectedCipher, 0, expectedCipher.Length);
+                    Assert.Equal<byte>(plainText, decrypted);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/Common/tests/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.TripleDes.Tests
+{
+    public static class TripleDESCipherTests
+    {
+        [Fact]
+        public static void TripleDESDefaults()
+        {
+            using (TripleDES des = TripleDESFactory.Create())
+            {
+                Assert.Equal(192, des.KeySize);
+                Assert.Equal(64, des.BlockSize);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESRoundTrip192BitsNoneECB()
+        {
+            byte[] key = "c5629363d957054eba793093b83739bb78711db221a82379".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.Padding = PaddingMode.None;
+                alg.Mode = CipherMode.ECB;
+
+                byte[] plainText = "de7d2dddea96b691e979e647dc9d3ca27d7f1ad673ca9570".HexToByteArray();
+                byte[] cipher = alg.Encrypt(plainText);
+                byte[] expectedCipher = "e56f72478c7479d169d54c0548b744af5b53efb1cdd26037".HexToByteArray();
+                Assert.Equal<byte>(expectedCipher, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                byte[] expectedDecrypted = "de7d2dddea96b691e979e647dc9d3ca27d7f1ad673ca9570".HexToByteArray();
+                Assert.Equal<byte>(expectedDecrypted, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESRoundTrip192BitsNoneCBC()
+        {
+            byte[] key = "b43eaf0260813fb47c87ae073a146006d359ad04061eb0e6".HexToByteArray();
+            byte[] iv = "5fbc5bc21b8597d8".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.IV = iv;
+                alg.Padding = PaddingMode.None;
+                alg.Mode = CipherMode.CBC;
+
+                byte[] plainText = "79a86903608e133e020e1dc68c9835250c2f17b0ebeed91b".HexToByteArray();
+                byte[] cipher = alg.Encrypt(plainText);
+                byte[] expectedCipher = "dea36279600f19c602b6ed9bf3ffdac5ebf25c1c470eb61c".HexToByteArray();
+                Assert.Equal<byte>(expectedCipher, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                byte[] expectedDecrypted = "79a86903608e133e020e1dc68c9835250c2f17b0ebeed91b".HexToByteArray();
+                Assert.Equal<byte>(expectedDecrypted, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESRoundTrip192BitsZerosECB()
+        {
+            byte[] key = "9da5b265179d65f634dfc95513f25094411e51bb3be877ef".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.Padding = PaddingMode.Zeros;
+                alg.Mode = CipherMode.ECB;
+
+                byte[] plainText = "77a8b2efb45addb38d7ef3aa9e6ab5d71957445ab8".HexToByteArray();
+                byte[] cipher = alg.Encrypt(plainText);
+                byte[] expectedCipher = "149ec32f558b27c7e4151e340d8184f18b4e25d2518f69d9".HexToByteArray();
+                Assert.Equal<byte>(expectedCipher, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                byte[] expectedDecrypted = "77a8b2efb45addb38d7ef3aa9e6ab5d71957445ab8000000".HexToByteArray();
+                Assert.Equal<byte>(expectedDecrypted, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESRoundTrip192BitsZerosCBC()
+        {
+            byte[] key = "5e970c0d2323d53b28fa3de507d6d20f9f0cd97123398b4d".HexToByteArray();
+            byte[] iv = "95498b5bf570f4c8".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.IV = iv;
+                alg.Padding = PaddingMode.Zeros;
+                alg.Mode = CipherMode.CBC;
+
+                byte[] plainText = "f9e9a1385bf3bd056d6a06eac662736891bd3e6837".HexToByteArray();
+                byte[] cipher = alg.Encrypt(plainText);
+                byte[] expectedCipher = "65f3dc211876a9daad238aa7d0c7ed7a3662296faf77dff9".HexToByteArray();
+                Assert.Equal<byte>(expectedCipher, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                byte[] expectedDecrypted = "f9e9a1385bf3bd056d6a06eac662736891bd3e6837000000".HexToByteArray();
+                Assert.Equal<byte>(expectedDecrypted, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESRoundTrip192BitsPKCS7ECB()
+        {
+            byte[] key = "155425f12109cd89378795a4ca337b3264689dca497ba2fa".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.ECB;
+
+                byte[] plainText = "5bd3c4e16a723a17ac60dd0efdb158e269cddfd0fa".HexToByteArray();
+                byte[] cipher = alg.Encrypt(plainText);
+                byte[] expectedCipher = "7b8d982ee0c14821daf1b8cf4e407c2eb328627b696ac36e".HexToByteArray();
+                Assert.Equal<byte>(expectedCipher, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                byte[] expectedDecrypted = "5bd3c4e16a723a17ac60dd0efdb158e269cddfd0fa".HexToByteArray();
+                Assert.Equal<byte>(expectedDecrypted, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESRoundTrip192BitsPKCS7CBC()
+        {
+            byte[] key = "6b42da08f93e819fbd26fce0785b0eec3d0cb6bfa053c505".HexToByteArray();
+            byte[] iv = "8fc67ce5e7f28cde".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.IV = iv;
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.CBC;
+
+                byte[] plainText = "e867f915e275eab27d6951165d26dec6dd0acafcfc".HexToByteArray();
+                byte[] cipher = alg.Encrypt(plainText);
+                byte[] expectedCipher = "446f57875e107702afde16b57eaf250b87b8110bef29af89".HexToByteArray();
+                Assert.Equal<byte>(expectedCipher, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                byte[] expectedDecrypted = "e867f915e275eab27d6951165d26dec6dd0acafcfc".HexToByteArray();
+                Assert.Equal<byte>(expectedDecrypted, decrypted);
+            }
+        }
+    }
+}

--- a/src/Common/tests/Cryptography/AlgorithmImplementations/TripleDES/TripleDESFactory.cs
+++ b/src/Common/tests/Cryptography/AlgorithmImplementations/TripleDES/TripleDESFactory.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.TripleDes.Tests
+{
+    public interface ITripleDESProvider
+    {
+        TripleDES Create();
+    }
+
+    public static partial class TripleDESFactory
+    {
+        public static TripleDES Create()
+        {
+            return s_provider.Create();
+        }
+    }
+}

--- a/src/Common/tests/Cryptography/CryptoUtils.cs
+++ b/src/Common/tests/Cryptography/CryptoUtils.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Cryptography;
+
+namespace Test.Cryptography
+{
+    internal static class CryptoUtils
+    {
+        internal static byte[] Encrypt(this SymmetricAlgorithm alg, byte[] plainText, int blockSizeMultipler = 1)
+        {
+            using (ICryptoTransform encryptor = alg.CreateEncryptor())
+            {
+                return encryptor.Transform(plainText, blockSizeMultipler);
+            }
+        }
+
+        internal static byte[] Decrypt(this SymmetricAlgorithm alg, byte[] cipher, int blockSizeMultipler = 1)
+        {
+            using (ICryptoTransform decryptor = alg.CreateDecryptor())
+            {
+                return decryptor.Transform(cipher, blockSizeMultipler);
+            }
+        }
+
+        internal static byte[] Transform(this ICryptoTransform transform, byte[] input, int blockSizeMultipler = 1)
+        {
+            List<byte> output = new List<byte>(input.Length);
+            int blockSize = transform.InputBlockSize * blockSizeMultipler;
+            for (int i = 0; i <= input.Length; i += blockSize)
+            {
+                int count = Math.Min(blockSize, input.Length - i);
+                if (count >= blockSize)
+                {
+                    byte[] buffer = new byte[blockSize];
+                    int numBytesWritten = transform.TransformBlock(input, i, count, buffer, 0);
+                    Array.Resize(ref buffer, numBytesWritten);
+                    output.AddRange(buffer);
+                }
+                else
+                {
+                    byte[] finalBlock = transform.TransformFinalBlock(input, i, count);
+                    output.AddRange(finalBlock);
+                    break;
+                }
+            }
+
+            return output.ToArray();
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -29,6 +29,9 @@
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesContractTests.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesCornerTests.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesModeTests.cs</Link>
     </Compile>
@@ -63,6 +66,9 @@
     <Compile Include="TripleDesTests.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\ByteUtils.cs">
       <Link>CommonTest\Cryptography\ByteUtils.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\CryptoUtils.cs">
+      <Link>CommonTest\Cryptography\CryptoUtils.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherCng.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+using ErrorCode = Interop.NCrypt.ErrorCode;
+using AsymmetricPaddingMode = Interop.NCrypt.AsymmetricPaddingMode;
+
+namespace Internal.Cryptography
+{
+    internal sealed class BasicSymmetricCipherCng : BasicSymmetricCipher
+    {
+        //
+        // The first parameter is a delegate that instantiates a CngKey rather than a CngKey itself. That's because CngKeys are stateful objects
+        // and concurrent encryptions on the same CngKey will corrupt each other.
+        //
+        // The delegate must instantiate a new CngKey, based on a new underlying NCryptKeyHandle, each time is called.
+        //
+        public BasicSymmetricCipherCng(Func<CngKey> cngKeyFactory, CipherMode cipherMode, int blockSizeInBytes, byte[] iv, bool encrypting)
+            : base(iv, blockSizeInBytes)
+        {
+            _encrypting = encrypting;
+            _cngKey = cngKeyFactory();
+
+            CngProperty chainingModeProperty;
+            switch (cipherMode)
+            {
+                case CipherMode.ECB:
+                    chainingModeProperty = s_ECBMode;
+                    break;
+                case CipherMode.CBC:
+                    chainingModeProperty = s_CBCMode;
+                    break;
+                default:
+                    throw new CryptographicException(SR.Cryptography_InvalidCipherMode);
+            }
+            _cngKey.SetProperty(chainingModeProperty);
+
+            Reset();
+        }
+
+        public sealed override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count > 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert(output != null);
+            Debug.Assert(outputOffset >= 0);
+            Debug.Assert(output.Length - outputOffset >= count);
+
+            unsafe
+            {
+                fixed (byte *pInput = input, pOutput = output)
+                {
+                    int numBytesWritten;
+                    ErrorCode errorCode;
+                    if (_encrypting)
+                    {
+                        errorCode = Interop.NCrypt.NCryptEncrypt(_cngKey.Handle, pInput + inputOffset, count, null, pOutput + outputOffset, count, out numBytesWritten, AsymmetricPaddingMode.None);
+                    }
+                    else
+                    {
+                        errorCode = Interop.NCrypt.NCryptDecrypt(_cngKey.Handle, pInput + inputOffset, count, null, pOutput + outputOffset, count, out numBytesWritten, AsymmetricPaddingMode.None);
+                    }
+                    if (errorCode != ErrorCode.ERROR_SUCCESS)
+                        throw errorCode.ToCryptographicException();
+
+                    if (numBytesWritten != count)
+                    {
+                        // CNG gives us no way to tell NCryptDecrypt() that we're decrypting the final block, nor is it performing any padding/depadding for us.
+                        // So there's no excuse for a provider to hold back output for "future calls." Though this isn't technically our problem to detect, we might as well
+                        // detect it now for easier diagnosis.
+                        throw new CryptographicException(SR.Cryptography_UnexpectedTransformTruncation);
+                    }
+
+                    return numBytesWritten;
+                }
+            }
+        }
+
+        public sealed override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+
+            byte[] output = new byte[count];
+            if (count != 0)
+            {
+                int numBytesWritten = Transform(input, inputOffset, count, output, 0);
+                Debug.Assert(numBytesWritten == count);  // Our implementation of Transform() guarantees this. See comment above.
+            }
+
+            Reset();
+            return output;
+        }
+
+        public sealed override void Dispose()
+        {
+            if (_cngKey != null)
+            {
+                _cngKey.Dispose();
+                _cngKey = null;
+            }
+            base.Dispose();
+        }
+
+        private void Reset()
+        {
+            if (IV != null)
+            {
+                CngProperty prop = new CngProperty(Interop.NCrypt.NCRYPT_INITIALIZATION_VECTOR, IV, CngPropertyOptions.None);
+                _cngKey.SetProperty(prop);
+            }
+        }
+
+        private static CngProperty CreateCngPropertyForCipherMode(string cipherMode)
+        {
+            byte[] cipherModeBytes = Encoding.Unicode.GetBytes((cipherMode + "\0").ToCharArray());
+            return new CngProperty(Interop.NCrypt.NCRYPT_CHAINING_MODE_PROPERTY, cipherModeBytes, CngPropertyOptions.None);
+        }
+
+        private CngKey _cngKey;
+        private readonly bool _encrypting;
+
+        private readonly static CngProperty s_ECBMode = CreateCngPropertyForCipherMode(Interop.BCrypt.BCRYPT_CHAIN_MODE_ECB);
+        private readonly static CngProperty s_CBCMode = CreateCngPropertyForCipherMode(Interop.BCrypt.BCRYPT_CHAIN_MODE_CBC);
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    //
+    // Common infrastructure for crypto symmetric algorithms that use Cng.
+    //
+    internal struct CngSymmetricAlgorithmCore
+    {
+        /// <summary>
+        /// Configures the core to use plaintext keys (to be auto-generated when first needed.)
+        /// </summary>
+        public CngSymmetricAlgorithmCore(string algorithm, ICngSymmetricAlgorithm outer)
+        {
+            _algorithm = algorithm;
+            _outer = outer;
+
+            _keyName = null; // Setting _keyName to null signifies that this object is based on a plaintext key, not a stored CNG key.
+            _provider = null;
+            _optionOptions = CngKeyOpenOptions.None;
+        }
+
+        /// <summary>
+        /// Constructs the core to use a stored CNG key. 
+        /// </summary>
+        public CngSymmetricAlgorithmCore(string algorithm, ICngSymmetricAlgorithm outer, string keyName, CngProvider provider, CngKeyOpenOptions openOptions)
+        {
+            if (keyName == null)
+                throw new ArgumentNullException("keyName");
+            if (provider == null)
+                throw new ArgumentNullException("provider");
+
+            _algorithm = algorithm;
+            _outer = outer;
+
+            _keyName = keyName;
+            _provider = provider;
+            _optionOptions = openOptions;
+
+            using (CngKey cngKey = ProduceCngKey())
+            {
+                CngAlgorithm actualAlgorithm = cngKey.Algorithm;
+                if (algorithm != actualAlgorithm.Algorithm)
+                    throw new CryptographicException(SR.Format(SR.Cryptography_CngKeyWrongAlgorithm, actualAlgorithm.Algorithm, algorithm));
+
+                _outer.BaseKeySize = cngKey.KeySize;
+            }
+        }
+
+        /// <summary>
+        /// Note! This can and likely will throw if the algorithm was given a hardware-based key.
+        /// </summary>
+        public byte[] GetKeyIfExportable()
+        {
+            if (KeyInPlainText)
+            {
+                return _outer.BaseKey;
+            }
+            else
+            {
+                using (CngKey cngKey = ProduceCngKey())
+                {
+                    return cngKey.GetSymmetricKeyDataIfExportable(_algorithm);
+                }
+            }
+        }
+
+        public void SetKey(byte[] key)
+        {
+            _outer.BaseKey = key;
+            _keyName = null; // Setting _keyName to null signifies that this object is now based on a plaintext key, not a stored CNG key.
+        }
+
+        public void SetKeySize(int keySize, ICngSymmetricAlgorithm outer)
+        {
+            // Warning: This gets invoked once before "this" is initialized, due to Aes(), DES(), etc., setting the KeySize property in their
+            // nullary constructor. That's why we require "outer" being passed as parameter.
+            Debug.Assert(_outer == null || _outer == outer);
+
+            outer.BaseKeySize = keySize;
+            _keyName = null; // Setting _keyName to null signifies that this object is now based on a plaintext key, not a stored CNG key.
+        }
+
+        public void GenerateKey()
+        {
+            byte[] key = Helpers.GenerateRandom(_outer.BaseKeySize.BitSizeToByteSize());
+            SetKey(key);
+        }
+
+        public void GenerateIV()
+        {
+            byte[] iv = Helpers.GenerateRandom(_outer.BlockSize.BitSizeToByteSize());
+            _outer.IV = iv;
+        }
+
+        public ICryptoTransform CreateEncryptor()
+        {
+            return CreateCryptoTransform(encrypting: true);
+        }
+
+        public ICryptoTransform CreateDecryptor()
+        {
+            return CreateCryptoTransform(encrypting: false);
+        }
+
+        public ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateCryptoTransform(rgbKey, rgbIV, encrypting: true);
+        }
+
+        public ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateCryptoTransform(rgbKey, rgbIV, encrypting: false);
+        }
+
+        private ICryptoTransform CreateCryptoTransform(bool encrypting)
+        {
+            return CreateCryptoTransformCore(ProduceCngKey, _outer.IV, encrypting);
+        }
+
+        private ICryptoTransform CreateCryptoTransform(byte[] rgbKey, byte[] rgbIV, bool encrypting)
+        {
+            if (rgbKey == null)
+                throw new ArgumentNullException("key");
+
+            byte[] key = rgbKey.CloneByteArray();
+
+            long keySize = key.Length * (long)BitsPerByte;
+            if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(_outer.LegalKeySizes))
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, "key");
+
+            if (_outer.IsWeakKey(key))
+                throw new CryptographicException(SR.Cryptography_WeakKey);
+
+            byte[] iv = rgbIV == null ? null : rgbIV.CloneByteArray();
+            if (iv != null && iv.Length != _outer.BlockSize.BitSizeToByteSize())
+                throw new ArgumentException(SR.Cryptography_InvalidIVSize, "iv");
+
+            if (iv == null && _outer.Mode != CipherMode.ECB)
+                throw new CryptographicException(SR.Cryptography_MissingIV);
+
+            string algorithm = _algorithm;
+            return CreateCryptoTransformCore(() => key.ToCngKey(algorithm), iv, encrypting);
+        }
+
+        private ICryptoTransform CreateCryptoTransformCore(Func<CngKey> cngKeyFactory, byte[] iv, bool encrypting)
+        {
+            int blockSizeInBytes = _outer.BlockSize.BitSizeToByteSize();
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherCng(cngKeyFactory, _outer.Mode, blockSizeInBytes, iv, encrypting);
+            return UniversalCryptoTransform.Create(_outer.Padding, cipher, encrypting);
+        }
+
+        private CngKey ProduceCngKey()
+        {
+            if (KeyInPlainText)
+            {
+                byte[] key = _outer.BaseKey;
+                return key.ToCngKey(_algorithm);
+            }
+            else
+            {
+                return CngKey.Open(_keyName, _provider, _optionOptions);
+            }
+        }
+
+        private bool KeyInPlainText
+        {
+            get { return _keyName == null; }
+        }
+
+        private readonly string _algorithm;
+        private readonly ICngSymmetricAlgorithm _outer;
+
+        // If using a stored CNG key, these fields provide the CngKey.Open() parameters. If using a plaintext key, _keyName is set to null.
+        private string _keyName;
+        private CngProvider _provider;
+        private CngKeyOpenOptions _optionOptions;
+
+        private const int BitsPerByte = 8;
+    }
+}
+

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -153,6 +153,43 @@ namespace Internal.Cryptography
                     throw errorCode.ToCryptographicException();
             }
         }
+
+        public static bool IsLegalSize(this int size, KeySizes[] legalSizes)
+        {
+            for (int i = 0; i < legalSizes.Length; i++)
+            {
+                // If a cipher has only one valid key size, MinSize == MaxSize and SkipSize will be 0
+                if (legalSizes[i].SkipSize == 0)
+                {
+                    if (legalSizes[i].MinSize == size)
+                        return true;
+                }
+                else
+                {
+                    for (int j = legalSizes[i].MinSize; j <= legalSizes[i].MaxSize; j += legalSizes[i].SkipSize)
+                    {
+                        if (j == size)
+                            return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public static int BitSizeToByteSize(this int bits)
+        {
+            return (bits + 7) / 8;
+        }
+
+        public static byte[] GenerateRandom(int count)
+        {
+            byte[] buffer = new byte[count];
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(buffer);
+            }
+            return buffer;
+        }
     }
 }
 

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/ICngSymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/ICngSymmetricAlgorithm.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    // 
+    // Internal interface that allows CngSymmetricAlgorithmCore to communicate back with the SymmetricAlgorithm it's embedded in.
+    // Any class that implements interface also derives from SymmetricAlgorithm so they'll implement most of these methods already.
+    // In addition to exposing a way to call the Key property non-virtually, this interface limits access to the outer object's
+    // methods to only what's needed, which is always handy in avoiding introducing infinite-recursion bugs.
+    //
+    internal interface ICngSymmetricAlgorithm
+    {
+        // SymmetricAlgorithm members used by the core.
+        int BlockSize { get; }
+        CipherMode Mode { get; }
+        PaddingMode Padding { get; }
+        byte[] IV { get; set; }
+        KeySizes[] LegalKeySizes { get; }
+
+        // SymmetricAlgorithm members that need to be called non-virtually to avoid infinite recursion.
+        byte[] BaseKey { get; set; }
+        int BaseKeySize { get; set; }
+
+        // Other members.
+        bool IsWeakKey(byte[] key);
+    }
+}
+

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/SymmetricImportExportExtensions.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/SymmetricImportExportExtensions.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal static class SymmetricImportExportExtensions
+    {
+        public static CngKey ToCngKey(this byte[] key, string algorithm)
+        {
+            int capacity = SizeOf_NCRYPT_KEY_BLOB_HEADER_SIZE + (algorithm.Length + 1) * 2 + SizeOf_BCRYPT_KEY_DATA_BLOB_HEADER + key.Length;
+            using (MemoryStream ms = new MemoryStream(capacity))
+            {
+                using (BinaryWriter bw = new BinaryWriter(ms, Encoding.Unicode))
+                {
+                    // Write out a NCRYPT_KEY_BLOB_HEADER
+                    bw.Write((int)SizeOf_NCRYPT_KEY_BLOB_HEADER_SIZE);                 // NCRYPT_KEY_BLOB_HEADER.cbSize
+                    bw.Write((int)Interop.NCrypt.NCRYPT_CIPHER_KEY_BLOB_MAGIC);        // NCRYPT_KEY_BLOB_HEADER.dwMagic
+                    bw.Write((int)((algorithm.Length + 1) * 2));                       // NCRYPT_KEY_BLOB_HEADER.cbAlgName
+                    bw.Write((int)(SizeOf_BCRYPT_KEY_DATA_BLOB_HEADER + key.Length));  // NCRYPT_KEY_BLOB_HEADER.cbKey = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + key.Length
+
+                    bw.Write(algorithm.ToCharArray());                                 // Write out the algorithm name (unicode null-terminated string)
+                    bw.Write((char)0);
+
+                    // Write out a BCRYPT_KEY_DATA_BLOB_HEADER
+                    bw.Write((int)Interop.BCrypt.BCRYPT_KEY_DATA_BLOB_MAGIC);          // BCRYPT_KEY_DATA_BLOB_HEADER.dwMagic
+                    bw.Write((int)Interop.BCrypt.BCRYPT_KEY_DATA_BLOB_VERSION1);       // BCRYPT_KEY_DATA_BLOB_HEADER.dwVersion
+                    bw.Write((int)(key.Length));                                       // BCRYPT_KEY_DATA_BLOB_HEADER.cbKeyData
+
+                    bw.Write((byte[])key);                                             // Write out the key data.
+                }
+                byte[] keyBlob = ms.ToArray();
+
+                CngKey cngKey = CngKey.Import(keyBlob, s_cipherKeyBlobFormat);
+                cngKey.ExportPolicy |= CngExportPolicies.AllowPlaintextExport;
+                return cngKey;
+            }
+        }
+
+        /// <summary>
+        /// Note! This can and likely will throw if the algorithm was given a hardware-based key.
+        /// </summary>
+        public static byte[] GetSymmetricKeyDataIfExportable(this CngKey cngKey, string algorithm)
+        {
+            byte[] keyBlob = cngKey.Export(s_cipherKeyBlobFormat);
+            using (MemoryStream ms = new MemoryStream(keyBlob))
+            {
+                using (BinaryReader br = new BinaryReader(ms, Encoding.Unicode))
+                {
+                    // Read NCRYPT_KEY_BLOB_HEADER
+                    int cbSize = br.ReadInt32();                      // NCRYPT_KEY_BLOB_HEADER.cbSize
+                    if (cbSize != SizeOf_NCRYPT_KEY_BLOB_HEADER_SIZE)
+                        throw new CryptographicException(SR.Cryptography_KeyBlobParsingError);
+
+                    int ncryptMagic = br.ReadInt32();                 // NCRYPT_KEY_BLOB_HEADER.dwMagic
+                    if (ncryptMagic != Interop.NCrypt.NCRYPT_CIPHER_KEY_BLOB_MAGIC)
+                        throw new CryptographicException(SR.Cryptography_KeyBlobParsingError);
+
+                    int cbAlgName = br.ReadInt32();                   // NCRYPT_KEY_BLOB_HEADER.cbAlgName
+
+                    br.ReadInt32();                                   // NCRYPT_KEY_BLOB_HEADER.cbKey
+
+                    string algorithmName = new string(br.ReadChars((cbAlgName / 2) - 1));
+                    if (algorithmName != algorithm)
+                        throw new CryptographicException(SR.Format(SR.Cryptography_CngKeyWrongAlgorithm, algorithmName, algorithm));
+
+                    char nullTerminator = br.ReadChar();
+                    if (nullTerminator != 0)
+                        throw new CryptographicException(SR.Cryptography_KeyBlobParsingError);
+
+                    // Read BCRYPT_KEY_DATA_BLOB_HEADER
+                    int bcryptMagic = br.ReadInt32();                 // BCRYPT_KEY_DATA_BLOB_HEADER.dwMagic
+                    if (bcryptMagic != Interop.BCrypt.BCRYPT_KEY_DATA_BLOB_MAGIC)
+                        throw new CryptographicException(SR.Cryptography_KeyBlobParsingError);
+
+                    int dwVersion = br.ReadInt32();                   // BCRYPT_KEY_DATA_BLOB_HEADER.dwVersion
+                    if (dwVersion != Interop.BCrypt.BCRYPT_KEY_DATA_BLOB_VERSION1)
+                        throw new CryptographicException(SR.Cryptography_KeyBlobParsingError);
+
+                    int keyLength = br.ReadInt32();                   // BCRYPT_KEY_DATA_BLOB_HEADER.cbKeyData
+                    byte[] key = br.ReadBytes(keyLength);
+                    return key;
+                }
+            }
+        }
+
+        private const int SizeOf_NCRYPT_KEY_BLOB_HEADER_SIZE = sizeof(int) + sizeof(int) + sizeof(int) + sizeof(int);
+        private const int SizeOf_BCRYPT_KEY_DATA_BLOB_HEADER = sizeof(int) + sizeof(int) + sizeof(int);
+
+        private static readonly CngKeyBlobFormat s_cipherKeyBlobFormat = new CngKeyBlobFormat(Interop.NCrypt.NCRYPT_CIPHER_KEY_BLOB);
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/Interop/NCrypt/NCrypt.cs
+++ b/src/System.Security.Cryptography.Cng/src/Interop/NCrypt/NCrypt.cs
@@ -48,7 +48,13 @@ internal static partial class Interop
         internal static unsafe extern ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, [In] byte[] pbInput, int cbInput, void* pPaddingInfo, [Out] byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
         internal static unsafe extern ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, [In] byte[] pbInput, int cbInput, void* pPaddingInfo, [Out] byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
         internal static unsafe extern ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, [In] byte[] pbHashValue, int cbHashValue, [Out] byte[] pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -141,6 +141,12 @@
   <data name="Cryptography_ArgRSAaRequiresRSAKey" xml:space="preserve">
     <value>Keys used with the RSACng algorithm must have an algorithm group of RSA.</value>
   </data>
+  <data name="Cryptography_CngKeyWrongAlgorithm" xml:space="preserve">
+    <value>This key is for algorithm '{0}'. Expected '{1}'.</value>
+  </data>
+  <data name="Cryptography_ECXmlSerializationFormatRequired" xml:space="preserve">
+    <value>XML serialization of an elliptic curve key requires using an overload which specifies the XML format to be used.</value>
+  </data>
   <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
     <value>The hash algorithm name cannot be null or empty.</value>
   </data>
@@ -150,14 +156,32 @@
   <data name="Cryptography_InvalidAlgorithmName" xml:space="preserve">
     <value>The algorithm name '{0}' is invalid.</value>
   </data>
+  <data name="Cryptography_InvalidCipherMode" xml:space="preserve">
+    <value>Specified cipher mode is not valid for this algorithm.</value>
+  </data>
+  <data name="Cryptography_InvalidIVSize" xml:space="preserve">
+    <value>Specified initialization vector (IV) does not match the block size for this algorithm.</value>
+  </data>
   <data name="Cryptography_InvalidKeyBlobFormat" xml:space="preserve">
     <value>The key blob format '{0}' is invalid.</value>
+  </data>
+  <data name="Cryptography_InvalidKeySize" xml:space="preserve">
+    <value>Specified key is not a valid size for this algorithm.</value>
+  </data>
+  <data name="Cryptography_InvalidPadding" xml:space="preserve">
+    <value>Specified padding mode is not valid for this algorithm.</value>
   </data>
   <data name="Cryptography_InvalidProviderName" xml:space="preserve">
     <value>The provider name '{0}' is invalid.</value>
   </data>
   <data name="Cryptography_InvalidRsaParameters" xml:space="preserve">
     <value>The specified RSA parameters are not valid; both Exponent and Modulus are required fields.</value>
+  </data>
+  <data name="Cryptography_InvalidSignatureAlgorithm" xml:space="preserve">
+    <value>The hash algorithm is not supported for signatures. Only MD5, SHA1, SHA256,SHA384, and SHA512 are supported at this time.</value>
+  </data>
+  <data name="Cryptography_KeyBlobParsingError" xml:space="preserve">
+    <value>Key Blob not in expected format.</value>
   </data>
   <data name="Cryptography_OpenEphemeralKeyHandleWithoutEphemeralFlag" xml:space="preserve">
     <value>The CNG key handle being opened was detected to be ephemeral, but the EphemeralKey open option was not specified.</value>
@@ -168,17 +192,26 @@
   <data name="NotSupported_Method" xml:space="preserve">
     <value>Method not supported.</value>
   </data>
+  <data name="Cryptography_MissingIV" xml:space="preserve">
+    <value>The cipher mode specified requires that an initialization vector (IV) be used.</value>
+  </data>
+  <data name="Cryptography_MustTransformWholeBlock" xml:space="preserve">
+    <value>TransformBlock may only process bytes in block sized increments.</value>
+  </data>
   <data name="Cryptography_NotValidPrivateKey" xml:space="preserve">
     <value>Key is not a valid private key.</value>
   </data>
   <data name="Cryptography_NotValidPublicOrPrivateKey" xml:space="preserve">
     <value>Key is not a valid public or private key.</value>
   </data>
-  <data name="Cryptography_InvalidSignatureAlgorithm" xml:space="preserve">
-    <value>The hash algorithm is not supported for signatures. Only MD5, SHA1, SHA256,SHA384, and SHA512 are supported at this time.</value>
-  </data>
   <data name="Cryptography_NonCompliantFIPSAlgorithm" xml:space="preserve">
     <value>This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms.</value>
+  </data>
+  <data name="Cryptography_PartialBlock" xml:space="preserve">
+    <value>The input data is not a complete block.</value>
+  </data>
+  <data name="Cryptography_RC2_EKSKS2" xml:space="preserve">
+    <value>EffectiveKeySize must be the same as KeySize in this implementation.</value>
   </data>
   <data name="Cryptography_TlsRequiresLabelAndSeed" xml:space="preserve">
     <value>The TLS key derivation function requires both the label and seed properties to be set.</value>
@@ -186,11 +219,20 @@
   <data name="Cryptography_UnsupportedPaddingMode" xml:space="preserve">
     <value>The specified PaddingMode is not supported.</value>
   </data>
-  <data name="Cryptography_ECXmlSerializationFormatRequired" xml:space="preserve">
-    <value>XML serialization of an elliptic curve key requires using an overload which specifies the XML format to be used.</value>
-  </data>
   <data name="Cryptography_PlatformNotSupported" xml:space="preserve">
     <value>The specified cryptographic algorithm is not supported on this platform.</value>
+  </data>
+  <data name="Cryptography_TransformBeyondEndOfBuffer" xml:space="preserve">
+    <value>Attempt to transform beyond end of buffer.</value>
+  </data>
+  <data name="Cryptography_UnexpectedTransformTruncation" xml:space="preserve">
+    <value>CNG provider unexpectedly terminated encryption or decryption prematurely.</value>
+  </data>
+  <data name="Cryptography_UnknownPaddingMode" xml:space="preserve">
+    <value>Unknown padding mode used.</value>
+  </data>
+  <data name="Cryptography_WeakKey" xml:space="preserve">
+    <value>Specified key is a known weak key for this algorithm and cannot be used.</value>
   </data>
   <data name="WorkInProgress" xml:space="preserve">
     <value>WorkInProgress.</value>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -26,6 +26,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+     <Compile Include="System\Security\Cryptography\AesCng.cs" />
      <Compile Include="System\Security\Cryptography\CngAlgorithm.cs" />
      <Compile Include="System\Security\Cryptography\CngAlgorithmGroup.cs" />
      <Compile Include="System\Security\Cryptography\CngExportPolicies.cs" />
@@ -61,16 +62,21 @@
      <Compile Include="System\Security\Cryptography\RSACng.ImportExport.cs" />
      <Compile Include="System\Security\Cryptography\RSACng.Key.cs" />
      <Compile Include="System\Security\Cryptography\RSACng.SignVerify.cs" />
+     <Compile Include="System\Security\Cryptography\TripleDESCng.cs" />
 
      <Compile Include="Microsoft\Win32\SafeHandles\NCryptSafeHandles.cs" />
 
+     <Compile Include="Internal\Cryptography\BasicSymmetricCipherCng.cs" />
      <Compile Include="Internal\Cryptography\CngAlgorithmCore.cs" />
      <Compile Include="Internal\Cryptography\CngCommon.Hash.cs" />
      <Compile Include="Internal\Cryptography\CngCommon.SignVerify.cs" />
      <Compile Include="Internal\Cryptography\Helpers.cs" />
+     <Compile Include="Internal\Cryptography\ICngSymmetricAlgorithm.cs" />
      <Compile Include="Internal\Cryptography\KeyPropertyName.cs" />
      <Compile Include="Internal\Cryptography\ProviderPropertyName.cs" />
      <Compile Include="Internal\Cryptography\SafeUnicodeStringHandle.cs" />
+     <Compile Include="Internal\Cryptography\SymmetricImportExportExtensions.cs" />
+     <Compile Include="Internal\Cryptography\CngSymmetricAlgorithmCore.cs" />
 
      <Compile Include="Interop\NCrypt\NCrypt.cs" />
      <Compile Include="Interop\BCrypt\Interop.Blobs.cs" />
@@ -112,6 +118,21 @@
      <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
        <Link>Internal\Windows\BCrypt\BCryptAlgorithmCache.cs</Link>
      </Compile>
+     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptChainingModes.cs">
+       <Link>Internal\Windows\BCrypt\Interop.BCryptChainingModes.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptKeyDataBlob.cs">
+       <Link>Internal\Windows\BCrypt\Interop.BCryptKeyDataBlob.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptAlgorithms.cs">
+       <Link>Internal\Windows\NCrypt\Interop.NCryptAlgorithms.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptCipherKeyBlob.cs">
+       <Link>Internal\Windows\NCrypt\Interop.NCryptCipherKeyBlob.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptPropertyNames.cs">
+       <Link>Internal\Windows\NCrypt\Interop.NCryptPropertyNames.cs</Link>
+     </Compile>
      <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
        <Link>Internal\Windows\mincore\Interop.FormatMessage.cs</Link>
      </Compile>
@@ -132,6 +153,18 @@
      </Compile>
      <Compile Include="$(CommonPath)\Internal\Cryptography\HashProviderCng.cs">
        <Link>Internal\Cryptography\HashProviderCng.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
+       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
+       <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoEncryptor.cs">
+       <Link>Internal\Cryptography\UniversalCryptoEncryptor.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
+       <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
      </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//
+// This file is one of a group of files (AesCng.cs, TripleDESCng.cs) that are almost identical except
+// for the algorithm name. If you make a change to this file, there's a good chance you'll have to make
+// the same change to the other files so please check. This is a pain but given that the contracts demand
+// that each of these derive from a different class, it can't be helped.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    public sealed class AesCng : Aes, ICngSymmetricAlgorithm
+    {
+        private const string s_Algorithm = Interop.NCrypt.NCRYPT_AES_ALGORITHM;
+
+        public AesCng()
+        {
+            _core = new CngSymmetricAlgorithmCore(s_Algorithm, this);
+        }
+
+        public AesCng(string keyName)
+            : this(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider)
+        {
+        }
+
+        public AesCng(string keyName, CngProvider provider)
+            : this(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider, CngKeyOpenOptions.None)
+        {
+        }
+
+        public AesCng(string keyName, CngProvider provider, CngKeyOpenOptions openOptions)
+        {
+            _core = new CngSymmetricAlgorithmCore(s_Algorithm, this, keyName, provider, openOptions);
+        }
+
+        public override byte[] Key
+        {
+            get
+            {
+                return _core.GetKeyIfExportable();
+            }
+            set
+            {
+                _core.SetKey(value);
+            }
+        }
+
+        public override int KeySize
+        {
+            get
+            {
+                return base.KeySize;
+            }
+
+            set
+            {
+                _core.SetKeySize(value, this);
+            }
+        }
+
+        public override ICryptoTransform CreateDecryptor()
+        {
+            // Do not change to CreateDecryptor(this.Key, this.IV). this.Key throws if a non-exportable hardware key is being used.
+            return _core.CreateDecryptor();
+        }
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return _core.CreateDecryptor(rgbKey, rgbIV);
+        }
+
+        public override ICryptoTransform CreateEncryptor()
+        {
+            // Do not change to CreateEncryptor(this.Key, this.IV). this.Key throws if a non-exportable hardware key is being used.
+            return _core.CreateEncryptor();
+        }
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return _core.CreateEncryptor(rgbKey, rgbIV);
+        }
+ 
+        public override void GenerateKey()
+        {
+            _core.GenerateKey();
+        }
+
+        public override void GenerateIV()
+        {
+            _core.GenerateIV();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+        }
+
+        byte[] ICngSymmetricAlgorithm.BaseKey { get { return base.Key; } set { base.Key = value; } }
+        int ICngSymmetricAlgorithm.BaseKeySize { get { return base.KeySize; } set { base.KeySize = value; } }
+
+        bool ICngSymmetricAlgorithm.IsWeakKey(byte[] key)
+        {
+            return false;
+        }
+
+        private CngSymmetricAlgorithmCore _core;
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//
+// This file is one of a group of files (AesCng.cs, TripleDESCng.cs) that are almost identical except
+// for the algorithm name. If you make a change to this file, there's a good chance you'll have to make
+// the same change to the other files so please check. This is a pain but given that the contracts demand
+// that each of these derive from a different class, it can't be helped.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    public sealed class TripleDESCng : TripleDES, ICngSymmetricAlgorithm
+    {
+        private const string s_Algorithm = Interop.NCrypt.NCRYPT_3DES_ALGORITHM;
+
+        public TripleDESCng()
+        {
+            _core = new CngSymmetricAlgorithmCore(s_Algorithm, this);
+        }
+
+        public TripleDESCng(string keyName)
+            : this(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider)
+        {
+        }
+
+        public TripleDESCng(string keyName, CngProvider provider)
+            : this(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider, CngKeyOpenOptions.None)
+        {
+        }
+
+        public TripleDESCng(string keyName, CngProvider provider, CngKeyOpenOptions openOptions)
+        {
+            _core = new CngSymmetricAlgorithmCore(s_Algorithm, this, keyName, provider, openOptions);
+        }
+
+        public override byte[] Key
+        {
+            get
+            {
+                return _core.GetKeyIfExportable();
+            }
+            set
+            {
+                _core.SetKey(value);
+            }
+        }
+
+        public override int KeySize
+        {
+            get
+            {
+                return base.KeySize;
+            }
+
+            set
+            {
+                _core.SetKeySize(value, this);
+            }
+        }
+
+        public override ICryptoTransform CreateDecryptor()
+        {
+            // Do not change to CreateDecryptor(this.Key, this.IV). this.Key throws if a non-exportable hardware key is being used.
+            return _core.CreateDecryptor();
+        }
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return _core.CreateDecryptor(rgbKey, rgbIV);
+        }
+
+        public override ICryptoTransform CreateEncryptor()
+        {
+            // Do not change to CreateEncryptor(this.Key, this.IV). this.Key throws if a non-exportable hardware key is being used.
+            return _core.CreateEncryptor();
+        }
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return _core.CreateEncryptor(rgbKey, rgbIV);
+        }
+ 
+        public override void GenerateKey()
+        {
+            _core.GenerateKey();
+        }
+
+        public override void GenerateIV()
+        {
+            _core.GenerateIV();
+        }
+
+        public override KeySizes[] LegalKeySizes
+        {
+            get
+            {
+                // CNG does not support 128-bit keys.
+                return new KeySizes[] { new KeySizes(minSize: 3 * 64, maxSize: 3 * 64, skipSize: 0) };
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+        }
+
+        byte[] ICngSymmetricAlgorithm.BaseKey { get { return base.Key; } set { base.Key = value; } }
+        int ICngSymmetricAlgorithm.BaseKeySize { get { return base.KeySize; } set { base.KeySize = value; } }
+
+        bool ICngSymmetricAlgorithm.IsWeakKey(byte[] key)
+        {
+            return TripleDES.IsWeakKey(key);
+        }
+
+        private CngSymmetricAlgorithmCore _core;
+    }
+}

--- a/src/System.Security.Cryptography.Cng/tests/AesProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/AesProvider.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Security.Cryptography.Encryption.Aes.Tests
+{
+    using Aes = System.Security.Cryptography.Aes;
+
+    public class AesProvider : IAesProvider
+    {
+        public Aes Create()
+        {
+            return new AesCng();
+        }
+    }
+
+    public partial class AesFactory
+    {
+        private static readonly IAesProvider s_provider = new AesProvider();
+    }
+}

--- a/src/System.Security.Cryptography.Cng/tests/InvasiveCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/InvasiveCngTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Aes.Tests
+{
+    using Aes = System.Security.Cryptography.Aes;
+
+    public static class InvasiveCngTests
+    {
+        //[Fact] - Keeping this test for reference but we don't want to run it as an inner-loop test because 
+        //         it creates a key on disk.
+        public static void StoredKeyAES()
+        {
+            CngAlgorithm algname = new CngAlgorithm("AES");
+            string keyName = "CoreFxTest-" + Guid.NewGuid();
+            CngKey _cngKey = CngKey.Create(algname, keyName);
+            try
+            {
+                using (Aes alg = new AesCng(keyName))
+                {
+                    int keySize = alg.KeySize;
+                    Assert.Equal(256, keySize);
+
+                    // Since this is a stored key, it's not going to surrender the actual key bytes. 
+                    Assert.ThrowsAny<CryptographicException>(() => alg.Key);
+                }
+            }
+            finally
+            {
+                _cngKey.Delete();
+            }
+        }
+
+        //[Fact] - Keeping this test for reference but we don't want to run it as an inner-loop test because 
+        //         it creates a key on disk.
+        public static void StoredKeyTripleDES()
+        {
+            CngAlgorithm algname = new CngAlgorithm("3DES");
+            string keyName = "CoreFxTest-" + Guid.NewGuid();
+            CngKey _cngKey = CngKey.Create(algname, keyName);
+            try
+            {
+                using (TripleDES alg = new TripleDESCng(keyName))
+                {
+                    int keySize = alg.KeySize;
+                    Assert.Equal(192, keySize);
+
+                    // Since this is a stored key, it's not going to surrender the actual key bytes. 
+                    Assert.ThrowsAny<CryptographicException>(() => alg.Key);
+                }
+            }
+            finally
+            {
+                _cngKey.Delete();
+            }
+        }
+
+        //[Fact] - Keeping this test for reference but we don't want to run it as an inner-loop test because 
+        //         it creates a key on disk.
+        public static void AesRoundTrip256BitsNoneECBUsingStoredKey()
+        {
+            CngAlgorithm algname = new CngAlgorithm("AES");
+            string keyName = "CoreFxTest-" + Guid.NewGuid();
+            CngKey _cngKey = CngKey.Create(algname, keyName);
+            try
+            {
+                using (Aes alg = new AesCng(keyName))
+                {
+                    try
+                    {
+                        alg.Padding = PaddingMode.None;
+                        alg.Mode = CipherMode.ECB;
+
+                        int keySize = alg.KeySize;
+
+                        byte[] plainText = "15a818701f0f7c99fe4b1b4b860f131b".HexToByteArray();
+                        byte[] cipher = alg.Encrypt(plainText);
+                        byte[] decrypted = alg.Decrypt(cipher);
+                        byte[] expectedDecrypted = "15a818701f0f7c99fe4b1b4b860f131b".HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted, decrypted);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e.Message);
+                    }
+                }
+            }
+            finally
+            {
+                _cngKey.Delete();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="CreateTests.cs" />
     <Compile Include="HandleTests.cs" />
     <Compile Include="OpenTests.cs" />
+    <Compile Include="InvasiveCngTests.cs" />
     <Compile Include="ImportExportTests.cs" />
     <Compile Include="PropertyTests.cs" />
     <Compile Include="RsaCngTests.cs" />
@@ -35,10 +36,45 @@
     <Compile Include="TestData.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="RSACngProvider.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\ByteUtils.cs">
       <Link>CommonTest\Cryptography\ByteUtils.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\CryptoUtils.cs">
+      <Link>CommonTest\Cryptography\CryptoUtils.cs</Link>
+    </Compile>
+
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.Data.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesContractTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesCornerTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesModeTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\DecryptorReusability.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
+      <Link>CommonTest\AlgorithmImplementations\AES\AesFactory.cs</Link>
+    </Compile>
+    <Compile Include="AesProvider.cs" />
+
+    <Compile Include="TripleDESCngProvider.cs" />
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
+      <Link>CommonTest\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
+    </Compile>
+
+    <Compile Include="RSACngProvider.cs" />
     <Compile Include="$(CommonTestPath)\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
       <Link>CommonTest\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Cng/tests/TripleDESCngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/TripleDESCngProvider.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Security.Cryptography.Encryption.TripleDes.Tests
+{
+    public class TripleDESCngProvider : ITripleDESProvider
+    {
+        public TripleDES Create()
+        {
+            return new TripleDESCng();
+        }
+    }
+
+    public partial class TripleDESFactory
+    {
+        private static readonly ITripleDESProvider s_provider = new TripleDESCngProvider();
+    }
+}


### PR DESCRIPTION
Implement AesCng and TripleDESCng.

This code is derived from the internal CNG-based Aes implementation in SSC.Algorithms
but the factoring has been redone so that the padding logic, cipher algorithm and the
underlying provider are now properly separated.

UniversalCryptoEncryptor and UniversalCryptoDecryptor implement the public-facing
ICryptoTransform interface and do the padding/depadding.

They are parameterized by a BasicSymmetricCipher which implements the unpadded transform
and encapsulates the cipher algorithm and underlying crypto technology (CNG or OpenSSL or
whatever.)

BasicSymmetricCipherCng is the CNG-based implementation of that, and
is parameterized by the algorithm (AES or 3DES.)

(The existing Aes implementations in Algorithms could be rewritten in terms of these
but I'm not doing that now. We don't even know that we'll keep those inside
SSC.Algorithms, in which case, redoing them would be throwaway work. I've put the agnostic
code in the Common folder just in case.)

Beefed up the shared Aes tests with a few more code-coverage tests, but what's there
seems pretty comprehensive already.

TripleDES tests exercise the basic cipher. No need to do more code-coverage with these
as AesCng and TripleDES are the virtually the same class on the managed side.

cc @bartonjs 
