### PR TITLE
Add argument validation tests for S.N.Sockets.

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -1,0 +1,429 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    // TODO:
+    //
+    // End*:
+    // - Invalid asyncresult type
+    // - asyncresult from different object
+    // - asyncresult with end already called
+    public class ArgumentValidation
+    {
+        private readonly static byte[] s_buffer = new byte[1];
+        private readonly static IList<ArraySegment<byte>> s_buffers = new List<ArraySegment<byte>> { new ArraySegment<byte>(s_buffer) };
+        private readonly static Socket s_ipv4Socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        private readonly static Socket s_ipv6Socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+
+        private static void TheAsyncCallback(IAsyncResult ar)
+        {
+        }
+
+        private static Socket GetSocket(AddressFamily addressFamily = AddressFamily.InterNetwork)
+        {
+            Debug.Assert(addressFamily == AddressFamily.InterNetwork || addressFamily == AddressFamily.InterNetworkV6);
+            return addressFamily == AddressFamily.InterNetwork ? s_ipv4Socket : s_ipv6Socket;
+        }
+
+        [Fact]
+        public void BeginAccept_NegativeReceiveSize_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginAccept(null, -1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginAccept_NotBound_Throws_InvalidOperation()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetSocket().BeginAccept(null, 0, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginAccept_NotListening_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+                Assert.Throws<InvalidOperationException>(() => socket.BeginAccept(null, 0, TheAsyncCallback, null));
+            }
+        }
+
+        [Fact]
+        public void EndAccept_NullAsyncResult_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndAccept(null));
+        }
+
+        [Fact]
+        public void BeginConnect_EndPoint_NullEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((EndPoint)null, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_EndPoint_ListeningSocket_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Listen(1);
+                Assert.Throws<InvalidOperationException>(() => socket.BeginConnect(new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
+            }
+        }
+
+        [Fact]
+        public void BeginConnect_EndPoint_AddressFamily_Throws_NotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6), TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_Host_NullHost_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((string)null, 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_Host_InvalidPort_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect("localhost", -1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect("localhost", 65536, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_Host_ListeningSocket_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Listen(1);
+                Assert.Throws<InvalidOperationException>(() => socket.BeginConnect("localhost", 1, TheAsyncCallback, null));
+            }
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddress_NullIPAddress_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((IPAddress)null, 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddress_InvalidPort_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(IPAddress.Loopback, -1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(IPAddress.Loopback, 65536, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddress_AddressFamily_Throws_NotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(IPAddress.IPv6Loopback, 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddresses_NullIPAddresses_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((IPAddress[])null, 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddresses_EmptyIPAddresses_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().BeginConnect(new IPAddress[0], 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddresses_InvalidPort_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(new[] { IPAddress.Loopback }, -1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(new[] { IPAddress.Loopback }, 65536, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddresses_ListeningSocket_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Listen(1);
+                Assert.Throws<InvalidOperationException>(() => socket.BeginConnect(new[] { IPAddress.Loopback }, 1, TheAsyncCallback, null));
+            }
+        }
+
+        [Fact]
+        public void EndConnect_NullAsyncResult_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndConnect(null));
+        }
+
+        [Fact]
+        public void EndDisconnect_NullAsyncResult_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndDisconnect(null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffer_NullBuffer_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSend(null, 0, 0, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffer_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, -1, 0, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, s_buffer.Length + 1, 0, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffer_InvalidCount_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, 0, -1, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, s_buffer.Length, 1, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffers_NullBuffers_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSend(null, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffers_EmptyBuffers_Throws_Argument()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentException>(() => GetSocket().BeginSend(new List<ArraySegment<byte>>(), SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndSend_NullAsyncResult_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndSend(null));
+        }
+
+        [Fact]
+        public void BeginSendTo_NullBuffer_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSendTo(null, 0, 0, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSendTo_NullEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSendTo(s_buffer, 0, 0, SocketFlags.None, null, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSendTo_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, -1, s_buffer.Length, SocketFlags.None, endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSendTo_InvalidSize_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, 0, -1, SocketFlags.None, endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, s_buffer.Length, 1, SocketFlags.None, endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndSendTo_NullAsyncResult_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndSendTo(null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffer_NullBuffer_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceive(null, 0, 0, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffer_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, -1, 0, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, s_buffer.Length + 1, 0, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffer_InvalidCount_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, 0, -1, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, s_buffer.Length, 1, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffers_NullBuffers_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceive(null, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffers_EmptyBuffers_Throws_Argument()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentException>(() => GetSocket().BeginReceive(new List<ArraySegment<byte>>(), SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndReceive_NullAsyncResult_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndReceive(null));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_NullBuffer_Throws_ArgumentNull()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveFrom(null, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_NullEndPoint_Throws_ArgumentNull()
+        {
+            EndPoint endpoint = null;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_AddressFamily_Throws_Argument()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.IPv6Loopback, 1);
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).BeginReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, -1, s_buffer.Length, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_InvalidSize_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, -1, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, s_buffer.Length, 1, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_NotBound_Throws_InvalidOperation()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<InvalidOperationException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndReceiveFrom_NullAsyncResult_Throws_ArgumentNull()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndReceiveFrom(null, ref endpoint));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_NullBuffer_Throws_ArgumentNull()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveMessageFrom(null, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_NullEndPoint_Throws_ArgumentNull()
+        {
+            EndPoint remote = null;
+
+            Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_AddressFamily_Throws_Argument()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.IPv6Loopback, 1);
+
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).BeginReceiveMessageFrom(s_buffer, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, -1, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_InvalidSize_Throws_ArgumentOutOfRange()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, -1, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, s_buffer.Length, 1, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_NotBound_Throws_InvalidOperation()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+
+            Assert.Throws<InvalidOperationException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndReceiveMessageFrom_NullEndPoint_Throws_ArgumentNull()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = null;
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndReceiveMessageFrom(null, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void EndReceiveMessageFrom_AddressFamily_Throws_Argument()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.IPv6Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).EndReceiveMessageFrom(null, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void EndReceiveMessageFrom_NullAsyncResult_Throws_ArgumentNull()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentNullException>(() => GetSocket().EndReceiveMessageFrom(null, ref flags, ref remote, out packetInfo));
+        }
+    }
+}

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DisposedSocketTests.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class DisposedSocket
+    {
+        private readonly static byte[] s_buffer = new byte[1];
+        private readonly static IList<ArraySegment<byte>> s_buffers = new List<ArraySegment<byte>> { new ArraySegment<byte>(s_buffer) };
+
+        private static Socket GetDisposedSocket(AddressFamily addressFamily = AddressFamily.InterNetwork)
+        {
+            using (var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                return socket;
+            }
+        }
+
+        private static void TheAsyncCallback(IAsyncResult ar)
+        {
+        }
+
+        [Fact]
+        public void BeginConnect_EndPoint_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginConnect(new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddress_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginConnect(IPAddress.Loopback, 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_IPAddresses_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginConnect(new[] { IPAddress.Loopback }, 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginConnect_Host_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginConnect("localhost", 1, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndConnect_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndConnect(null));
+        }
+
+        [Fact]
+        public void BeginDisconnect_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginDisconnect(false, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndDisconnect_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndDisconnect(null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffer_Throws_ObjectDisposedException()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginSend(s_buffer, 0, s_buffer.Length, SocketFlags.None, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffer_SocketError_Throws_ObjectDisposedException()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginSend(s_buffer, 0, s_buffer.Length, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffers_Throws_ObjectDisposedException()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginSend(s_buffers, SocketFlags.None, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginSend_Buffers_SocketError_Throws_ObjectDisposedException()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginSend(s_buffers, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndSend_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndSend(null));
+        }
+
+        [Fact]
+        public void EndSend_SocketError_Throws_ObjectDisposed()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndSend(null, out errorCode));
+        }
+
+        [Fact]
+        public void BeginSendTo_Throws_ObjectDisposedException()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginSendTo(s_buffer, 0, s_buffer.Length, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndSendTo_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndSendTo(null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffer_Throws_ObjectDisposedException()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceive(s_buffer, 0, s_buffer.Length, SocketFlags.None, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffer_SocketError_Throws_ObjectDisposedException()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceive(s_buffer, 0, s_buffer.Length, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffers_Throws_ObjectDisposedException()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceive(s_buffers, SocketFlags.None, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginReceive_Buffers_SocketError_Throws_ObjectDisposedException()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceive(s_buffers, SocketFlags.None, out errorCode, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndReceive_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceive(null));
+        }
+
+        [Fact]
+        public void EndReceive_SocketError_Throws_ObjectDisposed()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceive(null, out errorCode));
+        }
+
+        [Fact]
+        public void BeginReceiveFrom_Throws_ObjectDisposedException()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceiveFrom(s_buffer, 0, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndReceiveFrom_Throws_ObjectDisposed()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceiveFrom(null, ref remote));
+        }
+
+        [Fact]
+        public void BeginReceiveMessageFrom_Throws_ObjectDisposedException()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceiveMessageFrom(s_buffer, 0, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndReceiveMessageFrom_Throws_ObjectDisposed()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceiveMessageFrom(null, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void BeginAccept_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginAccept(TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginAccept_Int_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginAccept(0, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void BeginAccept_Socket_Int_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginAccept(null, 0, TheAsyncCallback, null));
+        }
+
+        [Fact]
+        public void EndAccept_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndAccept(null));
+        }
+
+        [Fact]
+        public void EndAccept_Buffer_Throws_ObjectDisposed()
+        {
+            byte[] buffer;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndAccept(out buffer, null));
+        }
+
+        [Fact]
+        public void EndAccept_Buffer_Int_Throws_ObjectDisposed()
+        {
+            byte[] buffer;
+            int received;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndAccept(out buffer, out received, null));
+        }
+    }
+}

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.APMServer.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.APMServer.Tests.csproj
@@ -15,10 +15,12 @@
   <ItemGroup>
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="AgnosticListenerTest.cs" />
+    <Compile Include="ArgumentValidationTests.cs" />
     <Compile Include="ConnectAsync.cs" />
     <Compile Include="ConnectExTest.cs" />
     <Compile Include="Disconnect.cs" />
     <Compile Include="DisconnectAsync.cs" />
+    <Compile Include="DisposedSocketTests.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
     <Compile Include="LingerStateTest.cs" />

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.AsyncServer.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.AsyncServer.Tests.csproj
@@ -15,10 +15,12 @@
   <ItemGroup>
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="AgnosticListenerTest.cs" />
+    <Compile Include="ArgumentValidationTests.cs" />
     <Compile Include="ConnectAsync.cs" />
     <Compile Include="ConnectExTest.cs" />
     <Compile Include="Disconnect.cs" />
     <Compile Include="DisconnectAsync.cs" />
+    <Compile Include="DisposedSocketTests.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
     <Compile Include="LingerStateTest.cs" />

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -1,0 +1,719 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    // TODO:
+    //
+    // - Connect(EndPoint):
+    //   - disconnected socket
+    // - Accept(EndPoint):
+    //   - disconnected socket
+    public class ArgumentValidation
+    {
+        // This type is used to test Socket.Select's argument validation.
+        private sealed class LargeList : IList
+        {
+            private const int MaxSelect = 65536;
+
+            public int Count { get { return MaxSelect + 1; } }
+            public bool IsFixedSize { get { return true; } }
+            public bool IsReadOnly { get { return true; } }
+            public bool IsSynchronized { get { return false; } }
+            public object SyncRoot { get { return null; } }
+
+            public object this[int index]
+            {
+                get { return null; }
+                set { }
+            }
+
+            public int Add(object value) { return -1; }
+            public void Clear() { }
+            public bool Contains(object value) { return false; }
+            public void CopyTo(Array array, int index) { }
+            public IEnumerator GetEnumerator() { return null; }
+            public int IndexOf(object value) { return -1; }
+            public void Insert(int index, object value) { }
+            public void Remove(object value) { }
+            public void RemoveAt(int index) { }
+        }
+
+        private readonly static byte[] s_buffer = new byte[1];
+        private readonly static IList<ArraySegment<byte>> s_buffers = new List<ArraySegment<byte>> { new ArraySegment<byte>(s_buffer) };
+        private readonly static SocketAsyncEventArgs s_eventArgs = new SocketAsyncEventArgs();
+        private readonly static Socket s_ipv4Socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        private readonly static Socket s_ipv6Socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+
+        private static Socket GetSocket(AddressFamily addressFamily = AddressFamily.InterNetwork)
+        {
+            Debug.Assert(addressFamily == AddressFamily.InterNetwork || addressFamily == AddressFamily.InterNetworkV6);
+            return addressFamily == AddressFamily.InterNetwork ? s_ipv4Socket : s_ipv6Socket;
+        }
+
+        [Fact]
+        public void SetExclusiveAddressUse_BoundSocket_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    socket.ExclusiveAddressUse = true;
+                });
+            }
+        }
+
+        [Fact]
+        public void SetReceiveBufferSize_Negative_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                GetSocket().ReceiveBufferSize = -1;
+            });
+        }
+
+        [Fact]
+        public void SetSendBufferSize_Negative_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                GetSocket().SendBufferSize = -1;
+            });
+        }
+
+        [Fact]
+        public void SetReceiveTimeout_LessThanNegativeOne_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                GetSocket().ReceiveTimeout = int.MinValue;
+            });
+        }
+
+        [Fact]
+        public void SetSendTimeout_LessThanNegativeOne_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                GetSocket().SendTimeout = int.MinValue;
+            });
+        }
+
+        [Fact]
+        public void SetTtl_OutOfRange_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                GetSocket().Ttl = -1;
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                GetSocket().Ttl = 256;
+            });
+        }
+
+        [Fact]
+        public void DontFragment_IPv6_Throws_NotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetworkV6).DontFragment);
+        }
+
+        [Fact]
+        public void SetDontFragment_Throws_NotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                GetSocket(AddressFamily.InterNetworkV6).DontFragment = true;
+            });
+        }
+
+        [Fact]
+        public void Bind_Throws_NullEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Bind(null));
+        }
+
+        [Fact]
+        public void Connect_EndPoint_NullEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Connect(null));
+        }
+
+        [Fact]
+        public void Connect_EndPoint_ListeningSocket_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Listen(1);
+                Assert.Throws<InvalidOperationException>(() => socket.Connect(new IPEndPoint(IPAddress.Loopback, 1)));
+            }
+        }
+
+        [Fact]
+        public void Connect_IPAddress_NullIPAddress_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Connect((IPAddress)null, 1));
+        }
+
+        [Fact]
+        public void Connect_IPAddress_InvalidPort_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Connect(IPAddress.Loopback, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Connect(IPAddress.Loopback, 65536));
+        }
+
+        [Fact]
+        public void Connect_IPAddress_InvalidAddressFamily_Throws_NotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).Connect(IPAddress.IPv6Loopback, 1));
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetworkV6).Connect(IPAddress.Loopback, 1));
+        }
+
+        [Fact]
+        public void Connect_Host_NullHost_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Connect((string)null, 1));
+        }
+
+        [Fact]
+        public void Connect_Host_InvalidPort_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Connect("localhost", -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Connect("localhost", 65536));
+        }
+
+        [Fact]
+        public void Connect_IPAddresses_NullArray_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Connect((IPAddress[])null, 1));
+        }
+
+        [Fact]
+        public void Connect_IPAddresses_EmptyArray_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().Connect(new IPAddress[0], 1));
+        }
+
+        [Fact]
+        public void Connect_IPAddresses_InvalidPort_Throws_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Connect(new[] { IPAddress.Loopback }, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Connect(new[] { IPAddress.Loopback }, 65536));
+        }
+
+        [Fact]
+        public void Close_TimeoutLessThanNegativeOne_ArgumentOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Close(-2));
+        }
+
+        [Fact]
+        public void Accept_NotBound_Throws_InvalidOperation()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetSocket().Accept());
+        }
+
+        [Fact]
+        public void Accept_NotListening_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                Assert.Throws<InvalidOperationException>(() => socket.Accept());
+            }
+        }
+
+        [Fact]
+        public void Send_Buffer_NullBuffer_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Send(null, 0, 0, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Send_Buffer_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Send(s_buffer, -1, 0, SocketFlags.None, out errorCode));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Send(s_buffer, s_buffer.Length + 1, 0, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Send_Buffer_InvalidCount_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Send(s_buffer, 0, -1, SocketFlags.None, out errorCode));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Send(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, out errorCode));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Send(s_buffer, s_buffer.Length, 1, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Send_Buffers_NullBuffers_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Send(null, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Send_Buffers_EmptyBuffers_Throws_Argument()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentException>(() => GetSocket().Send(new List<ArraySegment<byte>>(), SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void SendTo_NullBuffer_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendTo(null, 0, 0, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1)));
+        }
+
+        [Fact]
+        public void SendTo_NullEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendTo(s_buffer, 0, 0, SocketFlags.None, null));
+        }
+
+        [Fact]
+        public void SendTo_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().SendTo(s_buffer, -1, s_buffer.Length, SocketFlags.None, endpoint));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().SendTo(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, endpoint));
+        }
+
+        [Fact]
+        public void SendTo_InvalidSize_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().SendTo(s_buffer, 0, -1, SocketFlags.None, endpoint));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().SendTo(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, endpoint));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().SendTo(s_buffer, s_buffer.Length, 1, SocketFlags.None, endpoint));
+        }
+
+        [Fact]
+        public void Receive_Buffer_NullBuffer_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Receive(null, 0, 0, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Receive_Buffer_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Receive(s_buffer, -1, 0, SocketFlags.None, out errorCode));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Receive(s_buffer, s_buffer.Length + 1, 0, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Receive_Buffer_InvalidCount_Throws_ArgumentOutOfRange()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Receive(s_buffer, 0, -1, SocketFlags.None, out errorCode));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Receive(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, out errorCode));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Receive(s_buffer, s_buffer.Length, 1, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Receive_Buffers_NullBuffers_Throws_ArgumentNull()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().Receive(null, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Receive_Buffers_EmptyBuffers_Throws_Argument()
+        {
+            SocketError errorCode;
+            Assert.Throws<ArgumentException>(() => GetSocket().Receive(new List<ArraySegment<byte>>(), SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void ReceiveFrom_NullBuffer_Throws_ArgumentNull()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveFrom(null, 0, 0, SocketFlags.None, ref endpoint));
+        }
+
+        [Fact]
+        public void ReceiveFrom_NullEndPoint_Throws_ArgumentNull()
+        {
+            EndPoint endpoint = null;
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint));
+        }
+
+        [Fact]
+        public void ReceiveFrom_AddressFamily_Throws_Argument()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.IPv6Loopback, 1);
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).ReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint));
+        }
+
+        [Fact]
+        public void ReceiveFrom_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveFrom(s_buffer, -1, s_buffer.Length, SocketFlags.None, ref endpoint));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveFrom(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, ref endpoint));
+        }
+
+        [Fact]
+        public void ReceiveFrom_InvalidSize_Throws_ArgumentOutOfRange()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveFrom(s_buffer, 0, -1, SocketFlags.None, ref endpoint));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveFrom(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, ref endpoint));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveFrom(s_buffer, s_buffer.Length, 1, SocketFlags.None, ref endpoint));
+        }
+
+        [Fact]
+        public void ReceiveFrom_NotBound_Throws_InvalidOperation()
+        {
+            EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<InvalidOperationException>(() => GetSocket().ReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_NullBuffer_Throws_ArgumentNull()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveMessageFrom(null, 0, 0, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_NullEndPoint_Throws_ArgumentNull()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = null;
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveMessageFrom(s_buffer, 0, 0, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_AddressFamily_Throws_Argument()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.IPv6Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).ReceiveMessageFrom(s_buffer, 0, 0, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_InvalidOffset_Throws_ArgumentOutOfRange()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveMessageFrom(s_buffer, -1, s_buffer.Length, ref flags, ref remote, out packetInfo));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveMessageFrom(s_buffer, s_buffer.Length + 1, s_buffer.Length, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_InvalidSize_Throws_ArgumentOutOfRange()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveMessageFrom(s_buffer, 0, -1, ref flags, ref remote, out packetInfo));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveMessageFrom(s_buffer, 0, s_buffer.Length + 1, ref flags, ref remote, out packetInfo));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().ReceiveMessageFrom(s_buffer, s_buffer.Length, 1, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_NotBound_Throws_InvalidOperation()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+
+            Assert.Throws<InvalidOperationException>(() => GetSocket().ReceiveMessageFrom(s_buffer, 0, 0, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void SetIPProtectionLevel_Unspecified_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().SetIPProtectionLevel(IPProtectionLevel.Unspecified));
+        }
+
+        [Fact]
+        public void SetSocketOption_Object_ObjectNull_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, (object)null));
+        }
+
+        [Fact]
+        public void SetSocketOption_Linger_NotLingerOption_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, new object()));
+        }
+
+        [Fact]
+        public void SetSocketOption_Linger_InvalidLingerTime_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, new LingerOption(true, -1)));
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, new LingerOption(true, (int)ushort.MaxValue + 1)));
+        }
+
+        [Fact]
+        public void SetSocketOption_IPMulticast_NotIPMulticastOption_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new object()));
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.IP, SocketOptionName.DropMembership, new object()));
+        }
+
+        [Fact]
+        public void SetSocketOption_IPv6Multicast_NotIPMulticastOption_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddMembership, new object()));
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.DropMembership, new object()));
+        }
+
+        [Fact]
+        public void SetSocketOption_Object_InvalidOptionName_Throws_Argument()
+        {
+            Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.NoDelay, new object()));
+        }
+
+        // TODO: Select
+        [Fact]
+        public void Select_NullOrEmptyLists_Throws_ArgumentNull()
+        {
+            var emptyList = new List<Socket>();
+            
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(null, null, null, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(emptyList, null, null, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(null, emptyList, null, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(emptyList, emptyList, null, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(null, null, emptyList, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(emptyList, null, emptyList, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(null, emptyList, emptyList, -1));
+            Assert.Throws<ArgumentNullException>(() => Socket.Select(emptyList, emptyList, emptyList, -1));
+        }
+
+        [Fact]
+        public void Select_LargeList_Throws_ArgumentOutOfRange()
+        {
+            var largeList = new LargeList();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Socket.Select(largeList, null, null, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Socket.Select(null, largeList, null, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Socket.Select(null, null, largeList, -1));
+        }
+
+        [Fact]
+        public void AcceptAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().AcceptAsync(null));
+        }
+
+        [Fact]
+        public void AcceptAsync_BufferList_Throws_Argument()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                BufferList = s_buffers
+            };
+
+            Assert.Throws<ArgumentException>(() => GetSocket().AcceptAsync(eventArgs));
+        }
+
+        [Fact]
+        public void AcceptAsync_NotBound_Throws_InvalidOperation()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetSocket().AcceptAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void AcceptAsync_NotListening_Throws_InvalidOperation()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                Assert.Throws<InvalidOperationException>(() => socket.AcceptAsync(s_eventArgs));
+            }
+        }
+
+        [Fact]
+        public void ConnectAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ConnectAsync(null));
+        }
+
+        [Fact]
+        public void ConnectAsync_BufferList_Throws_Argument()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                BufferList = s_buffers
+            };
+
+            Assert.Throws<ArgumentException>(() => GetSocket().ConnectAsync(eventArgs));
+        }
+
+        [Fact]
+        public void ConnectAsync_NullRemoteEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ConnectAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ConnectAsync_ListeningSocket_Throws_InvalidOperation()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 1)
+            };
+
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Listen(1);
+                Assert.Throws<InvalidOperationException>(() => socket.ConnectAsync(eventArgs));
+            }
+        }
+
+        [Fact]
+        public void ConnectAsync_AddressFamily_Throws_NotSupported()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                RemoteEndPoint = new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6)
+            };
+
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).ConnectAsync(eventArgs));
+
+            eventArgs.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, 1);
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).ConnectAsync(eventArgs));
+        }
+
+        [Fact]
+        public void ConnectAsync_Static_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, null));
+        }
+
+        [Fact]
+        public void ConnectAsync_Static_BufferList_Throws_Argument()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                BufferList = s_buffers
+            };
+
+            Assert.Throws<ArgumentException>(() => Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, eventArgs));
+        }
+
+        [Fact]
+        public void ConnectAsync_Static_NullRemoteEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, s_eventArgs));
+        }
+
+        [Fact]
+        public void DisconnectAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().DisconnectAsync(null));
+        }
+
+        [Fact]
+        public void ReceiveAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveAsync(null));
+        }
+
+        [Fact]
+        public void ReceiveFromAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveFromAsync(null));
+        }
+
+        [Fact]
+        public void ReceiveFromAsync_NullRemoteEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveFromAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ReceiveFromAsync_AddressFamily_Throws_Argument()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, 1)
+            };
+
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).ReceiveFromAsync(eventArgs));
+        }
+
+        [Fact]
+        public void ReceiveMessageFromAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveMessageFromAsync(null));
+        }
+
+        [Fact]
+        public void ReceiveMessageFromAsync_NullRemoteEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().ReceiveMessageFromAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ReceiveMessageFromAsync_AddressFamily_Throws_Argument()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, 1)
+            };
+
+            Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).ReceiveMessageFromAsync(eventArgs));
+        }
+
+        [Fact]
+        public void SendAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendAsync(null));
+        }
+
+        [Fact]
+        public void SendPacketsAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendPacketsAsync(null));
+        }
+
+        [Fact]
+        public void SendPacketsAsync_NullSendPacketsElements_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendPacketsAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void SendPacketsAsync_NotConnected_Throws_NotSupported()
+        {
+            var eventArgs = new SocketAsyncEventArgs {
+                SendPacketsElements = new SendPacketsElement[0]
+            };
+
+            Assert.Throws<NotSupportedException>(() => GetSocket().SendPacketsAsync(eventArgs));
+        }
+
+        [Fact]
+        public void SendToAsync_NullAsyncEventArgs_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendToAsync(null));
+        }
+
+        [Fact]
+        public void SendToAsync_NullRemoteEndPoint_Throws_ArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetSocket().SendToAsync(s_eventArgs));
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -1,0 +1,607 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class DisposedSocket
+    {
+        private readonly static byte[] s_buffer = new byte[1];
+        private readonly static IList<ArraySegment<byte>> s_buffers = new List<ArraySegment<byte>> { new ArraySegment<byte>(s_buffer) };
+        private readonly static SocketAsyncEventArgs s_eventArgs = new SocketAsyncEventArgs();
+
+        private static Socket GetDisposedSocket(AddressFamily addressFamily = AddressFamily.InterNetwork)
+        {
+            using (var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                return socket;
+            }
+        }
+
+        private static void TheAsyncCallback(IAsyncResult ar)
+        {
+        }
+
+        [Fact]
+        public void Available_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Available);
+        }
+
+        [Fact]
+        public void LocalEndPoint_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().LocalEndPoint);
+        }
+
+        [Fact]
+        public void RemoteEndPoint_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().RemoteEndPoint);
+        }
+
+        [Fact]
+        public void SetBlocking_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().Blocking = true;
+            });
+        }
+
+        [Fact]
+        public void ExclusiveAddressUse_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ExclusiveAddressUse);
+        }
+
+        [Fact]
+        public void SetExclusiveAddressUse_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().ExclusiveAddressUse = true;
+            });
+        }
+
+        [Fact]
+        public void ReceiveBufferSize_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveBufferSize);
+        }
+
+        [Fact]
+        public void SetReceiveBufferSize_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().ReceiveBufferSize = 1;
+            });
+        }
+
+        [Fact]
+        public void SendBufferSize_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendBufferSize);
+        }
+
+        [Fact]
+        public void SetSendBufferSize_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().SendBufferSize = 1;
+            });
+        }
+
+        [Fact]
+        public void ReceiveTimeout_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveTimeout);
+        }
+
+        [Fact]
+        public void SetReceiveTimeout_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().ReceiveTimeout = 1;
+            });
+        }
+
+        [Fact]
+        public void SendTimeout_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendTimeout);
+        }
+
+        [Fact]
+        public void SetSendTimeout_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().SendTimeout = 1;
+            });
+        }
+
+        [Fact]
+        public void LingerState_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().LingerState);
+        }
+
+        [Fact]
+        public void SetLingerState_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().LingerState = new LingerOption(true, 1);
+            });
+        }
+
+        [Fact]
+        public void NoDelay_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().NoDelay);
+        }
+
+        [Fact]
+        public void SetNoDelay_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().NoDelay = true;
+            });
+        }
+
+        [Fact]
+        public void Ttl_IPv4_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetwork).Ttl);
+        }
+
+        [Fact]
+        public void SetTtl_IPv4_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket(AddressFamily.InterNetwork).Ttl = 1;
+            });
+        }
+
+        [Fact]
+        public void Ttl_IPv6_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetworkV6).Ttl);
+        }
+
+        [Fact]
+        public void SetTtl_IPv6_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket(AddressFamily.InterNetworkV6).Ttl = 1;
+            });
+        }
+
+        [Fact]
+        public void DontFragment_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().DontFragment);
+        }
+
+        [Fact]
+        public void SetDontFragment_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().DontFragment = true;
+            });
+        }
+
+        [Fact]
+        public void MulticastLoopback_IPv4_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetwork).MulticastLoopback);
+        }
+
+        [Fact]
+        public void SetMulticastLoopback_IPv4_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket(AddressFamily.InterNetwork).MulticastLoopback = true;
+            });
+        }
+
+        [Fact]
+        public void MulticastLoopback_IPv6_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetworkV6).MulticastLoopback);
+        }
+
+        [Fact]
+        public void SetMulticastLoopback_IPv6_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket(AddressFamily.InterNetworkV6).MulticastLoopback = true;
+            });
+        }
+
+        [Fact]
+        public void EnableBroadcast_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EnableBroadcast);
+        }
+
+        [Fact]
+        public void SetEnableBroadcast_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket().EnableBroadcast = true;
+            });
+        }
+
+        [Fact]
+        public void DualMode_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetworkV6).DualMode);
+        }
+
+        [Fact]
+        public void SetDualMode_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                GetDisposedSocket(AddressFamily.InterNetworkV6).DualMode = true;
+            });
+        }
+
+        [Fact]
+        public void Bind_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Bind(new IPEndPoint(IPAddress.Loopback, 0)));
+        }
+
+        [Fact]
+        public void Connect_IPEndPoint_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Connect(new IPEndPoint(IPAddress.Loopback, 1)));
+        }
+
+        [Fact]
+        public void Connect_IPAddress_Port_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Connect(IPAddress.Loopback, 1));
+        }
+
+        [Fact]
+        public void Connect_Host_Port_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Connect("localhost", 1));
+        }
+
+        [Fact]
+        public void Connect_IPAddresses_Port_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Connect(new[] { IPAddress.Loopback }, 1));
+        }
+
+        [Fact]
+        public void Disconnect_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Disconnect(false));
+        }
+
+        [Fact]
+        public void Listen_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Listen(1));
+        }
+
+        [Fact]
+        public void Accept_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Accept());
+        }
+
+        [Fact]
+        public void Send_Buffer_Size_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffer, s_buffer.Length, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Send_Buffer_SocketFlags_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffer, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Send_Buffer_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffer));
+        }
+
+        [Fact]
+        public void Send_Buffer_Offset_Size_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffer, 0, s_buffer.Length, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Send_Buffer_Offset_Size_SocketError_Throws_ObjectDisposed()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffer, 0, s_buffer.Length, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Send_Buffers_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffers));
+        }
+
+        [Fact]
+        public void Send_Buffers_SocketFlags_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffers, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Send_Buffers_SocketFlags_SocketError_Throws_ObjectDisposed()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Send(s_buffers, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void SendTo_Buffer_Offset_Size_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendTo(s_buffer, 0, s_buffer.Length, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1)));
+        }
+
+        [Fact]
+        public void SendTo_Buffer_Size_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendTo(s_buffer,  s_buffer.Length, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1)));
+        }
+
+        [Fact]
+        public void SendTo_Buffer_SocketFlags_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendTo(s_buffer, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1)));
+        }
+
+        [Fact]
+        public void SendTo_Buffer_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendTo(s_buffer, new IPEndPoint(IPAddress.Loopback, 1)));
+        }
+
+        [Fact]
+        public void Receive_Buffer_Size_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffer, s_buffer.Length, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Receive_Buffer_SocketFlags_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffer, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Receive_Buffer_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffer));
+        }
+
+        [Fact]
+        public void Receive_Buffer_Offset_Size_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffer, 0, s_buffer.Length, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Receive_Buffer_Offset_Size_SocketError_Throws_ObjectDisposed()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffer, 0, s_buffer.Length, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void Receive_Buffers_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffers));
+        }
+
+        [Fact]
+        public void Receive_Buffers_SocketFlags_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffers, SocketFlags.None));
+        }
+
+        [Fact]
+        public void Receive_Buffers_SocketFlags_SocketError_Throws_ObjectDisposed()
+        {
+            SocketError errorCode;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Receive(s_buffers, SocketFlags.None, out errorCode));
+        }
+
+        [Fact]
+        public void ReceiveMessageFrom_Throws_ObjectDisposed()
+        {
+            SocketFlags flags = SocketFlags.None;
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            IPPacketInformation packetInfo;
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveMessageFrom(s_buffer, 0, s_buffer.Length, ref flags, ref remote, out packetInfo));
+        }
+
+        [Fact]
+        public void ReceiveFrom_Buffer_Offset_Size_Throws_ObjectDisposed()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveFrom(s_buffer, 0, s_buffer.Length, SocketFlags.None, ref remote));
+        }
+
+        [Fact]
+        public void ReceiveFrom_Buffer_Size_Throws_ObjectDisposed()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveFrom(s_buffer,  s_buffer.Length, SocketFlags.None, ref remote));
+        }
+
+        [Fact]
+        public void ReceiveFrom_Buffer_SocketFlags_Throws_ObjectDisposed()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveFrom(s_buffer, SocketFlags.None, ref remote));
+        }
+
+        [Fact]
+        public void ReceiveFrom_Buffer_Throws_ObjectDisposed()
+        {
+            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveFrom(s_buffer, ref remote));
+        }
+
+        [Fact]
+        public void Shutdown_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Shutdown(SocketShutdown.Both));
+        }
+
+        [Fact]
+        public void IOControl_Int_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().IOControl(0, s_buffer, s_buffer));
+        }
+
+        [Fact]
+        public void IOControl_IOControlCode_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().IOControl(IOControlCode.Flush, s_buffer, s_buffer));
+        }
+
+        [Fact]
+        public void SetIPProtectionLevel_IPv4_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetwork).SetIPProtectionLevel(IPProtectionLevel.Unrestricted));
+        }
+
+        [Fact]
+        public void SetIPProtectionLevel_IPv6_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket(AddressFamily.InterNetworkV6).SetIPProtectionLevel(IPProtectionLevel.Unrestricted));
+        }
+
+        [Fact]
+        public void SetSocketOption_Int_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Error, 0)); 
+        }
+
+        [Fact]
+        public void SetSocketOption_Buffer_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Error, s_buffer)); 
+        }
+
+        [Fact]
+        public void SetSocketOption_Bool_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Error, true)); 
+        }
+
+        [Fact]
+        public void SetSocketOption_Object_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, new LingerOption(true, 1))); 
+        }
+
+        [Fact]
+        public void GetSocketOption_Int_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Error, 4)); 
+        }
+
+        [Fact]
+        public void GetSocketOption_Buffer_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Error, s_buffer)); 
+        }
+
+        [Fact]
+        public void GetSocketOption_Object_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger)); 
+        }
+
+        [Fact]
+        public void Poll_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Poll(-1, SelectMode.SelectWrite));
+        }
+
+        [Fact]
+        public void AcceptAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().AcceptAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ConnectAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ConnectAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void DisconnectAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().DisconnectAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ReceiveAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ReceiveFromAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveFromAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void ReceiveMessageFromAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().ReceiveMessageFromAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void SendAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void SendPacketsAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendPacketsAsync(s_eventArgs));
+        }
+
+        [Fact]
+        public void SendToAsync_Throws_ObjectDisposed()
+        {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().SendToAsync(s_eventArgs));
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -13,9 +13,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="AcceptAsync.cs" />
+    <Compile Include="ArgumentValidationTests.cs" />
     <Compile Include="ConnectAsync.cs" />
     <Compile Include="ConnectExTest.cs" />
     <Compile Include="CreateSocketTests.cs" />
+    <Compile Include="DisposedSocketTests.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
     <Compile Include="SendReceive.cs" />


### PR DESCRIPTION
These tests cover the validation of input arguments for all public methods
on the Socket class.