### PR TITLE
Update test namespaces in System.Net.Requests

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1,19 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-using System.Net;
-using System.Net.Http;
-using System.Net.Tests;
 using System.IO;
-
+using System.Net.Http;
+using System.Text;
 using Xunit;
 
-namespace System.Net.Requests.Test
+namespace System.Net.Tests
 {
     public class HttpWebRequestTest
     {

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Http;
-using System.Net.Tests;
 
 using Xunit;
 
-namespace System.Net.Requests.Test
+namespace System.Net.Tests
 {
     public class HttpWebResponseTest
     {

--- a/src/System.Net.Requests/tests/WebRequestTest.cs
+++ b/src/System.Net.Requests/tests/WebRequestTest.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.Net.Requests.Test
+namespace System.Net.Tests
 {
     public class WebRequestTest
     {


### PR DESCRIPTION
Update test namespaces in System.Net.Requests per #2898. 
Clean up `using`s.