### PR TITLE
Mark corerun as executable

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -214,6 +214,8 @@ runtest()
   then
     rm mscorlib.ni.dll
   fi
+
+  chmod +x ./corerun
   
   # Invoke xunit
 


### PR DESCRIPTION
Make sure corerun is marked as executable (since the version we pull down might not have the right bits set).  This is fall out from my recent refactoring of how we build the test layouts.