### PR TITLE
Adding OnesComplement node support in the expression interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -879,6 +879,11 @@ namespace System.Linq.Expressions.Interpreter
             Emit(NegateCheckedInstruction.Create(type));
         }
 
+        public void EmitOnesComplement(Type type)
+        {
+            Emit(OnesComplementInstruction.Create(type));
+        }
+
         public void EmitIncrement(Type type)
         {
             Emit(IncrementInstruction.Create(type));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1194,6 +1194,10 @@ namespace System.Linq.Expressions.Interpreter
                     case ExpressionType.IsFalse:
                         EmitUnaryBoolCheck(node);
                         break;
+                    case ExpressionType.OnesComplement:
+                        Compile(node.Operand);
+                        _instructions.EmitOnesComplement(node.Type);
+                        break;
                     default:
                         throw new PlatformNotSupportedException(SR.Format(SR.UnsupportedExpressionType, node.NodeType));
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -619,6 +619,180 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
+    internal abstract class OnesComplementInstruction : Instruction
+    {
+        private static Instruction s_byte, s_sbyte, s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
+
+        public override int ConsumedStack { get { return 1; } }
+        public override int ProducedStack { get { return 1; } }
+        public override string InstructionName
+        {
+            get { return "OnesComplement"; }
+        }
+        private OnesComplementInstruction()
+        {
+        }
+
+        internal sealed class OnesComplementInt32 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(~(Int32)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementInt16 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((Int16)(~(Int16)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementInt64 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((Int64)(~(Int64)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementUInt16 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((UInt16)(~(UInt16)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementUInt32 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((UInt32)(~(UInt32)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementUInt64 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((UInt64)(~(UInt64)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementByte : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((Byte)(~(Byte)obj));
+                }
+                return +1;
+            }
+        }
+
+        internal sealed class OnesComplementSByte : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push((SByte)(~(SByte)obj));
+                }
+                return +1;
+            }
+        }
+
+        public static Instruction Create(Type type)
+        {
+            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
+            {
+                case TypeCode.Byte: return s_byte ?? (s_byte = new OnesComplementByte());
+                case TypeCode.SByte: return s_sbyte ?? (s_sbyte = new OnesComplementSByte());
+                case TypeCode.Int16: return s_int16 ?? (s_int16 = new OnesComplementInt16());
+                case TypeCode.Int32: return s_int32 ?? (s_int32 = new OnesComplementInt32());
+                case TypeCode.Int64: return s_int64 ?? (s_int64 = new OnesComplementInt64());
+                case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new OnesComplementUInt16());
+                case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new OnesComplementUInt32());
+                case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new OnesComplementUInt64());
+
+                default:
+                    throw Error.ExpressionNotSupportedForType("OnesComplement", type);
+            }
+        }
+
+        public override string ToString()
+        {
+            return "OnesComplement()";
+        }
+    }
 
     internal abstract class IncrementInstruction : Instruction
     {

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -138,7 +138,9 @@
     <Compile Include="Unary\UnaryIsFalseTests.cs" />
     <Compile Include="Unary\UnaryIsTrueNullableTests.cs" />
     <Compile Include="Unary\UnaryIsTrueTests.cs" />
+    <Compile Include="Unary\UnaryOnesComplementNullableTests.cs" />
     <Compile Include="Unary\UnaryUnaryPlusNullableTests.cs" />
+    <Compile Include="Unary\UnaryOnesComplementTests.cs" />
     <Compile Include="Unary\UnaryUnaryPlusTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class OnesComplementNullableTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableShortTest()
+        {
+            short?[] values = new short?[] { null, 0, 1, -1, short.MinValue, short.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableUShortTest()
+        {
+            ushort?[] values = new ushort?[] { null, 0, 1, ushort.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableUShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableIntTest()
+        {
+            int?[] values = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableUIntTest()
+        {
+            uint?[] values = new uint?[] { null, 0, 1, uint.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableUInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableLongTest()
+        {
+            long?[] values = new long?[] { null, 0, 1, -1, long.MinValue, long.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableLong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableULongTest()
+        {
+            ulong?[] values = new ulong?[] { null, 0, 1, ulong.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableULong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableByteTest()
+        {
+            byte?[] values = new byte?[] { null, 0, 1, byte.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableByte(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementNullableSByteTest()
+        {
+            sbyte?[] values = new sbyte?[] { null, 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementNullableSByte(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyArithmeticOnesComplementNullableShort(short? value)
+        {
+            Expression<Func<short?>> e =
+                Expression.Lambda<Func<short?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(short?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short?> f = e.Compile();
+            Assert.Equal((short?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableUShort(ushort? value)
+        {
+            Expression<Func<ushort?>> e =
+                Expression.Lambda<Func<ushort?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(ushort?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort?> f = e.Compile();
+            Assert.Equal((ushort?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableInt(int? value)
+        {
+            Expression<Func<int?>> e =
+                Expression.Lambda<Func<int?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(int?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int?> f = e.Compile();
+            Assert.Equal((int?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableUInt(uint? value)
+        {
+            Expression<Func<uint?>> e =
+                Expression.Lambda<Func<uint?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(uint?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint?> f = e.Compile();
+            Assert.Equal((uint?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableLong(long? value)
+        {
+            Expression<Func<long?>> e =
+                Expression.Lambda<Func<long?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(long?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long?> f = e.Compile();
+            Assert.Equal((long?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableULong(ulong? value)
+        {
+            Expression<Func<ulong?>> e =
+                Expression.Lambda<Func<ulong?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(ulong?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong?> f = e.Compile();
+            Assert.Equal((ulong?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableByte(byte? value)
+        {
+            Expression<Func<byte?>> e =
+                Expression.Lambda<Func<byte?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(byte?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<byte?> f = e.Compile();
+            Assert.Equal((byte?)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementNullableSByte(sbyte? value)
+        {
+            Expression<Func<sbyte?>> e =
+                Expression.Lambda<Func<sbyte?>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(sbyte?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<sbyte?> f = e.Compile();
+            Assert.Equal((sbyte?)(~value), f());
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class OnesComplementTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementShortTest()
+        {
+            short[] values = new short[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementUShortTest()
+        {
+            ushort[] values = new ushort[] { 0, 1, ushort.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementUShort(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementIntTest()
+        {
+            int[] values = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementUIntTest()
+        {
+            uint[] values = new uint[] { 0, 1, uint.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementUInt(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementLongTest()
+        {
+            long[] values = new long[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementLong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementULongTest()
+        {
+            ulong[] values = new ulong[] { 0, 1, ulong.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementULong(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementByteTest()
+        {
+            byte[] values = new byte[] { 0, 1, byte.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementByte(values[i]);
+            }
+        }
+
+        [Fact] //[WorkItem(3737, "https://github.com/dotnet/corefx/issues/3737")]
+        public static void CheckUnaryArithmeticOnesComplementSByteTest()
+        {
+            sbyte[] values = new sbyte[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                VerifyArithmeticOnesComplementSByte(values[i]);
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyArithmeticOnesComplementShort(short value)
+        {
+            Expression<Func<short>> e =
+                Expression.Lambda<Func<short>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(short))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short> f = e.Compile();
+            Assert.Equal((short)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementUShort(ushort value)
+        {
+            Expression<Func<ushort>> e =
+                Expression.Lambda<Func<ushort>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(ushort))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort> f = e.Compile();
+            Assert.Equal((ushort)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementInt(int value)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(int))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile();
+            Assert.Equal((int)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementUInt(uint value)
+        {
+            Expression<Func<uint>> e =
+                Expression.Lambda<Func<uint>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(uint))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint> f = e.Compile();
+            Assert.Equal((uint)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementLong(long value)
+        {
+            Expression<Func<long>> e =
+                Expression.Lambda<Func<long>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(long))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long> f = e.Compile();
+            Assert.Equal((long)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementULong(ulong value)
+        {
+            Expression<Func<ulong>> e =
+                Expression.Lambda<Func<ulong>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(ulong))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong> f = e.Compile();
+            Assert.Equal((ulong)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementByte(byte value)
+        {
+            Expression<Func<byte>> e =
+                Expression.Lambda<Func<byte>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(byte))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<byte> f = e.Compile();
+            Assert.Equal((byte)(~value), f());
+        }
+
+        private static void VerifyArithmeticOnesComplementSByte(sbyte value)
+        {
+            Expression<Func<sbyte>> e =
+                Expression.Lambda<Func<sbyte>>(
+                    Expression.OnesComplement(Expression.Constant(value, typeof(sbyte))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<sbyte> f = e.Compile();
+            Assert.Equal((sbyte)(~value), f());
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Adding OnesComplement node support in the expression interpreter. This fixes issue #3737.

cc @VSadov