### PR TITLE
Enable support for secp256r1 (NIST-P256) in Unix ECDSA

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -15,9 +15,10 @@ internal static partial class Interop
     {
         internal const int NID_undef = 0;
 
-        internal const int NID_secp224r1 = 713; // NIST-224
-        internal const int NID_secp384r1 = 715; // NIST-384
-        internal const int NID_secp521r1 = 716; // NIST-521
+        internal const int NID_X9_62_prime256v1 = 415; // NIST P-256
+        internal const int NID_secp224r1 = 713; // NIST P-224
+        internal const int NID_secp384r1 = 715; // NIST P-384
+        internal const int NID_secp521r1 = 716; // NIST P-521
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern long Asn1IntegerGet(IntPtr a);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -305,6 +305,24 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+        [Theory]
+        [InlineData(256)]
+        [InlineData(384)]
+        [InlineData(521)]
+        public void CreateKey(int keySize)
+        {
+            using (ECDsa ecdsa = ECDsaFactory.Create())
+            {
+                // Step 1, don't throw here.
+                ecdsa.KeySize = keySize;
+
+                // Step 2, ensure the key was generated without throwing.
+                ecdsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA256);
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
         public static IEnumerable<object[]> InteroperableSignatureConfigurations()
         {
             foreach (HashAlgorithmName hashAlgorithm in new[] { 

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -6,6 +6,7 @@
 #include <openssl/objects.h>
 
 static_assert(PAL_NID_undef == NID_undef, "");
+static_assert(PAL_NID_X9_62_prime256v1 == NID_X9_62_prime256v1, "");
 static_assert(PAL_NID_secp224r1 == NID_secp224r1, "");
 static_assert(PAL_NID_secp384r1 == NID_secp384r1, "");
 static_assert(PAL_NID_secp521r1 == NID_secp521r1, "");

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.h
@@ -11,6 +11,7 @@ NID values that are used in managed code.
 enum SupportedAlgorithmNids
 {
     PAL_NID_undef = 0,
+    PAL_NID_X9_62_prime256v1 = 415,
     PAL_NID_secp224r1 = 713,
     PAL_NID_secp384r1 = 715,
     PAL_NID_secp521r1 = 716,

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -256,6 +256,7 @@ namespace System.Security.Cryptography
             new SupportedAlgorithm[]
             {
                 new SupportedAlgorithm(keySize: 224, nid: Interop.Crypto.NID_secp224r1),
+                new SupportedAlgorithm(keySize: 256, nid: Interop.Crypto.NID_X9_62_prime256v1),
                 new SupportedAlgorithm(keySize: 384, nid: Interop.Crypto.NID_secp384r1),
                 new SupportedAlgorithm(keySize: 521, nid: Interop.Crypto.NID_secp521r1),
             };


### PR DESCRIPTION
As of FIPS 186-3, the [SuiteB ECDsa curves](https://www.nsa.gov/ia/_files/ecdsa.pdf) are P-256 and P-384.  The Unix implementation doesn't allow P-256, which seems fairly limiting in interoperability.

Fixes #3772.

cc: @AtsushiKan 