### PR TITLE
Implement EnsureStoreOpened for the Unix PAL

### DIFF
--- a/src/System.Net.Security/src/System/Net/Unix/CertModule.cs
+++ b/src/System.Net.Security/src/System/Net/Unix/CertModule.cs
@@ -4,13 +4,17 @@
 using System.Diagnostics;
 using Microsoft.Win32.SafeHandles;
 using System.Net.Security;
-using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace System.Net
 {   
     internal partial class CertModule : CertInterface
     {
+        private static readonly object s_lockObject = new object();
+        private static X509Store s_userCertStore;
+
         #region internal Methods
         internal override SslPolicyErrors VerifyCertificateProperties(
             X509Chain chain,
@@ -140,8 +144,54 @@ namespace System.Net
 
         internal override X509Store EnsureStoreOpened(bool isMachineStore)
         {
-            // TODO (Issue #3362) do the implementation
-            return null;
+            if (isMachineStore)
+            {
+                // There's not currently a LocalMachine\My store on Unix, so don't bother trying
+                // and having to deal with the exception.
+                //
+                // https://github.com/dotnet/corefx/issues/3690 tracks the lack of this store.
+                return null;
+            }
+
+            return EnsureStoreOpened(ref s_userCertStore, StoreLocation.CurrentUser);
+        }
+
+        private static X509Store EnsureStoreOpened(ref X509Store storeField, StoreLocation storeLocation)
+        {
+            X509Store store = Volatile.Read(ref storeField);
+
+            if (store == null)
+            {
+                lock (s_lockObject)
+                {
+                    store = Volatile.Read(ref storeField);
+
+                    if (store == null)
+                    {
+                        try
+                        {
+                            store = new X509Store(StoreName.My, storeLocation);
+                            store.Open(OpenFlags.ReadOnly);
+
+                            Volatile.Write(ref storeField, store);
+
+                            GlobalLog.Print(
+                                "CertModule::EnsureStoreOpened() storeLocation:" + storeLocation +
+                                    " returned store:" + store.GetHashCode().ToString("x"));
+                        }
+                        catch (CryptographicException e)
+                        {
+                            GlobalLog.Assert(
+                                "CertModule::EnsureStoreOpened()",
+                                "Failed to open cert store, location:" + storeLocation + " exception:" + e);
+
+                            throw;
+                        }
+                    }
+                }
+            }
+
+            return store;
         }
 
         #endregion


### PR DESCRIPTION
Now that X509Certificate2Collection.Find has been implemented on Unix, it makes sense to wire this up.

There isn't yet a notion of LM\My on Unix, and rather than eating the exception over and over this code just doesn't bother trying.  It does, however, set itself up to do so in the future, by making the code that does the store opening take in a parameter for the store name (and a ref parameter for the object reference field).

This is a part of uber-issue #3362 (EnsureStoreOpened - Implement the method. (CertModule.cs))