### PR TITLE
Adding client cert validation logic and usage of EncryptionPolicy

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
@@ -125,5 +125,14 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern IntPtr SSL_get_version(SafeSslHandle ssl);
+        
+        [DllImport(Interop.Libraries.LibSsl)]
+        internal static extern void SSL_CTX_set_verify(SafeSslContextHandle ctx, int mode, [MarshalAs(UnmanagedType.FunctionPtr)] verify_callback callback);
+
+        [DllImport(Interop.Libraries.LibSsl, CharSet = CharSet.Ansi)]
+        internal static extern int SSL_CTX_set_cipher_list(SafeSslContextHandle ctx, string policy);
+        
+        [DllImport(Interop.Libraries.LibSsl)]
+        internal static extern void SSL_CTX_set_client_CA_list(SafeSslContextHandle ctx, SafeX509NameStackHandle x509NameStackPtr);
     }
 }

--- a/src/Common/src/Interop/Unix/libssl/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Unix/libssl/SecuritySafeHandles.cs
@@ -81,6 +81,11 @@ namespace System.Net.Security
             get { return _protocols; }
         }
 
+        internal EncryptionPolicy Policy
+        {
+            get { return _policy; }
+        }
+
         public SafeFreeCredentials(X509Certificate certificate, SslProtocols protocols, EncryptionPolicy policy)
             : base(IntPtr.Zero, true)
         {
@@ -205,7 +210,7 @@ namespace System.Net.Security
             }
         }
 
-        public SafeDeleteContext(SafeFreeCredentials credential, long options, bool isServer, bool remoteCertRequired)
+        public SafeDeleteContext(SafeFreeCredentials credential, long options, string encryptionPolicy, bool isServer, bool remoteCertRequired)
             : base(IntPtr.Zero, true)
         {
             Debug.Assert((null != credential) && !credential.IsInvalid, "Invalid credential used in SafeDeleteContext");
@@ -224,6 +229,7 @@ namespace System.Net.Security
                     options,
                     credential.CertHandle,
                     credential.CertKeyHandle,
+                    encryptionPolicy,
                     isServer,
                     remoteCertRequired);
             }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
+        internal SafeX509StoreCtxHandle(IntPtr handle, bool ownsHandle) :
+            base(handle, ownsHandle)
+        {
+        }
+
         protected override bool ReleaseHandle()
         {
             Interop.libcrypto.X509_STORE_CTX_free(handle);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -22,3 +22,28 @@ extern "C" X509_NAME* DecodeX509Name(const unsigned char* buf, int32_t len)
 
     return d2i_X509_NAME(nullptr, &buf, len);
 }
+
+extern "C" STACK_OF(X509_NAME)* NewX509NameStack()
+{
+    return sk_X509_NAME_new_null();
+}
+
+extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME)* stack, X509_NAME* x509Name)
+{
+    if (!stack)
+    {
+        return 0;
+    }
+
+    return sk_X509_NAME_push(stack, x509Name);
+}
+
+extern "C" void RecursiveFreeX509NameStack(STACK_OF(X509_NAME)* stack)
+{
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name)
+{
+    return X509_NAME_dup(x509Name);
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
@@ -24,3 +24,39 @@ extern "C" X509_NAME* GetX509NameStackField(STACK_OF(X509_NAME) * sk, int32_t lo
 Shims the d2i_X509_NAME method and makes it easier to invoke from managed code.
 */
 extern "C" X509_NAME* DecodeX509Name(const unsigned char* buf, int32_t len);
+
+/*
+Function:
+NewX509NameStack
+
+Direct shim to sk_X509_NAME_new_null
+*/
+extern "C" STACK_OF(X509_NAME)* NewX509NameStack();
+
+/*
+Function:
+PushX509NameStackField
+
+Direct shim to sk_X509_NAME_push
+Return values:
+1 on success
+0 on a NULL stack, or an error within sk_X509_NAME_push
+*/
+extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME)* stack, X509_NAME* x509Name);
+
+/*
+Function:
+RecursiveFreeX509NameStack
+
+Direct shim to sk_X509_NAME_pop_free
+*/
+extern "C" void RecursiveFreeX509NameStack(STACK_OF(X509_NAME)* stack);
+
+/*
+Function:
+DuplicateX509Name
+
+Direct shim to X509_NAME_dup
+*/
+extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name);
+

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -363,4 +363,7 @@
   <data name="net_ssl_write_bio_failed_error" xml:space="preserve">
     <value>SSL Write BIO failed with OpenSSL error - {0}.</value>
   </data>
+  <data name="net_ssl_x509Name_push_failed_error" xml:space="preserve">
+    <value>Failed to push X509_NAME into stack.</value>
+  </data>
 </root>

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -123,6 +123,28 @@ namespace System.Net
             return retVal;
         }
 
+        private static string GetCipherString(EncryptionPolicy encryptionPolicy)
+        {
+            string cipherString = null;
+
+            switch (encryptionPolicy)
+            {
+                case EncryptionPolicy.RequireEncryption:
+                    cipherString = Interop.libssl.CipherString.AllExceptNull;
+                    break;
+
+                case EncryptionPolicy.AllowNoEncryption:
+                    cipherString = Interop.libssl.CipherString.AllIncludingNull;
+                    break;
+
+                case EncryptionPolicy.NoEncryption:
+                    cipherString = Interop.libssl.CipherString.Null;
+                    break;
+            }
+
+            return cipherString;
+        }
+
         private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteContext context,
             SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, bool isServer, bool remoteCertRequired)
         {
@@ -133,7 +155,8 @@ namespace System.Net
                 if ((null == context) || context.IsInvalid)
                 {
                     long options = GetOptions(credential.Protocols);
-                    context = new SafeDeleteContext(credential, options, isServer, remoteCertRequired);
+                    string encryptionPolicy = GetCipherString(credential.Policy);
+                    context = new SafeDeleteContext(credential, options, encryptionPolicy, isServer, remoteCertRequired);
                 }
 
                 IntPtr inputPtr = IntPtr.Zero, outputPtr = IntPtr.Zero;


### PR DESCRIPTION
This includes:
1. Client Certificate validation logic at server side. 
         Enabled the Verify_callback.
         Added the logic of updating CA list to be sent to client.
2. Added the usage of EncryptionPolicy flag passed during handshake. 
3. Enabled the constructors of SafeX509Handle and X509StoeCTXHandle to generate the handle from an Intptr.
4. Added SafeX509NameStackHandle to be used by the stack related APIs.
5. Added a few  X509_NAME stack related Macro-functions in *X509_name.cpp/.h

Testing done locally using the existing security testcases for Encryption Policy variations.
Client Cert validation logic is tested by directly calling AuthenticateAsServer method by enabling clientCertificateRequired flag.



