### PR TITLE
license: Replace Apache with MIT

### DIFF
--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Framework.WebEncoders;
 using System;


### PR DESCRIPTION
Thought i will be fixing https://github.com/dotnet/corefx/issues/52, as this is the only file with Apache license. But after reading the comments, I realized that #52 belongs to https://github.com/microsoft/referencesource (and probably should be closed from this repo as is?)