### PR TITLE
Fix for LeftShift and RightShift code generation in LambdaCompiler

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -84,6 +84,23 @@ namespace System.Dynamic.Utils
             }
         }
 
+        public static bool IsInteger64(Type type)
+        {
+            type = GetNonNullableType(type);
+            if (type.GetTypeInfo().IsEnum)
+            {
+                return false;
+            }
+            switch (type.GetTypeCode())
+            {
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         public static bool IsArithmetic(Type type)
         {
             type = GetNonNullableType(type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -325,6 +325,7 @@ namespace System.Linq.Expressions.Compiler
                     {
                         throw ContractUtils.Unreachable;
                     }
+                    EmitShiftMask(leftType);
                     _ilg.Emit(OpCodes.Shl);
                     break;
                 case ExpressionType.RightShift:
@@ -332,6 +333,7 @@ namespace System.Linq.Expressions.Compiler
                     {
                         throw ContractUtils.Unreachable;
                     }
+                    EmitShiftMask(leftType);
                     if (TypeUtils.IsUnsigned(leftType))
                     {
                         _ilg.Emit(OpCodes.Shr_Un);
@@ -344,6 +346,16 @@ namespace System.Linq.Expressions.Compiler
                 default:
                     throw Error.UnhandledBinary(op);
             }
+        }
+
+        // Shift operations have undefined behavior if the shift amount exceeds
+        // the number of bits in the value operand. See CLI III.3.58 and C# 7.9
+        // for the bit mask used below.
+        private void EmitShiftMask(Type leftType)
+        {
+            int mask = TypeUtils.IsInteger64(leftType) ? 0x3F : 0x1F;
+            _ilg.EmitInt(mask);
+            _ilg.Emit(OpCodes.And);
         }
 
         // Binary/unary operations on 8 and 16 bit operand types will leave a 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -937,7 +937,6 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class LeftShiftInstruction : Instruction
     {
-        // Perf: LeftShiftityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_SByte,s_int16,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64;
 
         public override int ConsumedStack { get { return 2; } }
@@ -1123,7 +1122,6 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class RightShiftInstruction : Instruction
     {
-        // Perf: RightShiftityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_SByte,s_int16,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64;
 
         public override int ConsumedStack { get { return 2; } }
@@ -1309,7 +1307,6 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class ExclusiveOrInstruction : Instruction
     {
-        // Perf: ExclusiveOrityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_SByte,s_int16,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_bool;
 
         public override int ConsumedStack { get { return 2; } }
@@ -1501,7 +1498,6 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class OrInstruction : Instruction
     {
-        // Perf: OrityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_SByte,s_int16,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_bool;
 
         public override int ConsumedStack { get { return 2; } }
@@ -1700,7 +1696,6 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class AndInstruction : Instruction
     {
-        // Perf: AndityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_SByte,s_int16,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_bool;
 
         public override int ConsumedStack { get { return 2; } }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -1,0 +1,606 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Binary
+{
+    public static unsafe class BinaryShiftTests
+    {
+        #region Test methods
+
+        [Fact]
+        public static void CheckByteShiftTest()
+        {
+            byte[] array = new byte[] { 0, 1, byte.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyByteShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckSByteShiftTest()
+        {
+            sbyte[] array = new sbyte[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifySByteShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckUShortShiftTest()
+        {
+            ushort[] array = new ushort[] { 0, 1, ushort.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyUShortShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckShortShiftTest()
+        {
+            short[] array = new short[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyShortShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckUIntShiftTest()
+        {
+            uint[] array = new uint[] { 0, 1, uint.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyUIntShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckIntShiftTest()
+        {
+            int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyIntShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckULongShiftTest()
+        {
+            ulong[] array = new ulong[] { 0, 1, ulong.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyULongShift(array[i]);
+            }
+        }
+
+        [Fact]
+        public static void CheckLongShiftTest()
+        {
+            long[] array = new long[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyLongShift(array[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static int[] s_shifts = new[] { int.MinValue, -1, 0, 1, 2, 31, 32, 63, 64, int.MaxValue };
+
+        private static void VerifyByteShift(byte a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyByteShift(a, b, true);
+                VerifyByteShift(a, b, false);
+            }
+        }
+
+        private static void VerifyByteShift(byte a, int b, bool left)
+        {
+            Expression<Func<byte>> e =
+                Expression.Lambda<Func<byte>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(byte)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(byte)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<byte> f = e.Compile();
+
+            // shift with expression tree
+            byte etResult = default(byte);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            byte csResult = default(byte);
+            Exception csException = null;
+            try
+            {
+                csResult = (byte)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifySByteShift(sbyte a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifySByteShift(a, b, true);
+                VerifySByteShift(a, b, false);
+            }
+        }
+
+        private static void VerifySByteShift(sbyte a, int b, bool left)
+        {
+            Expression<Func<sbyte>> e =
+                Expression.Lambda<Func<sbyte>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(sbyte)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(sbyte)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<sbyte> f = e.Compile();
+
+            // shift with expression tree
+            sbyte etResult = default(sbyte);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            sbyte csResult = default(sbyte);
+            Exception csException = null;
+            try
+            {
+                csResult = (sbyte)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifyUShortShift(ushort a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyUShortShift(a, b, true);
+                VerifyUShortShift(a, b, false);
+            }
+        }
+
+        private static void VerifyUShortShift(ushort a, int b, bool left)
+        {
+            Expression<Func<ushort>> e =
+                Expression.Lambda<Func<ushort>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ushort)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ushort)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<ushort> f = e.Compile();
+
+            // shift with expression tree
+            ushort etResult = default(ushort);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            ushort csResult = default(ushort);
+            Exception csException = null;
+            try
+            {
+                csResult = (ushort)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifyShortShift(short a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyShortShift(a, b, true);
+                VerifyShortShift(a, b, false);
+            }
+        }
+
+        private static void VerifyShortShift(short a, int b, bool left)
+        {
+            Expression<Func<short>> e =
+                Expression.Lambda<Func<short>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(short)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(short)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<short> f = e.Compile();
+
+            // shift with expression tree
+            short etResult = default(short);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            short csResult = default(short);
+            Exception csException = null;
+            try
+            {
+                csResult = (short)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifyUIntShift(uint a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyUIntShift(a, b, true);
+                VerifyUIntShift(a, b, false);
+            }
+        }
+
+        private static void VerifyUIntShift(uint a, int b, bool left)
+        {
+            Expression<Func<uint>> e =
+                Expression.Lambda<Func<uint>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(uint)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(uint)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<uint> f = e.Compile();
+
+            // shift with expression tree
+            uint etResult = default(uint);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            uint csResult = default(uint);
+            Exception csException = null;
+            try
+            {
+                csResult = (uint)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifyIntShift(int a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyIntShift(a, b, true);
+                VerifyIntShift(a, b, false);
+            }
+        }
+
+        private static void VerifyIntShift(int a, int b, bool left)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(int)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(int)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<int> f = e.Compile();
+
+            // shift with expression tree
+            int etResult = default(int);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            int csResult = default(int);
+            Exception csException = null;
+            try
+            {
+                csResult = (int)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifyULongShift(ulong a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyULongShift(a, b, true);
+                VerifyULongShift(a, b, false);
+            }
+        }
+
+        private static void VerifyULongShift(ulong a, int b, bool left)
+        {
+            Expression<Func<ulong>> e =
+                Expression.Lambda<Func<ulong>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ulong)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ulong)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<ulong> f = e.Compile();
+
+            // shift with expression tree
+            ulong etResult = default(ulong);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            ulong csResult = default(ulong);
+            Exception csException = null;
+            try
+            {
+                csResult = (ulong)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        private static void VerifyLongShift(long a)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyLongShift(a, b, true);
+                VerifyLongShift(a, b, false);
+            }
+        }
+
+        private static void VerifyLongShift(long a, int b, bool left)
+        {
+            Expression<Func<long>> e =
+                Expression.Lambda<Func<long>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(long)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(long)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<long> f = e.Compile();
+
+            // shift with expression tree
+            long etResult = default(long);
+            Exception etException = null;
+            try
+            {
+                etResult = f();
+            }
+            catch (Exception ex)
+            {
+                etException = ex;
+            }
+
+            // shift with real IL
+            long csResult = default(long);
+            Exception csException = null;
+            try
+            {
+                csResult = (long)(left ? a << b : a >> b);
+            }
+            catch (Exception ex)
+            {
+                csException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (etException != null || csException != null)
+            {
+                Assert.NotNull(etException);
+                Assert.NotNull(csException);
+                Assert.Equal(csException.GetType(), etException.GetType());
+            }
+            else
+            {
+                Assert.Equal(csResult, etResult);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="Array\NullableNewArrayListTests.cs" />
     <Compile Include="Array\ObjectArrayBoundsTests.cs" />
     <Compile Include="Array\ObjectNullableArrayBoundsTests.cs" />
+    <Compile Include="BinaryOperators\Arithmetic\BinaryShiftTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinaryAddTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinaryDivideTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinaryModuloTests.cs" />


### PR DESCRIPTION
This fixes issue #3149 in the LambdaCompiler by inserting the masking behavior similar to what the C# and VB compilers do.