### PR TITLE
Editing Socket References

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -388,19 +388,19 @@ namespace System.Net.Sockets
 
     public static partial class SocketTaskExtensions
     {
-        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket thisSocket) { return default(System.Threading.Tasks.Task<Socket>); }
-        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket thisSocket, System.Net.Sockets.Socket acceptSocket) { return default(System.Threading.Tasks.Task<Socket>); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, string host, int port) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket thisSocket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult>); }
-        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult>); }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket thisSocket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendToAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket) { return default(System.Threading.Tasks.Task<Socket>); }
+        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket, System.Net.Sockets.Socket acceptSocket) { return default(System.Threading.Tasks.Task<Socket>); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, string host, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult>); }
+        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendToAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
     }
     public enum SocketType
     {
@@ -454,6 +454,7 @@ namespace System.Net.Sockets
         public UdpClient() { }
         public UdpClient(int port) { }
         public UdpClient(int port, System.Net.Sockets.AddressFamily family) { }
+        public UdpClient(System.Net.IPEndPoint localEP) { }
         public UdpClient(System.Net.Sockets.AddressFamily family) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
@@ -472,7 +473,6 @@ namespace System.Net.Sockets
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, int timeToLive) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, System.Net.IPAddress localAddress) { }
         public System.Threading.Tasks.Task<System.Net.Sockets.UdpReceiveResult> ReceiveAsync() { return default(System.Threading.Tasks.Task<System.Net.Sockets.UdpReceiveResult>); }
-        public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes) { return default(System.Threading.Tasks.Task<int>); }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, System.Net.IPEndPoint endPoint) { return default(System.Threading.Tasks.Task<int>); }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, string hostname, int port) { return default(System.Threading.Tasks.Task<int>); }
     }

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -182,27 +182,9 @@ namespace System.Net.Sockets
         public short Ttl { get { return default(short); } set { } }
         public System.Net.Sockets.Socket Accept() { return default(System.Net.Sockets.Socket); }
         public bool AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public System.Threading.Tasks.Task<Socket> AcceptAsync() { return default(System.Threading.Tasks.Task<Socket>); }
-        public System.Threading.Tasks.Task<Socket> AcceptAsync(int receiveSize) { return default(System.Threading.Tasks.Task<Socket>); }
-        public System.Threading.Tasks.Task<Socket> AcceptAsync(System.Net.Sockets.Socket acceptSocket, int receiveSize) { return default(System.Threading.Tasks.Task<Socket>); }
-        public System.Threading.Tasks.Task ConnectAsync(System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task); }
-        public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
-        public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
-        public System.Threading.Tasks.Task ConnectAsync(string host, int port) { return default(System.Threading.Tasks.Task); }
-        public System.Threading.Tasks.Task<int> ReceiveAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> ReceiveAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> ReceiveAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> ReceiveAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> ReceiveFromAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> ReceiveMessageFromAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> SendAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> SendAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> SendAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> SendAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public System.Threading.Tasks.Task<int> SendToAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task<int>); }
         public void Bind(System.Net.EndPoint localEP) { }
         public static void CancelConnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { }
-        public void Connect(System.Net.EndPoint remoteEP) { }
+        public void Connect(System.Net.EndPoint remoteEndPoint) { }
         public void Connect(System.Net.IPAddress address, int port) { }
         public void Connect(System.Net.IPAddress[] addresses, int port) { }
         public void Connect(string host, int port) { }
@@ -227,12 +209,12 @@ namespace System.Net.Sockets
         public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(int); }
         public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(int); }
         public bool ReceiveAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public int ReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(int); }
-        public int ReceiveFrom(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(int); }
-        public int ReceiveFrom(byte[] buffer, ref System.Net.EndPoint remoteEP) { return default(int); }
-        public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
         public bool ReceiveFromAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); return default(int); }
+        public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); return default(int); }
         public bool ReceiveMessageFromAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public static void Select(System.Collections.IList checkRead, System.Collections.IList checkWrite, System.Collections.IList checkError, int microSeconds) { }
         public int Send(byte[] buffer) { return default(int); }
@@ -245,16 +227,37 @@ namespace System.Net.Sockets
         public int Send(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(int); }
         public bool SendAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public bool SendPacketsAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public int SendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
-        public int SendTo(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
-        public int SendTo(byte[] buffer, System.Net.EndPoint remoteEP) { return default(int); }
-        public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
+        public int SendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int SendTo(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int SendTo(byte[] buffer, System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(int); }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, bool optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, object optionValue) { }
         public void Shutdown(System.Net.Sockets.SocketShutdown how) { }
+    }
+    
+    public static partial class SocketTaskExtensions
+    {
+        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket) { return default(System.Threading.Tasks.Task<Socket>); }
+        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket, System.Net.Sockets.Socket acceptSocket) { return default(System.Threading.Tasks.Task<Socket>); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, string host, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveFromAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveMessageFromAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendToAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
     }
     public partial class SocketAsyncEventArgs : System.EventArgs, System.IDisposable
     {

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -189,7 +189,6 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
         public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
         public System.Threading.Tasks.Task ConnectAsync(string host, int port) { return default(System.Threading.Tasks.Task); }
-        public System.Threading.Tasks.Task DisconnectAsync(bool reuseSocket) { return default(System.Threading.Tasks.Task); }
         public System.Threading.Tasks.Task<int> ReceiveAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
         public System.Threading.Tasks.Task<int> ReceiveAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
         public System.Threading.Tasks.Task<int> ReceiveAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
@@ -209,8 +208,6 @@ namespace System.Net.Sockets
         public void Connect(string host, int port) { }
         public bool ConnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public static bool ConnectAsync(System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType, System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public void Disconnect(bool reuseSocket) { }
-        public bool DisconnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         ~Socket() { }
@@ -306,7 +303,6 @@ namespace System.Net.Sockets
         Broadcast = 1024,
         ControlDataTruncated = 512,
         DontRoute = 4,
-        MaxIOVectorLength = 16,
         Multicast = 2048,
         None = 0,
         OutOfBand = 1,

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -266,13 +266,11 @@ namespace System.Net.Sockets
         public System.Exception ConnectByNameError { get { return default(System.Exception); } }
         public System.Net.Sockets.Socket ConnectSocket { get { return default(System.Net.Sockets.Socket); } }
         public int Count { get { return default(int); } }
-        public bool DisconnectReuseSocket { get { return default(bool); } set { } }
         public System.Net.Sockets.SocketAsyncOperation LastOperation { get { return default(System.Net.Sockets.SocketAsyncOperation); } }
         public int Offset { get { return default(int); } }
         public System.Net.Sockets.IPPacketInformation ReceiveMessageFromPacketInfo { get { return default(System.Net.Sockets.IPPacketInformation); } }
         public System.Net.EndPoint RemoteEndPoint { get { return default(System.Net.EndPoint); } set { } }
         public System.Net.Sockets.SendPacketsElement[] SendPacketsElements { get { return default(System.Net.Sockets.SendPacketsElement[]); } set { } }
-        public System.Net.Sockets.TransmitFileOptions SendPacketsFlags { get { return default(System.Net.Sockets.TransmitFileOptions); } set { } }
         public int SendPacketsSendSize { get { return default(int); } set { } }
         public System.Net.Sockets.SocketError SocketError { get { return default(System.Net.Sockets.SocketError); } set { } }
         public System.Net.Sockets.SocketFlags SocketFlags { get { return default(System.Net.Sockets.SocketFlags); } set { } }
@@ -322,7 +320,6 @@ namespace System.Net.Sockets
         Connected = 2,
         Listening = 4,
         NonBlocking = 1,
-        UseOnlyOverlappedIO = 8,
     }
     public enum SocketOptionLevel
     {
@@ -433,19 +430,11 @@ namespace System.Net.Sockets
         public void Start(int backlog) { }
         public void Stop() { }
     }
-    [System.FlagsAttribute]
-    public enum TransmitFileOptions
-    {
-        Disconnect = 1,
-        ReuseSocket = 2,
-        UseDefaultWorkerThread = 0,
-        UseKernelApc = 32,
-        UseSystemThread = 16,
-        WriteBehind = 4,
-    }
     public partial class UdpClient : System.IDisposable
     {
         public UdpClient() { }
+        public UdpClient(int port) { }
+        public UdpClient(int port, System.Net.Sockets.AddressFamily family) { }
         public UdpClient(System.Net.Sockets.AddressFamily family) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -156,7 +156,6 @@ namespace System.Net.Sockets
     public partial class Socket : System.IDisposable
     {
         public Socket(System.Net.Sockets.AddressFamily addressFamily, System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType) { }
-        public Socket(System.Net.Sockets.SocketInformation socketInformation) { }
         public Socket(System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType) { }
         public System.Net.Sockets.AddressFamily AddressFamily { get { return default(System.Net.Sockets.AddressFamily); } }
         public int Available { get { return default(int); } }
@@ -183,25 +182,25 @@ namespace System.Net.Sockets
         public short Ttl { get { return default(short); } set { } }
         public System.Net.Sockets.Socket Accept() { return default(System.Net.Sockets.Socket); }
         public bool AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public System.IAsyncResult BeginAccept(System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginAccept(int receiveSize, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginAccept(System.Net.Sockets.Socket acceptSocket, int receiveSize, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginConnect(System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginConnect(System.Net.IPAddress address, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginConnect(System.Net.IPAddress[] addresses, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginConnect(string host, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginDisconnect(bool reuseSocket, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginReceive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginReceive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginReceive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginReceive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginReceiveMessageFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
+        public System.Threading.Tasks.Task<Socket> AcceptAsync() { return default(System.Threading.Tasks.Task<Socket>); }
+        public System.Threading.Tasks.Task<Socket> AcceptAsync(int receiveSize) { return default(System.Threading.Tasks.Task<Socket>); }
+        public System.Threading.Tasks.Task<Socket> AcceptAsync(System.Net.Sockets.Socket acceptSocket, int receiveSize) { return default(System.Threading.Tasks.Task<Socket>); }
+        public System.Threading.Tasks.Task ConnectAsync(System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task); }
+        public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
+        public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
+        public System.Threading.Tasks.Task ConnectAsync(string host, int port) { return default(System.Threading.Tasks.Task); }
+        public System.Threading.Tasks.Task DisconnectAsync(bool reuseSocket) { return default(System.Threading.Tasks.Task); }
+        public System.Threading.Tasks.Task<int> ReceiveAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> ReceiveAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> ReceiveAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> ReceiveAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> ReceiveFromAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> ReceiveMessageFromAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> SendAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> SendAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> SendAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> SendAsync(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
+        public System.Threading.Tasks.Task<int> SendToAsync(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(System.Threading.Tasks.Task<int>); }
         public void Bind(System.Net.EndPoint localEP) { }
         public static void CancelConnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { }
         public void Connect(System.Net.EndPoint remoteEP) { }
@@ -215,18 +214,6 @@ namespace System.Net.Sockets
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public System.Net.Sockets.SocketInformation DuplicateAndClose(int targetProcessId) { return default(System.Net.Sockets.SocketInformation); }
-        public System.Net.Sockets.Socket EndAccept(out byte[] buffer, System.IAsyncResult asyncResult) { buffer = default(byte[]); return default(System.Net.Sockets.Socket); }
-        public System.Net.Sockets.Socket EndAccept(out byte[] buffer, out int bytesTransferred, System.IAsyncResult asyncResult) { buffer = default(byte[]); bytesTransferred = default(int); return default(System.Net.Sockets.Socket); }
-        public System.Net.Sockets.Socket EndAccept(System.IAsyncResult asyncResult) { return default(System.Net.Sockets.Socket); }
-        public void EndConnect(System.IAsyncResult asyncResult) { }
-        public void EndDisconnect(System.IAsyncResult asyncResult) { }
-        public int EndReceive(System.IAsyncResult asyncResult) { return default(int); }
-        public int EndReceive(System.IAsyncResult asyncResult, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(int); }
-        public int EndReceiveFrom(System.IAsyncResult asyncResult, ref System.Net.EndPoint endPoint) { return default(int); }
-        public int EndReceiveMessageFrom(System.IAsyncResult asyncResult, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint endPoint, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); return default(int); }
-        public int EndSend(System.IAsyncResult asyncResult) { return default(int); }
-        public int EndSend(System.IAsyncResult asyncResult, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(int); }
-        public int EndSendTo(System.IAsyncResult asyncResult) { return default(int); }
         ~Socket() { }
         public object GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName) { return default(object); }
         public void GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
@@ -417,9 +404,7 @@ namespace System.Net.Sockets
     public partial class TcpClient : System.IDisposable
     {
         public TcpClient() { }
-        public TcpClient(System.Net.IPEndPoint localEP) { }
         public TcpClient(System.Net.Sockets.AddressFamily family) { }
-        public TcpClient(string hostname, int port) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
         public System.Net.Sockets.Socket Client { get { return default(System.Net.Sockets.Socket); } set { } }
@@ -431,9 +416,6 @@ namespace System.Net.Sockets
         public int ReceiveTimeout { get { return default(int); } set { } }
         public int SendBufferSize { get { return default(int); } set { } }
         public int SendTimeout { get { return default(int); } set { } }
-        public System.IAsyncResult BeginConnect(System.Net.IPAddress address, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginConnect(System.Net.IPAddress[] addresses, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginConnect(string host, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
         public void Connect(System.Net.IPAddress address, int port) { }
         public void Connect(System.Net.IPAddress[] ipAddresses, int port) { }
         public void Connect(System.Net.IPEndPoint remoteEP) { }
@@ -443,7 +425,6 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task ConnectAsync(string host, int port) { return default(System.Threading.Tasks.Task); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public void EndConnect(System.IAsyncResult asyncResult) { }
         ~TcpClient() { }
         public System.Net.Sockets.NetworkStream GetStream() { return default(System.Net.Sockets.NetworkStream); }
     }
@@ -460,11 +441,7 @@ namespace System.Net.Sockets
         public System.Net.Sockets.TcpClient AcceptTcpClient() { return default(System.Net.Sockets.TcpClient); }
         public System.Threading.Tasks.Task<System.Net.Sockets.TcpClient> AcceptTcpClientAsync() { return default(System.Threading.Tasks.Task<System.Net.Sockets.TcpClient>); }
         public void AllowNatTraversal(bool allowed) { }
-        public System.IAsyncResult BeginAcceptSocket(System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginAcceptTcpClient(System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         public static System.Net.Sockets.TcpListener Create(int port) { return default(System.Net.Sockets.TcpListener); }
-        public System.Net.Sockets.Socket EndAcceptSocket(System.IAsyncResult asyncResult) { return default(System.Net.Sockets.Socket); }
-        public System.Net.Sockets.TcpClient EndAcceptTcpClient(System.IAsyncResult asyncResult) { return default(System.Net.Sockets.TcpClient); }
         public bool Pending() { return default(bool); }
         public void Start() { }
         public void Start(int backlog) { }
@@ -483,11 +460,7 @@ namespace System.Net.Sockets
     public partial class UdpClient : System.IDisposable
     {
         public UdpClient() { }
-        public UdpClient(int port) { }
-        public UdpClient(int port, System.Net.Sockets.AddressFamily family) { }
-        public UdpClient(System.Net.IPEndPoint localEP) { }
         public UdpClient(System.Net.Sockets.AddressFamily family) { }
-        public UdpClient(string hostname, int port) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
         public System.Net.Sockets.Socket Client { get { return default(System.Net.Sockets.Socket); } set { } }
@@ -497,10 +470,6 @@ namespace System.Net.Sockets
         public bool MulticastLoopback { get { return default(bool); } set { } }
         public short Ttl { get { return default(short); } set { } }
         public void AllowNatTraversal(bool allowed) { }
-        public System.IAsyncResult BeginReceive(System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(byte[] datagram, int bytes, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(byte[] datagram, int bytes, System.Net.IPEndPoint endPoint, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
-        public System.IAsyncResult BeginSend(byte[] datagram, int bytes, string hostname, int port, System.AsyncCallback requestCallback, object state) { return default(System.IAsyncResult); }
         public void Connect(System.Net.IPAddress addr, int port) { }
         public void Connect(System.Net.IPEndPoint endPoint) { }
         public void Connect(string hostname, int port) { }
@@ -508,8 +477,6 @@ namespace System.Net.Sockets
         protected virtual void Dispose(bool disposing) { }
         public void DropMulticastGroup(System.Net.IPAddress multicastAddr) { }
         public void DropMulticastGroup(System.Net.IPAddress multicastAddr, int ifindex) { }
-        public byte[] EndReceive(System.IAsyncResult asyncResult, ref System.Net.IPEndPoint remoteEP) { return default(byte[]); }
-        public int EndSend(System.IAsyncResult asyncResult) { return default(int); }
         public void JoinMulticastGroup(int ifindex, System.Net.IPAddress multicastAddr) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, int timeToLive) { }

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -308,19 +308,6 @@ namespace System.Net.Sockets
         Peek = 2,
         Truncated = 256,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SocketInformation
-    {
-        public System.Net.Sockets.SocketInformationOptions Options { get { return default(System.Net.Sockets.SocketInformationOptions); } set { } }
-        public byte[] ProtocolInformation { get { return default(byte[]); } set { } }
-    }
-    [System.FlagsAttribute]
-    public enum SocketInformationOptions
-    {
-        Connected = 2,
-        Listening = 4,
-        NonBlocking = 1,
-    }
     public enum SocketOptionLevel
     {
         IP = 0,

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -213,7 +213,6 @@ namespace System.Net.Sockets
         public bool DisconnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public System.Net.Sockets.SocketInformation DuplicateAndClose(int targetProcessId) { return default(System.Net.Sockets.SocketInformation); }
         ~Socket() { }
         public object GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName) { return default(object); }
         public void GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
@@ -254,7 +253,6 @@ namespace System.Net.Sockets
         public int SendTo(byte[] buffer, System.Net.EndPoint remoteEP) { return default(int); }
         public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public void SetIPProtectionLevel(System.Net.Sockets.IPProtectionLevel level) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, bool optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionValue) { }
@@ -416,10 +414,6 @@ namespace System.Net.Sockets
         public int ReceiveTimeout { get { return default(int); } set { } }
         public int SendBufferSize { get { return default(int); } set { } }
         public int SendTimeout { get { return default(int); } set { } }
-        public void Connect(System.Net.IPAddress address, int port) { }
-        public void Connect(System.Net.IPAddress[] ipAddresses, int port) { }
-        public void Connect(System.Net.IPEndPoint remoteEP) { }
-        public void Connect(string hostname, int port) { }
         public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
         public System.Threading.Tasks.Task ConnectAsync(System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
         public System.Threading.Tasks.Task ConnectAsync(string host, int port) { return default(System.Threading.Tasks.Task); }
@@ -436,12 +430,8 @@ namespace System.Net.Sockets
         public bool ExclusiveAddressUse { get { return default(bool); } set { } }
         public System.Net.EndPoint LocalEndpoint { get { return default(System.Net.EndPoint); } }
         public System.Net.Sockets.Socket Server { get { return default(System.Net.Sockets.Socket); } }
-        public System.Net.Sockets.Socket AcceptSocket() { return default(System.Net.Sockets.Socket); }
         public System.Threading.Tasks.Task<System.Net.Sockets.Socket> AcceptSocketAsync() { return default(System.Threading.Tasks.Task<System.Net.Sockets.Socket>); }
-        public System.Net.Sockets.TcpClient AcceptTcpClient() { return default(System.Net.Sockets.TcpClient); }
         public System.Threading.Tasks.Task<System.Net.Sockets.TcpClient> AcceptTcpClientAsync() { return default(System.Threading.Tasks.Task<System.Net.Sockets.TcpClient>); }
-        public void AllowNatTraversal(bool allowed) { }
-        public static System.Net.Sockets.TcpListener Create(int port) { return default(System.Net.Sockets.TcpListener); }
         public bool Pending() { return default(bool); }
         public void Start() { }
         public void Start(int backlog) { }
@@ -469,10 +459,6 @@ namespace System.Net.Sockets
         public bool ExclusiveAddressUse { get { return default(bool); } set { } }
         public bool MulticastLoopback { get { return default(bool); } set { } }
         public short Ttl { get { return default(short); } set { } }
-        public void AllowNatTraversal(bool allowed) { }
-        public void Connect(System.Net.IPAddress addr, int port) { }
-        public void Connect(System.Net.IPEndPoint endPoint) { }
-        public void Connect(string hostname, int port) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void DropMulticastGroup(System.Net.IPAddress multicastAddr) { }
@@ -481,11 +467,7 @@ namespace System.Net.Sockets
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, int timeToLive) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, System.Net.IPAddress localAddress) { }
-        public byte[] Receive(ref System.Net.IPEndPoint remoteEP) { return default(byte[]); }
         public System.Threading.Tasks.Task<System.Net.Sockets.UdpReceiveResult> ReceiveAsync() { return default(System.Threading.Tasks.Task<System.Net.Sockets.UdpReceiveResult>); }
-        public int Send(byte[] dgram, int bytes) { return default(int); }
-        public int Send(byte[] dgram, int bytes, System.Net.IPEndPoint endPoint) { return default(int); }
-        public int Send(byte[] dgram, int bytes, string hostname, int port) { return default(int); }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes) { return default(System.Threading.Tasks.Task<int>); }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, System.Net.IPEndPoint endPoint) { return default(System.Threading.Tasks.Task<int>); }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, string hostname, int port) { return default(System.Threading.Tasks.Task<int>); }

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -184,7 +184,7 @@ namespace System.Net.Sockets
         public bool AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public void Bind(System.Net.EndPoint localEP) { }
         public static void CancelConnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { }
-        public void Connect(System.Net.EndPoint remoteEndPoint) { }
+        public void Connect(System.Net.EndPoint remoteEP) { }
         public void Connect(System.Net.IPAddress address, int port) { }
         public void Connect(System.Net.IPAddress[] addresses, int port) { }
         public void Connect(string host, int port) { }
@@ -209,12 +209,12 @@ namespace System.Net.Sockets
         public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(int); }
         public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(int); }
         public bool ReceiveAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public int ReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
-        public int ReceiveFrom(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
-        public int ReceiveFrom(byte[] buffer, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
-        public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, ref System.Net.EndPoint remoteEP) { return default(int); }
+        public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { return default(int); }
         public bool ReceiveFromAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); return default(int); }
+        public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); return default(int); }
         public bool ReceiveMessageFromAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public static void Select(System.Collections.IList checkRead, System.Collections.IList checkWrite, System.Collections.IList checkError, int microSeconds) { }
         public int Send(byte[] buffer) { return default(int); }
@@ -227,37 +227,16 @@ namespace System.Net.Sockets
         public int Send(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(int); }
         public bool SendAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public bool SendPacketsAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
-        public int SendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(int); }
-        public int SendTo(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(int); }
-        public int SendTo(byte[] buffer, System.Net.EndPoint remoteEndPoint) { return default(int); }
-        public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(int); }
+        public int SendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
+        public int SendTo(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
+        public int SendTo(byte[] buffer, System.Net.EndPoint remoteEP) { return default(int); }
+        public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { return default(int); }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { return default(bool); }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, bool optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, object optionValue) { }
         public void Shutdown(System.Net.Sockets.SocketShutdown how) { }
-    }
-    
-    public static partial class SocketTaskExtensions
-    {
-        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket) { return default(System.Threading.Tasks.Task<Socket>); }
-        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket, System.Net.Sockets.Socket acceptSocket) { return default(System.Threading.Tasks.Task<Socket>); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, string host, int port) { return default(System.Threading.Tasks.Task); }
-        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> ReceiveFromAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> ReceiveMessageFromAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); return default(System.Threading.Tasks.Task<int>); }
-        public static System.Threading.Tasks.Task<int> SendToAsync(this System.Net.Sockets.Socket socket, byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
     }
     public partial class SocketAsyncEventArgs : System.EventArgs, System.IDisposable
     {
@@ -367,11 +346,61 @@ namespace System.Net.Sockets
         UpdateConnectContext = 28688,
         UseLoopback = 64,
     }
+    // TODO: Review note: RemoteEndPoint definition includes the Address and Port.
+    //       PacketInformation includes Address and Interface (physical interface number).
+    //       The redundancy could be removed by replacing RemoteEndPoint with Port.
+    public struct SocketReceiveFromResult
+    {
+        public int ReceivedBytes;
+        public EndPoint RemoteEndPoint;
+    }
+
+    // Alternative:
+    //    public struct SocketReceiveMessageFromResult
+    //    {
+    //        public int ReceivedBytes;
+    //        public IPAddress Address;
+    //        public int Port;
+    //    }
+    public struct SocketReceiveMessageFromResult
+    {
+        public int ReceivedBytes;
+        public SocketFlags SocketFlags;
+        public EndPoint RemoteEndPoint;
+        public IPPacketInformation PacketInformation;
+    }
+
+    // Alternative:
+    //    public struct SocketReceiveMessageFromResult
+    //    {
+    //        public int ReceivedBytes;
+    //        public SocketFlags SocketFlags;
+    //        public IPAddress Address;
+    //        public int Port;
+    //        public int Interface;
+    //    }
     public enum SocketShutdown
     {
         Both = 2,
         Receive = 0,
         Send = 1,
+    }
+
+    public static partial class SocketTaskExtensions
+    {
+        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket thisSocket) { return default(System.Threading.Tasks.Task<Socket>); }
+        public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket thisSocket, System.Net.Sockets.Socket acceptSocket) { return default(System.Threading.Tasks.Task<Socket>); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, System.Net.IPAddress address, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, System.Net.IPAddress[] addresses, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket thisSocket, string host, int port) { return default(System.Threading.Tasks.Task); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket thisSocket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult>); }
+        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket thisSocket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { return default(System.Threading.Tasks.Task<int>); }
+        public static System.Threading.Tasks.Task<int> SendToAsync(this System.Net.Sockets.Socket thisSocket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { return default(System.Threading.Tasks.Task<int>); }
     }
     public enum SocketType
     {


### PR DESCRIPTION
Some constructors that are doing time consuming operations for constructors (like interop or
trying to connect over the network) are removed.

APM methods are removed and replaced by TPL equivalent methods.