### PR TITLE
Implement NetworkStream.ReadAsync/WriteAsync

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -101,9 +101,11 @@ namespace System.Net.Sockets
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public override int Read(byte[] buffer, int offset, int size) { buffer = default(byte[]); return default(int); }
+        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int size, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task<int>); }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { return default(long); }
         public override void SetLength(long value) { }
         public override void Write(byte[] buffer, int offset, int size) { }
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int size, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
     }
     public enum ProtocolType
     {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -955,6 +955,68 @@ namespace System.Net.Sockets
 #endif
         }
 
+        // ReadAsync - provide async read functionality.
+        // 
+        // This method provides async read functionality. All we do is
+        // call through to the Begin/EndRead methods.
+        // 
+        // Input:
+        // 
+        //     buffer            - Buffer to read into.
+        //     offset            - Offset into the buffer where we're to read.
+        //     size              - Number of bytes to read.
+        //     cancellationtoken - Token used to request cancellation of the operation
+        // 
+        // Returns:
+        // 
+        //     A Task<int> representing the read.
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            return Task.Factory.FromAsync(
+                (bufferArg, offsetArg, sizeArg, callback, state) => ((NetworkStream)state).BeginRead(bufferArg, offsetArg, sizeArg, callback, state),
+                iar => ((NetworkStream)iar.AsyncState).EndRead(iar),
+                buffer, 
+                offset, 
+                size, 
+                this);
+        }
+
+        // WriteAsync - provide async write functionality.
+        // 
+        // This method provides async write functionality. All we do is
+        // call through to the Begin/EndWrite methods.
+        // 
+        // Input:
+        // 
+        //     buffer  - Buffer to write into.
+        //     offset  - Offset into the buffer where we're to write.
+        //     size    - Number of bytes to write.
+        //     cancellationtoken - Token used to request cancellation of the operation
+        // 
+        // Returns:
+        // 
+        //     A Task representing the write.
+        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            return Task.Factory.FromAsync(
+                (bufferArg, offsetArg, sizeArg, callback, state) => ((NetworkStream)state).BeginWrite(bufferArg, offsetArg, sizeArg, callback, state),
+                iar => ((NetworkStream)iar.AsyncState).EndWrite(iar),
+                buffer, 
+                offset, 
+                size, 
+                this);
+        }
+
         // Flushes data from the stream.  This is meaningless for us, so it does nothing.
         public override void Flush()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class NetworkStreamTest
+    {
+        [Theory]
+        [MemberData("NonCanceledTokens")]
+        public async Task ReadWriteAsync_NonCanceled_Success(CancellationToken nonCanceledToken)
+        {
+            await RunWithConnectedNetworkStreamsAsync(async (server, client) =>
+            {
+                var clientData = new byte[] { 42 };
+                await client.WriteAsync(clientData, 0, clientData.Length, nonCanceledToken);
+
+                var serverData = new byte[clientData.Length];
+                Assert.Equal(serverData.Length, await server.ReadAsync(serverData, 0, serverData.Length, nonCanceledToken));
+
+                Assert.Equal(clientData, serverData);
+            });
+        }
+
+        [Fact]
+        public async Task ReadWriteAsync_Canceled_ThrowsOperationCanceledException()
+        {
+            await RunWithConnectedNetworkStreamsAsync(async (server, client) =>
+            {
+                var canceledToken = new CancellationToken(canceled: true);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.WriteAsync(new byte[1], 0, 1, canceledToken));
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => server.ReadAsync(new byte[1], 0, 1, canceledToken));
+            });
+        }
+
+        public static object[][] NonCanceledTokens = new object[][]
+        {
+            new object[] { CancellationToken.None },             // CanBeCanceled == false
+            new object[] { new CancellationTokenSource().Token } // CanBeCanceled == true
+        };
+
+        /// <summary>
+        /// Creates a pair of connected NetworkStreams and invokes the provided <paramref name="func"/>
+        /// with them as arguments.
+        /// </summary>
+        private static async Task RunWithConnectedNetworkStreamsAsync(Func<NetworkStream, NetworkStream, Task> func)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            try
+            {
+                listener.Start(1);
+                var clientEndpoint = (IPEndPoint)listener.LocalEndpoint;
+
+                using (var client = new TcpClient(clientEndpoint.AddressFamily))
+                {
+                    Task<TcpClient> remoteTask = listener.AcceptTcpClientAsync();
+                    Task clientConnectTask = client.ConnectAsync(clientEndpoint.Address, clientEndpoint.Port);
+
+                    await Task.WhenAll(remoteTask, clientConnectTask);
+
+                    using (TcpClient remote = remoteTask.Result)
+                    using (NetworkStream serverStream = remote.GetStream())
+                    using (NetworkStream clientStream = client.GetStream())
+                    {
+                        await func(serverStream, clientStream);
+                    }
+                }
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="DisposedSocketTests.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
+    <Compile Include="NetworkStreamTest.cs" />
     <Compile Include="SendReceive.cs" />
     <Compile Include="Shutdown.cs" />
     <Compile Include="SocketAsyncExtensions.cs" />


### PR DESCRIPTION
NetworkStream currently implements its async functionality via the APM Begin/EndRead/Write methods.  In the full Framework, the base Stream exposes these methods as well, as virtual, and NetworkStream's override the base ones.  Then the base Stream's ReadAsync/WriteAsync implementations use these for their implementation, which means NetworkStream gets at least a basic async ReadAsync/WriteAsync implementation "for free".

In corefx, however, Stream doesn't expose the Begin/End methods, which means NetworkStream's Begin/End methods don't override them, which means NetworkStream's ReadAsync/WriteAsync methods are currently just using the base implementation that queues a work item to call the synchronous Read/Write methods.  That's far from ideal for a stream focused on I/O with high latency.

This commit just adds basic implementations of NetworkStream.ReadAsync/WriteAsync that use TPL's FromAsync methods to delegate to the Begin/End methods, very similar to how the base class would have.

There are currently no unit tests for NetworkStreamin the repo, so I haven't added any yet for these new methods.  However, there is an existing functional test that does use ReadAsync/WriteAsync, so they're getting at least some coverage.

cc: @cipop, @davidsh, @pgavlin 