### PR TITLE
Renable some HttpWebResponse tests

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers2.cs
+++ b/src/Common/tests/System/Net/HttpTestServers2.cs
@@ -12,8 +12,12 @@ namespace System.Net.Tests
         public const string Host = "corefx-networking.azurewebsites.net";
 
         private const string EchoHandler = "Echo.ashx";
+        private const string EmptyContentHandler = "EmptyContent.ashx";
+        
         public readonly static Uri RemoteEchoServer = new Uri("http://" + Host + "/" + EchoHandler);
         public readonly static Uri SecureRemoteEchoServer = new Uri("https://" + Host + "/" + EchoHandler);
+        
+        public readonly static Uri RemoteEmptyContentServer = new Uri("http://" + Host + "/" + EmptyContentHandler);
 
         public readonly static object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
 

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Http;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -9,37 +10,21 @@ namespace System.Net.Tests
 {
     public class HttpWebResponseTest
     {
-        public static object[][] HasContentTypeHeaderServers
+        [Fact]
+        public async Task ContentType_ServerResponseHasContentTypeHeader_ContentTypeIsNonEmptyString()
         {
-            get
-            {
-                return HttpTestServers.GetServers;
-            }
-        }
-
-        public static object[][] MissingContentTypeHeaderServers
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        [Theory, MemberData("HasContentTypeHeaderServers")]
-        public void ContentType_ServerResponseHasContentTypeHeader_ContentTypeIsNonEmptyString(Uri remoteServer)
-        {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
+            HttpWebRequest request = WebRequest.CreateHttp(HttpTestServers2.RemoteEchoServer);
             request.Method = HttpMethod.Get.Method;
-            WebResponse response = request.GetResponseAsync().GetAwaiter().GetResult();
+            WebResponse response = await request.GetResponseAsync();
             Assert.True(!string.IsNullOrEmpty(response.ContentType));
         }
 
-        [Theory, MemberData("MissingContentTypeHeaderServers"), ActiveIssue(2385)]
-        public void ContentType_ServerResponseMissingContentTypeHeader_ContentTypeIsEmptyString(Uri remoteServer)
+        [Fact]
+        public async Task ContentType_ServerResponseMissingContentTypeHeader_ContentTypeIsEmptyString()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
+            HttpWebRequest request = WebRequest.CreateHttp(HttpTestServers2.RemoteEmptyContentServer);
             request.Method = HttpMethod.Get.Method;
-            WebResponse response = request.GetResponseAsync().GetAwaiter().GetResult();
+            WebResponse response = await request.GetResponseAsync();
             Assert.Equal(string.Empty, response.ContentType);
         }
     }

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -27,6 +27,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers2.cs">
+      <Link>Common\System\Net\HttpTestServers2.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Modify tests checking for presence/absence of 'Content-Type' response
headers. Switch to using the new HttpTestServers2 class which supports
these kind of endpoints.

Simplify the tests to be [Fact] and not [Theory]. These tests don't require
to be run against both HTTP and HTTPS servers. I will be making these
kinds of changes further in order to streamline the number of tests
running in CI.

This PR also fixes #2385.