### PR TITLE
Add an EventSource to System.Diagnostics.DiagnosticSource.   

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />
+    <Compile Include="System\Diagnostics\DiagnosticSourceEventSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -359,45 +359,4 @@ namespace System.Diagnostics
 
         #endregion
     }
-
-    /// <summary>
-    /// Current this EventSource is only here so that the Debugger can inject code using Function evaluation
-    /// We may add actual logging requests as well at some point.   This can be removed if the debugger  no 
-    /// longer needs it.   
-    /// </summary>
-    [EventSource(Name = "Microsoft-Diagnostics-DiagnosticSource")]
-    class DiagnosticSourceEventSource : EventSource
-    {
-        static public DiagnosticSourceEventSource Logger = new DiagnosticSourceEventSource();
-
-        /// <summary>
-        /// On every command (which the debugger can force by turning on this EventSource with ETW)
-        /// call a function that the debugger can hook to do an arbitrary func evaluation.  
-        /// </summary>
-        /// <param name="args"></param>
-        protected override void OnEventCommand(EventCommandEventArgs args)
-        {
-            BreakPointWithDebuggerFuncEval();
-        }
-
-        #region private 
-        private volatile bool _false;       // A value that is always false but the compiler does not know this. 
-        /// <summary>
-        /// A function which is fully interruptible even in release code so we can stop here and 
-        /// do function evaluation in the debugger.   Thus this is just a place that is useful
-        /// for the debugger to place a breakpoint where it can inject code with function evaluation
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        private void BreakPointWithDebuggerFuncEval()
-        {
-            new object();   // This is only here because it helps old desktop runtimes emit a GC safe point at the start of the method
-            while (_false)
-            {
-                _false = false;
-            }
-        }
-        #endregion 
-    }
-
-
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Current this EventSource is only here so that the Debugger can inject code using Function evaluation
+    /// We may add actual logging requests as well at some point.   This can be removed if the debugger  no 
+    /// longer needs it.   
+    /// </summary>
+    [EventSource(Name = "Microsoft-Diagnostics-DiagnosticSource")]
+    internal class DiagnosticSourceEventSource : EventSource
+    {
+        public static DiagnosticSourceEventSource Logger = new DiagnosticSourceEventSource();
+
+        /// <summary>
+        /// On every command (which the debugger can force by turning on this EventSource with ETW)
+        /// call a function that the debugger can hook to do an arbitrary func evaluation.  
+        /// </summary>
+        /// <param name="args"></param>
+        protected override void OnEventCommand(EventCommandEventArgs args)
+        {
+            BreakPointWithDebuggerFuncEval();
+        }
+
+        #region private 
+        private volatile bool _false;       // A value that is always false but the compiler does not know this. 
+
+        /// <summary>
+        /// A function which is fully interruptible even in release code so we can stop here and 
+        /// do function evaluation in the debugger.   Thus this is just a place that is useful
+        /// for the debugger to place a breakpoint where it can inject code with function evaluation
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private void BreakPointWithDebuggerFuncEval()
+        {
+            new object();   // This is only here because it helps old desktop runtimes emit a GC safe point at the start of the method
+            while (_false)
+            {
+                _false = false;
+            }
+        }
+        #endregion 
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/src/project.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "System.Diagnostics.Debug": "4.0.0",
     "System.Runtime": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Threading": "4.0.0",
+    "System.Diagnostics.Tracing": "4.0.0"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Diagnostics.DiagnosticSource/src/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/src/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 1,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -10,6 +10,15 @@
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
         }
       },
       "System.Runtime/4.0.0": {
@@ -86,6 +95,52 @@
         "System.Diagnostics.Debug.4.0.0.nupkg",
         "System.Diagnostics.Debug.4.0.0.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.0": {
+      "type": "package",
+      "sha512": "tzqQJPgD4bKs0eE5Gx9HEsxiHSBGcL42PImkjhwXTQK6iQbLTTB9mi+G7mUyEjlH8LUcm7F5QHEs+O+LpruOrQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/it/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/es/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/fr/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/it/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ja/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ko/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ru/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/netcore50/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Diagnostics.Tracing.4.0.0.nupkg",
+        "System.Diagnostics.Tracing.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Runtime/4.0.0": {
@@ -237,7 +292,8 @@
     "": [
       "System.Diagnostics.Debug >= 4.0.0",
       "System.Runtime >= 4.0.0",
-      "System.Threading >= 4.0.0"
+      "System.Threading >= 4.0.0",
+      "System.Diagnostics.Tracing >= 4.0.0"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 1,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -355,7 +355,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00102": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1219,14 +1219,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00102": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YOLHpTXiw6lEGbsQ1uQ93BAPKiUtrj4l+Yr1+WGdZShfCtGc3Sq3R9dISIHM49znLo+qDcnmo2oMGJdVZ9YTVg==",
+      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00102.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00102.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
One of the scenarios that DiagnosticSource needs to support is to be turned on by an attached debugger.   

Given that the debugger has god-like capabilities over the process being debugger, this should have been easy,  However due to bugs / deficiencies in the generation of GC safe points in optimized code, it is surprisingly difficult for the debugger to reliably stop the process and inject code so that it can subscribe to the DiagnosticSource information.  

After trying several alternatives, this alternative was chosen as the least bad.  Basically a DiagnosticSource will have a EventSource associated with it (Microsoft-Diagnostics-DiagnosticSource), that is guaranteed to be present if DiagnosticSource is being used.   Currently this EventSource does not actually log anything, but acts as a mechanism for the debugger to send commands into the process.   This EventSource has a function BreakPointWithDebuggerFuncEval() that is well known to the debugger and as its name indicates is guaranteed to be a stop where the debugger can inject code (Func Eval works).   We do whatever is necessary in this function to insure that we work around all the present issues with GC safe points.   

Thus the debugger need only set a breakpoint in this function and then send a EventSource command to the Microsoft-Diagnostics-DiagnosticSource EventSource to reliably get the process to stop at a point where code can be injected.   

Note that this EventSource is currently present only for the benefit of the Debugger and thus we may change the conventions later (it is a private contract).   

This solution is better than most because 
    1) It works.   Namely it handles both the startup case and the attach case uniformly.   
    2) No hot paths are changed
    3) The DiagnosticSource class itself has changed only trivially (to initialize the EventSource)
    4) It is otherwise private / hidden (we could remove it if we find a better way in the future).  
    5) It is a minimal amount of new code 
    6) It is relatively easy to understand why the code is there and why it is the way it is.  
    7) It does not introduce dependencies we would rather not have (it does introduce a dependency on EventSource but that is OK, as we consider EventSource 'fundamental'.  
    7) It leaves open the door for more sophisticated commands in the future.  

All in all, not bad. 
