### PR TITLE
Fix async abort behavior for *nix accept().

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -216,8 +216,7 @@ namespace System.Net.Sockets
                         Interop.Sys.Close(fd);
                         fd = -1;
                     }
-
-                    if (addressFamily == AddressFamily.InterNetworkV6)
+                    else if (addressFamily == AddressFamily.InterNetworkV6)
                     {
                         int on = 1;
                         err = Interop.libc.setsockopt(fd, Interop.libc.IPPROTO_IPV6, Interop.libc.IPV6_V6ONLY, &on, (uint)sizeof(int));


### PR DESCRIPTION
Aborted accept attempts are currently returning an accepted file
descriptor of 0 instead of the proper -1. This change corrects this
behavior.