### PR TITLE
Allow "extra data" as native metadata reader does

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
@@ -117,6 +117,7 @@ namespace System.Reflection.Metadata.Ecma335
         GuidHeapLarge = 0x02,   // 4 byte uint indexes used for GUID heap offsets
         BlobHeapLarge = 0x04,   // 4 byte uint indexes used for Blob heap offsets
         EnCDeltas = 0x20,       // Indicates only EnC Deltas are present
+        ExtraData = 0x40,       // Indicates that there is an extra 4 bytes of data immediately after the row counts
         DeletedMarks = 0x80,    // Indicates metadata might contain items marked deleted
     }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -440,6 +440,13 @@ namespace System.Reflection.Metadata
             }
 
             metadataTableRowCounts = rowCounts;
+
+            if ((_MetadataTableHeader.HeapSizeFlags & HeapSizeFlag.ExtraData) == HeapSizeFlag.ExtraData)
+            {
+                // Skip "extra data" used by some obfuscators. Although it is not mentioned in the CLI spec,
+                // it is honored by the native metadata reader.
+                memReader.ReadUInt32();
+            }
         }
 
         private const int SmallIndexSize = 2;


### PR DESCRIPTION
Although not mentioned in the CLI spec, the native metadata reader allows an EXTRA_DATA flag to be set, which indicates that there are 4 bytes of extra data after the row counts. A customer has reported being unable to compile against obfuscated assemblies, and it turns out that the obfuscator in question is using this flag.

See [Customer report](https://connect.microsoft.com/VisualStudio/feedback/details/1582765/visual-studio-2015-build-errors-for-existing-projects-which-compile-fine-in-vs2013)

See [Native handling of EXTRA_DATA](https://github.com/dotnet/coreclr/blob/4cf8a6b082d9bb1789facd996d8265d3908757b2/src/md/runtime/metamodel.cpp#L275-L291)

There will be a small merge conflict here with some refactoring in the portable PDB work. I have the resolution ready, but wanted to keep this bug fix in its own PR to master.

I'm checking in a test that does the equivalent of the relevant obfuscation on the fly, but I've also tested with the customer-supplied repro.

cc @tmat @AlekseyTs 

