### PR TITLE
code: Fixes occurred spelling

### DIFF
--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel
 
         /// <devdoc>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the last Win32 error 
-        ///    that occured.</para>
+        ///    that occurred.</para>
         /// </devdoc>
         public Win32Exception() : this(Marshal.GetLastWin32Error())
         {

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -1271,7 +1271,7 @@ namespace Microsoft.Win32
         /**
          * Retrieves the current state of the dirty property.
          *
-         * A key is marked as dirty if any operation has occured that modifies the
+         * A key is marked as dirty if any operation has occurred that modifies the
          * contents of the key.
          *
          * @return <b>true</b> if the key has been modified.

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_Flush.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_Flush.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Win32.RegistryTests
 {
     public class RegistryKey_Flush : RegistryTestsBase
     {
-        // [] Flush is called if the state of the registry key is dirty - modifiable operation has occured in the key - and the 
+        // [] Flush is called if the state of the registry key is dirty - modifiable operation has occurred in the key - and the 
         // registry key is still a valid handle. From the MSDN
         /**
         It is not necessary to call RegFlushKey to change a key. Registry changes are flushed to disk by the registry using its lazy flusher. 

--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyItemThreadSafety.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyItemThreadSafety.cs
@@ -26,7 +26,7 @@ public class ItemThreadSafetyTests
     private object _value2 = "value2";
     private Hashtable _ht;
 
-    private bool _errorOccured = false;
+    private bool _errorOccurred = false;
     private bool _timeExpired = false;
 
     private const int MAX_TEST_TIME_MS = 10000; // 10 seconds
@@ -68,7 +68,7 @@ public class ItemThreadSafetyTests
         writer = Task.Run(new Action(WriterFunction));
 
         SpinWait spin = new SpinWait();
-        while (!_errorOccured && !_timeExpired)
+        while (!_errorOccurred && !_timeExpired)
         {
             if (MAX_TEST_TIME_MS < stopwatch.ElapsedMilliseconds)
             {
@@ -82,7 +82,7 @@ public class ItemThreadSafetyTests
         Task.WaitAll(readers2);
         writer.Wait();
 
-        Assert.False(_errorOccured);
+        Assert.False(_errorOccurred);
     }
 
     private void ReaderFunction1()
@@ -100,7 +100,7 @@ public class ItemThreadSafetyTests
 
     private void ReaderFunction2()
     {
-        while (!_errorOccured && !_timeExpired)
+        while (!_errorOccurred && !_timeExpired)
         {
             object value = _ht[_key2];
             if (value != null)
@@ -112,7 +112,7 @@ public class ItemThreadSafetyTests
 
     private void WriterFunction()
     {
-        while (!_errorOccured && !_timeExpired)
+        while (!_errorOccurred && !_timeExpired)
         {
             _ht.Add(_key1, _value1);
             _ht.Remove(_key1);

--- a/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilderOfT.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilderOfT.cs
@@ -46,7 +46,7 @@ namespace System.Composition.Convention
                     }
                 }
 
-                // An error occured the expression must be a void Method() Member Expression
+                // An error occurred the expression must be a void Method() Member Expression
                 throw ExceptionBuilder.Argument_ExpressionMustBeVoidMethodWithNoArguments("methodSelector");
             }
 
@@ -120,7 +120,7 @@ namespace System.Composition.Convention
                     }
                 }
 
-                // An error occured the expression must be a Property Member Expression
+                // An error occurred the expression must be a Property Member Expression
                 throw ExceptionBuilder.Argument_ExpressionMustBePropertyMember("propertySelector");
             }
 

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -469,7 +469,7 @@
     <value>Connection Timeout Expired.  The timeout period elapsed during the post-login phase.  The connection could have timed out while waiting for server to complete the login process and respond; Or it could have timed out while attempting to create multiple active connections.</value>
   </data>
   <data name="SQL_Timeout_FailoverInfo" xml:space="preserve">
-    <value>This failure occured while attempting to connect to the {0} server.</value>
+    <value>This failure occurred while attempting to connect to the {0} server.</value>
   </data>
   <data name="SQL_Timeout_RoutingDestinationInfo" xml:space="preserve">
     <value>This failure occurred while attempting to connect to the routing destination. The duration spent while attempting to connect to the original server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4};  </value>
@@ -937,7 +937,7 @@
     <value>A transport-level error has occurred while sending information to the server.</value>
   </data>
   <data name="Snix_ProcessSspi" xml:space="preserve">
-    <value>A transport-level error has occured during SSPI handshake.</value>
+    <value>A transport-level error has occurred during SSPI handshake.</value>
   </data>
   <data name="LocalDB_FailedGetDLLHandle" xml:space="preserve">
     <value>Local Database Runtime: Cannot load SQLUserInstance.dll.</value>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionTimeoutErrorInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionTimeoutErrorInternal.cs
@@ -197,7 +197,7 @@ namespace System.Data.SqlClient
             // In all other cases, it will default to the original error message.
             if ((_currentPhase != SqlConnectionTimeoutErrorPhase.Undefined) || (_currentPhase != SqlConnectionTimeoutErrorPhase.Complete))
             {
-                // NOTE: In case of a failover scenario, add a string that this failure occured as part of the primary or secondary server
+                // NOTE: In case of a failover scenario, add a string that this failure occurred as part of the primary or secondary server
                 if (_isFailoverScenario)
                 {
                     errorBuilder.Append("  ");

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -106,7 +106,7 @@ namespace System.Data.SqlClient
         internal volatile bool _attentionSent = false;               // true if we sent an Attention to the server
         internal bool _attentionReceived = false;               // NOTE: Received is not volatile as it is only ever accessed\modified by TryRun its callees (i.e. single threaded access)
         internal volatile bool _attentionSending = false;
-        internal bool _internalTimeout = false;               // an internal timeout occured
+        internal bool _internalTimeout = false;               // an internal timeout occurred
 
         private readonly LastIOTimer _lastSuccessfulIOTimer;
 
@@ -188,7 +188,7 @@ namespace System.Data.SqlClient
         internal object _errorAndWarningsLock = new object();
         private bool _hasErrorOrWarning = false;
 
-        // local exceptions to cache warnings and errors that occured prior to sending attention
+        // local exceptions to cache warnings and errors that occurred prior to sending attention
         internal SqlErrorCollection _preAttentionErrors;
         internal SqlErrorCollection _preAttentionWarnings;
 
@@ -2973,7 +2973,7 @@ namespace System.Data.SqlClient
             if (!captureSuccess)
             {
                 // Either there was no exception, or the task was already completed
-                // This is unusual, but possible if a fatal timeout occured on another thread (which should mean that the connection is now broken)
+                // This is unusual, but possible if a fatal timeout occurred on another thread (which should mean that the connection is now broken)
                 Debug.Assert(_parser.State == TdsParserState.Broken || _parser.State == TdsParserState.Closed || _parser.Connection.IsConnectionDoomed, "Failed to capture exception while the connection was still healthy");
 
                 // The safest thing to do is to ensure that the connection is broken and attempt to cancel the task
@@ -3573,7 +3573,7 @@ namespace System.Data.SqlClient
             Debug.Assert(Parser.Connection._parserLock.ThreadMayHaveLock(), "Thread is writing without taking the connection lock");
             Task task = SNIWritePacket(Handle, packet, out sniError, canAccumulate, callerHasConnectionLock: true);
 
-            // Check to see if the timeout has occured.  This time out code is special case code to allow BCP writes to timeout. Eventually we should make all writes timeout.
+            // Check to see if the timeout has occurred.  This time out code is special case code to allow BCP writes to timeout. Eventually we should make all writes timeout.
             if (_bulkCopyOpperationInProgress && 0 == GetTimeoutRemaining())
             {
                 _parser.Connection.ThreadHasParserLockForClose = true;
@@ -3896,7 +3896,7 @@ namespace System.Data.SqlClient
                 _errors = null;
                 _warnings = null;
 
-                // We also process the pre-attention error lists here since, if we are here and they are populated, then an error occured while sending attention so we should show the errors now (otherwise they'd be lost)
+                // We also process the pre-attention error lists here since, if we are here and they are populated, then an error occurred while sending attention so we should show the errors now (otherwise they'd be lost)
                 AddErrorsToCollection(_preAttentionErrors, ref allErrors, ref broken);
                 AddErrorsToCollection(_preAttentionWarnings, ref allErrors, ref broken);
                 _preAttentionErrors = null;

--- a/src/System.IO.Compression/src/System/IO/Compression/ZLibException.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZLibException.cs
@@ -23,7 +23,7 @@ namespace System.IO.Compression
         /// The other constructors are provided for compliance to Fx design guidelines.
         /// </summary>
         /// <param name="message">A (localised) human readable error description.</param>
-        /// <param name="zlibErrorContext">A description of the context within zlib where the error occured (e.g. the function name).</param>
+        /// <param name="zlibErrorContext">A description of the context within zlib where the error occurred (e.g. the function name).</param>
         /// <param name="zlibErrorCode">The error code returned by a ZLib function that casued this exception.</param>
         /// <param name="zlibErrorMessage">The string provided by ZLib as error information (unloicalised).</param>
         public ZLibException(string message, string zlibErrorContext, int zlibErrorCode, string zlibErrorMessage) :

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
@@ -16,13 +16,13 @@ public class ChangedTests
         using (var watcher = new FileSystemWatcher("."))
         {
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
             File.SetLastWriteTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -34,12 +34,12 @@ public class ChangedTests
         using (var watcher = new FileSystemWatcher("."))
         {
             watcher.Filter = Path.GetFileName(dir.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
             Directory.SetLastWriteTime(dir.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -53,7 +53,7 @@ public class ChangedTests
             // put everything in our own directory to avoid collisions
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*.*";
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             // run all scenarios together to avoid unnecessary waits, 
             // assert information is verbose enough to trace to failure cause
@@ -72,7 +72,7 @@ public class ChangedTests
                 // deleting a file & directory by leaving the using block
             }
 
-            Utility.ExpectNoEvent(eventOccured, "changed");
+            Utility.ExpectNoEvent(eventOccurred, "changed");
         }
     }
 
@@ -84,13 +84,13 @@ public class ChangedTests
         {
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
             Directory.SetLastAccessTime(watcher.Path, DateTime.Now);
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -125,7 +125,7 @@ public class ChangedTests
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             // Attach the FSW to the existing structure
             watcher.Path = Path.GetFullPath(dir.Path);
@@ -142,7 +142,7 @@ public class ChangedTests
                 file.Flush();
             }
 
-            Utility.ExpectEvent(eventOccured, "file changed");
+            Utility.ExpectEvent(eventOccurred, "file changed");
         }
     }
 
@@ -162,7 +162,7 @@ public class ChangedTests
             File.WriteAllBytes(filePath, new byte[4096]);
 
             // Attach the FSW to the existing structure
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
             watcher.NotifyFilter = NotifyFilters.Attributes;
@@ -173,9 +173,9 @@ public class ChangedTests
             File.SetAttributes(filePath, FileAttributes.Normal);
 
             if (includeSubdirectories)
-                Utility.ExpectEvent(eventOccured, "file changed");
+                Utility.ExpectEvent(eventOccurred, "file changed");
             else
-                Utility.ExpectNoEvent(eventOccured, "file changed");
+                Utility.ExpectNoEvent(eventOccurred, "file changed");
 
             // Restart the FSW
             watcher.EnableRaisingEvents = false;
@@ -185,9 +185,9 @@ public class ChangedTests
             File.SetAttributes(filePath, FileAttributes.Normal);
 
             if (includeSubdirectories)
-                Utility.ExpectEvent(eventOccured, "second file change");
+                Utility.ExpectEvent(eventOccurred, "second file change");
             else
-                Utility.ExpectNoEvent(eventOccured, "second file change");
+                Utility.ExpectNoEvent(eventOccurred, "second file change");
         }
     }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -17,13 +17,13 @@ public class CreatedTests
         {
             string fileName = Guid.NewGuid().ToString();
             watcher.Filter = fileName;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             watcher.EnableRaisingEvents = true;
 
             using (var file = new TemporaryTestFile(fileName))
             {
-                Utility.ExpectEvent(eventOccured, "created");
+                Utility.ExpectEvent(eventOccurred, "created");
             }
         }
     }
@@ -35,13 +35,13 @@ public class CreatedTests
         {
             string dirName = Guid.NewGuid().ToString();
             watcher.Filter = dirName;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             watcher.EnableRaisingEvents = true;
 
             using (var dir = new TemporaryTestDirectory(dirName))
             {
-                Utility.ExpectEvent(eventOccured, "created");
+                Utility.ExpectEvent(eventOccurred, "created");
             }
         }
     }
@@ -60,7 +60,7 @@ public class CreatedTests
             // watch the target dir
             watcher.Path = Path.GetFullPath(targetDir.Path);
             watcher.Filter = testFileName;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             string sourceFile = Path.Combine(dir.Path, testFileName);
             string targetFile = Path.Combine(targetDir.Path, testFileName);
@@ -73,7 +73,7 @@ public class CreatedTests
             // move the test file from source to target directory
             File.Move(sourceFile, targetFile);
 
-            Utility.ExpectEvent(eventOccured, "created");
+            Utility.ExpectEvent(eventOccurred, "created");
         }
     }
 
@@ -86,7 +86,7 @@ public class CreatedTests
             // put everything in our own directory to avoid collisions
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*.*";
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             // run all scenarios together to avoid unnecessary waits, 
             // assert information is verbose enough to trace to failure cause
@@ -114,7 +114,7 @@ public class CreatedTests
                 // deleting a file & directory by leaving the using block
             }
 
-            Utility.ExpectNoEvent(eventOccured, "created");
+            Utility.ExpectNoEvent(eventOccurred, "created");
         }
     }
 
@@ -143,7 +143,7 @@ public class CreatedTests
             using (var dir = Utility.CreateTestDirectory())
             using (var watcher = new FileSystemWatcher())
             {
-                AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+                AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
                 // put everything in our own directory to avoid collisions
                 watcher.Path = Path.GetFullPath(dir.Path);
@@ -154,19 +154,19 @@ public class CreatedTests
                 // Priming directory
                 TemporaryTestDirectory priming = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir"));
                 lst.Add(priming);
-                Utility.ExpectEvent(eventOccured, "priming create");
+                Utility.ExpectEvent(eventOccurred, "priming create");
 
                 // Create a deep directory structure and expect things to work
                 for (int i = 1; i < 20; i++)
                 {
                     lst.Add(new TemporaryTestDirectory(Path.Combine(lst[i - 1].Path, String.Format("dir{0}", i))));
-                    Utility.ExpectEvent(eventOccured, lst[i].Path + " create");
+                    Utility.ExpectEvent(eventOccurred, lst[i].Path + " create");
                 }
 
                 // Put a file at the very bottom and expect it to raise an event
                 using (var file = new TemporaryTestFile(Path.Combine(lst[lst.Count - 1].Path, "temp file")))
                 {
-                    Utility.ExpectEvent(eventOccured, "temp file create");
+                    Utility.ExpectEvent(eventOccurred, "temp file create");
                 }
             }
         }
@@ -187,7 +187,7 @@ public class CreatedTests
         using (var temp = Utility.CreateTestFile(Path.GetTempFileName()))
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             // put everything in our own directory to avoid collisions
             watcher.Path = Path.GetFullPath(dir.Path);
@@ -196,7 +196,7 @@ public class CreatedTests
 
             // Make the symlink in our path (to the temp file) and make sure an event is raised
             Utility.CreateSymLink(Path.GetFullPath(temp.Path), Path.Combine(dir.Path, Path.GetFileName(temp.Path)), false);
-            Utility.ExpectEvent(eventOccured, "symlink created");
+            Utility.ExpectEvent(eventOccurred, "symlink created");
         }
     }
 
@@ -207,7 +207,7 @@ public class CreatedTests
         using (var temp = Utility.CreateTestDirectory(Path.Combine(Path.GetTempPath(), "FooBar")))
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             // put everything in our own directory to avoid collisions
             watcher.Path = Path.GetFullPath(dir.Path);
@@ -216,7 +216,7 @@ public class CreatedTests
 
             // Make the symlink in our path (to the temp folder) and make sure an event is raised
             Utility.CreateSymLink(Path.GetFullPath(temp.Path), Path.Combine(dir.Path, Path.GetFileName(temp.Path)), true);
-            Utility.ExpectEvent(eventOccured, "symlink created");
+            Utility.ExpectEvent(eventOccurred, "symlink created");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
@@ -16,7 +16,7 @@ public class DeletedTests
         {
             string fileName = Guid.NewGuid().ToString();
             watcher.Filter = fileName;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
 
             using (var file = new TemporaryTestFile(fileName))
@@ -24,7 +24,7 @@ public class DeletedTests
                 watcher.EnableRaisingEvents = true;
             }
 
-            Utility.ExpectEvent(eventOccured, "deleted");
+            Utility.ExpectEvent(eventOccurred, "deleted");
         }
     }
 
@@ -35,14 +35,14 @@ public class DeletedTests
         {
             string dirName = Guid.NewGuid().ToString();
             watcher.Filter = dirName;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
             using (var dir = new TemporaryTestDirectory(dirName))
             {
                 watcher.EnableRaisingEvents = true;
             }
 
-            Utility.ExpectEvent(eventOccured, "deleted");
+            Utility.ExpectEvent(eventOccurred, "deleted");
         }
     }
 
@@ -55,7 +55,7 @@ public class DeletedTests
             // put everything in our own directory to avoid collisions
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*.*";
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
             // run all scenarios together to avoid unnecessary waits, 
             // assert information is verbose enough to trace to failure cause
@@ -80,7 +80,7 @@ public class DeletedTests
                     testDir.Move(testDir.Path + "_rename");
                 }
 
-                Utility.ExpectNoEvent(eventOccured, "deleted");
+                Utility.ExpectNoEvent(eventOccurred, "deleted");
             }
         }
     }
@@ -91,8 +91,8 @@ public class DeletedTests
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent createOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent createOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
@@ -102,26 +102,26 @@ public class DeletedTests
             using (var firstDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
                 // Wait for the created event
-                Utility.ExpectEvent(createOccured, "create");
+                Utility.ExpectEvent(createOccurred, "create");
 
                 using (var secondDir = new TemporaryTestDirectory(Path.Combine(firstDir.Path, "dir2")))
                 {
                     // Wait for the created event
-                    Utility.ExpectEvent(createOccured, "create");
+                    Utility.ExpectEvent(createOccurred, "create");
 
                     using (var nestedDir = new TemporaryTestDirectory(Path.Combine(secondDir.Path, "nested")))
                     {
                         // Wait for the created event
-                        Utility.ExpectEvent(createOccured, "create");
+                        Utility.ExpectEvent(createOccurred, "create");
                     }
 
-                    Utility.ExpectEvent(eventOccured, "deleted");
+                    Utility.ExpectEvent(eventOccurred, "deleted");
                 }
 
-                Utility.ExpectEvent(eventOccured, "deleted");
+                Utility.ExpectEvent(eventOccurred, "deleted");
             }
 
-            Utility.ExpectEvent(eventOccured, "deleted");
+            Utility.ExpectEvent(eventOccurred, "deleted");
         }
     }
 
@@ -131,8 +131,8 @@ public class DeletedTests
         using (var dir = Utility.CreateTestDirectory())
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent createOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent createOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
@@ -142,22 +142,22 @@ public class DeletedTests
             using (var firstDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
                 // Wait for the created event
-                Utility.ExpectEvent(createOccured, "create");
+                Utility.ExpectEvent(createOccurred, "create");
 
                 using (var secondDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir2")))
                 {
                     // Wait for the created event
-                    Utility.ExpectEvent(createOccured, "create");
+                    Utility.ExpectEvent(createOccurred, "create");
 
                     using (var nestedDir = new TemporaryTestFile(Path.Combine(secondDir.Path, "nestedFile"))) { }
 
-                    Utility.ExpectEvent(eventOccured, "deleted");
+                    Utility.ExpectEvent(eventOccurred, "deleted");
                 }
 
-                Utility.ExpectEvent(eventOccured, "deleted");
+                Utility.ExpectEvent(eventOccurred, "deleted");
             }
 
-            Utility.ExpectEvent(eventOccured, "deleted");
+            Utility.ExpectEvent(eventOccurred, "deleted");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Error.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Error.cs
@@ -23,10 +23,10 @@ public partial class ErrorTests
                 unblockHandler.WaitOne();
             };
 
-            AutoResetEvent eventOccured = new AutoResetEvent(false);
+            AutoResetEvent eventOccurred = new AutoResetEvent(false);
             watcher.Error += (o, e) =>
             {
-                eventOccured.Set();
+                eventOccurred.Set();
             };
             watcher.EnableRaisingEvents = true;
 
@@ -71,7 +71,7 @@ public partial class ErrorTests
 
             unblockHandler.Set();
 
-            Utility.ExpectEvent(eventOccured, "error");
+            Utility.ExpectEvent(eventOccurred, "error");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.IncludeSubDirectories.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.IncludeSubDirectories.cs
@@ -20,22 +20,22 @@ public partial class IncludeSubdirectoriesTests
 
             watcher.Path = dirPath;
             watcher.IncludeSubdirectories = true;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             Directory.CreateDirectory(subDirPath);
 
             watcher.EnableRaisingEvents = true;
 
             File.WriteAllText(Path.Combine(subDirPath, "1.txt"), "testcontent");
-            Utility.ExpectEvent(eventOccured, "created");
+            Utility.ExpectEvent(eventOccurred, "created");
 
             watcher.IncludeSubdirectories = false;
             File.WriteAllText(Path.Combine(subDirPath, "2.txt"), "testcontent");
-            Utility.ExpectNoEvent(eventOccured, "created");
+            Utility.ExpectNoEvent(eventOccurred, "created");
 
             watcher.IncludeSubdirectories = true;
             File.WriteAllText(Path.Combine(subDirPath, "3.txt"), "testcontent");
-            Utility.ExpectEvent(eventOccured, "created");
+            Utility.ExpectEvent(eventOccurred, "created");
         }
     }
 
@@ -51,22 +51,22 @@ public partial class IncludeSubdirectoriesTests
 
             watcher.Path = dirPath;
             watcher.IncludeSubdirectories = true;
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created);
 
             Directory.CreateDirectory(subDirPath);
 
             watcher.EnableRaisingEvents = true;
 
             Directory.CreateDirectory(Path.Combine(subDirPath, "1"));
-            Utility.ExpectEvent(eventOccured, "created");
+            Utility.ExpectEvent(eventOccurred, "created");
 
             watcher.IncludeSubdirectories = false;
             Directory.CreateDirectory(Path.Combine(subDirPath, "2"));
-            Utility.ExpectNoEvent(eventOccured, "created");
+            Utility.ExpectNoEvent(eventOccurred, "created");
 
             watcher.IncludeSubdirectories = true;
             Directory.CreateDirectory(Path.Combine(subDirPath, "3"));
-            Utility.ExpectEvent(eventOccured, "created");
+            Utility.ExpectEvent(eventOccurred, "created");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
@@ -24,10 +24,10 @@ public class InternalBufferSizeTests
                 unblockHandler.WaitOne();
             };
 
-            AutoResetEvent eventOccured = new AutoResetEvent(false);
+            AutoResetEvent eventOccurred = new AutoResetEvent(false);
             watcher.Error += (o, e) =>
             {
-                eventOccured.Set();
+                eventOccurred.Set();
             };
             watcher.EnableRaisingEvents = true;
 
@@ -39,7 +39,7 @@ public class InternalBufferSizeTests
             }
 
             unblockHandler.Set();
-            Utility.ExpectEvent(eventOccured, "error");
+            Utility.ExpectEvent(eventOccurred, "error");
 
             // Update InternalBufferSize to accomadate the data
             watcher.InternalBufferSize = watcher.InternalBufferSize * 2;
@@ -52,7 +52,7 @@ public class InternalBufferSizeTests
             }
             unblockHandler.Set();
             // This time we should not see an error
-            Utility.ExpectNoEvent(eventOccured, "error");
+            Utility.ExpectNoEvent(eventOccurred, "error");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MoveFile.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MoveFile.cs
@@ -130,16 +130,16 @@ public class MoveFileTests
             using (var testFile = new TemporaryTestFile(Path.Combine(dir.Path, "file")))
             {
                 watcher.EnableRaisingEvents = true;
-                AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, eventType);
+                AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, eventType);
 
                 // Move the testFile to a different name in the same directory
                 testFile.Move(testFile.Path + "_" + eventType.ToString());
 
                 // Test that the event is observed or not observed
                 if (moveRaisesEvent)
-                    Utility.ExpectEvent(eventOccured, eventType.ToString());
+                    Utility.ExpectEvent(eventOccurred, eventType.ToString());
                 else
-                    Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+                    Utility.ExpectNoEvent(eventOccurred, eventType.ToString());
             }
         }
     }
@@ -166,16 +166,16 @@ public class MoveFileTests
             using (var testFile = new TemporaryTestFile(Path.Combine(dir.Path, "file")))
             {
                 watcher.EnableRaisingEvents = true;
-                AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, eventType);
+                AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, eventType);
 
                 // Move the testFile to a different name in the same directory
                 testFile.Move(Path.Combine(dir_unwatched.Path, testFile.Name + "_" + eventType.ToString()));
 
                 // Test which events are thrown
                 if (moveRaisesEvent)
-                    Utility.ExpectEvent(eventOccured, eventType.ToString());
+                    Utility.ExpectEvent(eventOccurred, eventType.ToString());
                 else
-                    Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+                    Utility.ExpectNoEvent(eventOccurred, eventType.ToString());
             }
         }
     }
@@ -189,15 +189,15 @@ public class MoveFileTests
     /// </summary>
     private static void MoveAndCheck_NestedDirectory(WatcherChangeTypes eventType, bool moveRaisesEvent)
     {
-        Utility.TestNestedDirectoriesHelper(eventType, (AutoResetEvent eventOccured, TemporaryTestDirectory ttd) =>
+        Utility.TestNestedDirectoriesHelper(eventType, (AutoResetEvent eventOccurred, TemporaryTestDirectory ttd) =>
         {
             using (var nestedFile = new TemporaryTestFile(Path.Combine(ttd.Path, "nestedFile" + eventType.ToString())))
             {
                 nestedFile.Move(nestedFile.Path + "_2");
                 if (moveRaisesEvent)
-                    Utility.ExpectEvent(eventOccured, eventType.ToString());
+                    Utility.ExpectEvent(eventOccurred, eventType.ToString());
                 else
-                    Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+                    Utility.ExpectNoEvent(eventOccurred, eventType.ToString());
             }
         });
     }
@@ -217,7 +217,7 @@ public class MoveFileTests
         {
             watcher.NotifyFilter = NotifyFilters.FileName;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, eventType);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, eventType);
 
             string newName = file.Path + "_" + eventType.ToString();
             Utility.EnsureDelete(newName);
@@ -227,9 +227,9 @@ public class MoveFileTests
             file.Move(newName);
 
             if (moveRaisesEvent)
-                Utility.ExpectEvent(eventOccured, eventType.ToString());
+                Utility.ExpectEvent(eventOccurred, eventType.ToString());
             else
-                Utility.ExpectNoEvent(eventOccured, eventType.ToString());
+                Utility.ExpectNoEvent(eventOccurred, eventType.ToString());
         }
     }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.NotifyFilter.cs
@@ -18,7 +18,7 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.Attributes;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
@@ -27,7 +27,7 @@ public partial class NotifyFilterTests
 
             File.SetAttributes(file.Path, attributes);
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -41,13 +41,13 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.CreationTime;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
             File.SetCreationTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -59,7 +59,7 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.DirectoryName;
             watcher.Filter = Path.GetFileName(dir.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
 
             string newName = dir.Path + "_rename";
             Utility.EnsureDelete(newName);
@@ -68,7 +68,7 @@ public partial class NotifyFilterTests
 
             dir.Move(newName);
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -82,13 +82,13 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.LastAccess;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
             File.SetLastAccessTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -101,13 +101,13 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.LastWrite;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
             File.SetLastWriteTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -120,7 +120,7 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.Size;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
@@ -130,7 +130,7 @@ public partial class NotifyFilterTests
             // Size changes only occur when the file is written to disk
             file.Flush(flushToDisk: true);
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -163,7 +163,7 @@ public partial class NotifyFilterTests
         {
             watcher.NotifyFilter = NotifyFilters.Security;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
 
             watcher.EnableRaisingEvents = true;
 
@@ -177,7 +177,7 @@ public partial class NotifyFilterTests
                 sacl: IntPtr.Zero);
             Assert.Equal(ERROR_SUCCESS, result);
 
-            Utility.ExpectEvent(eventOccured, "changed");
+            Utility.ExpectEvent(eventOccurred, "changed");
         }
     }
 
@@ -192,7 +192,7 @@ public partial class NotifyFilterTests
             // only detect name.
             watcher.NotifyFilter = NotifyFilters.FileName;
             watcher.Filter = Path.GetFileName(file.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.All);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.All);
 
             string newName = file.Path + "_rename";
             Utility.EnsureDelete(newName);
@@ -232,7 +232,7 @@ public partial class NotifyFilterTests
             }
 
             // None of these should trigger any events
-            Utility.ExpectNoEvent(eventOccured, "any");
+            Utility.ExpectNoEvent(eventOccurred, "any");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Renamed.cs
@@ -14,7 +14,7 @@ public partial class RenamedTests
         using (var watcher = new FileSystemWatcher("."))
         {
             watcher.Filter = Path.GetFileName(dir.Path);
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
 
             string newName = dir.Path + "_rename";
             Utility.EnsureDelete(newName);
@@ -23,7 +23,7 @@ public partial class RenamedTests
 
             dir.Move(newName);
 
-            Utility.ExpectEvent(eventOccured, "renamed");
+            Utility.ExpectEvent(eventOccurred, "renamed");
         }
     }
 
@@ -36,7 +36,7 @@ public partial class RenamedTests
             // put everything in our own directory to avoid collisions
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*.*";
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Renamed);
 
             watcher.EnableRaisingEvents = true;
 
@@ -54,7 +54,7 @@ public partial class RenamedTests
                 // deleting a file & directory by leaving the using block
             }
 
-            Utility.ExpectNoEvent(eventOccured, "created");
+            Utility.ExpectNoEvent(eventOccurred, "created");
         }
     }
 
@@ -93,8 +93,8 @@ public partial class RenamedTests
         using (var temp = Utility.CreateTestDirectory(Path.Combine(root.Path, "temp")))
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
-            AutoResetEvent deletedOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent createdOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent deletedOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
@@ -103,11 +103,11 @@ public partial class RenamedTests
 
             using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
-                Utility.ExpectEvent(createdOccured, "dir1 created");
+                Utility.ExpectEvent(createdOccurred, "dir1 created");
 
                 using (var dir2 = new TemporaryTestDirectory(Path.Combine(dir1.Path, "dir2")))
                 {
-                    Utility.ExpectEvent(createdOccured, "dir2 created");
+                    Utility.ExpectEvent(createdOccurred, "dir2 created");
 
                     using (var file = Utility.CreateTestFile(Path.Combine(dir2.Path, "test file"))) { };
 
@@ -115,11 +115,11 @@ public partial class RenamedTests
                     string original = dir1.Path;
                     string target = Path.Combine(temp.Path, Path.GetFileName(dir1.Path));
                     dir1.Move(target);
-                    Utility.ExpectEvent(deletedOccured, "dir1 moved out");
+                    Utility.ExpectEvent(deletedOccurred, "dir1 moved out");
 
                     // Move the directory back and expect a created event
                     dir1.Move(original);
-                    Utility.ExpectEvent(createdOccured, "dir1 moved back");
+                    Utility.ExpectEvent(createdOccurred, "dir1 moved back");
                 }
             }
         }
@@ -136,8 +136,8 @@ public partial class RenamedTests
         using (var temp = Utility.CreateTestDirectory(Path.Combine(root.Path, "temp")))
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
-            AutoResetEvent deletedOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
+            AutoResetEvent createdOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent deletedOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Deleted);
 
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
@@ -146,11 +146,11 @@ public partial class RenamedTests
 
             using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
-                Utility.ExpectEvent(createdOccured, "dir1 created");
+                Utility.ExpectEvent(createdOccurred, "dir1 created");
 
                 using (var dir2 = new TemporaryTestDirectory(Path.Combine(dir1.Path, "dir2")))
                 {
-                    Utility.ExpectNoEvent(createdOccured, "dir2 created");
+                    Utility.ExpectNoEvent(createdOccurred, "dir2 created");
 
                     using (var file = Utility.CreateTestFile(Path.Combine(dir2.Path, "test file"))) { };
 
@@ -158,11 +158,11 @@ public partial class RenamedTests
                     string original = dir1.Path;
                     string target = Path.Combine(temp.Path, Path.GetFileName(dir1.Path));
                     dir1.Move(target);
-                    Utility.ExpectEvent(deletedOccured, "dir1 moved out");
+                    Utility.ExpectEvent(deletedOccurred, "dir1 moved out");
 
                     // Move the directory back and expect a created event
                     dir1.Move(original);
-                    Utility.ExpectEvent(createdOccured, "dir1 moved back");
+                    Utility.ExpectEvent(createdOccurred, "dir1 moved back");
                 }
             }
         }
@@ -178,7 +178,7 @@ public partial class RenamedTests
         using (var dir1 = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted | WatcherChangeTypes.Changed);
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted | WatcherChangeTypes.Changed);
 
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
@@ -189,22 +189,22 @@ public partial class RenamedTests
             using (var file = File.Create(filePath))
             {
                 // Wait for the file to be created then make a change to validate that we get a change
-                Utility.ExpectEvent(eventOccured, "test file created");
+                Utility.ExpectEvent(eventOccurred, "test file created");
                 byte[] buffer = new byte[4096];
                 file.Write(buffer, 0, buffer.Length);
                 file.Flush();
             }
-            Utility.ExpectEvent(eventOccured, "test file changed");
+            Utility.ExpectEvent(eventOccurred, "test file changed");
 
             // Move the nested dir out of scope and validate that we get a single deleted event
             string original = dir1.Path;
             string target = Path.Combine(temp.Path, "dir1");
             dir1.Move(target);
-            Utility.ExpectEvent(eventOccured, "nested dir deleted");
+            Utility.ExpectEvent(eventOccurred, "nested dir deleted");
 
             // Move the dir (and child file) back into scope and validate that we get a created event
             dir1.Move(original);
-            Utility.ExpectEvent(eventOccured, "nested dir created");
+            Utility.ExpectEvent(eventOccurred, "nested dir created");
 
             using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Write))
             {
@@ -212,7 +212,7 @@ public partial class RenamedTests
                 fs.Write(buffer, 0, buffer.Length);
                 fs.Flush();
             }
-            Utility.ExpectEvent(eventOccured, "test file changed");
+            Utility.ExpectEvent(eventOccurred, "test file changed");
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -272,19 +272,19 @@ public class FileSystemWatcherTests
     {
         using (TestFileSystemWatcher watcher = new TestFileSystemWatcher())
         {
-            bool eventOccured = false;
+            bool eventOccurred = false;
             object obj = null;
             FileSystemEventArgs actualArgs = null, expectedArgs = new FileSystemEventArgs(WatcherChangeTypes.Changed, "directory", "file");
 
             watcher.Changed += (o, e) =>
             {
-                eventOccured = true;
+                eventOccurred = true;
                 obj = o;
                 actualArgs = e;
             };
 
             watcher.CallOnChanged(expectedArgs);
-            Assert.True(eventOccured, "Event should be invoked");
+            Assert.True(eventOccurred, "Event should be invoked");
             Assert.Equal(watcher, obj);
             Assert.Equal(expectedArgs, actualArgs);
         }
@@ -295,19 +295,19 @@ public class FileSystemWatcherTests
     {
         using (TestFileSystemWatcher watcher = new TestFileSystemWatcher())
         {
-            bool eventOccured = false;
+            bool eventOccurred = false;
             object obj = null;
             FileSystemEventArgs actualArgs = null, expectedArgs = new FileSystemEventArgs(WatcherChangeTypes.Created, "directory", "file");
 
             watcher.Created += (o, e) =>
             {
-                eventOccured = true;
+                eventOccurred = true;
                 obj = o;
                 actualArgs = e;
             };
 
             watcher.CallOnCreated(expectedArgs);
-            Assert.True(eventOccured, "Event should be invoked");
+            Assert.True(eventOccurred, "Event should be invoked");
             Assert.Equal(watcher, obj);
             Assert.Equal(expectedArgs, actualArgs);
         }
@@ -318,19 +318,19 @@ public class FileSystemWatcherTests
     {
         using (TestFileSystemWatcher watcher = new TestFileSystemWatcher())
         {
-            bool eventOccured = false;
+            bool eventOccurred = false;
             object obj = null;
             FileSystemEventArgs actualArgs = null, expectedArgs = new FileSystemEventArgs(WatcherChangeTypes.Deleted, "directory", "file");
 
             watcher.Deleted += (o, e) =>
             {
-                eventOccured = true;
+                eventOccurred = true;
                 obj = o;
                 actualArgs = e;
             };
 
             watcher.CallOnDeleted(expectedArgs);
-            Assert.True(eventOccured, "Event should be invoked");
+            Assert.True(eventOccurred, "Event should be invoked");
             Assert.Equal(watcher, obj);
             Assert.Equal(expectedArgs, actualArgs);
         }
@@ -341,19 +341,19 @@ public class FileSystemWatcherTests
     {
         using (TestFileSystemWatcher watcher = new TestFileSystemWatcher())
         {
-            bool eventOccured = false;
+            bool eventOccurred = false;
             object obj = null;
             ErrorEventArgs actualArgs = null, expectedArgs = new ErrorEventArgs(new Exception());
 
             watcher.Error += (o, e) =>
             {
-                eventOccured = true;
+                eventOccurred = true;
                 obj = o;
                 actualArgs = e;
             };
 
             watcher.CallOnError(expectedArgs);
-            Assert.True(eventOccured, "Event should be invoked");
+            Assert.True(eventOccurred, "Event should be invoked");
             Assert.Equal(watcher, obj);
             Assert.Equal(expectedArgs, actualArgs);
         }
@@ -364,19 +364,19 @@ public class FileSystemWatcherTests
     {
         using (TestFileSystemWatcher watcher = new TestFileSystemWatcher())
         {
-            bool eventOccured = false;
+            bool eventOccurred = false;
             object obj = null;
             RenamedEventArgs actualArgs = null, expectedArgs = new RenamedEventArgs(WatcherChangeTypes.Renamed, "directory", "file", "oldFile");
 
             watcher.Renamed += (o, e) =>
             {
-                eventOccured = true;
+                eventOccurred = true;
                 obj = o;
                 actualArgs = e;
             };
 
             watcher.CallOnRenamed(expectedArgs);
-            Assert.True(eventOccured, "Event should be invoked");
+            Assert.True(eventOccurred, "Event should be invoked");
             Assert.Equal(watcher, obj);
             Assert.Equal(expectedArgs, actualArgs);
         }

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/Utility.cs
@@ -62,14 +62,14 @@ public static class Utility
 
     public static AutoResetEvent WatchForEvents(FileSystemWatcher watcher, WatcherChangeTypes actions)
     {
-        AutoResetEvent eventOccured = new AutoResetEvent(false);
+        AutoResetEvent eventOccurred = new AutoResetEvent(false);
 
         if (0 != (actions & WatcherChangeTypes.Changed))
         {
             watcher.Changed += (o, e) =>
             {
                 Assert.Equal(WatcherChangeTypes.Changed, e.ChangeType);
-                eventOccured.Set();
+                eventOccurred.Set();
             };
         }
 
@@ -78,7 +78,7 @@ public static class Utility
             watcher.Created += (o, e) =>
             {
                 Assert.Equal(WatcherChangeTypes.Created, e.ChangeType);
-                eventOccured.Set();
+                eventOccurred.Set();
             };
         }
 
@@ -87,7 +87,7 @@ public static class Utility
             watcher.Deleted += (o, e) =>
             {
                 Assert.Equal(WatcherChangeTypes.Deleted, e.ChangeType);
-                eventOccured.Set();
+                eventOccurred.Set();
             };
         }
 
@@ -96,23 +96,23 @@ public static class Utility
             watcher.Renamed += (o, e) =>
             {
                 Assert.Equal(WatcherChangeTypes.Renamed, e.ChangeType);
-                eventOccured.Set();
+                eventOccurred.Set();
             };
         }
 
-        return eventOccured;
+        return eventOccurred;
     }
 
-    public static void ExpectEvent(WaitHandle eventOccured, string eventName, int timeout = WaitForExpectedEventTimeout)
+    public static void ExpectEvent(WaitHandle eventOccurred, string eventName, int timeout = WaitForExpectedEventTimeout)
     {
         string message = String.Format("Didn't observe a {0} event within {1}ms", eventName, timeout);
-        Assert.True(eventOccured.WaitOne(timeout), message);
+        Assert.True(eventOccurred.WaitOne(timeout), message);
     }
 
-    public static void ExpectNoEvent(WaitHandle eventOccured, string eventName, int timeout = WaitForUnexpectedEventTimeout)
+    public static void ExpectNoEvent(WaitHandle eventOccurred, string eventName, int timeout = WaitForUnexpectedEventTimeout)
     {
         string message = String.Format("Should not observe a {0} event within {1}ms", eventName, timeout);
-        Assert.False(eventOccured.WaitOne(timeout), message);
+        Assert.False(eventOccurred.WaitOne(timeout), message);
     }
 
     public static void TestNestedDirectoriesHelper(
@@ -123,8 +123,8 @@ public static class Utility
         using (var dir = Utility.CreateTestDirectory(Guid.NewGuid().ToString()))
         using (var watcher = new FileSystemWatcher())
         {
-            AutoResetEvent createdOccured = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
-            AutoResetEvent eventOccured = Utility.WatchForEvents(watcher, change);
+            AutoResetEvent createdOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Created); // not "using" to avoid race conditions with FSW callbacks
+            AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, change);
 
             watcher.Path = Path.GetFullPath(dir.Path);
             watcher.Filter = "*";
@@ -134,13 +134,13 @@ public static class Utility
 
             using (var firstDir = new TemporaryTestDirectory(Path.Combine(dir.Path, "dir1")))
             {
-                Utility.ExpectEvent(createdOccured, "dir1 created");
+                Utility.ExpectEvent(createdOccurred, "dir1 created");
 
                 using (var nestedDir = new TemporaryTestDirectory(Path.Combine(firstDir.Path, "nested")))
                 {
-                    Utility.ExpectEvent(createdOccured, "nested created");
+                    Utility.ExpectEvent(createdOccurred, "nested created");
 
-                    action(eventOccured, nestedDir);
+                    action(eventOccurred, nestedDir);
                 }
             }
         }

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileSystemObject.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileSystemObject.cs
@@ -152,7 +152,7 @@ namespace System.IO
                 return properties.Size;
             }
 
-            // Consumes cached file/directory information and throw if any error occured retrieving 
+            // Consumes cached file/directory information and throw if any error occurred retrieving 
             // it, including file not found.
             private void EnsureItemExists()
             {

--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -1123,7 +1123,7 @@ namespace System.IO.Packaging
         }
 
         //We needed to separate the rels parts from the other parts
-        //because if a rels part for a part occured earlier than the part itself in the array,
+        //because if a rels part for a part occurred earlier than the part itself in the array,
         //the rels part would be closed and then when close the part and try to persist the relationships
         //for the particular part, it would throw an exception
         private bool DoClose(PackagePart p)

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/QueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/QueryOperator.cs
@@ -141,7 +141,7 @@ namespace System.Linq.Parallel
             Debug.Assert(mergeOptions != null);
 
             // Top-level preemptive cancellation test.
-            // This handles situations where cancellation has occured before execution commences
+            // This handles situations where cancellation has occurred before execution commences
             // The handling for in-execution occurs in QueryTaskGroupState.QueryEnd()
 
             if (querySettings.CancellationState.MergedCancellationToken.IsCancellationRequested)
@@ -210,7 +210,7 @@ namespace System.Linq.Parallel
                 QueryResults<TOutput> results = GetQueryResults(querySettings);
 
                 // Top-level preemptive cancellation test.
-                // This handles situations where cancellation has occured before execution commences
+                // This handles situations where cancellation has occurred before execution commences
                 // The handling for in-execution occurs in QueryTaskGroupState.QueryEnd()
 
                 if (querySettings.CancellationState.MergedCancellationToken.IsCancellationRequested)

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectManyQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectManyQueryOperator.cs
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel
 
         /// <summary>
         /// A helper method for WrapPartitionedStream. We use the helper to reuse a block of code twice, but with
-        /// a different order key type. (If premature merge occured, the order key type will be "int". Otherwise, 
+        /// a different order key type. (If premature merge occurred, the order key type will be "int". Otherwise, 
         /// it will be the same type as "TLeftKey" in WrapPartitionedStream.)
         /// </summary>
         private void WrapPartitionedStreamNotIndexed<TLeftKey>(

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/CancellationState.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/CancellationState.cs
@@ -40,7 +40,7 @@ namespace System.Linq.Parallel
             }
         }
 
-        // A shared boolean flag to track whether a query-opening-enumerator dispose has occured.
+        // A shared boolean flag to track whether a query-opening-enumerator dispose has occurred.
         internal Shared<bool> TopLevelDisposedFlag;
 
         internal CancellationState(CancellationToken externalCancellationToken)
@@ -77,7 +77,7 @@ namespace System.Linq.Parallel
                 throw new OperationCanceledException(token);
         }
 
-        // Test if external cancellation was requested and occured, and if so throw a standardize OCE with standardized message
+        // Test if external cancellation was requested and occurred, and if so throw a standardize OCE with standardized message
         internal static void ThrowWithStandardMessageIfCanceled(CancellationToken externalCancellationToken)
         {
             if (externalCancellationToken.IsCancellationRequested)

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/QueryTaskGroupState.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/QueryTaskGroupState.cs
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel
 
                 if (_cancellationState.MergedCancellationToken.IsCancellationRequested)
                 {
-                    // cancellation has occured but no user-delegate exceptions were detected 
+                    // cancellation has occurred but no user-delegate exceptions were detected 
 
                     // NOTE: it is important that we see other state variables correctly here, and that
                     // read-reordering hasn't played havoc. 

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -116,7 +116,7 @@ namespace System.Linq.Parallel.Tests
         /// <summary>
         ///
         /// [Regression Test]
-        ///   This issue occured because the QuerySettings structure was not being deep-cloned during
+        ///   This issue occurred because the QuerySettings structure was not being deep-cloned during
         ///   query-opening.  As a result, the concurrent inner-enumerators (for the RHS operators)
         ///   that occur in SelectMany were sharing CancellationState that they should not have.
         ///   The result was that enumerators could falsely believe they had been canceled when
@@ -202,7 +202,7 @@ namespace System.Linq.Parallel.Tests
                 Assert.True(false, string.Format("PlinqCancellationTests.AggregatesShouldntWrapOCE:  > Failed: got {0}, expected OperationCanceledException", e.GetType().ToString()));
             }
 
-            Assert.True(false, string.Format("PlinqCancellationTests.AggregatesShouldntWrapOCE:  > Failed: no exception occured, expected OperationCanceledException"));
+            Assert.True(false, string.Format("PlinqCancellationTests.AggregatesShouldntWrapOCE:  > Failed: no exception occurred, expected OperationCanceledException"));
         }
 
         // Plinq suppresses OCE(externalCT) occurring in worker threads and then throws a single OCE(ct)
@@ -405,7 +405,7 @@ namespace System.Linq.Parallel.Tests
                 {
                     var item = walker.Current;
                 }
-                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_1:  OperationCanceledException was expected, but no exception occured."));
+                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_1:  OperationCanceledException was expected, but no exception occurred."));
             }
             catch (OperationCanceledException)
             {
@@ -413,7 +413,7 @@ namespace System.Linq.Parallel.Tests
             }
             catch (Exception e)
             {
-                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_1:  OperationCanceledException was expected, but a different exception occured.  " + e.ToString()));
+                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_1:  OperationCanceledException was expected, but a different exception occurred.  " + e.ToString()));
             }
         }
 
@@ -433,7 +433,7 @@ namespace System.Linq.Parallel.Tests
                 while (walker.MoveNext())
                 {
                 }
-                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_2:  failed.  AggregateException was expected, but no exception occured."));
+                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_2:  failed.  AggregateException was expected, but no exception occurred."));
             }
             catch (AggregateException)
             {
@@ -441,7 +441,7 @@ namespace System.Linq.Parallel.Tests
             }
             catch (Exception e)
             {
-                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_2.  failed.  AggregateException was expected, but some other exception occured." + e.ToString()));
+                Assert.True(false, string.Format("PlinqCancellationTests.SetOperationsThrowAggregateOnCancelOrDispose_2.  failed.  AggregateException was expected, but some other exception occurred." + e.ToString()));
             }
         }
 

--- a/src/System.Net.Requests/src/System/Net/TaskExtensions.cs
+++ b/src/System.Net.Requests/src/System/Net/TaskExtensions.cs
@@ -46,7 +46,7 @@ namespace System.Net
                 else
                 {
                     // Verify that the current status of the tcs.Task is 'Canceled'.  This
-                    // occured due to a previous call of tcs.TrySetCanceled() from the
+                    // occurred due to a previous call of tcs.TrySetCanceled() from the
                     // HttpWebRequest.Abort() method.
                     Debug.Assert(tcs.Task.IsCanceled);
                 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -436,7 +436,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_readfailure, exception.Message), exception);
                 }
@@ -510,7 +510,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
                 }
@@ -674,7 +674,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_readfailure, exception.Message), exception);
                 }
@@ -717,7 +717,7 @@ namespace System.Net.Sockets
             {
                 if (ExceptionCheck.IsFatal(exception)) throw;
 
-                // Some sort of error occured on the socket call,
+                // Some sort of error occurred on the socket call,
                 // set the SocketException as InnerException and throw.
                 throw new IOException(SR.Format(SR.net_io_readfailure, exception.Message), exception);
             }
@@ -766,7 +766,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_readfailure, exception.Message), exception);
                 }
@@ -846,7 +846,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
                 }
@@ -899,7 +899,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
                 }
@@ -946,7 +946,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
                 }
@@ -985,7 +985,7 @@ namespace System.Net.Sockets
                     throw;
                 }
 
-                // Some sort of error occured on the socket call,
+                // Some sort of error occurred on the socket call,
                 // set the SocketException as InnerException and throw.
                 throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
             }
@@ -1033,7 +1033,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
                 }
@@ -1083,7 +1083,7 @@ namespace System.Net.Sockets
                         throw;
                     }
 
-                    // Some sort of error occured on the socket call,
+                    // Some sort of error occurred on the socket call,
                     // set the SocketException as InnerException and throw.
                     throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
                 }
@@ -1119,7 +1119,7 @@ namespace System.Net.Sockets
                     throw;
                 }
 
-                // Some sort of error occured on the socket call,
+                // Some sort of error occurred on the socket call,
                 // set the SocketException as InnerException and throw.
                 throw new IOException(SR.Format(SR.net_io_writefailure, exception.Message), exception);
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2757,7 +2757,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "EndDisconnect"));
             }
 
-            // Wait for completion if it hasn't occured.
+            // Wait for completion if it hasn't occurred.
             castedAsyncResult.InternalWaitForCompletion();
             castedAsyncResult.EndCalled = true;
 
@@ -6422,7 +6422,7 @@ namespace System.Net.Sockets
         }
 
         // UpdateStatusAfterSocketError(socketException) - updates the status of a connected socket
-        // on which a failure occured. it'll go to winsock and check if the connection
+        // on which a failure occurred. it'll go to winsock and check if the connection
         // is still open and if it needs to update our internal state.
         internal void UpdateStatusAfterSocketError(SocketException socketException)
         {

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -1229,7 +1229,7 @@ namespace System.Threading.Tasks.Dataflow
                     }
                     catch (Exception exc)
                     {
-                        // An error occured.  Take ourselves out of the game.
+                        // An error occurred.  Take ourselves out of the game.
                         status = DataflowMessageStatus.DecliningPermanently;
                         Common.StoreDataflowMessageValueIntoExceptionData(exc, messageValue);
                         _receivedException = exc;

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
@@ -547,7 +547,7 @@ namespace System.Threading.Tasks.Dataflow
             private bool _decliningPermanently;
             /// <summary>The task used to process the output and offer it to targets.</summary>
             private Task _taskForOutputProcessing;
-            /// <summary>Exceptions that may have occured and gone unhandled during processing.</summary>
+            /// <summary>Exceptions that may have occurred and gone unhandled during processing.</summary>
             private List<Exception> _exceptions;
             /// <summary>Counter for message IDs unique within this source block.</summary>
             private long _nextMessageId = 1; // We are going to use this value before incrementing.

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
@@ -89,7 +89,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         private bool _enableOffering = true; // Protected by ValueLock, sometimes read with volatile reads
         /// <summary>Whether someone has reserved the right to call CompleteBlockOncePossible.</summary>
         private bool _completionReserved; // Protected by OutgoingLock
-        /// <summary>Exceptions that may have occured and gone unhandled during processing.</summary>
+        /// <summary>Exceptions that may have occurred and gone unhandled during processing.</summary>
         private List<Exception> _exceptions; // Protected by ValueLock, sometimes read with volatile reads
 
         /// <summary>Initializes the source core.</summary>

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
@@ -53,7 +53,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// <summary>An action to invoke for every accepted message.</summary>
         private readonly Action<TInput> _action;
 
-        /// <summary>Exceptions that may have occured and gone unhandled during processing.  This field is lazily initialized.</summary>
+        /// <summary>Exceptions that may have occurred and gone unhandled during processing.  This field is lazily initialized.</summary>
         private volatile List<Exception> _exceptions;
         /// <summary>Whether to stop accepting new messages.</summary>
         private volatile bool _decliningPermanently;

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
@@ -83,7 +83,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
 
         // *** These fields are mutated during execution.
 
-        /// <summary>Exceptions that may have occured and gone unhandled during processing.</summary>
+        /// <summary>Exceptions that may have occurred and gone unhandled during processing.</summary>
         private List<Exception> _exceptions;
         /// <summary>Whether to stop accepting new messages.</summary>
         private bool _decliningPermanently;

--- a/src/System.Threading/tests/BarrierCancellationTests.cs
+++ b/src/System.Threading/tests/BarrierCancellationTests.cs
@@ -65,7 +65,7 @@ namespace System.Threading.Tests
 
             Task.Run(() => cancellationTokenSource.Cancel());
 
-            //Test that backout occured.
+            //Test that backout occurred.
             Assert.Equal(numberParticipants, barrier.ParticipantsRemaining);
 
             // the token should not have any listeners.


### PR DESCRIPTION
I admit, I `grep`'ed. :smile: 

Using Ubuntu, I ran: 

```bash
# counted anomalies
root:~/corefx $ grep -inr "occured" . &> spell.log ; nano spell.log
# there were 201 occurrences of the word `occured`

root:~/corefx $ find . -type f -exec sed -i 's/Occured/Occurred/g' {} \;
root:~/corefx $ find . -type f -exec sed -i 's/occured/occurred/g' {} \;

# and then re-verified with:
root:~/corefx $ grep -inr "occured" .
# zero occurrences!
```

/cc @Kagamine
Fixes #3661.
