### PR TITLE
Reduce allocations in Enumerable.Block and remove always-true test

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -847,14 +847,14 @@ namespace System.Linq.Expressions
         public static BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions)
         {
             ContractUtils.RequiresNotNull(expressions, "expressions");
-            var expressionList = expressions.ToReadOnly();
             var variableList = variables.ToReadOnly();
 
             if (variableList.Count == 0)
             {
-                return GetOptimizedBlockExpression(expressionList);
+                return GetOptimizedBlockExpression(expressions as IReadOnlyList<Expression> ?? expressions.ToReadOnly());
             }
 
+            var expressionList = expressions.ToReadOnly();
             return BlockCore(expressionList.Last().Type, variableList, expressionList);
         }
 
@@ -967,7 +967,7 @@ namespace System.Linq.Expressions
                 default:
                     ContractUtils.RequiresNotEmptyList(expressions, "expressions");
                     RequiresCanRead(expressions, "expressions");
-                    return new BlockN(expressions.ToArray());
+                    return new BlockN(expressions as ReadOnlyCollection<Expression> ?? (IList<Expression>)expressions.ToArray());
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -875,19 +875,15 @@ namespace System.Linq.Expressions
 
             if (variableList.Count == 0)
             {
-                var expressionsList = expressions as IReadOnlyList<Expression>;
-                if (expressionsList != null)
+                var expressionCount = expressionList.Count;
+
+                if (expressionCount != 0)
                 {
-                    var expressionCount = expressionsList.Count;
+                    var lastExpression = expressionList[expressionCount - 1];
 
-                    if (expressionCount > 0)
+                    if (lastExpression.Type == type)
                     {
-                        var lastExpression = expressionsList[expressionCount - 1];
-
-                        if (lastExpression.Type == type)
-                        {
-                            return GetOptimizedBlockExpression(expressionsList);
-                        }
+                        return GetOptimizedBlockExpression(expressionList);
                     }
                 }
             }


### PR DESCRIPTION
Don't call `ToArray()` in `GetOptimizedBlockExpression()` if the argument is
a `ReadOnlyCollection`, to work with the attempts throughout the project to
reduce allocations of such collections.

Conversely, don't call `ToReadOnlyCollection()` in one of the `Block()`
overloads if the source already implements `IReadOnlyList` to allow lighter
array objects to be used more often.

One overload of `Block` uses `as IReadOnlyList<Expression>` and a null-check on
a variable that will never be null, and of a type that implements
`IReadOnlyList<Expression>` and hence will always take that branch.

Change to just use that variable directly.