### PR TITLE
Implement GetECDsaPublicKey for Unix.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern SafeEvpPKeyHandle GetX509EvpPublicKey(SafeX509Handle x509);
+    }
+}

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -24,6 +24,7 @@ set(NATIVECRYPTO_SOURCES
     pal_evp.cpp
     pal_evp_cipher.cpp
     pal_hmac.cpp
+    pal_x509.cpp
     pal_x509_name.cpp
 )
 

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_x509.h"
+
+extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509)
+{
+    if (!x509)
+    {
+        return nullptr;
+    }
+
+    // X509_get_X509_PUBKEY returns an interior pointer, so should not be freed
+    return X509_PUBKEY_get(X509_get_X509_PUBKEY(x509));
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdint.h>
+#include <openssl/x509.h>
+
+/*
+Function:
+GetX509EvpPublicKey
+
+Returns a EVP_PKEY* equivalent to the public key of the certificate.
+*/
+extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -251,6 +251,14 @@ namespace Internal.Cryptography.Pal
             }
         }
 
+        public ECDsa GetECDsaPublicKey()
+        {
+            using (SafeEvpPKeyHandle publicKeyHandle = Interop.Crypto.GetX509EvpPublicKey(_cert))
+            {
+                return new ECDsaOpenSsl(publicKeyHandle);
+            }
+        }
+
         public ECDsa GetECDsaPrivateKey()
         {
             if (_privateKey == null || _privateKey.IsInvalid)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -19,6 +19,8 @@ namespace Internal.Cryptography.Pal
             {
                 case Oids.RsaRsa:
                     return BuildRsaPublicKey(encodedKeyValue);
+                case Oids.Ecc:
+                    return ((OpenSslX509CertificateReader)certificatePal).GetECDsaPublicKey();
             }
 
             // NotSupportedException is what desktop and CoreFx-Windows throw in this situation.

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -201,6 +201,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Pkcs7.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Pkcs7.cs</Link>
     </Compile>


### PR DESCRIPTION
Unfortunately, the test for this was the first place where Windows ECDsa and Unix ECDsa were in the same place with the same key, and it was observed that they do not use the same data format for Sign/Verify.  This problem is tracked in issue #3769.

Fixes #3383.

cc: @AtsushiKan 