### PR TITLE
Remove unnecessary TODO in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -314,9 +314,6 @@ namespace System.Net.Http
                 throw new InvalidOperationException(SR.net_http_invalid_cookiecontainer);
             }
 
-            // TODO: Check that SendAsync is not being called again for same request object.
-            //       Probably fix is needed in WinHttpHandler as well
-
             CheckDisposed();
             SetOperationStarted();
 


### PR DESCRIPTION
This is handled by HttpClient.

Fixes #3268 
cc: @kapilash 