### PR TITLE
Fixed second write issue, introduced by PR#3675

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/_SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/_SslStream.cs
@@ -196,7 +196,7 @@ namespace System.Net.Security
         }
 
         //
-        // Combined sync/async write method. For sync case asyncRequest==null.
+        // Sync write method.
         //
         private void ProcessWrite(byte[] buffer, int offset, int count)
         {
@@ -207,7 +207,6 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "Write", "write"));
             }
 
-            bool failed = false;
             try
             {
                 StartWriting(buffer, offset, count);
@@ -216,7 +215,6 @@ namespace System.Net.Security
             {
                 _SslState.FinishWrite();
 
-                failed = true;
                 if (e is IOException)
                 {
                     throw;
@@ -226,10 +224,7 @@ namespace System.Net.Security
             }
             finally
             {
-                if (failed)
-                {
-                    _NestedWrite = 0;
-                }
+                _NestedWrite = 0;
             }
         }
 
@@ -307,9 +302,7 @@ namespace System.Net.Security
         }
 
         //
-        // Combined sync/async read method. For sync request asyncRequest==null
-        // There is a little overhead because we need to pass buffer/offset/count used only in sync.
-        // Still the benefit is that we have a common sync/async code path.
+        // Sync read method.
         //
         private int ProcessRead(byte[] buffer, int offset, int count)
         {
@@ -320,7 +313,6 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "Read", "read"));
             }
 
-            bool failed = false;
             try
             {
                 int copyBytes;
@@ -341,7 +333,6 @@ namespace System.Net.Security
             catch (Exception e)
             {
                 _SslState.FinishRead(null);
-                failed = true;
                 if (e is IOException)
                 {
                     throw;
@@ -351,11 +342,7 @@ namespace System.Net.Security
             }
             finally
             {
-                // If sync request or exception.
-                if (failed)
-                {
-                    _NestedRead = 0;
-                }
+                _NestedRead = 0;
             }
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/FakeNetworkStream.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/FakeNetworkStream.cs
@@ -1,0 +1,109 @@
+using System.IO;
+namespace System.Net.Security.Tests
+{
+    internal class FakeNetworkStream : Stream
+    {
+        private readonly MockNetwork _network;
+        private MemoryStream _readStream;
+        private readonly bool _isServer;
+
+        public FakeNetworkStream(bool isServer, MockNetwork network)
+        {
+            _network = network;
+            _isServer = isServer;
+        }
+
+        public override bool CanRead
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool CanSeek
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            UpdateReadStream();
+            return _readStream.Read(buffer, offset, count);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            byte[] innerBuffer = new byte[count];
+
+            Buffer.BlockCopy(buffer, offset, innerBuffer, 0, count);
+            _network.WriteFrame(_isServer, buffer);
+        }
+
+        public void DoNetworkRead()
+        {
+            byte[] innerBuffer;
+
+            _network.ReadFrame(_isServer, out innerBuffer);
+
+            _readStream = new MemoryStream(innerBuffer);
+        }
+
+        private void UpdateReadStream()
+        {
+            if (_readStream != null && (_readStream.Position < _readStream.Length))
+            {
+                return;
+            }
+
+            DoNetworkRead();
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/MockNetwork.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/MockNetwork.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Threading;
+namespace System.Net.Security.Tests
+{
+    internal class MockNetwork
+    {
+        private readonly Queue<byte[]> _clientWriteQueue = new Queue<byte[]>();
+        private readonly Queue<byte[]> _serverWriteQueue = new Queue<byte[]>();
+
+        private readonly SemaphoreSlim _clientDataAvailable = new SemaphoreSlim(0);
+        private readonly SemaphoreSlim _serverDataAvailable = new SemaphoreSlim(0);
+
+        public MockNetwork()
+        {
+        }
+
+        public void ReadFrame(bool server, out byte[] buffer)
+        {
+            SemaphoreSlim semaphore;
+            Queue<byte[]> packetQueue;
+
+            if (server)
+            {
+                semaphore = _clientDataAvailable;
+                packetQueue = _clientWriteQueue;
+            }
+            else
+            {
+                semaphore = _serverDataAvailable;
+                packetQueue = _serverWriteQueue;
+            }
+
+            semaphore.Wait();
+            buffer = packetQueue.Dequeue();
+        }
+
+        public void WriteFrame(bool server, byte[] buffer)
+        {
+            SemaphoreSlim semaphore;
+            Queue<byte[]> packetQueue;
+
+            if (server)
+            {
+                semaphore = _serverDataAvailable;
+                packetQueue = _serverWriteQueue;
+            }
+            else
+            {
+                semaphore = _clientDataAvailable;
+                packetQueue = _clientWriteQueue;
+            }
+
+            byte[] innerBuffer = new byte[buffer.Length];
+            buffer.CopyTo(innerBuffer, 0);
+
+            packetQueue.Enqueue(innerBuffer);
+            semaphore.Release();
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +16,11 @@ namespace System.Net.Security.Tests
 {
     public class SslStreamStreamToStreamTest
     {
+        private readonly byte[] sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
+        private readonly TimeSpan TaskTimeSpan = TimeSpan.FromSeconds(15);
+
+        #region Tests
+
         [Fact]
         public void SslStream_StreamToStream_Authentication_Success()
         {
@@ -32,20 +39,6 @@ namespace System.Net.Security.Tests
                 bool finished = Task.WaitAll(auth, TimeSpan.FromSeconds(3));
                 Assert.True(finished, "Handshake completed in the allotted time");
             }
-        }
-
-        public bool AllowAnyServerCertificate(
-            object sender,
-            X509Certificate certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            if (sslPolicyErrors != SslPolicyErrors.RemoteCertificateNameMismatch)
-            {
-                return true;
-            }
-
-            return false;
         }
 
         [Fact]
@@ -71,160 +64,77 @@ namespace System.Net.Security.Tests
             }
         }
 
-        internal class MockNetwork
+        /// <summary>
+        /// Tests that a second clientSslStream.write after first clientSslStream.write is successfull.
+        /// </summary>
+        [Fact]
+        public void SslStream_StreamToStream_Successive_ClientWrite_Success()
         {
-            private readonly Queue<byte[]> _clientWriteQueue = new Queue<byte[]>();
-            private readonly Queue<byte[]> _serverWriteQueue = new Queue<byte[]>();
+            byte[] recvBuf = new byte[sampleMsg.Length];
+            MockNetwork network = new MockNetwork();
 
-            private readonly SemaphoreSlim _clientDataAvailable = new SemaphoreSlim(0);
-            private readonly SemaphoreSlim _serverDataAvailable = new SemaphoreSlim(0);
-
-            public MockNetwork()
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            using (var serverSslStream = new SslStream(serverStream))
             {
-            }
+                bool result = DoHandshake(clientSslStream, serverSslStream, TaskTimeSpan);
 
-            public void ReadFrame(bool server, out byte[] buffer)
-            {
-                SemaphoreSlim semaphore;
-                Queue<byte[]> packetQueue;
+                Assert.True(result, "Handshake completed.");
 
-                if (server)
-                {
-                    semaphore = _clientDataAvailable;
-                    packetQueue = _clientWriteQueue;
-                }
-                else
-                {
-                    semaphore = _serverDataAvailable;
-                    packetQueue = _serverWriteQueue;
-                }
+                clientSslStream.Write(sampleMsg);
 
-                semaphore.Wait();
-                buffer = packetQueue.Dequeue();
-            }
+                serverSslStream.Read(recvBuf, 0, sampleMsg.Length);
 
-            public void WriteFrame(bool server, byte[] buffer)
-            {
-                SemaphoreSlim semaphore;
-                Queue<byte[]> packetQueue;
+                clientSslStream.Write(sampleMsg);
 
-                if (server)
-                {
-                    semaphore = _serverDataAvailable;
-                    packetQueue = _serverWriteQueue;
-                }
-                else
-                {
-                    semaphore = _clientDataAvailable;
-                    packetQueue = _clientWriteQueue;
-                }
+                // TODO Issue#3802
+                // The condition on which read method (UpdateReadStream) in FakeNetworkStream does a network read is flawed.
+                // That works fine in single read/write but fails in multi read write as stream size can be more, but real data can be < stream size.
+                // So I am doing an explicit read here. This issue is specific to test only & irrespective of xplat.
+                serverStream.DoNetworkRead();
 
-                byte[] innerBuffer = new byte[buffer.Length];
-                buffer.CopyTo(innerBuffer, 0);
+                serverSslStream.Read(recvBuf, 0, sampleMsg.Length);
 
-                packetQueue.Enqueue(innerBuffer);
-                semaphore.Release();
+                Assert.True(VerifyOutput(recvBuf, sampleMsg), "verify second read data is as expected.");
             }
         }
 
-        internal class FakeNetworkStream : Stream
+        #endregion
+
+        #region Private Methods
+
+        private bool VerifyOutput(byte [] actualBuffer, byte [] expectedBuffer)
         {
-            private readonly MockNetwork _network;
-            private MemoryStream _readStream;
-            private readonly bool _isServer;
-
-            public FakeNetworkStream(bool isServer, MockNetwork network)
-            {
-                _network = network;
-                _isServer = isServer;
-            }
-
-            public override bool CanRead
-            {
-                get
-                {
-                    return true;
-                }
-            }
-
-            public override bool CanSeek
-            {
-                get
-                {
-                    return false;
-                }
-            }
-
-            public override bool CanWrite
-            {
-                get
-                {
-                    return true;
-                }
-            }
-
-            public override long Length
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public override long Position
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-
-                set
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public override void Flush()
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void SetLength(long value)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                UpdateReadStream();
-                return _readStream.Read(buffer, offset, count);
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                byte[] innerBuffer = new byte[count];
-
-                Buffer.BlockCopy(buffer, offset, innerBuffer, 0, count);
-                _network.WriteFrame(_isServer, buffer);
-            }
-
-            private void UpdateReadStream()
-            {
-                if (_readStream != null && (_readStream.Position < _readStream.Length))
-                {
-                    return;
-                }
-
-                byte[] innerBuffer;
-                _network.ReadFrame(_isServer, out innerBuffer);
-
-                _readStream = new MemoryStream(innerBuffer);
-            }
+            return expectedBuffer.SequenceEqual(actualBuffer);
         }
+
+        private bool AllowAnyServerCertificate(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors != SslPolicyErrors.RemoteCertificateNameMismatch)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream, TimeSpan waitTimeSpan)
+        {
+            X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+            Task[] auth = new Task[2];
+
+            auth[0] = clientSslStream.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false));
+            auth[1] = serverSslStream.AuthenticateAsServerAsync(certificate);
+
+            bool finished = Task.WaitAll(auth, waitTimeSpan);
+            return finished;
+        }
+
+        #endregion
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -15,6 +15,8 @@
     <Compile Include="ClientAsyncAuthenticateTest.cs" />
     <Compile Include="ClientDefaultEncryptionTest.cs" />
     <Compile Include="DummyTcpServer.cs" />
+    <Compile Include="FakeNetworkStream.cs" />
+    <Compile Include="MockNetwork.cs" />
     <Compile Include="ParameterValidationTest.cs" />
     <Compile Include="ServerAllowNoEncryptionTest.cs" />
     <Compile Include="ServerNoEncryptionTest.cs" />
@@ -24,7 +26,6 @@
     <Compile Include="SslStreamAPMExtensions.cs" />
     <Compile Include="TestConfiguration.cs" />
     <Compile Include="TransportContextTest.cs" />
-    
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)\System.Net\TestLogging.cs">
       <Link>Common\System.Net\TestLogging.cs</Link>
@@ -38,9 +39,7 @@
     <Compile Include="$(CommonTestPath)\System.Net\TaskAPMExtensions.cs">
       <Link>Common\System.Net\TaskAPMExtensions.cs</Link>
     </Compile>
-
   </ItemGroup>
-
   <!-- TODO: Remove after the packages are not using System.Private.Networking. -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Net.Security.csproj">
@@ -48,12 +47,10 @@
       <Name>System.Net.Security</Name>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-
   <!-- Temporary until we have new work in build tools to
        deploy content from nuget packages -->
   <Target Name="CopyX509TestDataToTestDirectory" AfterTargets="CopyTestToTestDirectory" Inputs="$(PackagesDir)$(X509TestPackage)\content" Outputs="$(TestPath)%(TestTargetFramework.Folder)\*.*">
@@ -69,5 +66,4 @@
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
   </Target>
-
 </Project>


### PR DESCRIPTION
1. PR #3675 broke the scenario where there will be successive read/write calls on stream (>1).
2. older code in finally was like, where asyncRequest will always be null.
 finally
            {
                if (asyncRequest == null || failed)
                {
                    _NestedWrite = 0;
                }
            }
3. After removing dead code i.e. asyncRequest in PR #3675 ,the flow will never set _NestedWrite==0 in positive scenario, causing failure when read/write is called next time by the user.
4. Added multi write testcase as well for this.