### PR TITLE
Allow recursive Directory.Delete of paths with trailing slash

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -513,7 +513,7 @@ namespace System.IO
                 Interop.mincore.WIN32_FIND_DATA data = new Interop.mincore.WIN32_FIND_DATA();
 
                 // Open a Find handle
-                using (SafeFindHandle hnd = Interop.mincore.FindFirstFile(fullPath + PathHelpers.DirectorySeparatorCharAsString + "*", ref data))
+                using (SafeFindHandle hnd = Interop.mincore.FindFirstFile(Directory.EnsureTrailingDirectorySeparator(fullPath) + "*", ref data))
                 {
                     if (hnd.IsInvalid)
                         throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -201,5 +201,12 @@ namespace System.IO.Tests
             Assert.False(testDir.Exists);
         }
 
+        [Fact]
+        public void RecursiveDeleteWithTrailingSlash()
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
+            Delete(testDir.FullName + Path.DirectorySeparatorChar, true);
+            Assert.False(testDir.Exists);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3780.

FindFirstFile with a normal path will happily collapse multiple
backslashes into a single logical path separator, but when presented
with a `\\?\` path, that doesn't happen.  As a result, unconditionally
concatenating a path-separator was fine until RemoveDirectoryHelper was
always called with EnsureExtendedPrefix (which is needed for extended
path support, introduced in 0721434).  With that, Win32 FindFirstFile
returns an error if there's a double backslash in the path beyond the
prefix.

@JeremyKuhne, are you a good person to review this?