### PR TITLE
Fixing the build.sh script to cause a native build to automatically format the C++ source code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -141,8 +141,12 @@ build_managed_corefx()
 
 build_native_corefx()
 {
+    # Format the Native Code to make sure it is format-compliant
+    echo "Formatting native source code..."
+    "$__nativeroot/format-code.sh"
+    echo "Done"
+    
     # All set to commence the build
-
     echo "Commencing build of corefx native components for $__BuildOS.$__BuildArch.$__BuildType"
     cd "$__IntermediatesDir"
 


### PR DESCRIPTION
Fixing the build.sh script to cause a native build to automatically format the C++ source code

@stephentoub  @weshaggard 