### PR TITLE
Fix bugs in IPPacketInformation.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
@@ -32,14 +32,15 @@ namespace System.Net.Sockets
             }
         }
 
-        public static bool operator ==(IPPacketInformation packetInformation1, IPPacketInformation packetInformation2)
+        public static bool operator ==(IPPacketInformation left, IPPacketInformation right)
         {
-            return packetInformation1.Equals(packetInformation2);
+            return left._networkInterface == right._networkInterface &&
+                (left._address == null && right._address == null || left._address.Equals(right._address));
         }
 
-        public static bool operator !=(IPPacketInformation packetInformation1, IPPacketInformation packetInformation2)
+        public static bool operator !=(IPPacketInformation left, IPPacketInformation right)
         {
-            return !packetInformation1.Equals(packetInformation2);
+            return !(left == right);
         }
 
         public override bool Equals(object comparand)
@@ -49,13 +50,13 @@ namespace System.Net.Sockets
                 return false;
             }
 
-            IPPacketInformation obj = (IPPacketInformation)comparand;
-            return _address.Equals(obj._address) && _networkInterface == obj._networkInterface;
+            return this == (IPPacketInformation)comparand;
         }
 
         public override int GetHashCode()
         {
-            return _address.GetHashCode() + _networkInterface.GetHashCode();
+            return unchecked(_networkInterface.GetHashCode() * (int)0xA5555529) +
+                (_address == null ? 0 : _address.GetHashCode());
         }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class IPPacketInformationTest
+    {
+        [Fact]
+        public void Equals_DefaultValues_Success()
+        {
+            Assert.Equal(default(IPPacketInformation), default(IPPacketInformation));
+            Assert.True(default(IPPacketInformation) == default(IPPacketInformation));
+            Assert.False(default(IPPacketInformation) != default(IPPacketInformation));
+        }
+
+        [Fact]
+        public void GetHashCode_DefaultValues_Success()
+        {
+            Assert.Equal(default(IPPacketInformation).GetHashCode(), default(IPPacketInformation).GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_NonDefaultValue_Success()
+        {
+            IPPacketInformation packetInfo = GetNonDefaultIPPacketInformation();
+            IPPacketInformation packetInfoCopy = packetInfo;
+
+            Assert.Equal(packetInfo, packetInfoCopy);
+            Assert.True(packetInfo == packetInfoCopy);
+            Assert.False(packetInfo != packetInfoCopy);
+
+            Assert.NotEqual(packetInfo, default(IPPacketInformation));
+            Assert.False(packetInfo == default(IPPacketInformation));
+            Assert.True(packetInfo != default(IPPacketInformation));
+        }
+
+        [Fact]
+        public void GetHashCode_NonDefaultValue_Succes()
+        {
+            IPPacketInformation packetInfo = GetNonDefaultIPPacketInformation();
+
+            Assert.Equal(packetInfo.GetHashCode(), packetInfo.GetHashCode());
+        }
+
+        private IPPacketInformation GetNonDefaultIPPacketInformation()
+        {
+            const int ReceiveTimeout = 5000;
+
+            using (var receiver = new Socket(SocketType.Dgram, ProtocolType.Udp))
+            using (var sender = new Socket(SocketType.Dgram, ProtocolType.Udp))
+            {
+                int port = receiver.BindToAnonymousPort(IPAddress.Loopback);
+
+                var waitHandle = new ManualResetEvent(false);
+
+                SocketAsyncEventArgs receiveArgs = new SocketAsyncEventArgs {
+                    RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, port),
+                    UserToken = waitHandle
+                };
+
+                receiveArgs.SetBuffer(new byte[1], 0, 1);
+                receiveArgs.Completed += (_, args) => ((ManualResetEvent)args.UserToken).Set();
+
+                Assert.True(receiver.ReceiveMessageFromAsync(receiveArgs));
+
+                sender.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, port));
+
+                Assert.True(waitHandle.WaitOne(ReceiveTimeout));
+
+                return receiveArgs.ReceiveMessageFromPacketInfo;
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="DisposedSocketTests.cs" />
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
+    <Compile Include="IPPacketInformationTest.cs" />
     <Compile Include="NetworkStreamTest.cs" />
     <Compile Include="SendReceive.cs" />
     <Compile Include="Shutdown.cs" />


### PR DESCRIPTION
- GetHashCode() and Equals() both stood the chance of dereferencing a null
  pointer when called on default values.
- GetHashCode() was using a weak method of combining hash codes. This has
  been updated to use the same technique used by Roslyn.
- The equality and inequality operators were unnecessarily boxing input
  parameters.