### PR TITLE
Consume build tools 00106, which adds support for auto test packages

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,12 +10,13 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00104</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00106</BuildToolsVersion>
     <DnxVersion>1.0.0-beta7</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
+    <NuProjVersion>0.10.4-beta-gf7fc34e7d8</NuProjVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,6 +42,7 @@
     <!-- Input Directories -->
     <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir)packages/</PackagesDir>
     <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)/lib/</ToolsDir>
+    <NuProjDir Condition="'$(NuProjDir)'==''">$(PackagesDir)NuProj.$(NuProjVersion)/tools/</NuProjDir>
   </PropertyGroup>
 
   <!-- Test runtime -->

--- a/dir.props
+++ b/dir.props
@@ -16,7 +16,6 @@
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
-    <NuProjVersion>0.10.4-beta-gf7fc34e7d8</NuProjVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,7 +41,6 @@
     <!-- Input Directories -->
     <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir)packages/</PackagesDir>
     <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)/lib/</ToolsDir>
-    <NuProjDir Condition="'$(NuProjDir)'==''">$(PackagesDir)NuProj.$(NuProjVersion)/tools/</NuProjDir>
   </PropertyGroup>
 
   <!-- Test runtime -->

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00106" />
-  <package id="NuProj" version="0.10.4-beta-gf7fc34e7d8" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta7" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00104" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00106" />
+  <package id="NuProj" version="0.10.4-beta-gf7fc34e7d8" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta7" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>


### PR DESCRIPTION
Consume build tools 00106, which adds support for automatically
generating test nuget packages.