### PR TITLE
Initial work to expose lambda interpreter alongside lambda compiler

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -34,7 +34,7 @@ namespace System.Dynamic.Utils
             return source.GetTypeInfo().IsSubclassOf(other);
         }
 
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         // Expression trees/compiler just use IsByRef, why do we need this?
         // (see LambdaCompiler.EmitArguments for usage in the compiler)
         internal static bool IsByRefParameter(this ParameterInfo pi)

--- a/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -39,7 +39,7 @@ namespace System.Linq.Expressions.Compiler
             return nextTypeInfo;
         }
 
-#if !FEATURE_CORECLR
+#if !FEATURE_COMPILE
 
         public delegate object VBCallSiteDelegate0<T>(T callSite, object instance);
         public delegate object VBCallSiteDelegate1<T>(T callSite, object instance, ref object arg1);
@@ -118,7 +118,7 @@ namespace System.Linq.Expressions.Compiler
 
             if (needCustom)
             {
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
                 return MakeNewCustomDelegate(types);
 #else
                 return TryMakeVBStyledCallSite(types) ?? MakeNewCustomDelegate(types);

--- a/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Expressions.Compiler
 {
     internal static partial class DelegateHelpers
     {
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         private const MethodAttributes CtorAttributes = MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public;
         private const MethodImplAttributes ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
         private const MethodAttributes InvokeAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual;
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Compiler
 
         private static Type MakeNewCustomDelegate(Type[] types)
         {
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
             Type returnType = types[types.Length - 1];
             Type[] parameters = types.RemoveLast();
 

--- a/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
+++ b/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>System.Dynamic.Runtime</AssemblyName>
     <RootNamespace>System.Dynamic.Runtime</RootNamespace>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
-    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_CORECLR</DefineConstants>
+    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILER</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/UpdateDelegates.Generated.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/UpdateDelegates.Generated.cs
@@ -7,7 +7,7 @@ namespace System.Dynamic
 {
     internal static partial class UpdateDelegates
     {
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
         internal static TRet UpdateAndExecute0<TRet>(CallSite site)
         {

--- a/src/System.Dynamic.Runtime/src/System/Linq/Expressions/Compiler/TypeInfoExtensions.cs
+++ b/src/System.Dynamic.Runtime/src/System/Linq/Expressions/Compiler/TypeInfoExtensions.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Expressions.Compiler
             // nope, go ahead and create it and spend the
             // cost of creating the array.
             Type[] paramTypes = new Type[args.Count + 2];
-#if FEATURE_CORECLR        
+#if FEATURE_COMPILE        
             paramTypes[0] = typeof(CallSite);
 #else
             paramTypes[0] = typeof(object);

--- a/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/CallSite.cs
@@ -9,7 +9,7 @@ using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Reflection;
 
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
 using System.Linq.Expressions.Compiler;
 #endif 
 
@@ -271,7 +271,7 @@ namespace System.Runtime.CompilerServices
 
         internal T MakeUpdateDelegate()
         {
-#if !FEATURE_CORECLR
+#if !FEATURE_COMPILE
             Type target = typeof(T);
             MethodInfo invoke = target.GetMethod("Invoke");
 
@@ -315,7 +315,7 @@ namespace System.Runtime.CompilerServices
 #endif
         }
 
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         // This needs to be SafeCritical to allow access to
         // internal types from user code as generic parameters.
         //

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -9,7 +9,8 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
-    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_CORECLR</DefineConstants>
+    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
+    <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -137,7 +138,6 @@
     <Compile Include="System\Linq\Expressions\Compiler\CompilerScope.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\CompilerScope.Storage.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\ConstantCheck.cs" />
-    <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.Generated.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\HoistedLocals.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\ILGen.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\KeyedQueue.cs" />
@@ -161,11 +161,10 @@
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.ExpressionQuoter.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.RuntimeVariableList.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsInterpreting)' == 'true' ">
+  <ItemGroup Condition=" '$(IsInterpreting)' == 'true' Or '$(FeatureInterpret)' == 'true' ">
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\DelegateHelpers.cs">
       <Link>Common\System\Dynamic\Utils\DelegateHelpers.cs</Link>
     </Compile>
-    <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.Generated.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\AddInstruction.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\ArrayOperations.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\BranchLabel.cs" />
@@ -198,6 +197,9 @@
     <Compile Include="System\Linq\Expressions\Interpreter\SubInstruction.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\TypeOperations.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\Utilities.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.Generated.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -683,7 +683,7 @@ namespace System.Dynamic.Utils
             return type.IsByRef ? type.GetElementType() : type;
         }
 
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         internal static bool IsUnsigned(Type type)
         {
             type = GetNonNullableType(type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1115,7 +1115,7 @@ namespace System.Linq.Expressions
             return new NotSupportedException();
         }
 
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         /// <summary>
         /// NotImplementedException with message like "The operator '{0}' is not implemented for type '{1}'"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -113,14 +113,9 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public Delegate Compile()
         {
-#if FEATURE_COMPILE
-            return Compiler.LambdaCompiler.Compile(this);
-#else
-            return Compile(preferInterpretation: true);
-#endif 
+            return Compile(preferInterpretation: false);
         }
 
-#if FEATURE_INTERPRET
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
@@ -128,16 +123,18 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public Delegate Compile(bool preferInterpretation)
         {
+#if FEATURE_COMPILE
+#if FEATURE_INTERPRET
             if (preferInterpretation)
             {
                 return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
             }
-            else
-            {
-                return Compiler.LambdaCompiler.Compile(this);
-            }
-        }
 #endif
+            return Compiler.LambdaCompiler.Compile(this);
+#else
+            return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+#endif
+        }
 
 #if FEATURE_COMPILE
         internal abstract LambdaExpression Accept(Compiler.StackSpiller spiller);
@@ -165,14 +162,9 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public new TDelegate Compile()
         {
-#if FEATURE_COMPILE
-            return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
-#else
-            return Compile(preferInterpretation: true);
-#endif
+            return Compile(preferInterpretation: false);
         }
 
-#if FEATURE_INTERPRET
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
@@ -180,16 +172,18 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public new TDelegate Compile(bool preferInterpretation)
         {
+#if FEATURE_COMPILE
+#if FEATURE_INTERPRET
             if (preferInterpretation)
             {
                 return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
             }
-            else
-            {
-                return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
-            }
-        }
 #endif
+            return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
+#else
+            return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+#endif
+        }
 
         /// <summary>
         /// Creates a new expression that is like this one, but using the

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -116,7 +116,7 @@ namespace System.Linq.Expressions
 #if FEATURE_COMPILE
             return Compiler.LambdaCompiler.Compile(this);
 #else
-            return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            return Compile(preferInterpretation: true);
 #endif 
         }
 
@@ -124,10 +124,18 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
+        /// <param name="preferInterpretation">A <see cref="Boolean"/> that indicates if the expression should be compiled to an interpreted form, if available. </param>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
-        public Delegate Interpret()
+        public Delegate Compile(bool preferInterpretation)
         {
-            return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            if (preferInterpretation)
+            {
+                return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            }
+            else
+            {
+                return Compiler.LambdaCompiler.Compile(this);
+            }
         }
 #endif
 
@@ -160,7 +168,7 @@ namespace System.Linq.Expressions
 #if FEATURE_COMPILE
             return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
 #else
-            return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            return Compile(preferInterpretation: true);
 #endif
         }
 
@@ -168,10 +176,18 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
+        /// <param name="preferInterpretation">A <see cref="Boolean"/> that indicates if the expression should be compiled to an interpreted form, if available. </param>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
-        public new TDelegate Interpret()
+        public new TDelegate Compile(bool preferInterpretation)
         {
-            return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            if (preferInterpretation)
+            {
+                return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            }
+            else
+            {
+                return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
+            }
         }
 #endif
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -1458,7 +1458,7 @@ namespace System.Linq.Expressions
             }
         }
 
-#if FEATURE_CORECLR
+#if FEATURE_COMPILE
         /// <summary>
         /// A string like "The operator '{0}' is not implemented for type '{1}'"
         /// </summary>

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
@@ -35,7 +35,7 @@ namespace Tests.ExpressionInterpreter
                     Enumerable.Empty<ParameterExpression>());
 
             Func<object> c = e.Compile();
-            Func<object> i = e.Interpret();
+            Func<object> i = e.Compile(preferInterpretation: true);
 
             // compute the value with the compiler
             object cResult = null;

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_INTERPRET
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionInterpreter
+{
+    public static unsafe class InterpreterTests
+    {
+        #region Test methods
+
+        [Fact]
+        public static void InterpretCompileCrossChecks()
+        {
+            Verify(Expression.Constant(1));
+            Verify(Expression.Constant("bar"));
+
+            Verify(Expression.Add(Expression.Constant(1), Expression.Constant(2)));
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void Verify(Expression expr)
+        {
+            Expression<Func<object>> e =
+                Expression.Lambda<Func<object>>(
+                    Expression.Convert(expr, typeof(object)),
+                    Enumerable.Empty<ParameterExpression>());
+
+            Func<object> c = e.Compile();
+            Func<object> i = e.Interpret();
+
+            // compute the value with the compiler
+            object cResult = null;
+            Exception cException = null;
+            try
+            {
+                cResult = c();
+            }
+            catch (Exception ex)
+            {
+                cException = ex;
+            }
+
+            // compute the value with the interpreter
+            object iResult = default(object);
+            Exception iException = null;
+            try
+            {
+                iResult = i();
+            }
+            catch (Exception ex)
+            {
+                iException = ex;
+            }
+
+            // either both should have failed the same way or they should both produce the same result
+            if (cException != null || iException != null)
+            {
+                Assert.NotNull(cException);
+                Assert.NotNull(iException);
+                Assert.Equal(iException.GetType(), cException.GetType());
+            }
+            else
+            {
+                Assert.Equal(iResult, cResult);
+            }
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Linq.Expressions.Tests</AssemblyName>
     <RootNamespace>System.Linq.Expressions.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -79,6 +80,7 @@
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="HelperTypes.cs" />
+    <Compile Include="Interpreter\InterpreterTests.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />
     <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Lambda\LambdaAddNullableTests.cs" />


### PR DESCRIPTION
See issue #3244. This is a first stab at exposing an Interpret method alongside the Compile method on LambdaExpression and Expression<T> so the user can choose whether to interpret (e.g. for small expression fragments that need to be evaluated once) or to compile (when available on the target platform).

Whether or not the Interpret method is included is based on the FeatureInterpret build flag. This is different from the IsInterpreting build flag which changes the behavior of Compile to use Interpret on platforms that don't have dynamic code gen. Note that I've switched the defined build-time constants to be a bit more descriptive, e.g. FEATURE_COMPILER (meaning the lambda compiler is available and should be used for the Compile method) and FEATURE_INTERPRETER (meaning the Interpret method is exposed) rather than being tied to the target platform e.g. FEATURE_CORECLR.

By adding this public API surface, we can cross-check the compiler and interpreter in tests. A simple example is provided in this initial PR. It can be used to repro a variety of issues with the interpreter that were reported before.