### PR TITLE
Add more tests for System.Net.Http library

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers2.cs
+++ b/src/Common/tests/System/Net/HttpTestServers2.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace System.Net.Tests
+{
+    internal class HttpTestServers2
+    {
+        // TODO: This class will be used to replace the HttpTestServers class. For now, it is separate
+        // while the test infrastructure issues (#2383 et. al) are being worked out.
+        public const string Host = "corefx-networking.azurewebsites.net";
+
+        private const string EchoHandler = "Echo.ashx";
+        public readonly static Uri RemoteEchoServer = new Uri("http://" + Host + "/" + EchoHandler);
+        public readonly static Uri SecureRemoteEchoServer = new Uri("https://" + Host + "/" + EchoHandler);
+
+        public readonly static object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
+
+        public static Uri BasicAuthUriForCreds(bool secure, string userName, string password)
+        {
+            string scheme;
+            
+            if (secure)
+            {
+                scheme = "https";
+            }
+            else
+            {
+                scheme = "http";
+            }
+            
+            return new Uri(
+                string.Format(
+                    "{0}://{1}/{2}?auth=basic&user={3}&password={4}",
+                    scheme,
+                    Host,
+                    EchoHandler,
+                    userName,
+                    password));
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/CustomContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CustomContent.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public sealed class CustomContent : StreamContent
+    {
+        private long _length;
+
+        public static CustomContent Create(string data, bool rewindable)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(data);
+            Stream stream = new CustomStream(bytes, rewindable);
+            
+            return new CustomContent(stream, bytes.Length);
+        }
+
+        private CustomContent(Stream stream, long length) : base(stream)
+        {
+            _length = length;
+        }
+
+        public long Length
+        {
+            get
+            {
+                return _length;
+            }
+        }
+
+        private class CustomStream : Stream
+        {
+            private byte[] _buffer;
+            private long _position;
+            private bool _rewindable;
+
+            public CustomStream(byte[] buffer, bool rewindable)
+            {
+                _buffer = buffer;
+                _position = 0;
+                _rewindable = rewindable;
+            }
+        
+            public override bool CanRead
+            {
+                get { return true; }
+            }
+
+            public override bool CanSeek
+            {
+                get { return _rewindable; }
+            }
+
+            public override bool CanWrite
+            {
+                get { return false; }
+            }
+
+            public override void Flush()
+            {
+                throw new NotSupportedException("CustomStream.Flush");
+            }
+
+            public override long Length
+            {
+                get
+                {
+                    if (_rewindable)
+                    {
+                        return (long)_buffer.Length;
+                    }
+                    else
+                    {
+                        throw new NotSupportedException("CustomStream.Length");
+                    }
+                }
+            }
+
+            public override long Position
+            {
+                get
+                {
+                    return _position;
+                }
+                set
+                {
+                    if (_rewindable)
+                    {
+                        _position = value;
+                    }
+                    else
+                    {
+                        throw new NotSupportedException("CustomStream.Position");
+                    }
+                }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int bytesRead = 0;
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (_position >= _buffer.Length)
+                    {
+                        break;
+                    }
+
+                    buffer[offset] = _buffer[_position];
+                    bytesRead++;
+                    offset++;
+                    _position++;
+                }
+
+                return bytesRead;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException("CustomStream.Seek");
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException("CustomStream.SetLength");
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException("CustomStream.Write");
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Net.Tests;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    // Note:  Disposing the HttpClient object automatically disposes the handler within. So, it is not necessary
+    // to separately Dispose (or have a 'using' statement) for the handler.
+    public class PostScenarioTest
+    {
+        private const string ExpectedContent = "Test contest";
+        private const string UserName = "user1";
+        private const string Password = "password1";
+        private readonly static Uri BasicAuthServerUri =
+            HttpTestServers2.BasicAuthUriForCreds(false, UserName, Password);
+        private readonly static Uri SecureBasicAuthServerUri =
+            HttpTestServers2.BasicAuthUriForCreds(true, UserName, Password);
+
+        private readonly ITestOutputHelper _output;
+
+        public readonly static object[][] EchoServers = HttpTestServers2.EchoServers;
+
+        public readonly static object[][] BasicAuthEchoServers =
+            new object[][]
+                {
+                    new object[] { BasicAuthServerUri },
+                    new object[] { SecureBasicAuthServerUri }
+                };
+
+        public PostScenarioTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostUsingContentLengthSemantics_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, ExpectedContent, new StringContent(ExpectedContent),
+                useContentLengthUpload: true, useChunkedEncodingUpload: false);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostUsingChunkedEncoding_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, ExpectedContent, new StringContent(ExpectedContent),
+                useContentLengthUpload: false, useChunkedEncodingUpload: true);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostRepeatedFlushContentUsingChunkedEncoding_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, ExpectedContent, new RepeatedFlushContent(ExpectedContent),
+                useContentLengthUpload: false, useChunkedEncodingUpload: true);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostUsingUsingConflictingSemantics_UsesChunkedSemantics(Uri serverUri)
+        {
+            await PostHelper(serverUri, ExpectedContent, new StringContent(ExpectedContent),
+                useContentLengthUpload: true, useChunkedEncodingUpload: true);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostUsingNoSpecifiedSemantics_UsesChunkedSemantics(Uri serverUri)
+        {
+            await PostHelper(serverUri, ExpectedContent, new StringContent(ExpectedContent),
+                useContentLengthUpload: false, useChunkedEncodingUpload: false);
+        }
+
+        [Theory, MemberData("BasicAuthEchoServers")]
+        [ActiveIssue(3699, PlatformID.AnyUnix)]
+        public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Uri serverUri)
+        {
+            HttpContent content = CustomContent.Create(ExpectedContent, true);
+            var credential = new NetworkCredential(UserName, Password);
+            await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, false);
+        }
+
+        [Theory, MemberData("BasicAuthEchoServers")]
+        [ActiveIssue(3693, PlatformID.AnyUnix)]
+        public async Task PostNonRewindableContentUsingAuth_NoPreAuthenticate_ThrowsInvalidOperationException(Uri serverUri)
+        {
+            HttpContent content = CustomContent.Create(ExpectedContent, false);
+            var credential = new NetworkCredential(UserName, Password);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: false));
+        }
+
+        [Theory, MemberData("BasicAuthEchoServers")]
+        [ActiveIssue(3695, PlatformID.AnyUnix)]
+        public async Task PostNonRewindableContentUsingAuth_PreAuthenticate_Success(Uri serverUri)
+        {
+            HttpContent content = CustomContent.Create(ExpectedContent, false);
+            var credential = new NetworkCredential(UserName, Password);
+            await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: true);
+        }
+        
+        private async Task PostHelper(
+            Uri serverUri,
+            string requestBody,
+            HttpContent requestContent,
+            bool useContentLengthUpload,
+            bool useChunkedEncodingUpload)
+        {
+            using (var client = new HttpClient())
+            {
+                if (!useContentLengthUpload)
+                {
+                    requestContent.Headers.ContentLength = null;
+                }
+                
+                if (useChunkedEncodingUpload)
+                {
+                    client.DefaultRequestHeaders.TransferEncodingChunked = true;
+                }
+
+                using (HttpResponseMessage response = await client.PostAsync(serverUri, requestContent))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    _output.WriteLine(responseContent);
+
+                    if (!useContentLengthUpload && !useChunkedEncodingUpload)
+                    {
+                        useChunkedEncodingUpload = true;
+                    }
+
+                    VerifyResponseBody(
+                        responseContent,
+                        response.Content.Headers.ContentMD5,
+                        useChunkedEncodingUpload,
+                        requestBody);
+                }
+            }          
+        }
+
+        private async Task PostUsingAuthHelper(
+            Uri serverUri,
+            string requestBody,
+            HttpContent requestContent,
+            NetworkCredential credential,
+            bool preAuthenticate)
+        {
+            var handler = new HttpClientHandler();
+            handler.PreAuthenticate = preAuthenticate;
+            handler.Credentials = credential;
+            using (var client = new HttpClient(handler))
+            {
+                // Send HEAD request to help bypass the 401 auth challenge for the latter POST assuming
+                // that the authentication will be cached and re-used later when PreAuthenticate is true.
+                var request = new HttpRequestMessage(HttpMethod.Head, serverUri);
+                HttpResponseMessage response;
+                using (response = await client.SendAsync(request))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                // Now send POST request.
+                request = new HttpRequestMessage(HttpMethod.Post, serverUri);
+                request.Content = requestContent;
+                requestContent.Headers.ContentLength = null;
+                request.Headers.TransferEncodingChunked = true;
+
+                using (response = await client.PostAsync(serverUri, requestContent))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    _output.WriteLine(responseContent);
+
+                    VerifyResponseBody(
+                        responseContent,
+                        response.Content.Headers.ContentMD5,
+                        true,
+                        requestBody);
+                }
+            }
+        }
+
+        private bool JsonMessageContainsKeyValue(string message, string key, string value)
+        {
+            // TODO: Align with the rest of tests w.r.t response parsing once the test server is finalized.
+            // Currently not adding any new dependencies
+            string pattern = string.Format(@"""{0}"": ""{1}""", key, value);
+            return message.Contains(pattern);
+        }
+
+        private void VerifyResponseBody(
+            string responseContent,
+            byte[] expectedMD5Hash,
+            bool chunkedUpload,
+            string requestBody)
+        {
+            // Compare computed hash with transmitted hash.
+            using (MD5 md5 = MD5.Create())
+            {
+                byte[] bytes = Encoding.ASCII.GetBytes(responseContent);
+                byte[] actualMD5Hash = md5.ComputeHash(bytes);
+                Assert.Equal(expectedMD5Hash, actualMD5Hash);
+            }
+
+            // Verify upload semsntics: 'Content-Length' vs. 'Transfer-Encoding: chunked'.
+            bool requestUsedContentLengthUpload =
+                JsonMessageContainsKeyValue(responseContent, "Content-Length", requestBody.Length.ToString());
+            bool requestUsedChunkedUpload =
+                JsonMessageContainsKeyValue(responseContent, "Transfer-Encoding", "chunked");
+            Assert.NotEqual(requestUsedContentLengthUpload, requestUsedChunkedUpload);
+            Assert.Equal(chunkedUpload, requestUsedChunkedUpload);
+            Assert.Equal(!chunkedUpload, requestUsedContentLengthUpload);
+
+            // Verify that request body content was correctly sent to server.
+            Assert.True(JsonMessageContainsKeyValue(responseContent, "BodyContent", requestBody), "Valid request body");
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/RepeatedFlushContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/RepeatedFlushContent.cs
@@ -3,24 +3,20 @@
 
 using System;
 using System.IO;
-using System.Security.Authentication.ExtendedProtection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public sealed class ChannelBindingAwareContent : StringContent
+    public sealed class RepeatedFlushContent : StringContent
     {
-        public ChannelBindingAwareContent(string content) : base(content)
+        public RepeatedFlushContent(string content) : base(content)
         {
         }
         
-        public ChannelBinding ChannelBinding { get ; private set; }
-        
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            ChannelBinding = context.GetChannelBinding(ChannelBindingKind.Endpoint);
-            
+            stream.Flush();
+            stream.Flush();
             return base.SerializeToStreamAsync(stream, context);
         }
     }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -21,11 +21,15 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers2.cs">
+      <Link>Common\System\Net\HttpTestServers2.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\Streams\DelegateStream.cs">
       <Link>Common\Streams\DelegateStream.cs</Link>
     </Compile>
     <Compile Include="ByteArrayContentTest.cs" />
     <Compile Include="ChannelBindingAwareContent.cs" />
+    <Compile Include="CustomContent.cs" />
     <Compile Include="DelegatingHandlerTest.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />
@@ -38,6 +42,8 @@
     <Compile Include="MessageProcessingHandlerTest.cs" />
     <Compile Include="MultipartContentTest.cs" />
     <Compile Include="MultipartFormDataContentTest.cs" />
+    <Compile Include="PostScenarioTest.cs" />
+    <Compile Include="RepeatedFlushContent.cs" />
     <Compile Include="ResponseStreamTest.cs" />
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="StringContentTest.cs" />


### PR DESCRIPTION
Ported more HTTP related tests.  These tests focus mostly on POST
scenarios mixed with authentication, pre-authentication, and the
"rewind-ability" of content if it needs to be re-POST'd due to AUTH
challeges by the server.

Added a new HttpTestServers2 class to Common/tests/System/Net. This is a
point-in-time thing as we improve the test infrastructure capability. In
particular, we are moving away from the use of the "httpbin.org" server.
Our new networking test server that we are bringing up has more features
than httpbin.org. It can support all the main HTTP verbs when doing "echo"
of request headers. It includes a "Content-MD5" HTTP response header. This
contains a hash of the response body. This makes it easier to validate the
returned payloads. The "httpbin.org" server also has a bug where it does
not properly echo chunked upload headers which was causing issues when
trying to port these tests.

I did not change other networking tests still using "httpbin.org" and the
Common HttpTestServers class. I will be doing that later as we finalize
the test infrastructure.