### PR TITLE
PreAuthenticate fix

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -291,6 +291,9 @@
   <data name="net_http_unix_invalid_client_cert_option" xml:space="preserve">
     <value>libcurl supports only manual client certificate selection</value>
   </data>
+  <data name="net_http_unix_invalid_credential" xml:space="preserve">
+    <value>libcurl does not support different credentials for different authentication schemes</value>
+  </data>
   <data name="net_http_unix_https_libcurl_too_old" xml:space="preserve">
     <value>libcurl library available is too old</value>
   </data>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -264,7 +264,8 @@ namespace System.Net.Http
                 SetCurlOption(CURLoption.CURLOPT_PROXYPORT, proxyUri.Port);
                 VerboseTrace("Set proxy: " + proxyUri.ToString());
 
-                NetworkCredential credentials = GetCredentials(_handler.Proxy.Credentials, _requestMessage.RequestUri);
+                KeyValuePair<NetworkCredential, ulong> credentialScheme = GetCredentials(_handler.Proxy.Credentials, _requestMessage.RequestUri);
+                NetworkCredential credentials = credentialScheme.Key;
                 if (credentials != null)
                 {
                     if (string.IsNullOrEmpty(credentials.UserName))
@@ -280,20 +281,22 @@ namespace System.Net.Http
                 }
             }
 
-            internal void SetCredentialsOptions(NetworkCredential credentials)
+            internal void SetCredentialsOptions(KeyValuePair<NetworkCredential, ulong> credentialSchemePair)
             {
-                if (credentials == null)
+                if (credentialSchemePair.Key == null)
                 {
                     _networkCredential = null;
                     return;
                 }
 
+                NetworkCredential credentials = credentialSchemePair.Key;
+                ulong authScheme = credentialSchemePair.Value;
                 string userName = string.IsNullOrEmpty(credentials.Domain) ?
                     credentials.UserName :
                     string.Format("{0}\\{1}", credentials.Domain, credentials.UserName);
 
                 SetCurlOption(CURLoption.CURLOPT_USERNAME, userName);
-                SetCurlOption(CURLoption.CURLOPT_HTTPAUTH, CURLAUTH.AuthAny);
+                SetCurlOption(CURLoption.CURLOPT_HTTPAUTH, authScheme);
                 if (credentials.Password != null)
                 {
                     SetCurlOption(CURLoption.CURLOPT_PASSWORD, credentials.Password);

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -95,7 +95,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("BasicAuthEchoServers")]
-        [ActiveIssue(3695, PlatformID.AnyUnix)]
         public async Task PostNonRewindableContentUsingAuth_PreAuthenticate_Success(Uri serverUri)
         {
             HttpContent content = CustomContent.Create(ExpectedContent, false);


### PR DESCRIPTION
When CURLOPT_HTTPAUTH is set to any, libcurl will first query the server to figure out the
right authentication scheme. This breaks the expectation when PreAuthenticate is set to true.

We need to iterate over available schemes and set the auth-scheme flags to only those that are available. 
Also, while updating the CredentialCache, we ignore ArgumentException (raised when the cache contains the given url and scheme pair)
 