### PR TITLE
Disable three Sockets tests

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
@@ -17,6 +17,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(3580)]
         public void Success()
         {
             AutoResetEvent completed = new AutoResetEvent(false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -89,6 +89,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(3494, PlatformID.AnyUnix)]
         [Fact] // Base Case
         public void ConnectV4MappedIPAddressToV4Host_Success()
         {
@@ -781,6 +782,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(3682, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {


### PR DESCRIPTION
These have been failing with some frequency, one on Windows (#3580), two on Linux (#3494, #3682).

cc: @davidsh, @cipop, @pgavlin 