### PR TITLE
Don't make imported key automatically exportable.

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/SymmetricImportExportExtensions.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/SymmetricImportExportExtensions.cs
@@ -38,7 +38,6 @@ namespace Internal.Cryptography
                 byte[] keyBlob = ms.ToArray();
 
                 CngKey cngKey = CngKey.Import(keyBlob, s_cipherKeyBlobFormat);
-                cngKey.ExportPolicy |= CngExportPolicies.AllowPlaintextExport;
                 return cngKey;
             }
         }


### PR DESCRIPTION
cc @bartonjs 

Removing the "set to exportable" behavior of the import helper I just added.

- It's an unnecessary hiccup in sharing the code with desktop (since the ExportPolicy setter is private, not internal there.)

- We don't need it. (We only use this to translate plaintext keys to Cng in AesCng - we still store the plaintext in the base class Key property so it's still retrievable.) So it's just wasted cycles.

- The decision should be up to the guy who called Import.

