### PR TITLE
Fix StringBuilder marshaling directions in Common\src\Interop

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         private static extern ulong ErrGetError([MarshalAs(UnmanagedType.Bool)] out bool isAllocFailure);
 
         [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
-        private static extern void ErrErrorStringN(ulong e, StringBuilder buf, int len);
+        private static extern void ErrErrorStringN(ulong e, [Out] StringBuilder buf, int len);
 
         private static string ErrErrorStringN(ulong error)
         {

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
         internal static extern SafeAsn1ObjectHandle OBJ_txt2obj(string s, [MarshalAs(UnmanagedType.Bool)] bool no_name);
 
         [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
-        private static extern int OBJ_obj2txt(StringBuilder buf, int buf_len, IntPtr a, [MarshalAs(UnmanagedType.Bool)] bool no_name);
+        private static extern int OBJ_obj2txt([Out] StringBuilder buf, int buf_len, IntPtr a, [MarshalAs(UnmanagedType.Bool)] bool no_name);
 
         [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
         internal static extern int OBJ_txt2nid(string s);

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.BIO.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.BIO.cs
@@ -29,7 +29,7 @@ internal static partial class Interop
         internal static extern bool BIO_free(IntPtr a);
 
         [DllImport(Libraries.LibCrypto, CharSet = CharSet.Ansi)]
-        internal static extern int BIO_gets(SafeBioHandle b, StringBuilder buf, int size);
+        internal static extern int BIO_gets(SafeBioHandle b, [Out] StringBuilder buf, int size);
 
         [DllImport(Libraries.LibCrypto)]
         internal static extern int BIO_read(SafeBioHandle b, byte[] data, int len);

--- a/src/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -246,7 +246,7 @@ namespace Internal.NativeCrypto
                 [In]      byte[] pbEncoded,         // Data to be formatted
                 [In]      int cbEncoded,            // Length of data to be formatted
                 [MarshalAs(UnmanagedType.LPWStr)]
-                [In, Out] StringBuilder pbFormat,   // Receives formatted string.
+                [Out]     StringBuilder pbFormat,   // Receives formatted string.
                 [In, Out] ref int pcbFormat);       // Sends/receives length of formatted String.
         }
     }

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv4AddressToStringEx.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv4AddressToStringEx.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         internal extern static uint RtlIpv4AddressToStringExW(
             [In] byte[] address,
             [In] ushort port,
-            [In, Out] StringBuilder addressString,
+            [Out] StringBuilder addressString,
             [In, Out] ref uint addressStringLength);
     }
 }

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv6AddressToStringEx.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv6AddressToStringEx.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
             [In] byte[] address,
             [In] uint scopeId,
             [In] ushort port,
-            [In, Out] StringBuilder addressString,
+            [Out] StringBuilder addressString,
             [In, Out] ref uint addressStringLength);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.GetNameInfoW.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.GetNameInfoW.cs
@@ -24,9 +24,9 @@ internal static partial class Interop
         internal static extern SocketError GetNameInfoW(
             [In]         byte[] sa,
             [In]         int salen,
-            [In, Out]     StringBuilder host,
+            [Out]        StringBuilder host,
             [In]         int hostlen,
-            [In, Out]     StringBuilder serv,
+            [Out]        StringBuilder serv,
             [In]         int servlen,
             [In]         int flags);
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.FormatMessage.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.FormatMessage.cs
@@ -23,7 +23,7 @@ internal partial class Interop
             IntPtr lpSource, 
             uint dwMessageId,
             int dwLanguageId,
-            StringBuilder lpBuffer,
+            [Out] StringBuilder lpBuffer,
             int nSize,
             IntPtr[] arguments);
 

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetModuleBaseName.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetModuleBaseName.cs
@@ -11,6 +11,6 @@ internal partial class Interop
     internal partial class mincore
     {
         [DllImport(Libraries.Psapi_Obsolete, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, EntryPoint = "K32GetModuleBaseNameW")]
-        internal static extern int GetModuleBaseName(SafeProcessHandle processHandle, IntPtr moduleHandle, StringBuilder baseName, int size);
+        internal static extern int GetModuleBaseName(SafeProcessHandle processHandle, IntPtr moduleHandle, [Out] StringBuilder baseName, int size);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetModuleFileNameEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetModuleFileNameEx.cs
@@ -11,6 +11,6 @@ internal partial class Interop
     internal partial class mincore
     {
         [DllImport(Libraries.Psapi_Obsolete, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, EntryPoint = "K32GetModuleFileNameExW")]
-        internal static extern int GetModuleFileNameEx(SafeProcessHandle processHandle, IntPtr moduleHandle, StringBuilder baseName, int size);
+        internal static extern int GetModuleFileNameEx(SafeProcessHandle processHandle, IntPtr moduleHandle, [Out] StringBuilder baseName, int size);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetNamedPipeHandleState.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetNamedPipeHandleState.cs
@@ -29,7 +29,7 @@ internal partial class Interop
             IntPtr lpCurInstances,
             IntPtr lpMaxCollectionCount,
             IntPtr lpCollectDataTimeout,
-            StringBuilder lpUserName,
+            [Out] StringBuilder lpUserName,
             int nMaxUserNameSize);
 
         [DllImport(Libraries.Pipe_L2, SetLastError = true, EntryPoint="GetNamedPipeHandleStateW")]

--- a/src/Common/src/Interop/Windows/mincore/Interop.VerLanguageName.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.VerLanguageName.cs
@@ -9,6 +9,6 @@ internal partial class Interop
     internal partial class mincore
     {
         [DllImport(Libraries.Localization, CharSet = CharSet.Unicode, EntryPoint = "VerLanguageNameW")]
-        internal static extern int VerLanguageName(uint langID, StringBuilder lpBuffer, uint nSize);
+        internal static extern int VerLanguageName(uint langID, [Out] StringBuilder lpBuffer, uint nSize);
     }
 }

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -61,7 +61,7 @@ internal partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpAddRequestHeaders(
             SafeWinHttpHandle requestHandle,
-            StringBuilder headers,
+            [In] StringBuilder headers,
             uint headersLength,
             uint modifiers);
 
@@ -77,7 +77,7 @@ internal partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpSendRequest(
             SafeWinHttpHandle requestHandle,
-            StringBuilder headers,
+            [In] StringBuilder headers,
             uint headersLength,
             IntPtr optional,
             uint optionalLength,
@@ -110,7 +110,7 @@ internal partial class Interop
             SafeWinHttpHandle requestHandle,
             uint infoLevel,
             string name,
-            StringBuilder buffer,
+            [Out] StringBuilder buffer,
             ref uint bufferLength,
             IntPtr index);
 
@@ -129,7 +129,7 @@ internal partial class Interop
         public static extern bool WinHttpQueryOption(
             SafeWinHttpHandle handle,
             uint option,
-            StringBuilder buffer,
+            [Out] StringBuilder buffer,
             ref uint bufferSize);
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]


### PR DESCRIPTION
StringBuilders by default are marshaled both In and Out.  Both directions incur cost.  But in most (all?) of our uses in corefx, we only care about marshaling in one direction, either passing the contents of the StringBuilder into the native function for it to use, or passing in an empty buffer for the native function to fill.  We can save most of the marshaling costs for the other direction by being explicit about [In] or [Out].

cc:
@bartonjs for crypto interop
@cipop, @davidsh for networking interop
@pallavit for process-related interop