### PR TITLE
Re-enable HttpClient encoding tests on Unix

### DIFF
--- a/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
@@ -203,7 +203,6 @@ namespace System.Net.Http.Tests
             Assert.Null(contentDisposition.FileNameStar);
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void FileNameStar_UnknownOrBadEncoding_PropertyFails()
         {

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/HostParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/HostParserTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.Http.Tests
             Assert.Equal(StringComparer.OrdinalIgnoreCase, parser.Comparer);
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
         {

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/WarningParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/WarningParserTest.cs
@@ -25,7 +25,6 @@ namespace System.Net.Http.Tests
             Assert.Null(parser.Comparer);
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
         {
@@ -47,7 +46,6 @@ namespace System.Net.Http.Tests
             CheckValidParsedValue("  ,,", 0, null, 4);
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
         {

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
@@ -61,7 +61,6 @@ namespace System.Net.Http.Tests
             Assert.Equal(" http://example.com http://other", headers.GetValues("Location").First());
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void Location_RequiresEncoding_Encoded()
         {

--- a/src/System.Net.Http/tests/UnitTests/Headers/UriHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/UriHeaderParserTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.Http.Tests
             Assert.Null(parser.Comparer);
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
         {

--- a/src/System.Net.Http/tests/UnitTests/Headers/WarningHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/WarningHeaderValueTest.cs
@@ -198,7 +198,6 @@ namespace System.Net.Http.Tests
             CheckInvalidWarningViaLength("123 host \"t\" \"\"", 0);
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void Parse_SetOfValidValueStrings_ParsedCorrectly()
         {
@@ -214,7 +213,6 @@ namespace System.Net.Http.Tests
             CheckValidParse("1 \u4F1A \"t\" ", new WarningHeaderValue(1, "\u4F1A", "\"t\""));
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void Parse_SetOfInvalidValueStrings_Throws()
         {
@@ -238,7 +236,6 @@ namespace System.Net.Http.Tests
             CheckInvalidParse("  ,,");
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
         {
@@ -254,7 +251,6 @@ namespace System.Net.Http.Tests
             CheckValidTryParse("1 \u4F1A \"t\" ", new WarningHeaderValue(1, "\u4F1A", "\"t\""));
         }
 
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         [Fact]
         public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
         {


### PR DESCRIPTION
cc: @davidsh, @kapilash 