### PR TITLE
build: Unset %Platform% on invoking build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -23,6 +23,11 @@ if not defined VisualStudioVersion (
 )
 
 :EnvSet
+:: Clear the 'Platform' env variable for this session,
+:: as it's a per-project setting within the build, and
+:: misleading value (such as 'MCD' in HP PCs) may lead
+:: to build breakage (issue: #69).
+set Platform=
 
 :: Log build command line
 set _buildproj=%~dp0build.proj


### PR DESCRIPTION
<del>If `%Platform%` is set to MCD, on invoking `build.cmd` it unsets the
var for local scope.</del>

Unset `%Platform%`, so build don't get disrupted by the incorrect value
set in evn variable.

Fixes #69.