### PR TITLE
Add more WinHttpHandler client certificate tests

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/ClientCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/ClientCertificateHelper.cs
@@ -255,6 +255,18 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             }
         }
 
+        public X509Certificate2Collection ValidClientCertificateCollection
+        {
+            get
+            {
+                X509Certificate2Collection certs = new X509Certificate2Collection();
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_EKUIncludesClientAuth_PrivateKey);
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_NoEKU_PrivateKey);
+                
+                return certs;
+            }
+        }
+
         public object[][] InvalidClientCertificates
         {
             get
@@ -266,6 +278,33 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                         new object[] { _cert_KeyUsageIncludesDigitalSignature_EKUMissingClientAuth_PrivateKey }
                     };
             }
-        }            
+        } 
+
+        public X509Certificate2Collection InvalidClientCertificateCollection
+        {
+            get
+            {
+                X509Certificate2Collection certs = new X509Certificate2Collection();
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_EKUIncludesClientAuth_NoPrivateKey);
+                certs.Add(_cert_KeyUsageMissingDigitalSignature_EKUIncludesClientAuth_PrivateKey);
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_EKUMissingClientAuth_PrivateKey);
+                
+                return certs;
+            }
+        }
+
+        public X509Certificate2Collection ValidAndInvalidClientCertificateCollection
+        {
+            get
+            {
+                X509Certificate2Collection certs = new X509Certificate2Collection();
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_EKUIncludesClientAuth_NoPrivateKey);
+                certs.Add(_cert_KeyUsageMissingDigitalSignature_EKUIncludesClientAuth_PrivateKey);
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_EKUIncludesClientAuth_PrivateKey);
+                certs.Add(_cert_KeyUsageIncludesDigitalSignature_EKUMissingClientAuth_PrivateKey);
+                
+                return certs;
+            }
+        }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/ClientCertificateScenarioTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/ClientCertificateScenarioTest.cs
@@ -112,6 +112,81 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                     Assert.Equal(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
                 }
             }
+        }
+        
+        [Fact]
+        public void SecureRequest_ClientCertificateOptionAutomatic_CertStoreEmpty_NullCertificateContextSet()
+        {
+            using (var handler = new WinHttpHandler())
+            {
+                handler.ClientCertificateOption = ClientCertificateOption.Automatic;
+                using (HttpResponseMessage response = SendRequestHelper.Send(
+                    handler,
+                    () => { },
+                    TestServer.FakeSecureServerEndpoint))
+                {
+                    Assert.Equal(1, APICallHistory.WinHttpOptionClientCertContext.Count);
+                    Assert.Equal(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
+                }
+            }
+        }
+        
+        [Fact]
+        public void SecureRequest_ClientCertificateOptionAutomatic_CertStoreHasInvalidCerts_NullCertificateContextSet()
+        {
+            using (var handler = new WinHttpHandler())
+            {
+                var helper = new ClientCertificateHelper();
+                TestControl.CurrentUserCertificateStore = helper.InvalidClientCertificateCollection;
+                handler.ClientCertificateOption = ClientCertificateOption.Automatic;
+                using (HttpResponseMessage response = SendRequestHelper.Send(
+                    handler,
+                    () => { },
+                    TestServer.FakeSecureServerEndpoint))
+                {
+                    Assert.Equal(1, APICallHistory.WinHttpOptionClientCertContext.Count);
+                    Assert.Equal(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
+                }
+            }
+        }
+        
+        [Fact]
+        public void SecureRequest_ClientCertificateOptionAutomatic_CertStoreHasValidCerts_ValidCertificateContextSet()
+        {
+            using (var handler = new WinHttpHandler())
+            {
+                var helper = new ClientCertificateHelper();
+                TestControl.CurrentUserCertificateStore = helper.ValidClientCertificateCollection;
+                handler.ClientCertificateOption = ClientCertificateOption.Automatic;
+                using (HttpResponseMessage response = SendRequestHelper.Send(
+                    handler,
+                    () => { },
+                    TestServer.FakeSecureServerEndpoint))
+                {
+                    Assert.Equal(1, APICallHistory.WinHttpOptionClientCertContext.Count);
+                    Assert.NotEqual(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
+                }
+            }
+        }
+        
+        
+        [Fact]
+        public void SecureRequest_ClientCertificateOptionAutomatic_CertStoreHasValidAndInvalidCerts_ValidCertificateContextSet()
+        {
+            using (var handler = new WinHttpHandler())
+            {
+                var helper = new ClientCertificateHelper();
+                TestControl.CurrentUserCertificateStore = helper.ValidAndInvalidClientCertificateCollection;
+                handler.ClientCertificateOption = ClientCertificateOption.Automatic;
+                using (HttpResponseMessage response = SendRequestHelper.Send(
+                    handler,
+                    () => { },
+                    TestServer.FakeSecureServerEndpoint))
+                {
+                    Assert.Equal(1, APICallHistory.WinHttpOptionClientCertContext.Count);
+                    Assert.NotEqual(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
+                }
+            }
         }        
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeX509Certificates.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeX509Certificates.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.WinHttpHandlerUnitTests;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Http
+{
+    public class X509Store : IDisposable
+    {
+        private bool _disposed;
+        
+        public X509Store()
+        {
+        }
+
+        public X509Certificate2Collection Certificates
+        {
+            get
+            {
+                return TestControl.CurrentUserCertificateStore;
+            }
+        }
+
+        public void Open(OpenFlags flags)
+        {
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="FakeMarshal.cs" />
     <Compile Include="FakeRegistry.cs" />
     <Compile Include="FakeSafeWinHttpHandle.cs" />
+    <Compile Include="FakeX509Certificates.cs" />
     <Compile Include="SafeWinHttpHandleTest.cs" />
     <Compile Include="SendRequestHelper.cs" />
     <Compile Include="TestServer.cs" />

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestControl.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestControl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
@@ -26,6 +27,8 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public static int ResponseDelayTime { get; set; }
 
         public static AutoResetEvent ResponseDelayCompletedEvent { get; internal set; }
+        
+        public static X509Certificate2Collection CurrentUserCertificateStore{ get; set; }
 
         public static void Reset()
         {
@@ -40,6 +43,8 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             PACFileNotDetectedOnNetwork = false;
             ResponseDelayTime = 0;
             ResponseDelayCompletedEvent = new AutoResetEvent(true);
+            
+            CurrentUserCertificateStore = new X509Certificate2Collection();
         }
 
         public static void ResetAll()


### PR DESCRIPTION
Add a fake X509Store to the unit tests to simulate a real per-user certificate store on the machine.

Add tests related to WinHttpHandler ClientCertificateOption.Automatic property setting.