### PR TITLE
Upgrading the System.Net.Sockets dependency

### DIFF
--- a/src/System.Data.SqlClient/src/project.json
+++ b/src/System.Data.SqlClient/src/project.json
@@ -13,7 +13,7 @@
     "System.IO.FileSystem": "4.0.0",
     "System.Net.Primitives": "4.0.10",
     "System.Net.Security": "4.0.0-beta-*",
-    "System.Net.Sockets": "4.0.10-beta-*",
+    "System.Net.Sockets": "4.1.0-beta-*",
     "System.Reflection": "4.0.0",
     "System.Reflection.TypeExtensions": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",

--- a/src/System.Data.SqlClient/src/project.lock.json
+++ b/src/System.Data.SqlClient/src/project.lock.json
@@ -70,7 +70,7 @@
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23401": {
+      "System.Console/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -226,10 +226,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23401": {
+      "System.Net.Security/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23401"
+          "System.Private.Networking": "4.0.1-beta-23406"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -238,10 +238,11 @@
           "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.0.10-beta-23213": {
+      "System.Net.Sockets/4.1.0-beta-23406": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23213"
+          "System.Private.Networking": "4.0.1-beta-23406",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -250,7 +251,7 @@
           "lib/DNXCore50/System.Net.Sockets.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23401": {
+      "System.Private.Networking/4.0.1-beta-23406": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -269,13 +270,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23401",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23401",
-          "System.Security.Principal.Windows": "4.0.0-beta-23401",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23406",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23406",
+          "System.Security.Principal.Windows": "4.0.0-beta-23406",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23401"
+          "System.Threading.ThreadPool": "4.0.10-beta-23406"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -413,18 +414,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23401": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23401"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23406"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23401": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -433,7 +434,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23401": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -451,13 +452,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23401": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23401",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23401"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23406",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23406"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -475,7 +476,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23401": {
+      "System.Security.Principal.Windows/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -600,7 +601,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23401": {
+      "System.Threading.Thread/4.0.0-beta-23406": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -828,10 +829,10 @@
         "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23401": {
+    "System.Console/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "49zWKpJWl584fCuBYIRg68wk69e2+r5g7K8vlZRijrmXqiMe8Bx0FEap7Dc1rPhTYD06g72P2u5v8QfLLDh4bQ==",
+      "sha512": "gKzQ/CkAP8fbyQ8+Vxf3lvW4+3qbZ8QpqwTWhRXImQ9QteXgI+q956weRMS1A8fN9BUR1sNnBDtS1sP7cts9fA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -845,8 +846,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-beta-23401.nupkg",
-        "System.Console.4.0.0-beta-23401.nupkg.sha512",
+        "System.Console.4.0.0-beta-23406.nupkg",
+        "System.Console.4.0.0-beta-23406.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -1182,9 +1183,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23401": {
+    "System.Net.Security/4.0.0-beta-23406": {
       "type": "package",
-      "sha512": "9QNDXeE1Og3TQmdzIR9pao3mO/yH6KSoJqeXL2Q59sLjf6eDVVmbaw1hkmd2W5uhxaMD9LbKvKBb/Xq1O+1H4A==",
+      "sha512": "C8qdJuFOKnu8WYd9FdKwZio/V2Z9zYJ/TOk1RrCe4XNDjfgvMUnfjNLC/HYnBw4Q0OWO3noVYhYzPaOSWK+Dlw==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1198,51 +1199,74 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23401.nupkg",
-        "System.Net.Security.4.0.0-beta-23401.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23406.nupkg",
+        "System.Net.Security.4.0.0-beta-23406.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
-    "System.Net.Sockets/4.0.10-beta-23213": {
+    "System.Net.Sockets/4.1.0-beta-23406": {
       "type": "package",
-      "sha512": "CpSrc6gCiRUHXZBIVZgoLNzQCvzYcyYMq6m590nkjoMWRSqh8hSX4b2DnxkJ9rZiOKDOwYu+goFL8vIEfCdpwQ==",
+      "serviceable": true,
+      "sha512": "LoMRH5vYDt9w1qTvXWHQ8AHSY6bhnglbrpFnI+iWqLwzcPIKQMhIyYxH/l2VZo7UiosFE3oKPeR/8DhUYJV7/g==",
       "files": [
+        "lib/DNXCore50/de/System.Net.Sockets.xml",
+        "lib/DNXCore50/es/System.Net.Sockets.xml",
+        "lib/DNXCore50/fr/System.Net.Sockets.xml",
+        "lib/DNXCore50/it/System.Net.Sockets.xml",
+        "lib/DNXCore50/ja/System.Net.Sockets.xml",
+        "lib/DNXCore50/ko/System.Net.Sockets.xml",
+        "lib/DNXCore50/ru/System.Net.Sockets.xml",
         "lib/DNXCore50/System.Net.Sockets.dll",
+        "lib/DNXCore50/System.Net.Sockets.xml",
+        "lib/DNXCore50/zh-hans/System.Net.Sockets.xml",
+        "lib/DNXCore50/zh-hant/System.Net.Sockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/de/System.Net.Sockets.xml",
+        "lib/net46/es/System.Net.Sockets.xml",
+        "lib/net46/fr/System.Net.Sockets.xml",
+        "lib/net46/it/System.Net.Sockets.xml",
+        "lib/net46/ja/System.Net.Sockets.xml",
+        "lib/net46/ko/System.Net.Sockets.xml",
+        "lib/net46/ru/System.Net.Sockets.xml",
+        "lib/net46/System.Net.Sockets.dll",
+        "lib/net46/System.Net.Sockets.xml",
+        "lib/net46/zh-hans/System.Net.Sockets.xml",
+        "lib/net46/zh-hant/System.Net.Sockets.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Net.Sockets.xml",
-        "ref/dotnet/es/System.Net.Sockets.xml",
-        "ref/dotnet/fr/System.Net.Sockets.xml",
-        "ref/dotnet/it/System.Net.Sockets.xml",
-        "ref/dotnet/ja/System.Net.Sockets.xml",
-        "ref/dotnet/ko/System.Net.Sockets.xml",
-        "ref/dotnet/ru/System.Net.Sockets.xml",
         "ref/dotnet/System.Net.Sockets.dll",
-        "ref/dotnet/System.Net.Sockets.xml",
-        "ref/dotnet/zh-hans/System.Net.Sockets.xml",
-        "ref/dotnet/zh-hant/System.Net.Sockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/de/System.Net.Sockets.xml",
+        "ref/net46/es/System.Net.Sockets.xml",
+        "ref/net46/fr/System.Net.Sockets.xml",
+        "ref/net46/it/System.Net.Sockets.xml",
+        "ref/net46/ja/System.Net.Sockets.xml",
+        "ref/net46/ko/System.Net.Sockets.xml",
+        "ref/net46/ru/System.Net.Sockets.xml",
+        "ref/net46/System.Net.Sockets.dll",
+        "ref/net46/System.Net.Sockets.xml",
+        "ref/net46/zh-hans/System.Net.Sockets.xml",
+        "ref/net46/zh-hant/System.Net.Sockets.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Sockets.4.0.10-beta-23213.nupkg",
-        "System.Net.Sockets.4.0.10-beta-23213.nupkg.sha512",
+        "System.Net.Sockets.4.1.0-beta-23406.nupkg",
+        "System.Net.Sockets.4.1.0-beta-23406.nupkg.sha512",
         "System.Net.Sockets.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23401": {
+    "System.Private.Networking/4.0.1-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "GqzZ13yHDt9+zosKii+6AHKea4XVE66fNKJ5zQS8nOFd9VZs4UXQGUfn31Wlt2h1bSc+UWqk/WUHLvrWuC1pdA==",
+      "sha512": "TgJQki0we6MyIuAZMLq/BBx9FdsnY9qxypjnRVPsHlcK448jLYvmaZCPun8sBI6xiDjaHYVrsHmqmlE5lk2keA==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23401.nupkg",
-        "System.Private.Networking.4.0.1-beta-23401.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23406.nupkg",
+        "System.Private.Networking.4.0.1-beta-23406.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -1579,10 +1603,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23401": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "unUfGNfc/kIWzbGZw+m0WkAlVzc1VhW3ayYhaUJla1B5XVokc0iMMFV9vCOQE54gNOA41E0xEY+EUo+DS9MWfQ==",
+      "sha512": "GpOsc681RXPvLTKOnuDKHz9jGRb2OmuoTENS/H8JBLquVGBnRhSmxy7LWWuwbJoRevVooWbdA7PU6Xx6P/51dw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1596,15 +1620,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23401.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23401.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23406.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23406.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23401": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "m0thm9z5xf+J3PmL638k/FvcL7tS6FJDfZ+7SATYvZOizQlcNIu86GcGamptQuXUpQA+t3gzhhsrvdS/mcvs8w==",
+      "sha512": "G6L6cX5EscnzbkkufTPPz5v/McrNDRc4Ar613UrMevyk3ITLmmboffMw4BuCEiV4Nox3Jqn2TWGnK8RtXzR2gg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1618,15 +1642,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23401.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23401.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23406.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23406.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23401": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RMF1swkhksZRBwFqzeI3axkOFHVILVxtaFuE61hqpuDa0l8y1C//S3QeTaUH6FSpWnhR6U8KCzj9z+tUsvKshg==",
+      "sha512": "Qo531j5XXcaZEt+2WNT12oByRknPO86SQh2gX95V0cewBCYGWmwPigxlbTPSbELSXYjOpFwDOjj1v5MQqhRTyw==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -1640,15 +1664,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23401.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23401.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23406.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23406.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23401": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bc99cqoPM15WccMCk6/bTOizw/vwNnoY/eJuFQBT9yLOFhdknY2Smp1I8gPkREzE/nvl/NemiHTEsjIlOudS2A==",
+      "sha512": "AdiWPxDItF1ld+74Y0axr4l102IQbaxdtQz+C2aXDtGgFmJ3FoEAOAcJzOJDC1GWbhW7W6o1o4b/F/OMioYbPg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1662,8 +1686,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23401.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23401.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23406.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23406.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -1700,10 +1724,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23401": {
+    "System.Security.Principal.Windows/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KI1teeWjqOT+Nen1ShiGjwTQ09/a6OxJw/Fn/Xx1BQ557COzVD//MpdzlCrcBE1gepBuPwHlkjtT4VY2Yb9vWA==",
+      "sha512": "U0CQZmBb/IzfMO2fq2He43LuJ4fzHJSumNJpFdtz8LlVHN7jPEE2glXHrRTwlAdos6L7/PzpTxEda8DqYo6IsQ==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -1719,8 +1743,8 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23401.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23401.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23406.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23406.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
@@ -1945,10 +1969,10 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.Thread/4.0.0-beta-23401": {
+    "System.Threading.Thread/4.0.0-beta-23406": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rkyJcFW7yT5BqvyNBbJRPeG9L4T0MBWeG+xfNjI/eJHf5Go217I+09GRK8GAkAmgYwVScVUmVtuLdD4pAUnFMA==",
+      "sha512": "gf6QhHhFkBKLBP46zytCFEtr4DXEsPe/h8tUN5X3qTAppTO6hwmR3gXE4xpsbIcVg8cWBPc+G0+w/vtZiPJftA==",
       "files": [
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
@@ -1962,8 +1986,8 @@
         "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.Thread.4.0.0-beta-23401.nupkg",
-        "System.Threading.Thread.4.0.0-beta-23401.nupkg.sha512",
+        "System.Threading.Thread.4.0.0-beta-23406.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23406.nupkg.sha512",
         "System.Threading.Thread.nuspec"
       ]
     },
@@ -2074,7 +2098,7 @@
       "System.IO.FileSystem >= 4.0.0",
       "System.Net.Primitives >= 4.0.10",
       "System.Net.Security >= 4.0.0-beta-*",
-      "System.Net.Sockets >= 4.0.10-beta-*",
+      "System.Net.Sockets >= 4.1.0-beta-*",
       "System.Reflection >= 4.0.0",
       "System.Reflection.TypeExtensions >= 4.0.0",
       "System.Resources.ResourceManager >= 4.0.0",


### PR DESCRIPTION
The dependency of System.Net.Sockets should be upgraded to 4.1.0-beta-* to utilize the xplat capabilities of Networking.
https://github.com/dotnet/corefx/issues/3629
