### PR TITLE
Use optimized N-ary BlockExpression nodes from all Block factories

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
@@ -46,6 +46,15 @@ namespace System.Dynamic.Utils
             }
         }
 
+        public static void RequiresNotEmptyList<T>(IReadOnlyList<T> collection, string paramName)
+        {
+            RequiresNotNull(collection, paramName);
+            if (collection.Count == 0)
+            {
+                throw new ArgumentException(Strings.NonEmptyCollectionRequired, paramName);
+            }
+        }
+
         /// <summary>
         /// Requires the array and all its items to be non-null.
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -779,17 +779,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(expressions, "expressions");
 
-            switch (expressions.Length)
-            {
-                case 2: return Block(expressions[0], expressions[1]);
-                case 3: return Block(expressions[0], expressions[1], expressions[2]);
-                case 4: return Block(expressions[0], expressions[1], expressions[2], expressions[3]);
-                case 5: return Block(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
-                default:
-                    ContractUtils.RequiresNotEmpty(expressions, "expressions");
-                    RequiresCanRead(expressions, "expressions");
-                    return new BlockN(expressions.Copy());
-            }
+            return GetOptimizedBlockExpression(expressions);
         }
 
         /// <summary>
@@ -935,6 +925,21 @@ namespace System.Linq.Expressions
                     throw Error.DuplicateVariable(v);
                 }
                 set.Add(v);
+            }
+        }
+
+        private static BlockExpression GetOptimizedBlockExpression(IReadOnlyList<Expression> expressions)
+        {
+            switch (expressions.Count)
+            {
+                case 2: return Block(expressions[0], expressions[1]);
+                case 3: return Block(expressions[0], expressions[1], expressions[2]);
+                case 4: return Block(expressions[0], expressions[1], expressions[2], expressions[3]);
+                case 5: return Block(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
+                default:
+                    ContractUtils.RequiresNotEmptyList(expressions, "expressions");
+                    RequiresCanRead(expressions, "expressions");
+                    return new BlockN(expressions.ToArray());
             }
         }
     }

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests
+{
+    public static class BlockFactoryTests
+    {
+        [Fact]
+        public static void CheckBlockFactoryOptimization2()
+        {
+            AssertBlockIsOptimized(2);
+        }
+
+        [Fact]
+        public static void CheckBlockFactoryOptimization3()
+        {
+            AssertBlockIsOptimized(3);
+        }
+
+        [Fact]
+        public static void CheckBlockFactoryOptimization4()
+        {
+            AssertBlockIsOptimized(4);
+        }
+
+        [Fact]
+        public static void CheckBlockFactoryOptimization5()
+        {
+            AssertBlockIsOptimized(5);
+        }
+
+        private static void AssertBlockIsOptimized(int n)
+        {
+            // (Expression[]) overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                var expr = Expression.Block(args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (IEnumerable<Expression>) overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                var expr = Expression.Block(args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (Type, Expression[]) overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                var expr = Expression.Block(args.Last().Type, args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (Type, IEnumerable<Expression>) overload
+            {
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                var expr = Expression.Block(args.Last().Type, args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (IEnumerable<ParameterExpression>, Expression[]) overload
+            {
+                var vars = new ParameterExpression[0];
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                var expr = Expression.Block(vars, args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (IEnumerable<ParameterExpression>, IEnumerable<Expression>) overload
+            {
+                var vars = new ParameterExpression[0];
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                var expr = Expression.Block(vars, args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (Type, IEnumerable<ParameterExpression>, Expression[]) overload
+            {
+                var vars = new ParameterExpression[0];
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                var expr = Expression.Block(args.Last().Type, vars, args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+
+            // (Type, IEnumerable<ParameterExpression>, IEnumerable<Expression>) overload
+            {
+                var vars = new ParameterExpression[0];
+                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                var expr = Expression.Block(args.Last().Type, vars, args);
+
+                AssertBlockIsOptimized(expr, args);
+            }
+        }
+
+        private static void AssertBlockIsOptimized(BlockExpression expr, IReadOnlyList<Expression> args)
+        {
+            var n = args.Count;
+
+            var updated = Update(expr);
+            var visited = Visit(expr);
+
+            foreach (var node in new[] { expr, updated, visited })
+            {
+                AssertBlock(n, node);
+
+                Assert.Equal(n, node.Expressions.Count);
+
+                if (node != visited) // our visitor clones argument nodes
+                {
+                    for (var i = 0; i < n; i++)
+                    {
+                        Assert.Same(args[i], node.Expressions[i]);
+                    }
+                }
+            }
+        }
+
+        private static void AssertBlock(int n, object obj)
+        {
+            AssertTypeName("Block" + n, obj);
+        }
+
+        private static void AssertTypeName(string expected, object obj)
+        {
+            Assert.Equal(expected, obj.GetType().Name);
+        }
+
+        private static BlockExpression Update(BlockExpression node)
+        {
+            // Tests the call of Update to Expression.Block factories.
+
+            var res = node.Update(node.Variables, node.Expressions.ToArray());
+
+            Assert.NotSame(node, res);
+
+            return res;
+        }
+
+        private static BlockExpression Visit(BlockExpression node)
+        {
+            // Tests dispatch of ExpressionVisitor into Rewrite method which calls Expression.Block factories.
+
+            return (BlockExpression)new Visitor().Visit(node);
+        }
+
+        class Visitor : ExpressionVisitor
+        {
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                return Expression.Constant(node.Value, node.Type); // clones
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BinaryOperators\Comparison\BinaryNullableNotEqualTests.cs" />
     <Compile Include="BinaryOperators\Logical\BinaryLogicalTests.cs" />
     <Compile Include="BinaryOperators\Logical\BinaryNullableLogicalTests.cs" />
+    <Compile Include="Block\BlockFactoryTests.cs" />
     <Compile Include="Call\CallFactoryTests.cs" />
     <Compile Include="Cast\AsNullable.cs" />
     <Compile Include="Cast\AsTests.cs" />


### PR DESCRIPTION
This addresses issue #3297 by using Block2-Block5 types when applicable, regardless of the factory method used to create the BlockExpression.