### PR TITLE
Update CurlHandler to use HttpContent.CopyToAsync

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -142,6 +142,7 @@
     <Compile Include="System\Net\Http\HttpClientHandler.Unix.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.EasyRequest.cs" />
+    <Compile Include="System\Net\Http\Unix\CurlHandler.HttpContentAsyncStream.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.MultiAgent.cs" />
     <Compile Include="System\Net\Http\Unix\CurlException.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.CurlResponseMessage.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -102,7 +102,11 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    TrySetException(error as HttpRequestException ?? CreateHttpRequestException(error));
+                    if (error is IOException || error == null)
+                    {
+                        error = CreateHttpRequestException(error);
+                    }
+                    TrySetException(error);
                 }
                 // There's not much we can reasonably assert here about the result of TrySet*.
                 // It's possible that the task wasn't yet completed (e.g. a failure while initiating the request),

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -102,7 +102,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    if (error is IOException || error == null)
+                    if (error is IOException || error is CurlException || error == null)
                     {
                         error = CreateHttpRequestException(error);
                     }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -27,11 +27,11 @@ namespace System.Net.Http
             internal readonly HttpRequestMessage _requestMessage;
             internal readonly CurlResponseMessage _responseMessage;
             internal readonly CancellationToken _cancellationToken;
+            internal readonly HttpContentAsyncStream _requestContentStream;
 
             internal SafeCurlHandle _easyHandle;
             private SafeCurlSlistHandle _requestHeaders;
 
-            internal Stream _requestContentStream;
             internal NetworkCredential _networkCredential;
 
             internal MultiAgent _associatedMultiAgent;
@@ -43,8 +43,14 @@ namespace System.Net.Http
             {
                 _handler = handler;
                 _requestMessage = requestMessage;
-                _responseMessage = new CurlResponseMessage(this);
                 _cancellationToken = cancellationToken;
+
+                if (requestMessage.Content != null)
+                {
+                    _requestContentStream = new HttpContentAsyncStream(requestMessage.Content);
+                }
+
+                _responseMessage = new CurlResponseMessage(this);
             }
 
             /// <summary>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.HttpContentAsyncStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.HttpContentAsyncStream.cs
@@ -1,0 +1,395 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    // libcurl has a pull-based model and needs to be able to read data on-demand
+    // from the request content stream.  HttpContent provides a ReadAsStreamAsync method
+    // that would theoretically enable this, however it's actually not intended for such
+    // scenarios and has some deficiencies in this regard.  For example, in certain scenarios,
+    // we may need to retry an HTTP request, which means sending the data again.  In such
+    // situations, libcurl will ask us to rewind the stream.  We can do this with ReadAsStreamAsync,
+    // but only if the returned stream supports seeking.  If it doesn't support seeking, we
+    // could ask for a new stream again via calling ReadAsStreamAsync again, but it doesn't
+    // do content consumption detection like you get with HttpContent.CopyToAsync.  CopyToAsync
+    // is the preferred, supported mechanism for a handler getting data from the HttpContent,
+    // and is what WinHttpHandler uses, but it also provides a push-based model.  In order to
+    // be able to pull from a push-based model, we need an adapter stream that straddles
+    // the divide.  This implementation provides that.
+
+    internal partial class CurlHandler : HttpMessageHandler
+    {
+        /// <summary>
+        /// Provides a stream that lets CurlHandler read the data from an
+        /// HttpContent via HttpContent's CopyToAsync.
+        /// </summary>
+        private sealed class HttpContentAsyncStream : Stream
+        {
+            /// <summary>Cached task that contains the Int32 value 0.</int></summary>
+            private static readonly Task<int> s_zeroTask = Task.FromResult(0);
+
+            /// <summary>Object used to synchronize all activity on the stream.</summary>
+            private readonly object _syncObj = new object();
+            /// <summary>The HttpContent to read from.</summary>
+            private readonly HttpContent _content;
+
+            /// <summary>true if the stream has been disposed; otherwise, false.</summary>
+            private bool _disposed;
+            /// <summary>Task representing the transfer of data from the HttpContent to this stream.</summary>
+            private Task _copyTask;
+
+            /// <summary>TaskCompletionSource for the currently outstanding read or write operation.</summary>
+            private TaskCompletionSource<int> _asyncOp;
+            /// <summary>Cancellation registration associated with the currently pending async operation.</summary>
+            private CancellationTokenRegistration _cancellationRegistration;
+
+            /// <summary>Whether the currently oustanding async operation is a reader.</summary>
+            private bool _waiterIsReader;
+            /// <summary>The current outstanding async operation's buffer.</summary>
+            private byte[] _buffer;
+            /// <summary>The current outstanding async operations offset.</summary>
+            private int _offset;
+            /// <summary>The current outstanding async operations count.</summary>
+            private int _count;
+
+            /// <summary>Initializes the stream.</summary>
+            /// <param name="content">The content the stream should read from.</param>
+            internal HttpContentAsyncStream(HttpContent content)
+            {
+                Debug.Assert(content != null, "Expected non-null content");
+                _content = content;
+            }
+
+            /// <summary>Gets whether the stream is readable.  It is, but it should only be read from by CurlHandler's libcurl callbacks.</summary>
+            public override bool CanRead { get { return true; } }
+
+            /// <summary>Gets whether the stream is writable.  It is, but it should only be written to by HttpContent.CopyToAsync.</summary>
+            public override bool CanWrite { get { return true; } }
+            
+            /// <summary>Gets whether the stream is seekable. It's not.</summary>
+            public override bool CanSeek { get { return false; } }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                // If no data was requested, give back 0 bytes.
+                if (count == 0)
+                {
+                    return s_zeroTask;
+                }
+
+                // If cancellation was requested, bail.
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled<int>(cancellationToken);
+                }
+
+                lock (_syncObj)
+                {
+                    // If we've been disposed, return that no data is available.
+                    if (_disposed)
+                    {
+                        return s_zeroTask;
+                    }
+
+                    // Start the transfer of data from the HttpContent to this stream, if it hasn't been started yet.
+                    if (_copyTask == null)
+                    {
+                        _copyTask = Task.Run(new Func<Task>(TransferAsync)); // use a task to escape the lock
+                    }
+
+                    // If we've already completed, return 0 bytes or fail with the same error that the CopyToAsync failed with.
+                    if (_copyTask.IsCompleted)
+                    {
+                        return _copyTask.Status == TaskStatus.RanToCompletion ?
+                            s_zeroTask :
+                            PropagateError<int>(_copyTask);
+                    }
+
+                    // If there's no writer waiting for us, register our buffer/offset/count and return.
+                    if (_buffer == null)
+                    {
+                        VerboseTrace("No waiting writer. Queueing.");
+                        Update(true, buffer, offset, count, NewTcs());
+                        RegisterCancellation(cancellationToken);
+                        return _asyncOp.Task;
+                    }
+
+                    // There's writer data available to use.  Read it to satisfy this request.
+                    int bytesToCopy = Math.Min(_count, count);
+                    Debug.Assert(bytesToCopy > 0, "Expected to be copying at least 1 byte");
+                    Buffer.BlockCopy(_buffer, _offset, buffer, offset, bytesToCopy);
+                    VerboseTrace("Read " + bytesToCopy + " from writer.");
+
+                    if (bytesToCopy == _count)
+                    {
+                        // We exhausted all of the writer's data, so complete the writer
+                        // and clear out the state.
+                        TaskCompletionSource<int> tcs = _asyncOp;
+                        Update(false, null, 0, 0, null);
+                        _cancellationRegistration.Dispose();
+                        bool writerCompleted = tcs.TrySetResult(default(int)); // value doesn't matter, as the Task is a writer
+                        Debug.Assert(writerCompleted, "No one else should have completed the writer");
+                    }
+                    else
+                    {
+                        // The writer still has more data to provide to a future read.
+                        // Update based on this read.
+                        _offset += bytesToCopy;
+                        _count -= bytesToCopy;
+                    }
+
+                    // Return the number of bytes read.
+                    return Task.FromResult(bytesToCopy);
+                }
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                // If no data was provided, we're done.
+                if (count == 0)
+                {
+                    return Task.CompletedTask;
+                }
+
+                // If cancellation was requested, bail.
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled<int>(cancellationToken);
+                }
+
+                lock (_syncObj)
+                {
+                    // If we've been disposed, throw an exception so as to end the CopyToAsync operation.
+                    if (_disposed)
+                    {
+                        VerboseTrace("WriteAsync when already disposed");
+                        throw CreateHttpRequestException();
+                    }
+
+                    if (_buffer == null)
+                    {
+                        // There's no waiting reader.  Store everything for later.
+                        VerboseTrace("No waiting reader. Queueing.");
+                        Debug.Assert(_asyncOp == null, "No one else should be waiting");
+                        Update(false, buffer, offset, count, NewTcs());
+                        RegisterCancellation(cancellationToken);
+                        return _asyncOp.Task;
+                    }
+
+                    // There's a waiting reader.  We'll give them our data and store
+                    // for later anything they can't use.
+                    Debug.Assert(_waiterIsReader, "Concurrent WriteAsync calls are not permitted");
+                    Debug.Assert(_count > 0, "Expected reader to need at least 1 byte");
+                    Debug.Assert(_asyncOp != null, "Reader should have created a task to complete");
+
+                    // Complete the waiting reader with however much we can give them
+                    int bytesToCopy = Math.Min(count, _count);
+                    Buffer.BlockCopy(buffer, offset, _buffer, _offset, bytesToCopy);
+                    _cancellationRegistration.Dispose();
+                    bool completed = _asyncOp.TrySetResult(bytesToCopy);
+                    Debug.Assert(completed, "No one else should have completed the reader");
+                    VerboseTrace("Writer transferred " + bytesToCopy + " to reader.");
+
+                    if (bytesToCopy < count)
+                    {
+                        // If we have more bytes from this write, store the arguments
+                        // for use later and return a task to be completed by a reader.
+                        Update(false, buffer, offset + bytesToCopy, count - bytesToCopy, NewTcs());
+                        RegisterCancellation(cancellationToken);
+                        return _asyncOp.Task;
+                    }
+                    else
+                    {
+                        // We used up all of the data in this write, so complete
+                        // the caller synchronously.
+                        Update(false, null, 0, 0, null);
+                        return Task.CompletedTask;
+                    }
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                lock (_syncObj)
+                {
+                    // Mark ourselves as disposed, and make sure to wake
+                    // up any writer or reader who's been waiting.
+                    _disposed = true;
+                    if (_asyncOp != null)
+                    {
+                        _cancellationRegistration.Dispose();
+                        bool canceled = _asyncOp.TrySetCanceled();
+                        Debug.Assert(canceled, "No one else should have completed the operation.");
+                    }
+                    Update(false, null, 0, 0, null);
+                }
+                base.Dispose(disposing);
+            }
+
+            /// <summary>Registers with the specified cancellation token to cancel the pending operation.</summary>
+            private void RegisterCancellation(CancellationToken cancellationToken)
+            {
+                if (!cancellationToken.CanBeCanceled)
+                    return;
+
+                _cancellationRegistration = cancellationToken.Register(s =>
+                {
+                    VerboseTrace("Cancellation requested");
+                    var thisRef = (HttpContentAsyncStream)s;
+                    lock (thisRef._syncObj)
+                    {
+                        if (thisRef._asyncOp != null)
+                        {
+                            bool canceled = thisRef._asyncOp.TrySetCanceled();
+                            Debug.Assert(canceled, "Expected to be able to cancel pending async op");
+                            thisRef.Update(false, null, 0, 0, null);
+                        }
+                    }
+                }, this);
+            }
+
+            /// <summary>
+            /// Try to rewind the stream to the beginning.  If successful, the next call to ReadAsync
+            /// will initiate a new CopyToAsync operation.  Reset is only successful when there's
+            /// no CopyToAsync in progress.
+            /// </summary>
+            /// <returns></returns>
+            internal bool TryReset()
+            {
+                lock (_syncObj)
+                {
+                    if (_copyTask == null || _copyTask.IsCompleted)
+                    {
+                        VerboseTrace("TryReset successful");
+                        _copyTask = null;
+                        return true;
+                    }
+                }
+
+                VerboseTrace("TryReset failed");
+                return false;
+            }
+
+            private Task TransferAsync()
+            {
+                VerboseTrace("Initiating new CopyToAsync");
+
+                Task t;
+                try
+                {
+                    t = _content.CopyToAsync(this);
+                }
+                catch (Exception exc)
+                {
+                    t = Task.FromException(exc);
+                }
+
+                // Transfer the data from the content to this stream
+                return t.ContinueWith(p =>
+                {
+                    lock (_syncObj)
+                    {
+                        VerboseTrace("CopyToAsync completed " + p.Status + " " + p.Exception);
+
+                        // We're done transferring, but a reader doesn't know that until they successfully
+                        // read 0 bytes, which won't happen until either a) we complete an already waiting
+                        // reader or b) a new reader comes along and see _copyTask completed.  We also need
+                        // to make sure that, once we do signal completion by giving a reader 0 bytes, we're
+                        // immediately ready for a TryReset, which means the _copyTask needs to be completed.
+                        // As such, while we're holding the lock, we need to both give 0 bytes to any waiting
+                        // reader and force _copyTask to complete, which we do by replacing this Task's
+                        // reference with one known to already be complete.
+
+                        if (_asyncOp != null)
+                        {
+                            _cancellationRegistration.Dispose();
+                            Debug.Assert(_waiterIsReader, "We're done writing, so a waiter must be a reader.");
+                            if (p.IsFaulted)
+                            {
+                                _asyncOp.TrySetException(p.Exception.InnerException);
+                                _copyTask = p;
+                            }
+                            else if (p.IsCanceled)
+                            {
+                                _asyncOp.TrySetCanceled();
+                                _copyTask = p;
+                            }
+                            else
+                            {
+                                _asyncOp.TrySetResult(0);
+                                _copyTask = s_zeroTask;
+                            }
+                            Update(false, null, 0, 0, null);
+                        }
+                        else
+                        {
+                            _copyTask = p.Status == TaskStatus.RanToCompletion ? s_zeroTask : p;
+                        }
+                    }
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+
+            /// <summary>Returns a task that's faulted or canceled based on the specified task's state.</summary>
+            private static async Task<T> PropagateError<T>(Task failedTask)
+            {
+                Debug.Assert(failedTask.IsFaulted || failedTask.IsCanceled, "Task must have already faulted or been canceled");
+                await failedTask;
+                return default(T); // should never get here
+            }
+
+            /// <summary>Updates the state on the stream to the specified values.</summary>
+            private void Update(bool isReader, byte[] buffer, int offset, int count, TaskCompletionSource<int> asyncOp)
+            {
+                _waiterIsReader = isReader;
+                _buffer = buffer;
+                _offset = offset;
+                _count = count;
+                _asyncOp = asyncOp;
+            }
+
+            /// <summary>Creates a new TaskCompletionSource to use to represent a pending read or write.</summary>
+            private static TaskCompletionSource<int> NewTcs()
+            {
+                return new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            public override long Length
+            {
+                get { throw new NotSupportedException(); }
+            }
+
+            public override long Position
+            {
+                get { throw new NotSupportedException(); }
+                set { throw new NotSupportedException(); }
+            }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -805,11 +805,15 @@ namespace System.Net.Http
                         if (offset == 0 && origin == (int)SeekOrigin.Begin && 
                             easy._requestContentStream != null && easy._requestContentStream.TryReset())
                         {
+                            // Dump any state associated with the old stream's position
                             if (easy._sendTransferState != null)
                             {
-                                // Dump any state associated with the old stream's position
                                 easy._sendTransferState.SetTaskOffsetCount(null, 0, 0);
                             }
+
+                            // Restart the transfer
+                            easy._requestContentStream.Run();
+
                             return Interop.libcurl.CURL_SEEKFUNC.CURL_SEEKFUNC_OK;
                         }
                         else

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -460,7 +460,7 @@ namespace System.Net.Http
             {
                 var inner = new CurlException(error, isMulti: false);
                 VerboseTrace(inner.Message);
-                throw CreateHttpRequestException(inner);
+                throw inner;
             }
         }
 
@@ -483,7 +483,7 @@ namespace System.Net.Http
                         throw new OutOfMemoryException(msg);
                     case CURLMcode.CURLM_INTERNAL_ERROR:
                     default:
-                        throw CreateHttpRequestException(new CurlException(error, msg));
+                        throw new CurlException(error, msg);
                 }
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -333,6 +333,10 @@ namespace System.Net.Http
             try
             {
                 easy.InitializeCurl();
+                if (easy._requestContentStream != null)
+                {
+                    easy._requestContentStream.Run();
+                }
                 _agent.Queue(new MultiAgent.IncomingRequest { Easy = easy, Type = MultiAgent.IncomingRequestType.New });
             }
             catch (Exception exc)

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -86,7 +86,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("BasicAuthEchoServers")]
-        [ActiveIssue(3693, PlatformID.AnyUnix)]
         public async Task PostNonRewindableContentUsingAuth_NoPreAuthenticate_ThrowsInvalidOperationException(Uri serverUri)
         {
             HttpContent content = CustomContent.Create(ExpectedContent, false);

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -78,7 +78,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("BasicAuthEchoServers")]
-        [ActiveIssue(3699, PlatformID.AnyUnix)]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Uri serverUri)
         {
             HttpContent content = CustomContent.Create(ExpectedContent, true);


### PR DESCRIPTION
To get a request content stream, CurlHandler currently uses the HttpContent's ReadAsStreamAsync, and when libcurl needs to rewind the stream, CurlHandler seeks on the stream.

Unfortunately, it turns out ReadAsStreamAsync isn't actually intended to be used by handlers in this manner, and as such there are some deficiencies that lead to correctness problems.  For example, some of the WCF HttpContent-derived types return non-seekable streams from CreateContentReadStreamAsync and thus from ReadAsStreamAsync.  This means that, using ReadAsStreamAsync, if we need to resend a request, we need to call ReadAsStreamAsync again. But ReadAsStreamAsync doesn't do the same _contentConsumed check that SerializeToStreamAsync does. That means if the content is actually a StreamContent, whose CreateContentReadStreamAsync just does ```return Task.FromResult(new ReadOnlyStream(this._content));```, and if the stream is non-seekable, then we'll end up getting back the "new" stream but that's already had its content consumed, and we won't know. We can't even try to do an object reference comparison, because StreamContent is wrapping the returned stream in a new ReadOnlyStream instance each time.  The recommended approach for handlers is to use HttpContent.CopyToAsync.

CopyToAsync is a push-based model, letting the HttpContent write to a target stream.  CurlHandler/libcurl have a pull-based model, with CurlHandler ReadAsync'ing from the request content based on callback from libcurl.  To straddle this divide, this commit adds a specialized push/pull adapter stream that let's CurlHandler effectively read from the pushing source.  If/when libcurl asks to rewind, the stream resets itself by doing a new CopyToAsync operation.

This revised approach does incur more costs, however care has been taken to try to minimize those overheads as much as possible, and the change is necessary for correctness.

This PR also fixes an issue with regards to which exception type CurlHandler wraps.

Fixes #3699, #3693
cc: @kapilash, @vijaykota, @davidsh, @pgavlin, @CIPop 