### PR TITLE
#1991 - Reusable/Reset approach

### DIFF
--- a/src/System.IO.Compression/System.IO.Compression.sln
+++ b/src/System.IO.Compression/System.IO.Compression.sln
@@ -45,4 +45,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = a7e376ea-0587-47fe-88c2-fd75be4b20bb
+	EndGlobalSection
 EndGlobal

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflaterManaged.cs
@@ -60,6 +60,18 @@ namespace System.IO.Compression
             _processingState = DeflaterState.NotStarted;
         }
 
+        public void Reset()
+        {
+            _processingState = DeflaterState.NotStarted;
+
+            _deflateEncoder.Reset();
+            _copyEncoder = new CopyEncoder();
+
+            _input = new DeflateInput();
+            _inputFromHistory = new DeflateInput();
+            _output = new OutputBuffer();
+        }
+
         private bool NeedsInput()
         {
             // Convenience method to call NeedsInput privately without a cast.

--- a/src/System.IO.Compression/src/System/IO/Compression/FastEncoder.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/FastEncoder.cs
@@ -19,6 +19,12 @@ namespace System.IO.Compression
             _currentMatch = new Match();
         }
 
+        public void Reset()
+        {
+            _inputWindow.ResetWindow();
+            _currentMatch = new Match();
+        }
+
         internal int BytesInHistory
         {
             get

--- a/src/System.IO.Compression/src/System/IO/Compression/FastEncoderWindow.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/FastEncoderWindow.cs
@@ -66,11 +66,22 @@ namespace System.IO.Compression
             ResetWindow();
         }
 
-        private void ResetWindow()
+        public void ResetWindow()
         {
-            _window = new byte[2 * FastEncoderWindowSize + MaxMatch + 4];
-            _prev = new ushort[FastEncoderWindowSize + MaxMatch];
-            _lookup = new ushort[FastEncoderHashtableSize];
+            if (_window == null)
+            {
+                _window = new byte[2 * FastEncoderWindowSize + MaxMatch + 4];
+                _prev = new ushort[FastEncoderWindowSize + MaxMatch];
+                _lookup = new ushort[FastEncoderHashtableSize];
+            }
+            else
+            {
+                // TODO: Check if we can get away with not clearing this. 
+                Array.Clear(_window, 0, _window.Length);
+                Array.Clear(_prev, 0, _prev.Length);
+                Array.Clear(_lookup, 0, _lookup.Length);
+            }
+
             _bufPos = FastEncoderWindowSize;
             _bufEnd = _bufPos;
         }

--- a/src/System.IO.Compression/src/System/IO/Compression/FileFormats.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/FileFormats.cs
@@ -5,6 +5,8 @@ namespace System.IO.Compression
 {
     internal interface IFileFormatWriter
     {
+        void Reset();
+
         byte[] GetHeader();
         void UpdateWithBytesRead(byte[] buffer, int offset, int bytesToCopy);
         byte[] GetFooter();
@@ -12,6 +14,8 @@ namespace System.IO.Compression
 
     internal interface IFileFormatReader
     {
+        void Reset();
+
         bool ReadHeader(InputBuffer input);
         bool ReadFooter(InputBuffer input);
         void UpdateWithBytesRead(byte[] buffer, int offset, int bytesToCopy);

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipDecoder.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipDecoder.cs
@@ -34,15 +34,20 @@ namespace System.IO.Compression
 
         public GZipDecoder()
         {
-            Reset();
+            _gzipHeaderSubstate = GzipHeaderState.ReadingID1;
+            _gzipFooterSubstate = GzipHeaderState.ReadingCRC;
         }
 
         public void Reset()
         {
             _gzipHeaderSubstate = GzipHeaderState.ReadingID1;
             _gzipFooterSubstate = GzipHeaderState.ReadingCRC;
+
             _expectedCrc32 = 0;
             _expectedOutputStreamSizeModulo = 0;
+            _actualCrc32 = 0;
+            _actualStreamSizeModulo = 0;
+            _loopCounter = 0;
         }
 
         public bool ReadHeader(InputBuffer input)

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -11,6 +11,16 @@ namespace System.IO.Compression
     {
         private DeflateStream _deflateStream;
 
+        public virtual bool IsOpen
+        {
+            get
+            {
+                if (_deflateStream == null)
+                    return false;
+
+                return _deflateStream.IsOpen;
+            }
+        }
 
         public GZipStream(Stream stream, CompressionMode mode)
 
@@ -46,6 +56,16 @@ namespace System.IO.Compression
         {
             _deflateStream = new DeflateStream(stream, compressionLevel, leaveOpen);
             _deflateStream.SetFileFormatWriter(new GZipFormatter());
+        }
+
+        public virtual void Close ()
+        {
+            _deflateStream.Close();
+        }
+
+        public virtual void Reset( Stream stream )
+        {
+            _deflateStream.Reset(stream);
         }
 
         public override bool CanRead

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipUtils.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipUtils.cs
@@ -57,6 +57,12 @@ namespace System.IO.Compression
             }
         }
 
+        public void Reset()
+        {
+            _crc32 = 0;
+            _inputStreamSizeModulo = 0;
+        }
+
         public byte[] GetHeader()
         {
             return _headerBytes;

--- a/src/System.IO.Compression/src/System/IO/Compression/IDeflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/IDeflater.cs
@@ -7,6 +7,7 @@ namespace System.IO.Compression
 {
     internal interface IDeflater : IDisposable
     {
+        void Reset();
         [Pure]
         bool NeedsInput();
         void SetInput(byte[] inputBuffer, int startIndex, int count);

--- a/src/System.IO.Compression/src/System/IO/Compression/IInflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/IInflater.cs
@@ -12,6 +12,11 @@ namespace System.IO.Compression
         int AvailableOutput { get;}
 
         /// <summary>
+        /// Ensures the infrater internal state is reset and be ready to start again.
+        /// </summary>
+        void Reset();
+
+        /// <summary>
         /// Performs the actual inflation of data currently in the input buffer of the Inflater
         /// and stores it into the given array with the given information
         /// </summary>

--- a/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/InflaterManaged.cs
@@ -95,6 +95,7 @@ namespace System.IO.Compression
 
             _codeList = new byte[HuffmanTree.MaxLiteralTreeElements + HuffmanTree.MaxDistTreeElements];
             _codeLengthTreeCodeLength = new byte[HuffmanTree.NumberOfCodeLengthTreeElements];
+
             Reset();
         }
 
@@ -105,11 +106,13 @@ namespace System.IO.Compression
 
             _codeList = new byte[HuffmanTree.MaxLiteralTreeElements + HuffmanTree.MaxDistTreeElements];
             _codeLengthTreeCodeLength = new byte[HuffmanTree.NumberOfCodeLengthTreeElements];
+
             if (reader != null)
             {
                 _formatReader = reader;
                 _hasFormatReader = true;
             }
+
             Reset();
         }
 
@@ -117,14 +120,16 @@ namespace System.IO.Compression
         {
             _formatReader = reader;
             _hasFormatReader = true;
+
             Reset();
         }
 
-        private void Reset()
+        public void Reset()
         {
             if (_hasFormatReader)
             {
                 _state = InflaterState.ReadingHeader;     // start by reading Header info
+                _formatReader.Reset();
             }
             else
             {
@@ -744,6 +749,7 @@ namespace System.IO.Compression
         }
 
         public void Dispose() { }
+
     }
 }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/InflaterZlib.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/InflaterZlib.cs
@@ -14,6 +14,7 @@ namespace System.IO.Compression
     /// </summary>
     internal class InflaterZlib : IInflater
     {
+        private int _windowBits;
         private bool _finished;                             // Whether the end of the stream has been reached
         private bool _isDisposed;                           // Prevents multiple disposals
         private ZLibNative.ZLibStreamHandle _zlibStream;    // The handle to the primary underlying zlib stream
@@ -27,9 +28,20 @@ namespace System.IO.Compression
         /// </summary>
         internal InflaterZlib(int windowBits)
         {
+            _windowBits = windowBits;
             _finished = false;
             _isDisposed = false;
-            InflateInit(windowBits);
+
+            InflateInit(_windowBits);
+        }
+
+
+        public void Reset()
+        {
+            _finished = false;
+            _zlibStream.Dispose();
+
+            InflateInit(_windowBits);
         }
 
         public int AvailableOutput

--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -249,7 +249,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        public void TestLevelOptimial()
+        public void TestLevelOptimal()
         {
             TestCtor(CompressionLevel.Optimal);
         }
@@ -515,10 +515,11 @@ namespace System.IO.Compression.Tests
             var decompressed = new MemoryStream();
             using (var decompressor = useGzip ? (Stream)new GZipStream(compressed, CompressionMode.Decompress, true) : new DeflateStream(compressed, CompressionMode.Decompress, true))
             {
-                if (useAsync)
-                    decompressor.CopyTo(decompressed, chunkSize);
-                else
-                    await decompressor.CopyToAsync(decompressed, chunkSize, CancellationToken.None);
+                switch (useAsync)
+                {
+                    case true: await decompressor.CopyToAsync(decompressed, chunkSize, CancellationToken.None); break;
+                    case false: decompressor.CopyTo(decompressed, chunkSize); break;
+                }
             }
 
             Assert.Equal<byte>(data, decompressed.ToArray());


### PR DESCRIPTION
Allow DefrateStream to be able to be closed and reset to allow users to avoid the heavy allocations that happen with the managed implementation and the construction costs.

Alternative approach: #1991