### PR TITLE
Disable socket perf tests

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/SocketPerformanceAPMTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/SocketPerformanceAPMTests.cs
@@ -22,7 +22,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_SingleSocketClientAPM_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;
@@ -44,8 +44,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_MultipleSocketClientAPM_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;
@@ -67,7 +66,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_SingleSocketClientAPM_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
@@ -89,8 +88,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_MultipleSocketClientAPM_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
@@ -112,7 +110,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;
@@ -134,8 +132,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -12,8 +12,6 @@ namespace System.Net.Sockets.Performance.Tests
     [Trait("Perf", "true")]
     public class SocketPerformanceAsyncTests
     {
-        private const int DummyOSXPerfIssue = 123456;
-
         private readonly ITestOutputHelper _log;
 
         public SocketPerformanceAsyncTests(ITestOutputHelper output)
@@ -22,7 +20,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
@@ -44,8 +42,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
+        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;


### PR DESCRIPTION
These are currently in outer loop, but they're sporadically failing due to lack of appropriate infrastructure to accurately run and measure them.

cc: @pgavlin, @CIPop, @davidsh