### PR TITLE
Shim OpenSSL ERR* methods.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -160,7 +160,7 @@ internal static partial class Interop
 
             if (succeeded != 1)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
         }
 
@@ -176,7 +176,7 @@ internal static partial class Interop
 
             if (result != 1)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             // Track the parent relationship for the interior pointer so lifetime is well-managed.
@@ -191,7 +191,7 @@ internal static partial class Interop
 
             if (negativeSize > 0)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             byte[] bytes = new byte[-negativeSize];
@@ -200,7 +200,7 @@ internal static partial class Interop
 
             if (ret != 1)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             return bytes;

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     internal static partial class Crypto
     {
         [DllImport(Libraries.CryptoNative)]
-        private static extern ulong ErrGetError();
+        private static extern ulong ErrGetError([MarshalAs(UnmanagedType.Bool)] out bool isAllocFailure);
 
         [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
         private static extern void ErrErrorStringN(ulong e, StringBuilder buf, int len);
@@ -27,9 +27,6 @@ internal static partial class Interop
 
         internal static Exception CreateOpenSslCryptographicException()
         {
-            const uint ReasonMask = 0x0FFF;
-            const uint ERR_R_MALLOC_FAILURE = 64 | 1;
-
             // The Windows cryptography library reports error codes through
             // Marshal.GetLastWin32Error, which has a single value when the
             // function exits, last writer wins.
@@ -43,15 +40,19 @@ internal static partial class Interop
             // Windows code and the OpenSSL-calling code, drain the queue
             // whenever an Exception is desired, and report the exception
             // related to the last value in the queue.
-            ulong error = ErrGetError();
+            bool isAllocFailure;
+            ulong error = ErrGetError(out isAllocFailure);
             ulong lastRead = error;
+            bool lastIsAllocFailure = isAllocFailure;
 
             // 0 (there's no named constant) is only returned when the calls
             // to ERR_get_error exceed the calls to ERR_set_error.
             while (lastRead != 0)
             {
                 error = lastRead;
-                lastRead = ErrGetError();
+                isAllocFailure = lastIsAllocFailure;
+
+                lastRead = ErrGetError(out lastIsAllocFailure);
             }
 
             // If we're in an error flow which results in an Exception, but
@@ -62,17 +63,14 @@ internal static partial class Interop
                 return new CryptographicException();
             }
 
-            // Even though ErrGetError returns ulong (C++ unsigned long), we 
-            // really only expect error codes in the UInt32 range
-            Debug.Assert(error <= uint.MaxValue, "ErrGetError should only return error codes in the UInt32 range.");
-
-            // Inline version of the ERR_GET_REASON macro.
-            ulong reason = error & ReasonMask;
-
-            if (reason == ERR_R_MALLOC_FAILURE)
+            if (isAllocFailure)
             {
                 return new OutOfMemoryException();
             }
+
+            // Even though ErrGetError returns ulong (C++ unsigned long), we 
+            // really only expect error codes in the UInt32 range
+            Debug.Assert(error <= uint.MaxValue, "ErrGetError should only return error codes in the UInt32 range.");
 
             // If there was an error code, and it wasn't something handled specially,
             // use the OpenSSL error string as the message to a CryptographicException.

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.Print.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.Print.cs
@@ -40,7 +40,7 @@ internal static partial class Interop
 
                 if (len < 0)
                 {
-                    throw CreateOpenSslCryptographicException();
+                    throw Crypto.CreateOpenSslCryptographicException();
                 }
 
                 int bioSize = GetMemoryBioSize(bio);
@@ -50,7 +50,7 @@ internal static partial class Interop
 
                 if (read < 0)
                 {
-                    throw CreateOpenSslCryptographicException();
+                    throw Crypto.CreateOpenSslCryptographicException();
                 }
             }
 

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.ASN1.cs
@@ -93,7 +93,7 @@ internal static partial class Interop
 
             if (bytesNeeded < 0)
             {
-                throw CreateOpenSslCryptographicException();
+                throw Crypto.CreateOpenSslCryptographicException();
             }
 
             Debug.Assert(bytesNeeded != 0, "OBJ_obj2txt reported a zero-length response");
@@ -110,7 +110,7 @@ internal static partial class Interop
 
                 if (bytesNeeded < 0)
                 {
-                    throw CreateOpenSslCryptographicException();
+                    throw Crypto.CreateOpenSslCryptographicException();
                 }
 
                 Debug.Assert(

--- a/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
+++ b/src/Common/src/Interop/Unix/libcrypto/Interop.d2i.cs
@@ -29,7 +29,7 @@ internal static partial class Interop
 
                 if (checkHandle)
                 {
-                    CheckValidOpenSslHandle(handle);
+                    Crypto.CheckValidOpenSslHandle(handle);
                 }
 
                 return handle;
@@ -43,7 +43,7 @@ internal static partial class Interop
 
             if (size < 1)
             {
-                throw CreateOpenSslCryptographicException();
+                throw Crypto.CreateOpenSslCryptographicException();
             }
 
             byte[] data = new byte[size];

--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -336,7 +336,7 @@ internal static partial class Interop
                     return CreateSslException(msg);
 
                 case libssl.SslErrorCode.SSL_ERROR_SSL:
-                    Exception innerEx = Interop.libcrypto.CreateOpenSslCryptographicException();
+                    Exception innerEx = Interop.Crypto.CreateOpenSslCryptographicException();
                     return new SslException(innerEx.Message, innerEx);
 
                 default:

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Win32.SafeHandles
 
             if (!Interop.libcrypto.EC_KEY_up_ref(handle))
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             safeHandle.SetHandle(handle);

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Win32.SafeHandles
 
             if (!Interop.libcrypto.RSA_up_ref(handle))
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             safeHandle.SetHandle(handle);

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 set(NATIVECRYPTO_SOURCES
     openssl.c
+    pal_err.cpp
     pal_evp.cpp
     pal_evp_cipher.cpp
     pal_hmac.cpp

--- a/src/Native/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.cpp
@@ -2,15 +2,20 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "pal_err.h"
+#include "pal_utilities.h"
 
 #include <openssl/err.h>
 
-extern "C" uint64_t ErrGetError()
+extern "C" uint64_t ErrGetError(int32_t* isAllocFailure)
 {
-    return ERR_get_error();
+    unsigned long err = ERR_get_error();
+
+    *isAllocFailure = ERR_GET_REASON(err) == ERR_R_MALLOC_FAILURE;
+
+    return err;
 }
 
 extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len)
 {
-    ERR_error_string_n(e, buf, static_cast<size_t>(len));
+    ERR_error_string_n(e, buf, UnsignedCast(len));
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_err.h"
+
+#include <openssl/err.h>
+
+extern "C" uint64_t ErrGetError()
+{
+    return ERR_get_error();
+}
+
+extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len)
+{
+    ERR_error_string_n(e, buf, static_cast<size_t>(len));
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_err.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdlib.h>
+#include <stdint.h>
+
+/*
+Direct shim to ERR_get_error.
+*/
+extern "C" uint64_t ErrGetError();
+
+/*
+Direct shim to ERR_error_string_n.
+*/
+extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len);

--- a/src/Native/System.Security.Cryptography.Native/pal_err.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.h
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
 #include <stdint.h>
 
 /*
-Direct shim to ERR_get_error.
+Shim to ERR_get_error which also returns whether the error
+was caused by an allocation failure.
 */
-extern "C" uint64_t ErrGetError();
+extern "C" uint64_t ErrGetError(int32_t* isAllocFailure);
 
 /*
 Direct shim to ERR_error_string_n.

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -188,14 +188,14 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.BIO.cs">
       <Link>Interop\Unix\libcrypto\Interop.BIO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
-      <Link>Interop\Unix\libcrypto\Interop.ERR.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ASN1.cs">
       <Link>Interop\Unix\libcrypto\Interop.ASN1.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Pkcs7.cs">
       <Link>Interop\Unix\libcrypto\Interop.Pkcs7.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>

--- a/src/System.Net.Security/src/System/Net/Unix/SecuritySafeHandles.cs
+++ b/src/System.Net.Security/src/System/Net/Unix/SecuritySafeHandles.cs
@@ -99,7 +99,7 @@ namespace System.Net.Security
                     if (rsa != null)
                     {
                         _certKeyHandle = rsa.DuplicateKeyHandle();
-                        Interop.libcrypto.CheckValidOpenSslHandle(_certKeyHandle);
+                        Interop.Crypto.CheckValidOpenSslHandle(_certKeyHandle);
                     }
                 }
 
@@ -108,7 +108,7 @@ namespace System.Net.Security
                 Debug.Assert(_certKeyHandle != null, "Failed to extract a private key handle");
 
                 _certHandle = Interop.libcrypto.X509_dup(cert.Handle);
-                Interop.libcrypto.CheckValidOpenSslHandle(_certHandle);
+                Interop.Crypto.CheckValidOpenSslHandle(_certHandle);
             }
 
             _protocols = protocols;

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesOpenSslCryptoTransform.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesOpenSslCryptoTransform.cs
@@ -134,7 +134,7 @@ namespace Internal.Cryptography
 
             if (_ctx == null)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             // OpenSSL will happily do PKCS#7 padding for us, but since we support padding modes
@@ -288,7 +288,7 @@ namespace Internal.Cryptography
                 return;
             }
 
-            throw Interop.libcrypto.CreateOpenSslCryptographicException();
+            throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -70,7 +70,7 @@ namespace Internal.Cryptography
 
                 _ctx = Interop.Crypto.EvpMdCtxCreate(_algorithmEvp);
 
-                Interop.libcrypto.CheckValidOpenSslHandle(_ctx);
+                Interop.Crypto.CheckValidOpenSslHandle(_ctx);
             }
 
             public sealed override unsafe void AppendHashDataCore(byte[] data, int offset, int count)
@@ -129,7 +129,7 @@ namespace Internal.Cryptography
                 fixed (byte* keyPtr = key)
                 {
                     _hmacCtx = Interop.Crypto.HmacCreate(keyPtr, key.Length, algorithmEvp);
-                    Interop.libcrypto.CheckValidOpenSslHandle(_hmacCtx);
+                    Interop.Crypto.CheckValidOpenSslHandle(_hmacCtx);
                 }
             }
 
@@ -179,7 +179,7 @@ namespace Internal.Cryptography
             if (result != Success)
             {
                 Debug.Assert(result == 0);
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
         }
     }

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -136,8 +136,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RNGCryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RNGCryptoServiceProvider.Unix.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography
             {
                 if (!Interop.Crypto.GetRandomBytes(data, data.Length))
                 {
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
             }
         }

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Unix.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Unix.cs
@@ -28,7 +28,7 @@ namespace Internal.Cryptography
                     // The pointer is to a shared string, so marshalling it out is all that's required.
                     return Marshal.PtrToStringAnsi(friendlyNamePtr);
                 case -1: /* OpenSSL internal error */
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 default:
                     Debug.Assert(result == 0, "LookupFriendlyNameByOid returned unexpected result " + result);
                     return null;

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -67,11 +67,11 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.BIO.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.BIO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.X509Ext.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -28,9 +28,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Bignum.cs</Link>
     </Compile>
@@ -51,6 +48,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EcDsa.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.EcDsa.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs"</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"</Link>

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography
 
             if (ecKey.IsInvalid)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             // Set base.KeySize rather than this.KeySize to avoid an unnecessary Lazy<> allocation.
@@ -90,7 +90,7 @@ namespace System.Security.Cryptography
                 // So everything should be copacetic.
                 if (!Interop.libcrypto.EVP_PKEY_set1_EC_KEY(pkeyHandle, currentKey))
                 {
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
 
                 return pkeyHandle;
@@ -140,7 +140,7 @@ namespace System.Security.Cryptography
             int signatureLength = Interop.libcrypto.ECDSA_size(key);
             byte[] signature = new byte[signatureLength];
             if (!Interop.libcrypto.ECDSA_sign(0, hash, hash.Length, signature, ref signatureLength, key))
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             Array.Resize(ref signature, signatureLength);
             return signature;
         }
@@ -223,10 +223,10 @@ namespace System.Security.Cryptography
                     int nid = s_supportedAlgorithms[i].Nid;
                     SafeEcKeyHandle key = Interop.libcrypto.EC_KEY_new_by_curve_name(nid);
                     if (key == null || key.IsInvalid)
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
 
                     if (!Interop.libcrypto.EC_KEY_generate_key(key))
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
 
                     return key;
                 }

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -80,7 +80,7 @@ namespace System.Security.Cryptography
 
             if (rsa.IsInvalid)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             // Set base.KeySize rather than this.KeySize to avoid an unnecessary Lazy<> allocation.
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography
                 // So everything should be copacetic.
                 if (!Interop.libcrypto.EVP_PKEY_set1_RSA(pkeyHandle, currentKey))
                 {
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
 
                 return pkeyHandle;
@@ -277,7 +277,7 @@ namespace System.Security.Cryptography
             SafeRsaHandle key = Interop.libcrypto.RSA_new();
             bool imported = false;
 
-            Interop.libcrypto.CheckValidOpenSslHandle(key);
+            Interop.Crypto.CheckValidOpenSslHandle(key);
 
             try
             {
@@ -387,7 +387,7 @@ namespace System.Security.Cryptography
         {
             if (returnValue == -1)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
         }
 
@@ -398,7 +398,7 @@ namespace System.Security.Cryptography
                 return;
             }
 
-            throw Interop.libcrypto.CreateOpenSslCryptographicException();
+            throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
         private SafeRsaHandle GenerateKey()
@@ -406,7 +406,7 @@ namespace System.Security.Cryptography
             SafeRsaHandle key = Interop.libcrypto.RSA_new();
             bool generated = false;
 
-            Interop.libcrypto.CheckValidOpenSslHandle(key);
+            Interop.Crypto.CheckValidOpenSslHandle(key);
 
             try
             {
@@ -477,7 +477,7 @@ namespace System.Security.Cryptography
 
             if (!success)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             Debug.Assert(

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/SafeEvpPKeyHandle.Unix.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/SafeEvpPKeyHandle.Unix.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography
             if (newRefCount < 2)
             {
                 Debug.Fail("Called UpRefEvpPkey on a key which was already marked for destruction");
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             // Since we didn't actually create a new handle, copy the handle

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -39,7 +39,7 @@ namespace Internal.Cryptography.Pal
             }
 
             // Unsupported
-            throw Interop.libcrypto.CreateOpenSslCryptographicException();
+            throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
         public static ICertificatePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
@@ -47,7 +47,7 @@ namespace Internal.Cryptography.Pal
             // If we can't open the file, fail right away.
             using (SafeBioHandle fileBio = Interop.libcrypto.BIO_new_file(fileName, "rb"))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(fileBio);
+                Interop.Crypto.CheckValidOpenSslHandle(fileBio);
 
                 return FromBio(fileBio, password);
             }
@@ -102,7 +102,7 @@ namespace Internal.Cryptography.Pal
             // 
             // But, before seeking back to start, save the Exception representing the last reported
             // OpenSSL error in case the last BioSeek would change it.
-            Exception openSslException = Interop.libcrypto.CreateOpenSslCryptographicException();
+            Exception openSslException = Interop.Crypto.CreateOpenSslCryptographicException();
 
             // Use BioSeek directly for the last seek attempt, because any failure here should instead
             // report the already created (but not yet thrown) exception.
@@ -117,7 +117,7 @@ namespace Internal.Cryptography.Pal
 
             if (ret < 0)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
         }
 
@@ -157,7 +157,7 @@ namespace Internal.Cryptography.Pal
             SafeX509Handle certHandle;
             using (SafeBioHandle bio = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(bio);
+                Interop.Crypto.CheckValidOpenSslHandle(bio);
 
                 Interop.libcrypto.BIO_write(bio, rawData, rawData.Length);
                 certHandle = Interop.libcrypto.PEM_read_bio_X509_AUX(bio, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
@@ -87,7 +87,7 @@ namespace Internal.Cryptography.Pal
                         {
                             if (!Interop.Crypto.PushX509StackField(publicCerts, certHandle))
                             {
-                                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                                throw Interop.Crypto.CreateOpenSslCryptographicException();
                             }
 
                             // The handle ownership has been transferred into the STACK_OF(X509).
@@ -125,7 +125,7 @@ namespace Internal.Cryptography.Pal
                 {
                     if (pkcs12.IsInvalid)
                     {
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 
                     unsafe

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -88,7 +88,7 @@ namespace Internal.Cryptography.Pal
 
             if (!parsed)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -30,7 +30,7 @@ namespace Internal.Cryptography.Pal
 
             if (!init)
             {
-                throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
             _cert = handle;
@@ -205,18 +205,18 @@ namespace Internal.Cryptography.Pal
                 {
                     IntPtr ext = Interop.libcrypto.X509_get_ext(_cert, i);
 
-                    Interop.libcrypto.CheckValidOpenSslHandle(ext);
+                    Interop.Crypto.CheckValidOpenSslHandle(ext);
 
                     IntPtr oidPtr = Interop.libcrypto.X509_EXTENSION_get_object(ext);
 
-                    Interop.libcrypto.CheckValidOpenSslHandle(oidPtr);
+                    Interop.Crypto.CheckValidOpenSslHandle(oidPtr);
 
                     string oidValue = Interop.libcrypto.OBJ_obj2txt_helper(oidPtr);
                     Oid oid = new Oid(oidValue);
 
                     IntPtr dataPtr = Interop.libcrypto.X509_EXTENSION_get_data(ext);
 
-                    Interop.libcrypto.CheckValidOpenSslHandle(dataPtr);
+                    Interop.Crypto.CheckValidOpenSslHandle(dataPtr);
 
                     byte[] extData = Interop.Crypto.GetAsn1StringBytes(dataPtr);
                     bool critical = Interop.libcrypto.X509_EXTENSION_get_critical(ext);
@@ -280,7 +280,7 @@ namespace Internal.Cryptography.Pal
 
                 if (read < 0)
                 {
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
 
                 return builder.ToString();
@@ -331,7 +331,7 @@ namespace Internal.Cryptography.Pal
 
         private static X500DistinguishedName LoadX500Name(IntPtr namePtr)
         {
-            Interop.libcrypto.CheckValidOpenSslHandle(namePtr);
+            Interop.Crypto.CheckValidOpenSslHandle(namePtr);
 
             byte[] buf = Interop.Crypto.GetX509NameRawBytes(namePtr);
             return new X500DistinguishedName(buf);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -61,8 +61,8 @@ namespace Internal.Cryptography.Pal
             using (SafeX509StoreHandle store = Interop.libcrypto.X509_STORE_new())
             using (SafeX509StoreCtxHandle storeCtx = Interop.libcrypto.X509_STORE_CTX_new())
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(store);
-                Interop.libcrypto.CheckValidOpenSslHandle(storeCtx);
+                Interop.Crypto.CheckValidOpenSslHandle(store);
+                Interop.Crypto.CheckValidOpenSslHandle(storeCtx);
 
                 bool lookupCrl = revocationMode != X509RevocationMode.NoCheck;
 
@@ -72,7 +72,7 @@ namespace Internal.Cryptography.Pal
 
                     if (!Interop.libcrypto.X509_STORE_add_cert(store, pal.SafeHandle))
                     {
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 
                     if (lookupCrl)
@@ -101,7 +101,7 @@ namespace Internal.Cryptography.Pal
 
                     if (!Interop.libcrypto.X509_STORE_set_flags(store, vfyFlags))
                     {
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
                 }
 
@@ -112,7 +112,7 @@ namespace Internal.Cryptography.Pal
 
                 if (!Interop.libcrypto.X509_STORE_CTX_init(storeCtx, store, leafHandle, IntPtr.Zero))
                 {
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
 
                 Interop.Crypto.SetX509ChainVerifyTime(storeCtx, verificationTime);
@@ -121,7 +121,7 @@ namespace Internal.Cryptography.Pal
 
                 if (verify < 0)
                 {
-                    throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
 
                 using (SafeX509StackHandle chainStack = Interop.libcrypto.X509_STORE_CTX_get1_chain(storeCtx))
@@ -153,7 +153,7 @@ namespace Internal.Cryptography.Pal
 
                         if (elementCertPtr == IntPtr.Zero)
                         {
-                            throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                            throw Interop.Crypto.CreateOpenSslCryptographicException();
                         }
 
                         // Duplicate the certificate handle

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -35,11 +35,11 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeX509NameHandle x509Name = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_X509_NAME, encodedDistinguishedName))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(x509Name);
+                Interop.Crypto.CheckValidOpenSslHandle(x509Name);
 
                 using (SafeBioHandle bioHandle = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
                 {
-                    Interop.libcrypto.CheckValidOpenSslHandle(bioHandle);
+                    Interop.Crypto.CheckValidOpenSslHandle(bioHandle);
 
                     int written = Interop.libcrypto.X509_NAME_print_ex(
                         bioHandle,
@@ -55,7 +55,7 @@ namespace Internal.Cryptography.Pal
 
                     if (read < 0)
                     {
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 
                     return builder.ToString();
@@ -92,7 +92,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeAsn1BitStringHandle bitString = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_ASN1_BIT_STRING, encoded))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(bitString);
+                Interop.Crypto.CheckValidOpenSslHandle(bitString);
 
                 byte[] decoded = Interop.Crypto.GetAsn1StringBytes(bitString.DangerousGetHandle());
 
@@ -166,7 +166,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeBasicConstraintsHandle constraints = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_BASIC_CONSTRAINTS, encoded))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(constraints);
+                Interop.Crypto.CheckValidOpenSslHandle(constraints);
 
                 Interop.libcrypto.BASIC_CONSTRAINTS* data = (Interop.libcrypto.BASIC_CONSTRAINTS*)constraints.DangerousGetHandle();
                 certificateAuthority = data->CA != 0;
@@ -195,7 +195,7 @@ namespace Internal.Cryptography.Pal
 
             using (SafeEkuExtensionHandle eku = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_EXTENDED_KEY_USAGE, encoded))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(eku);
+                Interop.Crypto.CheckValidOpenSslHandle(eku);
 
                 int count = Interop.Crypto.GetX509EkuFieldCount(eku);
 
@@ -205,7 +205,7 @@ namespace Internal.Cryptography.Pal
 
                     if (oidPtr == IntPtr.Zero)
                     {
-                        throw Interop.libcrypto.CreateOpenSslCryptographicException();
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 
                     string oidValue = Interop.libcrypto.OBJ_obj2txt_helper(oidPtr);
@@ -231,7 +231,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeAsn1OctetStringHandle octetString = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_ASN1_OCTET_STRING, encoded))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(octetString);
+                Interop.Crypto.CheckValidOpenSslHandle(octetString);
 
                 return Interop.Crypto.GetAsn1StringBytes(octetString.DangerousGetHandle());
             }
@@ -290,7 +290,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeRsaHandle rsaHandle = Interop.libcrypto.OpenSslD2I(Interop.libcrypto.d2i_RSAPublicKey, encodedData))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(rsaHandle);
+                Interop.Crypto.CheckValidOpenSslHandle(rsaHandle);
 
                 RSAParameters rsaParameters = Interop.libcrypto.ExportRsaParameters(rsaHandle, false);
                 RSA rsa = new RSAOpenSsl();

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -119,7 +119,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeBioHandle bio = Interop.libcrypto.BIO_new(Interop.libcrypto.BIO_s_mem()))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(bio);
+                Interop.Crypto.CheckValidOpenSslHandle(bio);
 
                 Interop.libcrypto.BIO_write(bio, rawData, rawData.Length);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -49,7 +49,7 @@ namespace Internal.Cryptography.Pal
         {
             using (SafeBioHandle bio = Interop.libcrypto.BIO_new_file(fileName, "rb"))
             {
-                Interop.libcrypto.CheckValidOpenSslHandle(bio);
+                Interop.Crypto.CheckValidOpenSslHandle(bio);
 
                 return FromBio(bio, password);
             }
@@ -106,7 +106,7 @@ namespace Internal.Cryptography.Pal
             // 
             // But, before seeking back to start, save the Exception representing the last reported
             // OpenSSL error in case the last BioSeek would change it.
-            Exception openSslException = Interop.libcrypto.CreateOpenSslCryptographicException();
+            Exception openSslException = Interop.Crypto.CreateOpenSslCryptographicException();
 
             // Use BioSeek directly for the last seek attempt, because any failure here should instead
             // report the already created (but not yet thrown) exception.

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -183,9 +183,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EcKey.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.EcKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.ERR.cs">
-      <Link>Common\Interop\Unix\libcrypto\Interop.ERR.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.EvpPkey.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.EvpPkey.cs</Link>
     </Compile>
@@ -197,6 +194,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.Initialization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>


### PR DESCRIPTION
Adding shims for all OpenSSL methods in Interop.ERR.cs.

@bartonjs, @nguerrera, @sokket 