### PR TITLE
#1991 - ObjectPool approach

### DIFF
--- a/src/System.IO.Compression/System.IO.Compression.sln
+++ b/src/System.IO.Compression/System.IO.Compression.sln
@@ -45,4 +45,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = a7e376ea-0587-47fe-88c2-fd75be4b20bb
+	EndGlobalSection
 EndGlobal

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -48,6 +48,7 @@
     <Compile Include="System\IO\Compression\InflaterState.cs" />
     <Compile Include="System\IO\Compression\InflaterZlib.cs" />
     <Compile Include="System\IO\Compression\InputBuffer.cs" />
+    <Compile Include="System\IO\Compression\Internal\ObjectPool`1.cs" />
     <Compile Include="System\IO\Compression\Match.cs" />
     <Compile Include="System\IO\Compression\MatchState.cs" />
     <Compile Include="System\IO\Compression\OutputBuffer.cs" />

--- a/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
@@ -743,7 +743,10 @@ namespace System.IO.Compression
             return true;
         }
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            _output.Dispose();
+        }
     }
 }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/Internal/ObjectPool`1.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Internal/ObjectPool`1.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+
+namespace System.IO.Compression.Internal
+{
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    /// 
+    /// Notes: 
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    /// 
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but 
+    ///    reduces usefulness of pooling. Just new up your own.
+    /// 
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice. 
+    /// Rationale: 
+    ///    If there is no intent for reusing the object, do not use pool - just use "new". 
+    /// </summary>
+    internal sealed class ObjectPool<T> where T : class
+    {
+        private struct Element
+        {
+            internal T Value;
+        }
+
+        // storage for the pool objects.
+        private readonly Element[] _items;
+
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Func<T> _factory;
+
+
+        internal ObjectPool(Func<T> factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        { }
+
+        internal ObjectPool(Func<T> factory, int size)
+        {
+            _factory = factory;
+            _items = new Element[size];
+        }
+
+        private T CreateInstance()
+        {
+            var inst = _factory();
+            return inst;
+        }
+
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search.
+        /// </remarks>
+        internal T Allocate()
+        {
+            var items = _items;
+            T inst;
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                // Note that the read is optimistically not synchronized. That is intentional. 
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                inst = items[i].Value;
+                if (inst != null)
+                {
+                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
+                    {
+                        goto gotInstance;
+                    }
+                }
+            }
+
+            inst = CreateInstance();
+            gotInstance:
+
+            return inst;
+        }
+
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        internal void Free(T obj)
+        {
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].Value == null)
+                {
+                    // Intentionally not using interlocked here. 
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[i].Value = obj;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allow DefrateStream and OutputWindow to pool internal resources that causes stress allocation when DefrateStream is used in high throughput small data packages. Those commonly happen in web servers which accept gzipped incoming connections and must respond accordingly. DefrateStream will allocate for reuse up to 256Kb of memory (or up to 32 concurrent streams without allocations) and will apply both to ZLib and Managed versions. On the managed implementation (InfrateManaged), there will exist a reservation of up to 512Kb of memory (or up to 16 concurrent compression streams without allocations). The rationale is that on the web server scenario messages are paired, one incoming and one outgoing, therefore there are half as many InfrateManaged than total DefrateStreams.

Reservations happen lazily, therefore in low throughput scenarios the probability of allocating the whole 768Kb is pretty low.

Fix: #1991