### PR TITLE
Shim socket addresses.

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.sockaddr.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.sockaddr.cs
@@ -5,7 +5,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
-using in_port_t = System.UInt16;
 using sa_family_t = System.UInt16;
 
 internal static partial class Interop
@@ -21,45 +20,15 @@ internal static partial class Interop
         // (Field 'Interop.libc.sockaddr.sa_family' is never assigned to, and will always have its
         // default value 0)
 #pragma warning disable 169, 649
-
-        // NOTE: this type is incomplete, and its values should never be used directly.
-        // Specific sockaddr types (e.g. sockaddr_in or sockaddr_in6) should be used instead.
-        public unsafe struct sockaddr
-        {
-            public sa_family_t sa_family;
-        }
-
         public struct in_addr
         {
             public uint s_addr; // Address in network byte order.
-        }
-
-        public struct sockaddr_in
-        {
-            public const int Size = 16;
-
-            public sa_family_t sin_family; // Address family: AF_INET
-            public in_port_t sin_port;     // Port in network byte order
-            public in_addr sin_addr;       // Internet address
-            private ulong padding;         // 8 bytes of padding
         }
 
         public unsafe struct in6_addr
         {
             public fixed byte s6_addr[16]; // IPv6 address
         }
-
-        public struct sockaddr_in6
-        {
-            public const int Size = 28;
-
-            public sa_family_t sin6_family; // AF_INET6
-            public in_port_t sin6_port;     // Port number
-            public uint sin6_flowinfo;      // IPv6 flow information
-            public in6_addr sin6_addr;      // IPv6 address
-            public uint sin6_scope_id;      // Scope ID
-        }
-
 #pragma warning restore 169, 649
     }
 }

--- a/src/Common/src/Interop/OSX/libc/Interop.sockaddr.cs
+++ b/src/Common/src/Interop/OSX/libc/Interop.sockaddr.cs
@@ -5,7 +5,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
-using in_port_t = System.UInt16;
 using sa_family_t = System.Byte;
 
 internal static partial class Interop
@@ -21,48 +20,15 @@ internal static partial class Interop
         // (Field 'Interop.libc.sockaddr.sa_family' is never assigned to, and will always have its
         // default value 0)
 #pragma warning disable 169, 649
-
-        // NOTE: this type is incomplete, and its values should never be used directly.
-        // Specific sockaddr types (e.g. sockaddr_in or sockaddr_in6) should be used instead.
-        public unsafe struct sockaddr
-        {
-            public byte sa_len;
-            public sa_family_t sa_family;
-        }
-
         public struct in_addr
         {
             public uint s_addr; // Address in network byte order.
-        }
-
-        public struct sockaddr_in
-        {
-            public const int Size = 16;
-
-            public byte sin_len;           // sizeof(sockaddr_in)
-            public sa_family_t sin_family; // Address family: AF_INET
-            public in_port_t sin_port;     // Port in network byte order
-            public in_addr sin_addr;       // Internet address
-            private ulong padding;        // 8 bytes of padding
         }
 
         public unsafe struct in6_addr
         {
             public fixed byte s6_addr[16]; // IPv6 address
         }
-
-        public struct sockaddr_in6
-        {
-            public const int Size = 28;
-
-            public byte sin6_len;           // sizeof(sockaddr_in6)
-            public sa_family_t sin6_family; // AF_INET6
-            public in_port_t sin6_port;     // Port number
-            public uint sin6_flowinfo;      // IPv6 flow information
-            public in6_addr sin6_addr;      // IPv6 address
-            public uint sin6_scope_id;      // Scope ID
-        }
-
 #pragma warning restore 169, 649
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.HostEntry.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.HostEntry.cs
@@ -11,6 +11,9 @@ internal static partial class Interop
         internal const int NI_MAXHOST = 1025;
         internal const int NI_MAXSERV = 32;
 
+        internal const int NUM_BYTES_IN_IPV6_ADDRESS = 16;
+        internal const int MAX_IP_ADDRESS_BYTES = 16;
+
         internal enum GetAddrInfoErrorFlags : int
         {
             EAI_AGAIN = 1,      // Temporary failure in name resolution.
@@ -18,6 +21,8 @@ internal static partial class Interop
             EAI_FAIL = 3,       // Non-recoverable failure in name resolution.
             EAI_FAMILY = 4,     // 'ai_family' not supported.
             EAI_NONAME = 5,     // NAME or SERVICE is unknown.
+            EAI_BADARG = 6,     // One or more input arguments were invalid.
+            EAI_NOMORE = 7,     // No more entries are present in the list.
         }
 
         internal enum GetHostErrorCodes : int
@@ -30,27 +35,29 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct PalIpAddress
+        internal unsafe struct IPAddress
         {
-            internal byte* Address;     // Buffer to fit IPv4 or IPv6 address
-            internal int Count;         // Number of bytes in the address buffer
-            internal bool IsIpv6;       // If this is an IPv6 Address or IPv4
-            private fixed byte padding[3];
+            internal fixed byte Address[MAX_IP_ADDRESS_BYTES]; // Buffer to fit an IPv4 or IPv6 address
+            internal uint IsIPv6;                              // Non-zero if this is an IPv6 address; zero for IPv4.
+            internal uint ScopeId;                             // Scope ID (IPv6 only)
         }
         
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct HostEntry
         {
-            internal byte* CanonicalName;       // Canonical Name of the Host
-            internal PalIpAddress* Addresses;   // List of IP Addresses associated with this host
-            internal int Count;                 // Number of IP Addresses associated with this host
-            private int reserved;
+            internal byte* CanonicalName;     // Canonical Name of the Host
+            internal void* AddressListHandle; // Handle for socket address list
+            internal int IPAddressCount;      // Number of IP addresses in the list
+            private int Padding;              // Pad out to 8-byte alignment
         }
 
         [DllImport(Libraries.SystemNative)]
-        internal static unsafe extern int GetHostEntriesForName(string address, HostEntry** entry);
+        internal static extern unsafe int GetHostEntryForName(string address, HostEntry* entry);
 
         [DllImport(Libraries.SystemNative)]
-        internal static unsafe extern void FreeHostEntriesForName(HostEntry* entry);
+        internal static extern unsafe int GetNextIPAddress(void** addressListHandle, IPAddress* endPoint);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe void FreeHostEntry(HostEntry* entry);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -16,15 +16,15 @@ internal static partial class Interop
         internal const int INET6_ADDRSTRLEN = 65;
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int Ipv6StringToAddress(string address, string port, byte[] buffer, int bufferLength, out uint scope);
+        internal static extern int IPv6StringToAddress(string address, string port, byte[] buffer, int bufferLength, out uint scope);
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int Ipv4StringToAddress(string address, byte[] buffer, int bufferLength, out ushort port);
+        internal static extern int IPv4StringToAddress(string address, byte[] buffer, int bufferLength, out ushort port);
 
         [DllImport(Libraries.SystemNative)]
-        internal unsafe static extern int IpAddressToString(byte* address, int addressLength, bool isIpv6, byte* str, int stringLength, uint scope = 0);
+        internal unsafe static extern int IPAddressToString(byte* address, int addressLength, bool isIPv6, byte* str, int stringLength, uint scope = 0);
 
-        internal unsafe static uint IpAddressToString(byte[] address, bool isIpV6, System.Text.StringBuilder addressString, uint scope = 0)
+        internal unsafe static uint IPAddressToString(byte[] address, bool isIPv6, System.Text.StringBuilder addressString, uint scope = 0)
         {
             Debug.Assert(address != null);
             Debug.Assert((address.Length == IPv4AddressBytes) || (address.Length == IPv6AddressBytes));
@@ -32,9 +32,9 @@ internal static partial class Interop
             int err;
             fixed (byte* rawAddress = address)
             {
-                int bufferLength = isIpV6 ? INET6_ADDRSTRLEN : INET_ADDRSTRLEN;
+                int bufferLength = isIPv6 ? INET6_ADDRSTRLEN : INET_ADDRSTRLEN;
                 byte* buffer = stackalloc byte[bufferLength];
-                err = IpAddressToString(rawAddress, address.Length, isIpV6, buffer, bufferLength, scope);
+                err = IPAddressToString(rawAddress, address.Length, isIPv6, buffer, bufferLength, scope);
                 if (err == 0)
                 {
                     addressString.Append(Marshal.PtrToStringAnsi((IntPtr)buffer));

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error GetIPSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error GetAddressFamily(byte* socketAddress, int socketAddressLen, int* addressFamily);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error SetAddressFamily(byte* socketAddress, int socketAddressLen, int addressFamily);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error GetPort(byte* socketAddress, int socketAddressLen, ushort* port);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error SetPort(byte* socketAddress, int socketAddressLen, ushort port);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error GetIPv4Address(byte* socketAddress, int socketAddressLen, uint* address);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error SetIPv4Address(byte* socketAddress, int socketAddressLen, uint address);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error GetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint* scopeId);
+
+        [DllImport(Libraries.SystemNative)]
+        internal static extern unsafe Error SetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint scopeId);
+    }
+}

--- a/src/Common/src/Interop/Unix/libc/Interop.accept.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.accept.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe int accept(int sockfd, sockaddr* addr, socklen_t* addrlen);
+        public static extern unsafe int accept(int sockfd, byte* addr, socklen_t* addrlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.bind.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.bind.cs
@@ -12,6 +12,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe int bind(int sockfd, sockaddr* addr, socklen_t addrlen);
+        public static extern unsafe int bind(int sockfd, byte* addr, socklen_t addrlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.connect.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.connect.cs
@@ -12,6 +12,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe int connect(int sockfd, sockaddr* addr, socklen_t addrlen);
+        public static extern unsafe int connect(int sockfd, byte* addr, socklen_t addrlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.getpeername.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.getpeername.cs
@@ -12,6 +12,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe int getpeername(int sockfd, sockaddr* addr, socklen_t* addrlen);
+        public static extern unsafe int getpeername(int sockfd, byte* addr, socklen_t* addrlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.getsockname.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.getsockname.cs
@@ -12,6 +12,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe int getsockname(int sockfd, sockaddr* addr, socklen_t* addrlen);
+        public static extern unsafe int getsockname(int sockfd, byte* addr, socklen_t* addrlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.recvfrom.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.recvfrom.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe size_t recvfrom(int sockfd, void* buf, size_t len, int flags, sockaddr* dest_addr, socklen_t* addrlen);
+        public static extern unsafe size_t recvfrom(int sockfd, void* buf, size_t len, int flags, byte* dest_addr, socklen_t* addrlen);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.sendto.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.sendto.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        public static extern unsafe size_t sendto(int sockfd, void* buf, size_t len, int flags, sockaddr* dest_addr, socklen_t addrlen);
+        public static extern unsafe size_t sendto(int sockfd, void* buf, size_t len, int flags, byte* dest_addr, socklen_t addrlen);
     }
 }

--- a/src/Common/src/System/Net/SocketAddress.cs
+++ b/src/Common/src/System/Net/SocketAddress.cs
@@ -21,8 +21,8 @@ namespace System.Net.Internals
 #endif
     class SocketAddress
     {
-        internal const int IPv6AddressSize = SocketAddressPal.IPv6AddressSize;
-        internal const int IPv4AddressSize = SocketAddressPal.IPv4AddressSize;
+        internal readonly static int IPv6AddressSize = SocketAddressPal.IPv6AddressSize;
+        internal readonly static int IPv4AddressSize = SocketAddressPal.IPv4AddressSize;
 
         internal int InternalSize;
         internal byte[] Buffer;

--- a/src/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -10,156 +10,129 @@ namespace System.Net
 {
     internal static class SocketAddressPal
     {
-        public const int IPv6AddressSize = Interop.libc.sockaddr_in6.Size;
-        public const int IPv4AddressSize = Interop.libc.sockaddr_in.Size;
         public const int DataOffset = 0;
+
+        public readonly static int IPv6AddressSize;
+        public readonly static int IPv4AddressSize;
+
+        static SocketAddressPal()
+        {
+            int ipv4AddressSize, ipv6AddressSize;
+            unsafe
+            {
+                Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&ipv4AddressSize, &ipv6AddressSize);
+                Debug.Assert(err == Interop.Error.SUCCESS);
+            }
+
+            IPv4AddressSize = ipv4AddressSize;
+            IPv6AddressSize = ipv6AddressSize;
+        }
+
+        private static void ThrowOnFailure(Interop.Error err)
+        {
+            switch (err)
+            {
+                case Interop.Error.SUCCESS:
+                    return;
+
+                case Interop.Error.EFAULT:
+                    // The buffer was either null or too small.
+                    throw new IndexOutOfRangeException();
+
+                case Interop.Error.EAFNOSUPPORT:
+                    // There was no appropriate mapping from the platform address family.
+                    throw new PlatformNotSupportedException();
+
+                default:
+                    Debug.Fail("Unexpected failure in GetAddressFamily");
+                    throw new PlatformNotSupportedException();
+            }
+        }
 
         public static unsafe AddressFamily GetAddressFamily(byte[] buffer)
         {
+            AddressFamily family;
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr*)rawAddress;
-                switch (Interop.CheckedRead((byte*)sockaddr, buffer.Length, &sockaddr->sa_family))
-                {
-                    case Interop.libc.AF_UNSPEC:
-                        return AddressFamily.Unspecified;
-
-                    case Interop.libc.AF_UNIX:
-                        return AddressFamily.Unix;
-
-                    case Interop.libc.AF_INET:
-                        return AddressFamily.InterNetwork;
-
-                    case Interop.libc.AF_INET6:
-                        return AddressFamily.InterNetworkV6;
-
-                    default:
-                        throw new PlatformNotSupportedException();
-                }
+                err = Interop.Sys.GetAddressFamily(rawAddress, buffer.Length, (int*)&family);
             }
+
+            ThrowOnFailure(err);
+            return family;
         }
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr*)rawAddress;
-                Interop.CheckBounds((byte*)sockaddr, buffer.Length, &sockaddr->sa_family);
-
-                switch (family)
-                {
-                    case AddressFamily.Unspecified:
-                        sockaddr->sa_family = Interop.libc.AF_UNSPEC;
-                        break;
-
-                    case AddressFamily.Unix:
-                        sockaddr->sa_family = Interop.libc.AF_UNIX;
-                        break;
-
-                    case AddressFamily.InterNetwork:
-                        sockaddr->sa_family = Interop.libc.AF_INET;
-                        break;
-
-                    case AddressFamily.InterNetworkV6:
-                        sockaddr->sa_family = Interop.libc.AF_INET6;
-                        break;
-
-                    default:
-                        Debug.Fail("Unsupported addres family");
-                        throw new PlatformNotSupportedException();
-                }
+                err = Interop.Sys.SetAddressFamily(rawAddress, buffer.Length, (int)family);
             }
+
+            ThrowOnFailure(err);
         }
 
         public static unsafe ushort GetPort(byte[] buffer)
         {
             ushort port;
-
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr*)rawAddress;
-                switch (sockaddr->sa_family)
-                {
-                    case Interop.libc.AF_INET:
-                        port = Interop.CheckedRead((byte*)sockaddr, buffer.Length, &((Interop.libc.sockaddr_in*)sockaddr)->sin_port);
-                        break;
-
-                    case Interop.libc.AF_INET6:
-                        port = Interop.CheckedRead((byte*)sockaddr, buffer.Length, &((Interop.libc.sockaddr_in6*)sockaddr)->sin6_port);
-                        break;
-
-                    default:
-                        Debug.Fail("Unsupported address family");
-                        throw new PlatformNotSupportedException();
-                }
+                err = Interop.Sys.GetPort(rawAddress, buffer.Length, &port);
             }
 
-            return port.NetworkToHost();
+            ThrowOnFailure(err);
+            return port;
         }
 
         public static unsafe void SetPort(byte[] buffer, ushort port)
         {
-            port = port.HostToNetwork();
-
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr*)rawAddress;
-                switch (sockaddr->sa_family)
-                {
-                    case Interop.libc.AF_INET:
-                        Interop.CheckedWrite((byte*)sockaddr, buffer.Length, &((Interop.libc.sockaddr_in*)sockaddr)->sin_port, port);
-                        break;
-
-                    case Interop.libc.AF_INET6:
-                        Interop.CheckedWrite((byte*)sockaddr, buffer.Length, &((Interop.libc.sockaddr_in6*)sockaddr)->sin6_port, port);
-                        break;
-
-                    default:
-                        Debug.Fail("Unsupported address family");
-                        throw new PlatformNotSupportedException();
-                }
+                err = Interop.Sys.SetPort(rawAddress, buffer.Length, port);
             }
+
+            ThrowOnFailure(err);
         }
 
         public static unsafe uint GetIPv4Address(byte[] buffer)
         {
+            uint ipAddress;
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr_in*)rawAddress;
-                Debug.Assert(sockaddr->sin_family == Interop.libc.AF_INET);
-
-                return Interop.CheckedRead((byte*)sockaddr, buffer.Length, &sockaddr->sin_addr.s_addr);
+                err = Interop.Sys.GetIPv4Address(rawAddress, buffer.Length, &ipAddress);
             }
+
+            ThrowOnFailure(err);
+            return ipAddress;
         }
 
         public static unsafe void GetIPv6Address(byte[] buffer, byte[] address, out uint scope)
         {
-            Debug.Assert(address.Length == sizeof(Interop.libc.in6_addr));
-
+            uint localScope;
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
+            fixed (byte* ipAddress = address)
             {
-                var sockaddr = (Interop.libc.sockaddr_in6*)rawAddress;
-                Debug.Assert(sockaddr->sin6_family == Interop.libc.AF_INET6);
-
-                Interop.CheckBounds((byte*)sockaddr, buffer.Length, (byte*)&sockaddr->sin6_addr.s6_addr[0], sizeof(Interop.libc.in6_addr));
-                for (int i = 0; i < sizeof(Interop.libc.in6_addr); i++)
-                {
-                    address[i] = sockaddr->sin6_addr.s6_addr[i];
-                }
-
-                scope = Interop.CheckedRead((byte*)sockaddr, buffer.Length, &sockaddr->sin6_scope_id);
+                err = Interop.Sys.GetIPv6Address(rawAddress, buffer.Length, ipAddress, address.Length, &localScope);
             }
+
+            ThrowOnFailure(err);
+            scope = localScope;
         }
 
         public static unsafe void SetIPv4Address(byte[] buffer, uint address)
         {
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr_in*)rawAddress;
-                Debug.Assert(sockaddr->sin_family == Interop.libc.AF_INET);
-
-                Interop.CheckedWrite((byte*)sockaddr, buffer.Length, &sockaddr->sin_addr.s_addr, address);
+                err = Interop.Sys.SetIPv4Address(rawAddress, buffer.Length, address);
             }
+
+            ThrowOnFailure(err);
         }
 
         public static unsafe void SetIPv4Address(byte[] buffer, byte* address)
@@ -170,8 +143,6 @@ namespace System.Net
 
         public static unsafe void SetIPv6Address(byte[] buffer, byte[] address, uint scope)
         {
-            Debug.Assert(address.Length == sizeof(Interop.libc.in6_addr));
-
             fixed (byte* rawInput = address)
             {
                 SetIPv6Address(buffer, rawInput, address.Length, scope);
@@ -180,23 +151,13 @@ namespace System.Net
 
         public static unsafe void SetIPv6Address(byte[] buffer, byte* address, int addressLength, uint scope)
         {
-            Debug.Assert(addressLength == sizeof(Interop.libc.in6_addr));
-
+            Interop.Error err;
             fixed (byte* rawAddress = buffer)
             {
-                var sockaddr = (Interop.libc.sockaddr_in6*)rawAddress;
-                Debug.Assert(sockaddr->sin6_family == Interop.libc.AF_INET6);
-
-                Interop.CheckedWrite((byte*)sockaddr, buffer.Length, &sockaddr->sin6_flowinfo, 0);
-
-                Interop.CheckBounds((byte*)sockaddr, buffer.Length, (byte*)&sockaddr->sin6_addr.s6_addr[0], sizeof(Interop.libc.in6_addr));
-                for (int i = 0; i < sizeof(Interop.libc.in6_addr); i++)
-                {
-                    sockaddr->sin6_addr.s6_addr[i] = address[i];
-                }
-
-                Interop.CheckedWrite((byte*)sockaddr, buffer.Length, &sockaddr->sin6_scope_id, scope);
+                err = Interop.Sys.SetIPv6Address(rawAddress, buffer.Length, address, addressLength, scope);
             }
+
+            ThrowOnFailure(err);
         }
     }
 }

--- a/src/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -12,20 +12,23 @@ namespace System.Net
     {
         public const int DataOffset = 0;
 
-        public readonly static int IPv6AddressSize;
-        public readonly static int IPv4AddressSize;
+        public readonly static int IPv6AddressSize = GetIPv6AddressSize();
+        public readonly static int IPv4AddressSize = GetIPv4AddressSize();
 
-        static SocketAddressPal()
+        private static unsafe int GetIPv6AddressSize()
         {
-            int ipv4AddressSize, ipv6AddressSize;
-            unsafe
-            {
-                Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&ipv4AddressSize, &ipv6AddressSize);
-                Debug.Assert(err == Interop.Error.SUCCESS);
-            }
+            int ipv6AddressSize, unused;
+            Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&unused, &ipv6AddressSize);
+            Debug.Assert(err == Interop.Error.SUCCESS);
+            return ipv6AddressSize;
+        }
 
-            IPv4AddressSize = ipv4AddressSize;
-            IPv6AddressSize = ipv6AddressSize;
+        private static unsafe int GetIPv4AddressSize()
+        {
+            int ipv4AddressSize, unused;
+            Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&ipv4AddressSize, &unused);
+            Debug.Assert(err == Interop.Error.SUCCESS);
+            return ipv4AddressSize;
         }
 
         private static void ThrowOnFailure(Interop.Error err)

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "pal_types.h"
+#include "pal_errno.h"
 
 /**
  * These error values are different on every platform so make a
@@ -11,11 +12,14 @@
  */
 enum GetAddrInfoErrorFlags
 {
+    PAL_EAI_SUCCESS = 0,  // Success
     PAL_EAI_AGAIN = 1,    // Temporary failure in name resolution.
     PAL_EAI_BADFLAGS = 2, // Invalid value for `ai_flags' field.
     PAL_EAI_FAIL = 3,     // Non-recoverable failure in name resolution.
     PAL_EAI_FAMILY = 4,   // 'ai_family' not supported.
     PAL_EAI_NONAME = 5,   // NAME or SERVICE is unknown.
+    PAL_EAI_BADARG = 6,   // One or more input arguments were invalid.
+    PAL_EAI_NOMORE = 7,   // No more entries are present in the list.
 };
 
 /**
@@ -40,43 +44,65 @@ enum GetHostErrorCodes
     PAL_NO_ADDRESS = PAL_NO_DATA,
 };
 
-struct PalIpAddress
+/**
+ * Address families recognized by {Get,Set}AddressFamily
+ */
+enum AddressFamily : int32_t
 {
-    uint8_t* Address;    // Buffer to fit IPv4 or IPv6 address
-    int32_t Count;       // Number of bytes in the address buffer
-    bool IsIpv6;         // If this is an IPv6 Address or IPv4
-    uint8_t reserved[3]; // Padding on 64 bit systems to align struct and not compile with a warning.
+    PAL_AF_UNSPEC = 0,
+    PAL_AF_UNIX = 1,
+    PAL_AF_INET = 2,
+    PAL_AF_INET6 = 23,
+};
+
+/**
+ * IP address sizes.
+ */
+enum
+{
+    NUM_BYTES_IN_IPV4_ADDRESS = 4,
+    NUM_BYTES_IN_IPV6_ADDRESS = 16,
+    MAX_IP_ADDRESS_BYTES = 16,
+};
+
+struct IPAddress
+{
+    uint8_t Address[MAX_IP_ADDRESS_BYTES]; // Buffer to fit IPv4 or IPv6 address
+    uint32_t IsIPv6;                       // Non-zero if this is an IPv6 endpoint; zero for IPv4.
+    uint32_t ScopeId;                      // Scope ID (IPv6 only)
 };
 
 struct HostEntry
 {
     uint8_t* CanonicalName;  // Canonical Name of the Host
-    PalIpAddress* Addresses; // List of IP Addresses associated with this host
-    int32_t Count;           // Number of IP Addresses associated with this host
-    int32_t reserved;        // Padding on 64 bit systems to align struct and not compile with a warning.
+    void* AddressListHandle; // Handle for host socket addresses
+    int32_t IPAddressCount; // Number of IP end points in the list
+    int32_t Padding;         // Pad out to 8-byte alignment
 };
 
 /**
  * Converts string-representations of IP Addresses to
  */
-extern "C" int32_t Ipv6StringToAddress(
-    const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope);
-extern "C" int32_t Ipv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port);
+extern "C" int32_t IPv6StringToAddress(const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope);
 
-extern "C" int32_t IpAddressToString(const uint8_t* address,
+extern "C" int32_t IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port);
+
+extern "C" int32_t IPAddressToString(const uint8_t* address,
                                      int32_t addressLength,
-                                     bool isIpv6,
+                                     bool isIPv6,
                                      uint8_t* string,
                                      int32_t stringLength,
                                      uint32_t scope = 0);
 
-extern "C" int32_t GetHostEntriesForName(const uint8_t* address, HostEntry** entry);
+extern "C" int32_t GetHostEntryForName(const uint8_t* address, HostEntry* entry);
 
-extern "C" void FreeHostEntriesForName(HostEntry* entry);
+extern "C" int32_t GetNextIPAddress(void** addressListHandle, IPAddress* endPoint);
+
+extern "C" void FreeHostEntry(HostEntry* entry);
 
 extern "C" int32_t GetNameInfo(const uint8_t* address,
                                int32_t addressLength,
-                               bool isIpv6,
+                               bool isIPv6,
                                uint8_t* host,
                                int32_t hostLength,
                                uint8_t* service,
@@ -84,3 +110,21 @@ extern "C" int32_t GetNameInfo(const uint8_t* address,
                                int32_t flags);
 
 extern "C" int32_t GetHostName(uint8_t* name, int32_t nameLength);
+
+extern "C" Error GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize);
+
+extern "C" Error GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily);
+
+extern "C" Error SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily);
+
+extern "C" Error GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port);
+
+extern "C" Error SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port);
+
+extern "C" Error GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address);
+
+extern "C" Error SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address);
+
+extern "C" Error GetIPv6Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t* scopeId);
+
+extern "C" Error SetIPv6Address(uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t scopeId);

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -45,14 +45,17 @@ enum GetHostErrorCodes
 };
 
 /**
- * Address families recognized by {Get,Set}AddressFamily
+ * Address families recognized by {Get,Set}AddressFamily.
+ *
+ * NOTE: these values are taken from System.Net.AddressFamily. If you add
+ *       new entries, be sure that the values are chosen accordingly.
  */
 enum AddressFamily : int32_t
 {
-    PAL_AF_UNSPEC = 0,
-    PAL_AF_UNIX = 1,
-    PAL_AF_INET = 2,
-    PAL_AF_INET6 = 23,
+    PAL_AF_UNSPEC = 0,  // System.Net.AddressFamily.Unspecified
+    PAL_AF_UNIX = 1,    // System.Net.AddressFamily.Unix
+    PAL_AF_INET = 2,    // System.Net.AddressFamily.InterNetwork
+    PAL_AF_INET6 = 23,  // System.Net.AddressFamily.InterNetworkV6
 };
 
 /**

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.lock.json
@@ -355,7 +355,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1219,14 +1219,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -164,6 +164,12 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.hostent.cs">
+      <Link>Interop\Unix\libc\Interop.hostent.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.socket.cs">
+      <Link>Interop\Unix\libc\Interop.socket.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Interop\Unix\System.Native\Interop.Close.cs</Link>
     </Compile>
@@ -173,14 +179,11 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs">
       <Link>Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.hostent.cs">
-      <Link>Interop\Unix\libc\Interop.hostent.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntries.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
       <Link>Interop\Unix\System.Native\Interop.HostEntries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.socket.cs">
-      <Link>Interop\Unix\libc\Interop.socket.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+      <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Linux.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Linux.cs
@@ -49,7 +49,7 @@ namespace System.Net
             var result = (Interop.libc.hostent*)null;
             if (TryGetHostByName(hostName, stackBuffer, bufferSize, &hostent, &result))
             {
-                return CreateHostEntry(&hostent);
+                return CreateHostEntry(result);
             }
 
             for (; ;)
@@ -59,7 +59,7 @@ namespace System.Net
                 {
                     if (TryGetHostByName(hostName, heapBuffer, bufferSize, &hostent, &result))
                     {
-                        return CreateHostEntry(&hostent);
+                        return CreateHostEntry(result);
                     }
                 }
             }
@@ -78,7 +78,7 @@ namespace System.Net
             var result = (Interop.libc.hostent*)null;
             if (TryGetHostByAddr(address, stackBuffer, bufferSize, &hostent, &result))
             {
-                return CreateHostEntry(&hostent);
+                return CreateHostEntry(result);
             }
 
             for (; ;)
@@ -88,7 +88,7 @@ namespace System.Net
                 {
                     if (TryGetHostByAddr(address, heapBuffer, bufferSize, &hostent, &result))
                     {
-                        return CreateHostEntry(&hostent);
+                        return CreateHostEntry(result);
                     }
                 }
             }

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.msbuild
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.msbuild
@@ -142,6 +142,12 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.hostent.cs">
+      <Link>Interop\Unix\libc\Interop.hostent.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.socket.cs">
+      <Link>Interop\Unix\libc\Interop.socket.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Interop\Unix\System.Native\Interop.Close.cs</Link>
     </Compile>
@@ -151,14 +157,11 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs">
       <Link>Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.hostent.cs">
-      <Link>Interop\Unix\libc\Interop.hostent.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+      <Link>Interop\Unix\System.Native\Interop.HostEntry.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntries.cs">
-      <Link>Interop\Unix\System.Native\Interop.HostEntries.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.socket.cs">
-      <Link>Interop\Unix\libc\Interop.socket.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+      <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -178,38 +178,29 @@
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs</Link>
     </Compile>
 
-    <Compile Include="$(CommonPath)\Interop\Interop.CheckedAccess.cs" >
-      <Link>Common\Interop\Interop.CheckedAccess.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs" >
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" >
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetHostName.cs" >
-      <Link>Common\Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getdomainname.cs" >
       <Link>Common\Interop\Unix\libc\Interop.getdomainname.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetHostName.cs" >
+      <Link>Common\Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs" >
       <Link>Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntries.cs">
-      <Link>Common\Interop\Unix\System.Native\Interop.HostEntries.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.HostEntry.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.sockaddr.cs" >
-      <Link>Common\Interop\Linux\libc\Interop.sockaddr.cs</Link>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.sockaddr.cs" >
-      <Link>Common\Interop\OSX\libc\Interop.sockaddr.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+      <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Net.Primitives/src/System/Net/IPAddressPal.Unix.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressPal.Unix.cs
@@ -18,7 +18,7 @@ namespace System.Net
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Capacity >= IPAddressParser.INET_ADDRSTRLEN);
 
-            return Interop.Sys.IpAddressToString(address, false, buffer);
+            return Interop.Sys.IPAddressToString(address, false, buffer);
         }
 
         public static unsafe uint Ipv6AddressToString(byte[] address, uint scopeId, StringBuilder buffer)
@@ -28,7 +28,7 @@ namespace System.Net
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Capacity >= IPAddressParser.INET6_ADDRSTRLEN);
 
-            return Interop.Sys.IpAddressToString(address, true, buffer, scopeId);
+            return Interop.Sys.IPAddressToString(address, true, buffer, scopeId);
         }
 
         public static unsafe uint Ipv4StringToAddress(string ipString, byte[] bytes, out ushort port)
@@ -37,7 +37,7 @@ namespace System.Net
             Debug.Assert(bytes != null);
             Debug.Assert(bytes.Length >= IPAddressParserStatics.IPv4AddressBytes);
 
-            return unchecked((uint)Interop.Sys.Ipv4StringToAddress(ipString, bytes, bytes.Length, out port));
+            return unchecked((uint)Interop.Sys.IPv4StringToAddress(ipString, bytes, bytes.Length, out port));
         }
 
         private static bool IsHexString(string input, int startIndex)
@@ -134,7 +134,7 @@ namespace System.Net
                 return unchecked((uint)Interop.Sys.GetAddrInfoErrorFlags.EAI_NONAME);
             }
 
-            return unchecked((uint)Interop.Sys.Ipv6StringToAddress(host, port, bytes, bytes.Length, out scope));
+            return unchecked((uint)Interop.Sys.IPv6StringToAddress(host, port, bytes, bytes.Length, out scope));
         }
 
         public static SocketError GetSocketErrorForErrorCode(uint status)

--- a/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -161,23 +161,29 @@
     <Compile Include="$(CommonPath)\Interop\Interop.CheckedAccess.cs" >
       <Link>ProductionCode\Common\Interop\Interop.CheckedAccess.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs" >
+      <Link>ProductionCode\Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" >
       <Link>ProductionCode\Common\Interop\Unix\Interop.Libraries.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetHostName.cs" >
-      <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getdomainname.cs" >
       <Link>ProductionCode\Common\Interop\Unix\libc\Interop.getdomainname.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetHostName.cs" >
+      <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs" >
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntries.cs">
-      <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.HostEntries.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+      <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.HostEntry.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+      <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -132,20 +132,14 @@
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>
     </Compile>
 
-    <Compile Include="$(CommonPath)\Interop\Interop.CheckedAccess.cs" >
-      <Link>ProductionCode\Common\Interop\Interop.CheckedAccess.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" >
+      <Link>ProductionCode\Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.sockaddr.cs" >
-      <Link>ProductionCode\Common\Interop\Linux\libc\Interop.sockaddr.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs" >
+      <Link>ProductionCode\Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.sockaddr.cs" >
-      <Link>ProductionCode\Common\Interop\OSX\libc\Interop.sockaddr.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+      <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -392,6 +392,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
       <Link>Interop\Unix\System.Native\Interop.Fcntl.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+      <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
@@ -15,12 +15,12 @@ namespace System.Net.Sockets
             // with another connect to AF_UNSPEC before further connect() attempts will return
             // valid errors. Otherwise, further connect() attempts will return ECONNABORTED.
             
-            var socketAddressBuffer = stackalloc byte[socketAddressLen];
-            var sockAddr = (Interop.libc.sockaddr*)socketAddressBuffer;
-            sockAddr->sa_family = Interop.libc.AF_UNSPEC;
+            var sockAddr = stackalloc byte[socketAddressLen];
+            Interop.Error afErr = Interop.Sys.SetAddressFamily(sockAddr, socketAddressLen, (int)AddressFamily.Unspecified);
+            Debug.Assert(afErr == Interop.Error.SUCCESS, "PrimeForNextConnectAttempt: failed to set address family");
 
             int err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
-            Debug.Assert(err == 0, "TryCompleteConnect: failed to disassociate socket after failed connect()");
+            Debug.Assert(err == 0, "PrimeForNextConnectAttempt: failed to disassociate socket after failed connect()");
         }
 
         public static void SetReceivingDualModeIPv4PacketInformation(Socket socket)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -595,7 +595,7 @@ namespace System.Net.Sockets
             Debug.Assert(socketAddress != null || socketAddressLen == 0);
 
             var pinnedSocketAddress = default(GCHandle);
-            Interop.libc.sockaddr* sockAddr = null;
+            byte* sockAddr = null;
             uint sockAddrLen = 0;
 
             int received;
@@ -604,7 +604,7 @@ namespace System.Net.Sockets
                 if (socketAddress != null)
                 {
                     pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
-                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddr = (byte*)pinnedSocketAddress.AddrOfPinnedObject();
                     sockAddrLen = (uint)socketAddressLen;
                 }
 
@@ -643,7 +643,7 @@ namespace System.Net.Sockets
         private static unsafe int Send(int fd, int flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
         {
             var pinnedSocketAddress = default(GCHandle);
-            Interop.libc.sockaddr* sockAddr = null;
+            byte* sockAddr = null;
             uint sockAddrLen = 0;
 
             int sent;
@@ -652,7 +652,7 @@ namespace System.Net.Sockets
                 if (socketAddress != null)
                 {
                     pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
-                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddr = (byte*)pinnedSocketAddress.AddrOfPinnedObject();
                     sockAddrLen = (uint)socketAddressLen;
                 }
 
@@ -687,7 +687,7 @@ namespace System.Net.Sockets
             int startIndex = bufferIndex, startOffset = offset;
 
             var pinnedSocketAddress = default(GCHandle);
-            Interop.libc.sockaddr* sockAddr = null;
+            byte* sockAddr = null;
             uint sockAddrLen = 0;
 
             int maxBuffers = buffers.Count - startIndex;
@@ -713,7 +713,7 @@ namespace System.Net.Sockets
                 if (socketAddress != null)
                 {
                     pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
-                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddr = (byte*)pinnedSocketAddress.AddrOfPinnedObject();
                     sockAddrLen = (uint)socketAddressLen;
                 }
 
@@ -774,7 +774,7 @@ namespace System.Net.Sockets
             var iovecs = new Interop.libc.iovec[maxBuffers];
 
             var pinnedSocketAddress = default(GCHandle);
-            Interop.libc.sockaddr* sockAddr = null;
+            byte* sockAddr = null;
             uint sockAddrLen = 0;
 
             int received = 0;
@@ -803,7 +803,7 @@ namespace System.Net.Sockets
                 if (socketAddress != null)
                 {
                     pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
-                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddr = (byte*)pinnedSocketAddress.AddrOfPinnedObject();
                     sockAddrLen = (uint)socketAddressLen;
                 }
 
@@ -859,7 +859,7 @@ namespace System.Net.Sockets
             fixed (byte* rawSocketAddress = socketAddress)
             fixed (byte* b = buffer)
             {
-                var sockAddr = (Interop.libc.sockaddr*)rawSocketAddress;
+                var sockAddr = (byte*)rawSocketAddress;
 
                 var iov = new Interop.libc.iovec {
                     iov_base = &b[offset],
@@ -892,7 +892,7 @@ namespace System.Net.Sockets
             uint sockAddrLen = (uint)socketAddressLen;
             fixed (byte* rawSocketAddress = socketAddress)
             {
-                fd = Interop.libc.accept(fileDescriptor, (Interop.libc.sockaddr*)rawSocketAddress, &sockAddrLen);
+                fd = Interop.libc.accept(fileDescriptor, (byte*)rawSocketAddress, &sockAddrLen);
             }
 
             if (fd != -1)
@@ -935,7 +935,7 @@ namespace System.Net.Sockets
             int err;
             fixed (byte* rawSocketAddress = socketAddress)
             {
-                var sockAddr = (Interop.libc.sockaddr*)rawSocketAddress;
+                var sockAddr = (byte*)rawSocketAddress;
                 err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
             }
 
@@ -1157,7 +1157,7 @@ namespace System.Net.Sockets
             uint addrLen = (uint)nameLen;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.libc.getsockname(handle.FileDescriptor, (Interop.libc.sockaddr*)rawBuffer, &addrLen);
+                err = Interop.libc.getsockname(handle.FileDescriptor, (byte*)rawBuffer, &addrLen);
             }
             nameLen = (int)addrLen;
 
@@ -1179,7 +1179,7 @@ namespace System.Net.Sockets
             uint addrLen = (uint)nameLen;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.libc.getpeername(handle.FileDescriptor, (Interop.libc.sockaddr*)rawBuffer, &addrLen);
+                err = Interop.libc.getpeername(handle.FileDescriptor, (byte*)rawBuffer, &addrLen);
             }
             nameLen = (int)addrLen;
 
@@ -1191,7 +1191,7 @@ namespace System.Net.Sockets
             int err;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.libc.bind(handle.FileDescriptor, (Interop.libc.sockaddr*)rawBuffer, (uint)nameLen);
+                err = Interop.libc.bind(handle.FileDescriptor, (byte*)rawBuffer, (uint)nameLen);
             }
 
             return err == -1 ? GetLastSocketError() : SocketError.Success;


### PR DESCRIPTION
The socket address shim adds native accessors for the various bits that
managed code needs to access, namely:
- Address families
- Port numbers
- IP addresses

This change also updates the name resolution shim to use an iterator-based
design for walking host entries. This interface trades chattiness (a
P/Invoke per IP address) for memory footprint (various native and managed
allocations per IP address).