### PR TITLE
Fix inconsistent behavior of UnmanagedMemoryAccessor.ReadDecimal()

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/src/Resources/Strings.resx
+++ b/src/System.IO.UnmanagedMemoryStream/src/Resources/Strings.resx
@@ -198,4 +198,7 @@
   <data name="IO_StreamTooLong" xml:space="preserve">
     <value>Stream was too long.</value>
   </data>
+  <data name="Arg_BadDecimal" xml:space="preserve">
+    <value>Read an invalid decimal value from the buffer.</value>
+  </data>
 </root>

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmaTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmaTests.cs
@@ -40,6 +40,23 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public static void UmaInvalidReadDecimal()
+        {
+            const int capacity = 16; // sizeof(decimal)
+
+            using (var buffer = new TestSafeBuffer(capacity))
+            using (var uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                // UMA should throw when reading bad decimal values (some bits of flags are reserved and must be 0)
+                uma.Write(0, 0); // lo
+                uma.Write(4, 0); // mid
+                uma.Write(8, 0); // hi
+                uma.Write(12, -1); // flags (all bits are set, so this should raise an exception)
+                Assert.Throws<ArgumentException>(() => uma.ReadDecimal(0)); // Should throw same exception as decimal(int[]) ctor for compat
+            }
+        }
+
+        [Fact]
         public static void UmaReadWrite()
         {
             const int capacity = 199;


### PR DESCRIPTION
Noticed a few discrepancies in behavior from the CoreCLR and CoreFX versions of `UnmanagedMemoryStream` recently:

- If the decimal read has an invalid value, the [mscorlib](https://github.com/dotnet/coreclr/blob/4cf8a6b082d9bb1789facd996d8265d3908757b2/src/mscorlib/src/System/IO/UnmanagedMemoryAccessor.cs#L311) version will throw because it calls the decimal constructor, which [checks](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Decimal.cs#L278) that the decimal read is valid. We don't.

- If the target machine is big endian, `ReadDecimal` will return a corrupt decimal value since the fields are arranged in reverse order.

This PR fixes those issues.