### PR TITLE
Read the allowed certificate issuers list on Unix SslStream

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -132,9 +133,12 @@ internal static partial class Interop
             return GetDynamicBuffer((handle, buf, i) => GetX509Thumbprint(handle, buf, i), x509);
         }
 
-        internal static byte[] GetX509NameRawBytes(IntPtr x509Name)
+        internal static X500DistinguishedName LoadX500Name(IntPtr namePtr)
         {
-            return GetDynamicBuffer((ptr, buf, i) => GetX509NameRawBytes(ptr, buf, i), x509Name);
+            CheckValidOpenSslHandle(namePtr);
+
+            byte[] buf = GetDynamicBuffer((ptr, buf1, i) => GetX509NameRawBytes(ptr, buf1, i), namePtr);
+            return new X500DistinguishedName(buf);
         }
 
         internal static byte[] GetX509PublicKeyParameterBytes(SafeX509Handle x509)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int GetX509NameStackFieldCount(SafeSharedX509NameStackHandle sk);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameStackField")]
+        private static extern SafeSharedX509NameHandle GetX509NameStackField_private(SafeSharedX509NameStackHandle sk,
+            int loc);
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int GetX509NameRawBytes(SafeSharedX509NameHandle x509Name, byte[] buf, int cBuf);
+
+        internal static X500DistinguishedName LoadX500Name(SafeSharedX509NameHandle namePtr)
+        {
+            CheckValidOpenSslHandle(namePtr);
+
+            byte[] buf = GetDynamicBuffer((ptr, buf1, i) => GetX509NameRawBytes(ptr, buf1, i), namePtr);
+            return new X500DistinguishedName(buf);
+        }
+
+        internal static SafeSharedX509NameHandle GetX509NameStackField(SafeSharedX509NameStackHandle sk, int loc)
+        {
+            CheckValidOpenSslHandle(sk);
+
+            SafeSharedX509NameHandle handle = GetX509NameStackField_private(sk, loc);
+
+            if (!handle.IsInvalid)
+            {
+                handle.SetParent(sk);
+            }
+
+            return handle;
+        }
+    }
+}
+
+namespace Microsoft.Win32.SafeHandles
+{
+    /// <summary>
+    /// Represents access to a X509_NAME* which is a member of a structure tracked
+    /// by another SafeHandle.
+    /// </summary>
+    internal sealed class SafeSharedX509NameHandle : SafeInteriorHandle
+    {
+        private SafeSharedX509NameHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Represents access to a STACK_OF(X509_NAME)* which is a member of a structure tracked
+    /// by another SafeHandle.
+    /// </summary>
+    internal sealed class SafeSharedX509NameStackHandle : SafeInteriorHandle
+    {
+        private SafeSharedX509NameStackHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+    }
+}
+

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
@@ -85,6 +85,9 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern SafeX509Handle SSL_get_peer_certificate(SafeSslHandle ssl);
 
+        [DllImport(Interop.Libraries.LibSsl, EntryPoint = "SSL_get_client_CA_list")]
+        private static extern SafeSharedX509NameStackHandle SSL_get_client_CA_list_private(SafeSslHandle ssl);
+
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern SafeSharedX509StackHandle SSL_get_peer_cert_chain(SafeSslHandle ssl);
 
@@ -105,5 +108,19 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern void SSL_CTX_set_quiet_shutdown(SafeSslContextHandle ctx, int mode);
+
+        internal static SafeSharedX509NameStackHandle SSL_get_client_CA_list(SafeSslHandle ssl)
+        {
+            Interop.Crypto.CheckValidOpenSslHandle(ssl);
+
+            SafeSharedX509NameStackHandle handle = SSL_get_client_CA_list_private(ssl);
+
+            if (!handle.IsInvalid)
+            {
+                handle.SetParent(ssl);
+            }
+
+            return handle;
+        }
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeInteriorHandle.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeInteriorHandle.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal abstract class SafeInteriorHandle : SafeHandle
+    {
+        private SafeHandle _parent;
+
+        protected SafeInteriorHandle(IntPtr invalidHandleValue, bool ownsHandle)
+            : base(invalidHandleValue, ownsHandle)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            SafeHandle parent = _parent;
+
+            if (parent != null)
+            {
+                parent.DangerousRelease();
+            }
+
+            _parent = null;
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid
+        {
+            get
+            {
+                // If handle is 0, we're invalid.
+                // If we have a _parent and they're invalid, we're invalid.
+                return handle == IntPtr.Zero || (_parent != null && _parent.IsInvalid);
+            }
+        }
+
+        internal void SetParent(SafeHandle parent)
+        {
+            bool addedRef = false;
+            parent.DangerousAddRef(ref addedRef);
+            Debug.Assert(addedRef);
+
+            _parent = parent;
+        }
+    }
+}

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -120,47 +120,13 @@ namespace Microsoft.Win32.SafeHandles
     /// by another SafeHandle.
     /// </summary>
     [SecurityCritical]
-    internal sealed class SafeSharedX509StackHandle : SafeHandle
+    internal sealed class SafeSharedX509StackHandle : SafeInteriorHandle
     {
         internal static readonly SafeSharedX509StackHandle InvalidHandle = new SafeSharedX509StackHandle();
-        private SafeHandle _parent;
 
         private SafeSharedX509StackHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
-        }
-
-        protected override bool ReleaseHandle()
-        {
-            SafeHandle parent = _parent;
-
-            if (parent != null)
-            {
-                parent.DangerousRelease();
-            }
-
-            _parent = null;
-            SetHandle(IntPtr.Zero);
-            return true;
-        }
-
-        public override bool IsInvalid
-        {
-            get
-            {
-                // If handle is 0, we're invalid.
-                // If we have a _parent and they're invalid, we're invalid.
-                return handle == IntPtr.Zero || (_parent != null && _parent.IsInvalid);
-            }
-        }
-
-        internal void SetParent(SafeHandle parent)
-        {
-            bool addedRef = false;
-            parent.DangerousAddRef(ref addedRef);
-            Debug.Assert(addedRef);
-
-            _parent = parent;
         }
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -23,6 +23,7 @@ set(NATIVECRYPTO_SOURCES
     pal_evp.cpp
     pal_evp_cipher.cpp
     pal_hmac.cpp
+    pal_x509_name.cpp
 )
 
 add_library(System.Security.Cryptography.Native

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_x509_name.h"
+
+extern "C" int32_t GetX509NameStackFieldCount(STACK_OF(X509_NAME)* sk)
+{
+    return sk_X509_NAME_num(sk);
+}
+
+extern "C" X509_NAME* GetX509NameStackField(STACK_OF(X509_NAME)* sk, int32_t loc)
+{
+    return sk_X509_NAME_value(sk, loc);
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdint.h>
+#include <openssl/x509.h>
+
+/*
+Function:
+GetX509NameStackFieldCount
+
+Direct shim to sk_X509_NAME_num
+*/
+extern "C" int32_t GetX509NameStackFieldCount(STACK_OF(X509_NAME)* sk);
+
+/*
+Function:
+GetX509NameStackField
+
+Direct shim to sk_X509_NAME_value
+*/
+extern "C" X509_NAME* GetX509NameStackField(STACK_OF(X509_NAME)* sk, int32_t loc);

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -217,6 +217,9 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs</Link>
     </Compile>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -205,6 +205,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -174,7 +174,7 @@ namespace Internal.Cryptography.Pal
             {
                 if (_subjectName == null)
                 {
-                    _subjectName = LoadX500Name(Interop.libcrypto.X509_get_subject_name(_cert));
+                    _subjectName = Interop.Crypto.LoadX500Name(Interop.libcrypto.X509_get_subject_name(_cert));
                 }
 
                 return _subjectName;
@@ -187,7 +187,7 @@ namespace Internal.Cryptography.Pal
             {
                 if (_issuerName == null)
                 {
-                    _issuerName = LoadX500Name(Interop.libcrypto.X509_get_issuer_name(_cert));
+                    _issuerName = Interop.Crypto.LoadX500Name(Interop.libcrypto.X509_get_issuer_name(_cert));
                 }
 
                 return _issuerName;
@@ -327,14 +327,6 @@ namespace Internal.Cryptography.Pal
             }
 
             return duplicate;
-        }
-
-        private static X500DistinguishedName LoadX500Name(IntPtr namePtr)
-        {
-            Interop.Crypto.CheckValidOpenSslHandle(namePtr);
-
-            byte[] buf = Interop.Crypto.GetX509NameRawBytes(namePtr);
-            return new X500DistinguishedName(buf);
         }
 
         internal static DateTime ExtractValidityDateTime(IntPtr validityDatePtr)

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -255,6 +255,9 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs</Link>
     </Compile>


### PR DESCRIPTION
The Unix PAL version of GetRequestCertificateAuthorities.

Development:
* Split out SafeInteriorHandle to facilitate creating two more SafeHandle types following that pattern.
* Applied the new shim style for the two macro-functions that were needed for reading STACK_OF(X509_NAME)
* Created two new internal SafeHandle types.  While in the past these were in isolated files in Common\src\Microsoft\Win32\SafeHandles, I wanted to try something new: keeping them in the file with their create/free/primary-usage.

Testing:
I couldn't figure out how to cause the flow that results in the PAL method getting called, so I inserted an artificial call to it in CompleteHandshake, and saw that it was decoding as expected.

This is yet another partial fix for issue #3362 (GetRequestCertificateAuthorities - populate issuers. (CertModule.cs))

cc: @stephentoub @vijaykota @rajansingh10 @shrutigarg @CIPop 