### PR TITLE
System.Diagnostics.Tracing.Logger implementation

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,16 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <!-- NOTE: Leave this file here and keep it in sync with list in dir.props. -->
   <!-- The command-line doesn't need it, but the IDE does.                    -->
+  <config>
+    <add key="repositoryPath" value="..\packages" />
+  </config>
   <packageSources>
-    <clear/>
     <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
     <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
     <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
-  <config>
-    <add key="repositoryPath" value="..\packages" />
-  </config>
 </configuration>

--- a/src/System.Diagnostics.Tracing.Logger/System.Diagnostics.Tracing.Logger.sln
+++ b/src/System.Diagnostics.Tracing.Logger/System.Diagnostics.Tracing.Logger.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23103.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tracing.Logger", "src\System.Diagnostics.Tracing.Logger.csproj", "{F24D3391-2928-4E83-AADE-B34423498750}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tracing.Logger.Tests", "tests\System.Diagnostics.Tracing.Logger.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Diagnostics.Tracing.Logger/ref/System.Diagnostics.Tracing.Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/ref/System.Diagnostics.Tracing.Logger.cs
@@ -1,0 +1,5 @@
+namespace System.Diagnostics.Tracing {
+  public partial class Logger {
+  }
+}
+

--- a/src/System.Diagnostics.Tracing.Logger/ref/System.Diagnostics.Tracing.Logger.csproj
+++ b/src/System.Diagnostics.Tracing.Logger/ref/System.Diagnostics.Tracing.Logger.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Diagnostics.Tracing.Logger.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing.Logger/ref/project.json
+++ b/src/System.Diagnostics.Tracing.Logger/ref/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing.Logger/ref/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/ref/project.lock.json
@@ -1,0 +1,70 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    ".NETPlatform,Version=v5.0": {
+      "System.Runtime/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Runtime/4.0.0": {
+      "type": "package",
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.4.0.0.nupkg",
+        "System.Runtime.4.0.0.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Runtime >= 4.0.0"
+    ],
+    ".NETPlatform,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.Tracing.Logger/src/System.Diagnostics.Tracing.Logger.csproj
+++ b/src/System.Diagnostics.Tracing.Logger/src/System.Diagnostics.Tracing.Logger.csproj
@@ -18,6 +18,7 @@
     <NoWarn>0420</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Diagnostics\Tracing\ILogger.cs" />
     <Compile Include="System\Diagnostics\Tracing\Logger.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Diagnostics.Tracing.Logger/src/System.Diagnostics.Tracing.Logger.csproj
+++ b/src/System.Diagnostics.Tracing.Logger/src/System.Diagnostics.Tracing.Logger.csproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <ProjectGuid>{F24D3391-2928-4E83-AADE-B34423498750}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Diagnostics.Tracing.Logger</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <NoWarn>0420</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <NoWarn>0420</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System\Diagnostics\Tracing\Logger.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
@@ -30,13 +30,5 @@ namespace System.Diagnostics.Tracing
         /// <param name="arguments"></param>
         /// <returns></returns>
         IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null);
-
-        /// <summary>
-        /// Add an observer
-        /// </summary>
-        /// <param name="observer"></param>
-        /// <param name="filter"></param>
-        /// <returns></returns>
-        IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, LogLevel, bool> filter);
     }
 }

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace System.Diagnostics.Tracing
+{
+    interface ILogger
+    {
+        bool IsEnabled(LogLevel level);
+        void Log(string logItemName, LogLevel level, object arguments = null);
+        IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null);
+        IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, LogLevel level);
+    }
+}

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
@@ -2,11 +2,41 @@
 
 namespace System.Diagnostics.Tracing
 {
-    interface ILogger
+    /// <summary>
+    /// A generic interface for logging.
+    /// </summary>
+    public interface ILogger
     {
+        /// <summary>
+        /// Checks if the given LogLevel is enabled.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <returns></returns>
         bool IsEnabled(LogLevel level);
+
+        /// <summary>
+        /// Log a single item
+        /// </summary>
+        /// <param name="logItemName"></param>
+        /// <param name="level"></param>
+        /// <param name="arguments"></param>
         void Log(string logItemName, LogLevel level, object arguments = null);
+
+        /// <summary>
+        /// Start of new Activity
+        /// </summary>
+        /// <param name="activityName"></param>
+        /// <param name="level"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
         IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null);
+
+        /// <summary>
+        /// Add an observer
+        /// </summary>
+        /// <param name="observer"></param>
+        /// <param name="level"></param>
+        /// <returns></returns>
         IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, LogLevel level);
     }
 }

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
@@ -35,8 +35,8 @@ namespace System.Diagnostics.Tracing
         /// Add an observer
         /// </summary>
         /// <param name="observer"></param>
-        /// <param name="level"></param>
+        /// <param name="filter"></param>
         /// <returns></returns>
-        IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, LogLevel level);
+        IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, LogLevel, bool> filter);
     }
 }

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/ILogger.cs
@@ -3,32 +3,35 @@
 namespace System.Diagnostics.Tracing
 {
     /// <summary>
-    /// A generic interface for logging.
+    /// A interface for logging.  It is supported by System.Diagnostics.Tracing.Logger, but it could in theory have
+    /// other implementations.   See Logger for more details on expected use.  
     /// </summary>
     public interface ILogger
     {
         /// <summary>
-        /// Checks if the given LogLevel is enabled.
+        /// returns true if the given verbosity level is active (will be logged if 'Log' is called).  
         /// </summary>
-        /// <param name="level"></param>
-        /// <returns></returns>
         bool IsEnabled(LogLevel level);
 
         /// <summary>
-        /// Log a single item
+        /// Log a single message.   A message has a name, a Verbosity level and a object that contains any other
+        /// information needed by the message.   Typical this object is created using an anonymous type.  
         /// </summary>
-        /// <param name="logItemName"></param>
-        /// <param name="level"></param>
-        /// <param name="arguments"></param>
-        void Log(string logItemName, LogLevel level, object arguments = null);
+
+        void Log(string messageName, LogLevel level, object arguments = null);
 
         /// <summary>
-        /// Start of new Activity
+        /// Indicats the begining of a new Activity.  Formally an activity is simply something that has a 
+        /// begining (start) and end (stop).   Like log messages Activities have names log levels and an 
+        /// argument object, however it returns an IDisposable, that is indended to be used in a 'using' 
+        /// clause that establishes the scope for the activity.   When the returns IDisposable is disposed
+        /// the 'Stop' message is sent.  
+        /// 
+        /// Typically the intent of an activity is to form this scope, so that information either logged
+        /// as part of the start, stop, (or any message in between), can be assciated with the activity
+        /// (and thus with each other).    It is expected that Activities nest, and thus form stacks. 
+        /// Typically activities that do not propery nest are treated as errors.   
         /// </summary>
-        /// <param name="activityName"></param>
-        /// <param name="level"></param>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
         IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null);
     }
 }

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
@@ -58,9 +58,9 @@ namespace System.Diagnostics.Tracing
                 return false;
             if (_filter != null)
             {
-                foreach (Func<string, LogLevel, bool> filter in _filter.GetInvocationList())
+                foreach (Predicate<LogLevel> filter in _filter.GetInvocationList())
                 {
-                    if (filter(Name, level))
+                    if (filter(level))
                         return true;
                 }
             }
@@ -110,7 +110,7 @@ namespace System.Diagnostics.Tracing
         /// You can filter them out yourself.   If there is only one subscriber (or all subscribers subscribe at the 
         /// same verbosity.  It works fine.   
         /// </summary>
-        public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, LogLevel, bool> filter)
+        public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<LogLevel> filter)
         {
             _filter += filter;
             return base.Subscribe(observer);
@@ -143,7 +143,7 @@ namespace System.Diagnostics.Tracing
         }
 
         private LogLevel _maxLevel;
-        private Func<string, LogLevel, bool> _filter;
+        private Predicate<LogLevel> _filter;
         #endregion 
     }
 

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
@@ -16,18 +16,18 @@ namespace System.Diagnostics.Tracing
         /// Creates a new logger with the given name.   A Logger is a TelemetrySource which understands LogLevel (verbosity levels)
         /// </summary>
         /// <param name="name"></param>
-        /// <param name="minLevel"></param>
-        public Logger(string name, LogLevel minLevel = Off) : base(name)
+        /// <param name="maxLevel"></param>
+        public Logger(string name, LogLevel maxLevel = LogLevel.Debug) : base(name)
         {
-            _minLevel = minLevel;     // Turn the verbosity to 'off' initially as there are no subscribers
+            _maxLevel = maxLevel;     // Turn the verbosity to 'off' initially as there are no subscribers
         }
 
         /// <summary>
         /// Returns true if 'level' is less verbose (more severe) than the current level for the Logger.  
         /// </summary>
-        public bool IsEnabled(LogLevel level)
+        public virtual bool IsEnabled(LogLevel level)
         {
-            if (level >= _minLevel)
+            if (level > _maxLevel)
                 return false;
             if (_filter != null)
             {
@@ -45,7 +45,7 @@ namespace System.Diagnostics.Tracing
         /// value if this logging happens in a 'hot' code path you should have a 'IsEnabled' check before calling
         /// it to avoid having to make the object just to throw it away if logging is off.   
         /// </summary>
-        public void Log(string logItemName, LogLevel level, object arguments = null)
+        public virtual void Log(string logItemName, LogLevel level, object arguments = null)
         {
             if (IsEnabled(level))
             {
@@ -58,7 +58,7 @@ namespace System.Diagnostics.Tracing
         /// It returns an IDisposable that when Disposed() will send a 'activityName'.Stop message with the SAME arguments 
         /// object.  Thus the arguments object itself can be used as an ID that links the two together.
         /// </summary>
-        public IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null)
+        public virtual IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null)
         {
             var activity = new LoggerActivity(this, level, activityName, arguments);
             if (IsEnabled(level))
@@ -107,8 +107,7 @@ namespace System.Diagnostics.Tracing
             object _arguments;
         }
 
-        const LogLevel Off = (LogLevel)(6);
-        private LogLevel _minLevel;
+        private LogLevel _maxLevel;
         private Func<string, LogLevel, bool> _filter;
         #endregion 
     }
@@ -157,12 +156,16 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         Warning,
         /// <summary>
-        /// All informational events, including previous levels
+        /// All informational, including previous levels
         /// </summary>
         Informational,
         /// <summary>
+        /// All verbose, including previous levels 
+        /// </summary>
+        Verbose,  // = 5
+        /// <summary>
         /// All events, including previous levels 
         /// </summary>
-        Verbose  // = 5
+        Debug  // = 6
     }
 }

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace System.Diagnostics.Tracing
+{
+    /// <summary>
+    /// 
+    /// 
+    /// Logger uses TelemetryListener in its implementation, which means that you can listen to the data presented here using TelemetryListener.AllListeners
+    /// </summary>
+    public class Logger : DiagnosticListener
+    {
+        /// <summary>
+        /// Creates a new logger with the given name.   A Logger is a TelemetrySource which understands LogLevel (verbosity levels)
+        /// </summary>
+        /// <param name="name"></param>
+        public Logger(string name) : base(name)
+        {
+            _level = Off;     // Turn the verbosity to 'off' initially as there are no subscribers
+        }
+
+        /// <summary>
+        /// Returns true if 'level' is less verbose (more severe) than the current level for the Logger.  
+        /// </summary>
+        public bool IsEnabled(LogLevel level)
+        {
+            return (level <= _level);
+        }
+
+        /// <summary>
+        /// Because calling this method typically requires a anonymous type to be generated for the 'arguments'
+        /// value if this logging happens in a 'hot' code path you should have a 'IsEnabled' check before calling
+        /// it to avoid having to make the object just to throw it away if logging is off.   
+        /// </summary>
+        public void Log(LogLevel level, string logItemName, object arguments = null)
+        {
+            if (IsEnabled(level))
+            {
+                 Write(logItemName, new LoggerArguments { Level = level, LoggerName = Name, Arguments = arguments });
+            }
+        }
+
+        /// <summary>
+        /// If the logger is enabled for 'level' then geneate a 'activityName'.Start message with the given argument.
+        /// It returns an IDisposable that when Disposed() will send a 'activityName'.Stop message with the SAME arguments 
+        /// object.  Thus the arguments object itself can be used as an ID that links the two together.
+        /// </summary>
+        public IDisposable ActivityStart(LogLevel level, string activityName, object arguments)
+        {
+            var activity = new LoggerActivity(this, level, activityName, arguments);
+            if (IsEnabled(level))
+                Log(level, activityName + ".Start", arguments);
+            else
+                activity.Disposed = true;
+            return activity;
+        }
+
+        /// <summary>
+        /// Subscribe to the Logger, sending events to 'observer' for any logging that is enabled for verbosity 'level'.  
+        /// 
+        /// Note that in multi-subscriber cases you MAY get messages that have a more verbose level than you asked for.
+        /// You can filter them out yourself.   If there is only one subscriber (or all subscribers subscribe at the 
+        /// same verbosity.  It works fine.   
+        /// </summary>
+        public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, LogLevel level)
+        {
+            // We turn up the volume to the maximum of any subscriber.
+            if (_level < level || _level == Off)
+                _level = level;
+            return base.Subscribe(observer);
+        }
+
+        #region private
+        const LogLevel Off = (LogLevel)(-1);
+
+        private sealed class LoggerActivity : IDisposable
+        {
+            public LoggerActivity(Logger logger, LogLevel level, string activityName, object arguments)
+            {
+                _logger = logger;
+                _level = level;
+                _activityName = activityName;
+                _arguments = arguments;
+            }
+            public bool Disposed;
+
+            public void Dispose()
+            {
+                if (!Disposed)
+                {
+                    Disposed = true;
+                    _logger.Log(_level, _activityName + ".Stop", _arguments);
+                }
+            }
+            Logger _logger;
+            LogLevel _level;
+            string _activityName;
+            object _arguments;
+        }
+
+        private LogLevel _level;
+        #endregion 
+    }
+
+    /// <summary>
+    /// LoggerArguments is the payload that you get back from the LogStream.   The string in the KeyValue pair
+    /// is the name of the logging message, and the object is a LoggerArguments.  
+    /// </summary>
+    public class LoggerArguments
+    {
+        /// <summary>
+        /// This is the verbosity level that was passed to the 'Log' function 
+        /// </summary>
+        public LogLevel Level;
+        /// <summary>
+        /// This is the name of the logger that logged the event 
+        /// </summary>
+        public string LoggerName;
+        /// <summary>
+        /// This is the 'arguments parameter passed to the 'Log' method.  
+        /// </summary>
+        public object Arguments;
+        // TODO should we add a IsActivity? (They can get that from the suffix).  
+    }
+
+    /// <summary>
+    /// This is identical to System.Diagnostics.Tracing.EventLevel.  It is only here to avoid taking a dependency on that type. 
+    /// They should be kept in sync. 
+    /// </summary>
+    public enum LogLevel
+    {
+        /// <summary>
+        /// Log always. This level is not supported for subscribers. 
+        /// </summary>
+        LogAlways = 0,
+        /// <summary>
+        /// Only critical errors
+        /// </summary>
+        Critical,
+        /// <summary>
+        /// All errors, including previous levels
+        /// </summary>
+        Error,
+        /// <summary>
+        /// All warnings, including previous levels
+        /// </summary>
+        Warning,
+        /// <summary>
+        /// All informational events, including previous levels
+        /// </summary>
+        Informational,
+        /// <summary>
+        /// All events, including previous levels 
+        /// </summary>
+        Verbose  // = 5
+    }
+}

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
@@ -8,22 +8,25 @@ namespace System.Diagnostics.Tracing
     /// <summary>
     /// 
     /// 
-    /// Logger uses TelemetryListener in its implementation, which means that you can listen to the data presented here using TelemetryListener.AllListeners
+    /// Logger uses DiagnosticListener in its implementation, which means that you can listen to the data presented here using DiagnosticListener.AllListeners
     /// </summary>
     public class Logger : DiagnosticListener, ILogger
     {
         /// <summary>
-        /// Creates a new logger with the given name.   A Logger is a TelemetrySource which understands LogLevel (verbosity levels)
+        /// Creates a new logger with the given name.   A Logger is a DiagnosticSource which understands LogLevel (verbosity levels)
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="maxLevel"></param>
+        /// <param name="name">The name of the logger.  This is often the comonent name.</param>
+        /// <param name="maxLevel">The most verbose message that will ever be logged.  It defaults to Debug which, being the most
+        /// verbose level, means any message will be logged.   Useful in the context of security to make it less likely that 
+        /// private (debug) information does not get logged.  It also increases the efficienctly of IsEnabled if you only wish
+        /// to EVER turn low-verbosity events.</param>
         public Logger(string name, LogLevel maxLevel = LogLevel.Debug) : base(name)
         {
-            _maxLevel = maxLevel;     // Turn the verbosity to 'off' initially as there are no subscribers
+            _maxLevel = maxLevel;  
         }
 
         /// <summary>
-        /// Returns true if 'level' is less verbose (more severe) than the current level for the Logger.  
+        /// Returns true if 'level' is less verbose (more important) than the current level for the Logger.  
         /// </summary>
         public virtual bool IsEnabled(LogLevel level)
         {

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
@@ -58,9 +58,9 @@ namespace System.Diagnostics.Tracing
                 return false;
             if (_filter != null)
             {
-                foreach (Predicate<LogLevel> filter in _filter.GetInvocationList())
+                foreach (Func<string, LogLevel, bool> filter in _filter.GetInvocationList())
                 {
-                    if (filter(level))
+                    if (filter(Name, level))
                         return true;
                 }
             }
@@ -110,7 +110,7 @@ namespace System.Diagnostics.Tracing
         /// You can filter them out yourself.   If there is only one subscriber (or all subscribers subscribe at the 
         /// same verbosity.  It works fine.   
         /// </summary>
-        public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<LogLevel> filter)
+        public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, LogLevel, bool> filter)
         {
             _filter += filter;
             return base.Subscribe(observer);
@@ -143,7 +143,7 @@ namespace System.Diagnostics.Tracing
         }
 
         private LogLevel _maxLevel;
-        private Predicate<LogLevel> _filter;
+        private Func<string, LogLevel, bool> _filter;
         #endregion 
     }
 

--- a/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
+++ b/src/System.Diagnostics.Tracing.Logger/src/System/Diagnostics/Tracing/Logger.cs
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-using System.Diagnostics;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 
 namespace System.Diagnostics.Tracing
 {
@@ -14,7 +10,7 @@ namespace System.Diagnostics.Tracing
     /// 
     /// Logger uses TelemetryListener in its implementation, which means that you can listen to the data presented here using TelemetryListener.AllListeners
     /// </summary>
-    public class Logger : DiagnosticListener
+    public class Logger : DiagnosticListener, ILogger
     {
         /// <summary>
         /// Creates a new logger with the given name.   A Logger is a TelemetrySource which understands LogLevel (verbosity levels)
@@ -38,7 +34,7 @@ namespace System.Diagnostics.Tracing
         /// value if this logging happens in a 'hot' code path you should have a 'IsEnabled' check before calling
         /// it to avoid having to make the object just to throw it away if logging is off.   
         /// </summary>
-        public void Log(LogLevel level, string logItemName, object arguments = null)
+        public void Log(string logItemName, LogLevel level, object arguments = null)
         {
             if (IsEnabled(level))
             {
@@ -51,11 +47,11 @@ namespace System.Diagnostics.Tracing
         /// It returns an IDisposable that when Disposed() will send a 'activityName'.Stop message with the SAME arguments 
         /// object.  Thus the arguments object itself can be used as an ID that links the two together.
         /// </summary>
-        public IDisposable ActivityStart(LogLevel level, string activityName, object arguments)
+        public IDisposable ActivityStart(string activityName, LogLevel level = LogLevel.Critical, object arguments = null)
         {
             var activity = new LoggerActivity(this, level, activityName, arguments);
             if (IsEnabled(level))
-                Log(level, activityName + ".Start", arguments);
+                Log(activityName + ".Start", level, arguments);
             else
                 activity.Disposed = true;
             return activity;
@@ -95,7 +91,7 @@ namespace System.Diagnostics.Tracing
                 if (!Disposed)
                 {
                     Disposed = true;
-                    _logger.Log(_level, _activityName + ".Stop", _arguments);
+                    _logger.Log(_activityName + ".Stop", _level, _arguments);
                 }
             }
             Logger _logger;

--- a/src/System.Diagnostics.Tracing.Logger/src/project.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.20",
+    "System.Threading": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.DiagnosticSource": "4.0.0-beta-*"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing.Logger/src/project.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
+    "System.Runtime": "4.0.0",
     "System.Threading": "4.0.0",
     "System.Diagnostics.Debug": "4.0.0",
     "System.Diagnostics.DiagnosticSource": "4.0.0-beta-*"

--- a/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
@@ -12,7 +12,7 @@
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Tracing": "4.0.0",
@@ -111,15 +111,17 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZIzF+hsqa7Ujp+8chy8qRA5HuxanvltJ6/Kb/TxPCQ8thgQ3BlbED8MKeK7SWWeJijAlhKMw7MOd3LzX7cs8eA==",
+      "sha512": "1iN7EMAvI5vEGHoOZv+6vC8r0Wf6ruA3p6jGvSdhOi9SX0utwR6DCRNNO+OctDXvOGElZblqa/OfbalX0bsAew==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
+        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg.sha512",
+        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
       ]
     },

--- a/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
@@ -1,0 +1,288 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Diagnostics.Debug/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Threading/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Diagnostics.Debug/4.0.0": {
+      "type": "package",
+      "sha512": "AYJsLLGDVTC/nyURjgAo7Lpye0+HuSkcQujUf+NgQVdC/C/ky5NyamQHCforHJzgqspitMMtBe8B4UBdGXy1zQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Diagnostics.Debug.xml",
+        "ref/netcore50/es/System.Diagnostics.Debug.xml",
+        "ref/netcore50/fr/System.Diagnostics.Debug.xml",
+        "ref/netcore50/it/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ja/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ko/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ru/System.Diagnostics.Debug.xml",
+        "ref/netcore50/System.Diagnostics.Debug.dll",
+        "ref/netcore50/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Diagnostics.Debug.4.0.0.nupkg",
+        "System.Diagnostics.Debug.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Y2VYZb9pgMQgsJHIdYsmAtuv0JxUBi9qrzkmPDeqYjaD0nSAfxbueRQZJz9l8Gu97MPz004YhLEqJ85uyvztvQ==",
+      "files": [
+        "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
+        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
+        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0.nupkg",
+        "System.Private.Uri.4.0.0.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20.nupkg",
+        "System.Runtime.4.0.20.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Threading/4.0.0": {
+      "type": "package",
+      "sha512": "H6O/9gUrjPDNYanh/7OFGAZHjVXvEuITD0RcnjfvIV04HOGrOPqUBU0kmz9RIX/7YGgCQn1o1S2DX6Cuv8kVGQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.xml",
+        "ref/netcore50/es/System.Threading.xml",
+        "ref/netcore50/fr/System.Threading.xml",
+        "ref/netcore50/it/System.Threading.xml",
+        "ref/netcore50/ja/System.Threading.xml",
+        "ref/netcore50/ko/System.Threading.xml",
+        "ref/netcore50/ru/System.Threading.xml",
+        "ref/netcore50/System.Threading.dll",
+        "ref/netcore50/System.Threading.xml",
+        "ref/netcore50/zh-hans/System.Threading.xml",
+        "ref/netcore50/zh-hant/System.Threading.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.4.0.0.nupkg",
+        "System.Threading.4.0.0.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0": {
+      "type": "package",
+      "sha512": "dA3y1B6Pc8mNt9obhEWWGGpvEakS51+nafXpmM/Z8IF847GErLXGTjdfA+AYEKszfFbH7SVLWUklXhYeeSQ1lw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.Tasks.xml",
+        "ref/netcore50/es/System.Threading.Tasks.xml",
+        "ref/netcore50/fr/System.Threading.Tasks.xml",
+        "ref/netcore50/it/System.Threading.Tasks.xml",
+        "ref/netcore50/ja/System.Threading.Tasks.xml",
+        "ref/netcore50/ko/System.Threading.Tasks.xml",
+        "ref/netcore50/ru/System.Threading.Tasks.xml",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Tasks.4.0.0.nupkg",
+        "System.Threading.Tasks.4.0.0.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Runtime >= 4.0.20",
+      "System.Threading >= 4.0.0",
+      "System.Diagnostics.Debug >= 4.0.0",
+      "System.Diagnostics.DiagnosticSource >= 4.0.0-beta-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
@@ -12,7 +12,7 @@
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Tracing": "4.0.0",
@@ -35,25 +35,10 @@
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0": {
+      "System.Runtime/4.0.0": {
         "type": "package",
-        "compile": {
-          "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.Uri.dll": {}
-        }
-      },
-      "System.Runtime/4.0.20": {
-        "type": "package",
-        "dependencies": {
-          "System.Private.Uri": "4.0.0"
-        },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
       "System.Threading/4.0.0": {
@@ -126,15 +111,15 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uSNqrGOs66HTQxycuc2HuJ3PRej5HaeUDwSOkSvONJF4dJV4EKliDEg7xCAmxk0f8IwCr1jeTo2i/Rt2PGslQw==",
+      "sha512": "ZIzF+hsqa7Ujp+8chy8qRA5HuxanvltJ6/Kb/TxPCQ8thgQ3BlbED8MKeK7SWWeJijAlhKMw7MOd3LzX7cs8eA==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
       ]
     },
@@ -184,33 +169,19 @@
         "System.Diagnostics.Tracing.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.0": {
+    "System.Runtime/4.0.0": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
       "files": [
-        "lib/DNXCore50/System.Private.Uri.dll",
-        "lib/netcore50/System.Private.Uri.dll",
-        "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.4.0.0.nupkg",
-        "System.Private.Uri.4.0.0.nupkg.sha512",
-        "System.Private.Uri.nuspec"
-      ]
-    },
-    "System.Runtime/4.0.20": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
-      "files": [
-        "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net46/_._",
-        "lib/netcore50/System.Runtime.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "License.rtf",
         "ref/dotnet/de/System.Runtime.xml",
         "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
@@ -224,12 +195,25 @@
         "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net46/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.20.nupkg",
-        "System.Runtime.4.0.20.nupkg.sha512",
+        "System.Runtime.4.0.0.nupkg",
+        "System.Runtime.4.0.0.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
@@ -332,7 +316,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "System.Runtime >= 4.0.20",
+      "System.Runtime >= 4.0.0",
       "System.Threading >= 4.0.0",
       "System.Diagnostics.Debug >= 4.0.0",
       "System.Diagnostics.DiagnosticSource >= 4.0.0-beta-*"

--- a/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
@@ -12,9 +12,10 @@
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
+          "System.Diagnostics.Tracing": "4.0.0",
           "System.Runtime": "4.0.0",
           "System.Threading": "4.0.0"
         },
@@ -23,6 +24,15 @@
         },
         "runtime": {
           "lib/dotnet/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
         }
       },
       "System.Private.Uri/4.0.0": {
@@ -116,18 +126,62 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Y2VYZb9pgMQgsJHIdYsmAtuv0JxUBi9qrzkmPDeqYjaD0nSAfxbueRQZJz9l8Gu97MPz004YhLEqJ85uyvztvQ==",
+      "sha512": "uSNqrGOs66HTQxycuc2HuJ3PRej5HaeUDwSOkSvONJF4dJV4EKliDEg7xCAmxk0f8IwCr1jeTo2i/Rt2PGslQw==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
-        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.0": {
+      "type": "package",
+      "sha512": "tzqQJPgD4bKs0eE5Gx9HEsxiHSBGcL42PImkjhwXTQK6iQbLTTB9mi+G7mUyEjlH8LUcm7F5QHEs+O+LpruOrQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/it/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/es/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/fr/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/it/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ja/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ko/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ru/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/netcore50/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Diagnostics.Tracing.4.0.0.nupkg",
+        "System.Diagnostics.Tracing.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {

--- a/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/src/project.lock.json
@@ -12,7 +12,7 @@
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Tracing": "4.0.0",
@@ -111,17 +111,15 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1iN7EMAvI5vEGHoOZv+6vC8r0Wf6ruA3p6jGvSdhOi9SX0utwR6DCRNNO+OctDXvOGElZblqa/OfbalX0bsAew==",
+      "sha512": "ZIzF+hsqa7Ujp+8chy8qRA5HuxanvltJ6/Kb/TxPCQ8thgQ3BlbED8MKeK7SWWeJijAlhKMw7MOd3LzX7cs8eA==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
-        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
       ]
     },

--- a/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
+++ b/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, LogLevel.Verbose);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
@@ -44,7 +44,7 @@ namespace System.Diagnostics.Tracing.Tests
             Logger logger = new Logger("Component1");
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, LogLevel.Verbose);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
 
             logger.Log("StructPayLoad", LogLevel.Verbose, new Payload() { Name = "Hi", Id = 67 });
 
@@ -69,12 +69,12 @@ namespace System.Diagnostics.Tracing.Tests
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), false);
 
             IObserver<kvp> listener1 = MakeObserver<kvp>();
-            logger.Subscribe(listener1, LogLevel.Critical);
+            logger.Subscribe(listener1, (name, level) => level <= LogLevel.Critical);
             Assert.Equal(logger.IsEnabled(LogLevel.Verbose), false);
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
 
             IObserver<kvp> listener2 = MakeObserver<kvp>();
-            logger.Subscribe(listener2, LogLevel.Verbose);
+            logger.Subscribe(listener2, (name, level) => level <= LogLevel.Verbose);
             Assert.Equal(logger.IsEnabled(LogLevel.Verbose), true);
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
         }
@@ -89,7 +89,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, LogLevel.Critical);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Critical);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
             logger.Log("IntPayLoad", LogLevel.Critical, 6);
@@ -115,7 +115,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, LogLevel.Informational);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Informational);
 
             logger.LogFormat("FormattedIntPayLoad", LogLevel.Informational, "payload value = %d", 5);
             Assert.Equal(result.Count, 1);
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, LogLevel.Verbose);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
 
             using (var i = logger.ActivityStart("Main", LogLevel.Error, 4))
             {
@@ -180,8 +180,8 @@ namespace System.Diagnostics.Tracing.Tests
             List<kvp> result2 = new List<kvp>();
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
-            logger.Subscribe(listListener1, LogLevel.Verbose);
-            logger.Subscribe(listListener2, LogLevel.Verbose);
+            logger.Subscribe(listListener1, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener2, (name, level) => level <= LogLevel.Verbose);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
@@ -214,12 +214,12 @@ namespace System.Diagnostics.Tracing.Tests
             List<kvp> result2 = new List<kvp>();
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
-            logger.Subscribe(listListener1, LogLevel.Critical);
+            logger.Subscribe(listListener1, (name, level) => level <= LogLevel.Critical);
             logger.Log("IntPayLoad", LogLevel.Error, 5);
             Assert.Equal(result1.Count, 0);
 
             // This causes effective log level of all subsribers to be Error
-            logger.Subscribe(listListener2, LogLevel.Error);
+            logger.Subscribe(listListener2, (name, level) => level <= LogLevel.Error);
             logger.Log("IntPayLoad", LogLevel.Error, 5);
 
             // Both subscribers receive log information
@@ -238,8 +238,8 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger1.Subscribe(listListener, LogLevel.Critical);
-            logger2.Subscribe(listListener, LogLevel.Error);
+            logger1.Subscribe(listListener, (name, level) => level <= LogLevel.Critical);
+            logger2.Subscribe(listListener, (name, level) => level <= LogLevel.Error);
 
             logger1.Log("IntPayLoad", LogLevel.Critical, 5);
             logger2.Log("IntPayLoad", LogLevel.Critical, 6);

--- a/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
+++ b/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener, level => level <= LogLevel.Verbose);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
@@ -44,10 +44,10 @@ namespace System.Diagnostics.Tracing.Tests
             Logger logger = new Logger("Component1");
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener, level => level <= LogLevel.Verbose);
 
             logger.Log("StructPayLoad", LogLevel.Verbose, new Payload() { Name = "Hi", Id = 67 });
-
+       
             Assert.Equal(result.Count, 1);
             Assert.Equal(result[0].Key, "StructPayLoad");
             LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
@@ -69,12 +69,12 @@ namespace System.Diagnostics.Tracing.Tests
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), false);
 
             IObserver<kvp> listener1 = MakeObserver<kvp>();
-            logger.Subscribe(listener1, (name, level) => level <= LogLevel.Critical);
+            logger.Subscribe(listener1, level => level <= LogLevel.Critical);
             Assert.Equal(logger.IsEnabled(LogLevel.Verbose), false);
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
 
             IObserver<kvp> listener2 = MakeObserver<kvp>();
-            logger.Subscribe(listener2, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listener2, level => level <= LogLevel.Verbose);
             Assert.Equal(logger.IsEnabled(LogLevel.Verbose), true);
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
         }
@@ -89,7 +89,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Critical);
+            logger.Subscribe(listListener, level => level <= LogLevel.Critical);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
             logger.Log("IntPayLoad", LogLevel.Critical, 6);
@@ -115,7 +115,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Informational);
+            logger.Subscribe(listListener, level => level <= LogLevel.Informational);
 
             logger.LogFormat("FormattedIntPayLoad", LogLevel.Informational, "payload value = %d", 5);
             Assert.Equal(result.Count, 1);
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener, level => level <= LogLevel.Verbose);
 
             using (var i = logger.ActivityStart("Main", LogLevel.Error, 4))
             {
@@ -180,8 +180,8 @@ namespace System.Diagnostics.Tracing.Tests
             List<kvp> result2 = new List<kvp>();
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
-            logger.Subscribe(listListener1, (name, level) => level <= LogLevel.Verbose);
-            logger.Subscribe(listListener2, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener1, level => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener2, level => level <= LogLevel.Verbose);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
@@ -214,12 +214,12 @@ namespace System.Diagnostics.Tracing.Tests
             List<kvp> result2 = new List<kvp>();
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
-            logger.Subscribe(listListener1, (name, level) => level <= LogLevel.Critical);
+            logger.Subscribe(listListener1, level => level <= LogLevel.Critical);
             logger.Log("IntPayLoad", LogLevel.Error, 5);
             Assert.Equal(result1.Count, 0);
 
             // This causes effective log level of all subsribers to be Error
-            logger.Subscribe(listListener2, (name, level) => level <= LogLevel.Error);
+            logger.Subscribe(listListener2, level => level <= LogLevel.Error);
             logger.Log("IntPayLoad", LogLevel.Error, 5);
 
             // Both subscribers receive log information
@@ -238,8 +238,8 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger1.Subscribe(listListener, (name, level) => level <= LogLevel.Critical);
-            logger2.Subscribe(listListener, (name, level) => level <= LogLevel.Error);
+            logger1.Subscribe(listListener, level => level <= LogLevel.Critical);
+            logger2.Subscribe(listListener, level => level <= LogLevel.Error);
 
             logger1.Log("IntPayLoad", LogLevel.Critical, 5);
             logger2.Log("IntPayLoad", LogLevel.Critical, 6);

--- a/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
+++ b/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
@@ -1,0 +1,353 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+using kvp = System.Collections.Generic.KeyValuePair<string, object>;
+
+namespace System.Diagnostics.Tracing.Tests
+{
+    /// <summary>
+    /// Tests for TelemetrySource and TelemetryListener
+    /// </summary>
+    public class LoggerTest
+    {
+        /// <summary>
+        /// Trivial example of passing an integer
+        /// </summary>
+        [Fact]
+        public void IntPayload()
+        {
+            Logger logger = new Logger("Component1");
+
+            List<kvp> result = new List<kvp>();
+            IObserver<kvp> listListener = new ObserverToList<kvp>(result);
+            logger.Subscribe(listListener, LogLevel.Verbose);
+
+            logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+
+            Assert.Equal(result.Count, 1);
+            Assert.Equal(result[0].Key, "IntPayLoad");
+
+            LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Verbose);
+            Assert.Equal(loggerArgs.Arguments, 5);
+        }
+
+        /// <summary>
+        /// slightly less trivial of passing a structure with a couple of fields 
+        /// </summary>
+        [Fact]
+        public void StructPayload()
+        {
+            Logger logger = new Logger("Component1");
+            List<kvp> result = new List<kvp>();
+            IObserver<kvp> listListener = new ObserverToList<kvp>(result);
+            logger.Subscribe(listListener, LogLevel.Verbose);
+
+            logger.Log(LogLevel.Verbose, "StructPayLoad", new Payload() { Name = "Hi", Id = 67 });
+
+            Assert.Equal(result.Count, 1);
+            Assert.Equal(result[0].Key, "StructPayLoad");
+            LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Verbose);
+            var payload = loggerArgs.Arguments as Payload;
+            Assert.Equal(payload.Name, "Hi");
+            Assert.Equal(payload.Id, 67);
+        }
+
+        /// <summary>
+        /// Simple tests for the IsEnabled method.
+        /// </summary>
+        [Fact]
+        public void IsEnabled()
+        {
+            Logger logger = new Logger("Component1");
+            Assert.Equal(logger.IsEnabled(LogLevel.Verbose), false);
+            Assert.Equal(logger.IsEnabled(LogLevel.Critical), false);
+
+            IObserver<kvp> listener1 = MakeObserver<kvp>();
+            logger.Subscribe(listener1, LogLevel.Critical);
+            Assert.Equal(logger.IsEnabled(LogLevel.Verbose), false);
+            Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
+
+            IObserver<kvp> listener2 = MakeObserver<kvp>();
+            logger.Subscribe(listener2, LogLevel.Verbose);
+            Assert.Equal(logger.IsEnabled(LogLevel.Verbose), true);
+            Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
+        }
+
+        /// <summary>
+        /// Ensure that logLevel is honored when logging messages
+        /// </summary>
+        [Fact]
+        public void LogLevelTest()
+        {
+            Logger logger = new Logger("Component1");
+
+            List<kvp> result = new List<kvp>();
+            IObserver<kvp> listListener = new ObserverToList<kvp>(result);
+            logger.Subscribe(listListener, LogLevel.Critical);
+
+            logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+            logger.Log(LogLevel.Critical, "IntPayLoad", 6);
+            logger.Log(LogLevel.Warning, "IntPayLoad", 7);
+            logger.Log(LogLevel.Error, "IntPayLoad", 8);
+
+            Assert.Equal(result.Count, 1);
+            Assert.Equal(result[0].Key, "IntPayLoad");
+
+            LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Critical);
+            Assert.Equal(loggerArgs.Arguments, 6);
+        }
+
+        /// <summary>
+        /// Ensure that arguments are received by subscribers
+        /// </summary>
+        [Fact]
+        public void SubclassLoggerArguments()
+        {
+            Logger logger = new Logger("Component1");
+
+            List<kvp> result = new List<kvp>();
+            IObserver<kvp> listListener = new ObserverToList<kvp>(result);
+            logger.Subscribe(listListener, LogLevel.Informational);
+
+            logger.LogFormat(LogLevel.Informational, "FormattedIntPayLoad", "payload value = %d", 5);
+            Assert.Equal(result.Count, 1);
+            Assert.Equal(result[0].Key, "FormattedIntPayLoad");
+
+            LoggerArgumentsWithFormat loggerArgs = result[0].Value as LoggerArgumentsWithFormat;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Informational);
+            Assert.Equal(loggerArgs.Format, "payload value = %d");
+            Assert.Equal(loggerArgs.Arguments, 5);
+        }
+
+        /// <summary>
+        /// Basic test for activity
+        /// </summary>
+        [Fact]
+        public void Activity()
+        {
+            Logger logger = new Logger("Component1");
+
+            List<kvp> result = new List<kvp>();
+            IObserver<kvp> listListener = new ObserverToList<kvp>(result);
+            logger.Subscribe(listListener, LogLevel.Verbose);
+
+            using (var i = logger.ActivityStart(LogLevel.Error, "Main", 4))
+            {
+                logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+            }
+            Assert.Equal(result.Count, 3);
+
+            Assert.Equal(result[0].Key, "Main.Start");
+            LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Error);
+            Assert.Equal(loggerArgs.Arguments, 4);
+
+            Assert.Equal(result[1].Key, "IntPayLoad");
+            loggerArgs = result[1].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Verbose);
+            Assert.Equal(loggerArgs.Arguments, 5);
+
+            Assert.Equal(result[2].Key, "Main.Stop");
+            loggerArgs = result[2].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Error);
+            Assert.Equal(loggerArgs.Arguments, 4);
+
+        }
+
+        /// <summary>
+        /// Test if it works when you have two subscribers active simultaneously
+        /// </summary>
+        [Fact]
+        public void MultiSubscriber()
+        {
+            Logger logger = new Logger("Component1");
+
+            List<kvp> result1 = new List<kvp>();
+            IObserver<kvp> listListener1 = new ObserverToList<kvp>(result1);
+
+            List<kvp> result2 = new List<kvp>();
+            IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
+
+            logger.Subscribe(listListener1, LogLevel.Verbose);
+            logger.Subscribe(listListener2, LogLevel.Verbose);
+
+            logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+
+            Assert.Equal(result1.Count, 1);
+            Assert.Equal(result1[0].Key, "IntPayLoad");
+            LoggerArguments loggerArgs = result1[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Verbose);
+            Assert.Equal(loggerArgs.Arguments, 5);
+
+            Assert.Equal(result2.Count, 1);
+            Assert.Equal(result2[0].Key, "IntPayLoad");
+            loggerArgs = result2[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+            Assert.Equal(loggerArgs.Level, LogLevel.Verbose);
+            Assert.Equal(loggerArgs.Arguments, 5);
+        }
+
+        /// <summary>
+        /// Loglevel test in case of multisubscriber
+        /// </summary>
+        [Fact]
+        public void MultiSubscriberLogLevel()
+        {
+            Logger logger = new Logger("Component1");
+
+            List<kvp> result1 = new List<kvp>();
+            IObserver<kvp> listListener1 = new ObserverToList<kvp>(result1);
+
+            List<kvp> result2 = new List<kvp>();
+            IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
+
+            logger.Subscribe(listListener1, LogLevel.Critical);
+            logger.Log(LogLevel.Error, "IntPayLoad", 5);
+            Assert.Equal(result1.Count, 0);
+
+            // This causes effective log level of all subsribers to be Error
+            logger.Subscribe(listListener2, LogLevel.Error);
+            logger.Log(LogLevel.Error, "IntPayLoad", 5);
+
+            // Both subscribers receive log information
+            Assert.Equal(result1.Count, 1);
+            Assert.Equal(result2.Count, 1);
+        }
+
+        /// <summary>
+        /// Test if it works when you have two loggers
+        /// </summary>
+        [Fact]
+        public void MultiLogger()
+        {
+            Logger logger1 = new Logger("Component1");
+            Logger logger2 = new Logger("Component2");
+
+            List<kvp> result = new List<kvp>();
+            IObserver<kvp> listListener = new ObserverToList<kvp>(result);
+            logger1.Subscribe(listListener, LogLevel.Critical);
+            logger2.Subscribe(listListener, LogLevel.Error);
+
+            logger1.Log(LogLevel.Critical, "IntPayLoad", 5);
+            logger2.Log(LogLevel.Critical, "IntPayLoad", 6);
+            logger1.Log(LogLevel.Error, "IntPayLoad", 7);
+
+            Assert.Equal(result.Count, 2);
+            LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component1");
+
+            loggerArgs = result[1].Value as LoggerArguments;
+            Assert.Equal(loggerArgs.LoggerName, "Component2");
+        }
+
+        #region Helpers 
+        /// <summary>
+        /// Used to make an observer out of a action delegate. 
+        /// </summary>
+        private static IObserver<T> MakeObserver<T>(
+            Action<T> onNext = null, Action onCompleted = null)
+        {
+            return new Observer<T>(onNext, onCompleted);
+        }
+
+        /// <summary>
+        /// Used in the implementation of MakeObserver.  
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        private class Observer<T> : IObserver<T>
+        {
+            public Observer(Action<T> onNext, Action onCompleted)
+            {
+                _onNext = onNext ?? new Action<T>(_ => { });
+                _onCompleted = onCompleted ?? new Action(() => { });
+            }
+
+            public void OnCompleted() { _onCompleted(); }
+            public void OnError(Exception error) { }
+            public void OnNext(T value) { _onNext(value); }
+
+            private Action<T> _onNext;
+            private Action _onCompleted;
+        }
+        #endregion 
+    }
+
+    // Takes an IObserver and returns a List<T> that are the elements observed.
+    // Will assert on error and 'Completed' is set if the 'OnCompleted' callback
+    // is issued.  
+    internal class ObserverToList<T> : IObserver<T>
+    {
+        public ObserverToList(List<T> output, Predicate<T> filter = null, string name = null)
+        {
+            _output = output;
+            _output.Clear();
+            _filter = filter;
+            _name = name;
+        }
+
+        public bool Completed { get; private set; }
+
+        #region private
+
+        public void OnCompleted()
+        {
+            Completed = true;
+        }
+
+        public void OnError(Exception error)
+        {
+            // No errors should be thrown.
+            throw new ShouldNotBeInvokedException();
+        }
+
+        public void OnNext(T value)
+        {
+            Assert.False(Completed);
+            if (_filter == null || _filter(value))
+                _output.Add(value);
+        }
+
+        private List<T> _output;
+        private Predicate<T> _filter;
+        private string _name;  // for debugging 
+        #endregion
+    }
+
+    /// <summary>
+    /// Trivial class used for payloads.  (Usually anonymous types are used.  
+    /// </summary>
+    internal class Payload
+    {
+        public string Name { get; set; }
+        public int Id { get; set; }
+    }
+
+    public static class LoggerExtensions
+    {
+        public static void LogFormat(this Logger logger, LogLevel level, string logItemName, string format, object arguments = null)
+        {
+            if (logger.IsEnabled(level))
+            {
+                logger.Write(logItemName, new LoggerArgumentsWithFormat { Level = level, LoggerName = logger.Name, Format = format, Arguments = arguments });
+            }
+        }
+    }
+
+    internal class LoggerArgumentsWithFormat : LoggerArguments
+    {
+        public string Format { get; set; }
+    }
+}

--- a/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
+++ b/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, level => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
@@ -44,10 +44,10 @@ namespace System.Diagnostics.Tracing.Tests
             Logger logger = new Logger("Component1");
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, level => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
 
             logger.Log("StructPayLoad", LogLevel.Verbose, new Payload() { Name = "Hi", Id = 67 });
-       
+
             Assert.Equal(result.Count, 1);
             Assert.Equal(result[0].Key, "StructPayLoad");
             LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
@@ -69,12 +69,12 @@ namespace System.Diagnostics.Tracing.Tests
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), false);
 
             IObserver<kvp> listener1 = MakeObserver<kvp>();
-            logger.Subscribe(listener1, level => level <= LogLevel.Critical);
+            logger.Subscribe(listener1, (name, level) => level <= LogLevel.Critical);
             Assert.Equal(logger.IsEnabled(LogLevel.Verbose), false);
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
 
             IObserver<kvp> listener2 = MakeObserver<kvp>();
-            logger.Subscribe(listener2, level => level <= LogLevel.Verbose);
+            logger.Subscribe(listener2, (name, level) => level <= LogLevel.Verbose);
             Assert.Equal(logger.IsEnabled(LogLevel.Verbose), true);
             Assert.Equal(logger.IsEnabled(LogLevel.Critical), true);
         }
@@ -89,7 +89,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, level => level <= LogLevel.Critical);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Critical);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
             logger.Log("IntPayLoad", LogLevel.Critical, 6);
@@ -115,7 +115,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, level => level <= LogLevel.Informational);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Informational);
 
             logger.LogFormat("FormattedIntPayLoad", LogLevel.Informational, "payload value = %d", 5);
             Assert.Equal(result.Count, 1);
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger.Subscribe(listListener, level => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener, (name, level) => level <= LogLevel.Verbose);
 
             using (var i = logger.ActivityStart("Main", LogLevel.Error, 4))
             {
@@ -180,8 +180,8 @@ namespace System.Diagnostics.Tracing.Tests
             List<kvp> result2 = new List<kvp>();
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
-            logger.Subscribe(listListener1, level => level <= LogLevel.Verbose);
-            logger.Subscribe(listListener2, level => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener1, (name, level) => level <= LogLevel.Verbose);
+            logger.Subscribe(listListener2, (name, level) => level <= LogLevel.Verbose);
 
             logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
@@ -214,12 +214,12 @@ namespace System.Diagnostics.Tracing.Tests
             List<kvp> result2 = new List<kvp>();
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
-            logger.Subscribe(listListener1, level => level <= LogLevel.Critical);
+            logger.Subscribe(listListener1, (name, level) => level <= LogLevel.Critical);
             logger.Log("IntPayLoad", LogLevel.Error, 5);
             Assert.Equal(result1.Count, 0);
 
             // This causes effective log level of all subsribers to be Error
-            logger.Subscribe(listListener2, level => level <= LogLevel.Error);
+            logger.Subscribe(listListener2, (name, level) => level <= LogLevel.Error);
             logger.Log("IntPayLoad", LogLevel.Error, 5);
 
             // Both subscribers receive log information
@@ -238,8 +238,8 @@ namespace System.Diagnostics.Tracing.Tests
 
             List<kvp> result = new List<kvp>();
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
-            logger1.Subscribe(listListener, level => level <= LogLevel.Critical);
-            logger2.Subscribe(listListener, level => level <= LogLevel.Error);
+            logger1.Subscribe(listListener, (name, level) => level <= LogLevel.Critical);
+            logger2.Subscribe(listListener, (name, level) => level <= LogLevel.Error);
 
             logger1.Log("IntPayLoad", LogLevel.Critical, 5);
             logger2.Log("IntPayLoad", LogLevel.Critical, 6);

--- a/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
+++ b/src/System.Diagnostics.Tracing.Logger/tests/LoggerTests.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics.Tracing.Tests
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
             logger.Subscribe(listListener, LogLevel.Verbose);
 
-            logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+            logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
             Assert.Equal(result.Count, 1);
             Assert.Equal(result[0].Key, "IntPayLoad");
@@ -46,7 +46,7 @@ namespace System.Diagnostics.Tracing.Tests
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
             logger.Subscribe(listListener, LogLevel.Verbose);
 
-            logger.Log(LogLevel.Verbose, "StructPayLoad", new Payload() { Name = "Hi", Id = 67 });
+            logger.Log("StructPayLoad", LogLevel.Verbose, new Payload() { Name = "Hi", Id = 67 });
 
             Assert.Equal(result.Count, 1);
             Assert.Equal(result[0].Key, "StructPayLoad");
@@ -91,10 +91,10 @@ namespace System.Diagnostics.Tracing.Tests
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
             logger.Subscribe(listListener, LogLevel.Critical);
 
-            logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
-            logger.Log(LogLevel.Critical, "IntPayLoad", 6);
-            logger.Log(LogLevel.Warning, "IntPayLoad", 7);
-            logger.Log(LogLevel.Error, "IntPayLoad", 8);
+            logger.Log("IntPayLoad", LogLevel.Verbose, 5);
+            logger.Log("IntPayLoad", LogLevel.Critical, 6);
+            logger.Log("IntPayLoad", LogLevel.Warning, 7);
+            logger.Log("IntPayLoad", LogLevel.Error, 8);
 
             Assert.Equal(result.Count, 1);
             Assert.Equal(result[0].Key, "IntPayLoad");
@@ -117,7 +117,7 @@ namespace System.Diagnostics.Tracing.Tests
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
             logger.Subscribe(listListener, LogLevel.Informational);
 
-            logger.LogFormat(LogLevel.Informational, "FormattedIntPayLoad", "payload value = %d", 5);
+            logger.LogFormat("FormattedIntPayLoad", LogLevel.Informational, "payload value = %d", 5);
             Assert.Equal(result.Count, 1);
             Assert.Equal(result[0].Key, "FormattedIntPayLoad");
 
@@ -140,9 +140,9 @@ namespace System.Diagnostics.Tracing.Tests
             IObserver<kvp> listListener = new ObserverToList<kvp>(result);
             logger.Subscribe(listListener, LogLevel.Verbose);
 
-            using (var i = logger.ActivityStart(LogLevel.Error, "Main", 4))
+            using (var i = logger.ActivityStart("Main", LogLevel.Error, 4))
             {
-                logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+                logger.Log("IntPayLoad", LogLevel.Verbose, 5);
             }
             Assert.Equal(result.Count, 3);
 
@@ -183,7 +183,7 @@ namespace System.Diagnostics.Tracing.Tests
             logger.Subscribe(listListener1, LogLevel.Verbose);
             logger.Subscribe(listListener2, LogLevel.Verbose);
 
-            logger.Log(LogLevel.Verbose, "IntPayLoad", 5);
+            logger.Log("IntPayLoad", LogLevel.Verbose, 5);
 
             Assert.Equal(result1.Count, 1);
             Assert.Equal(result1[0].Key, "IntPayLoad");
@@ -215,12 +215,12 @@ namespace System.Diagnostics.Tracing.Tests
             IObserver<kvp> listListener2 = new ObserverToList<kvp>(result2);
 
             logger.Subscribe(listListener1, LogLevel.Critical);
-            logger.Log(LogLevel.Error, "IntPayLoad", 5);
+            logger.Log("IntPayLoad", LogLevel.Error, 5);
             Assert.Equal(result1.Count, 0);
 
             // This causes effective log level of all subsribers to be Error
             logger.Subscribe(listListener2, LogLevel.Error);
-            logger.Log(LogLevel.Error, "IntPayLoad", 5);
+            logger.Log("IntPayLoad", LogLevel.Error, 5);
 
             // Both subscribers receive log information
             Assert.Equal(result1.Count, 1);
@@ -241,9 +241,9 @@ namespace System.Diagnostics.Tracing.Tests
             logger1.Subscribe(listListener, LogLevel.Critical);
             logger2.Subscribe(listListener, LogLevel.Error);
 
-            logger1.Log(LogLevel.Critical, "IntPayLoad", 5);
-            logger2.Log(LogLevel.Critical, "IntPayLoad", 6);
-            logger1.Log(LogLevel.Error, "IntPayLoad", 7);
+            logger1.Log("IntPayLoad", LogLevel.Critical, 5);
+            logger2.Log("IntPayLoad", LogLevel.Critical, 6);
+            logger1.Log("IntPayLoad", LogLevel.Error, 7);
 
             Assert.Equal(result.Count, 2);
             LoggerArguments loggerArgs = result[0].Value as LoggerArguments;
@@ -337,7 +337,7 @@ namespace System.Diagnostics.Tracing.Tests
 
     public static class LoggerExtensions
     {
-        public static void LogFormat(this Logger logger, LogLevel level, string logItemName, string format, object arguments = null)
+        public static void LogFormat(this Logger logger, string logItemName, LogLevel level, string format, object arguments = null)
         {
             if (logger.IsEnabled(level))
             {

--- a/src/System.Diagnostics.Tracing.Logger/tests/System.Diagnostics.Tracing.Logger.Tests.csproj
+++ b/src/System.Diagnostics.Tracing.Logger/tests/System.Diagnostics.Tracing.Logger.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Diagnostics.Tracing.Logger.Tests</AssemblyName>
+    <RootNamespace>System.Diagnostics.Tracing.Logger.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+      <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
+    </Compile>
+    <Compile Include="LoggerTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Diagnostics.Tracing.Logger.csproj">
+      <Project>{F24D3391-2928-4E83-AADE-B34423498750}</Project>
+      <Name>System.Diagnostics.Tracing.Logger</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing.Logger/tests/project.json
+++ b/src/System.Diagnostics.Tracing.Logger/tests/project.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Globalization": "4.0.10",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "System.Diagnostics.DiagnosticSource": "4.0.0-beta-*",
+    "xunit": "2.1.0-beta3-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
@@ -27,7 +27,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Tracing": "4.0.0",
@@ -396,17 +396,15 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1iN7EMAvI5vEGHoOZv+6vC8r0Wf6ruA3p6jGvSdhOi9SX0utwR6DCRNNO+OctDXvOGElZblqa/OfbalX0bsAew==",
+      "sha512": "ZIzF+hsqa7Ujp+8chy8qRA5HuxanvltJ6/Kb/TxPCQ8thgQ3BlbED8MKeK7SWWeJijAlhKMw7MOd3LzX7cs8eA==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
-        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
       ]
     },

--- a/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
@@ -1,0 +1,1011 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "xunit/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.assert": "[2.1.0-beta3-build3029]",
+          "xunit.core": "[2.1.0-beta3-build3029]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-beta3-build3029": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-beta3-build3029]",
+          "xunit.extensibility.execution": "[2.1.0-beta3-build3029]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0]"
+        },
+        "compile": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll": {},
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.tdnet.dll": {},
+          "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-beta3-build3029": {
+        "type": "package",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-beta3-build3029]"
+        },
+        "compile": {
+          "lib/dnxcore50/xunit.execution.dnx.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/xunit.execution.dnx.dll": {}
+        }
+      },
+      "xunit.netcore.extensions/1.0.0-prerelease-00103": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "xunit": "2.1.0"
+        },
+        "compile": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Collections/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
+      "files": [
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.4.0.10.nupkg",
+        "System.Collections.4.0.10.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.4.0.10.nupkg",
+        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Y2VYZb9pgMQgsJHIdYsmAtuv0JxUBi9qrzkmPDeqYjaD0nSAfxbueRQZJz9l8Gu97MPz004YhLEqJ85uyvztvQ==",
+      "files": [
+        "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
+        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
+        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.nuspec"
+      ]
+    },
+    "System.Globalization/4.0.10": {
+      "type": "package",
+      "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.4.0.10.nupkg",
+        "System.Globalization.4.0.10.nupkg.sha512",
+        "System.Globalization.nuspec"
+      ]
+    },
+    "System.IO/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
+      "files": [
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.4.0.10.nupkg",
+        "System.IO.4.0.10.nupkg.sha512",
+        "System.IO.nuspec"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.4.0.0.nupkg",
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0.nupkg",
+        "System.Private.Uri.4.0.0.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.10": {
+      "type": "package",
+      "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.4.0.10.nupkg",
+        "System.Reflection.4.0.10.nupkg.sha512",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.4.0.0.nupkg",
+        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.4.0.0.nupkg",
+        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20.nupkg",
+        "System.Runtime.4.0.20.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.4.0.0.nupkg",
+        "System.Runtime.Handles.4.0.0.nupkg.sha512",
+        "System.Runtime.Handles.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.4.0.20.nupkg",
+        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
+      "files": [
+        "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23213.nupkg",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23213.nupkg.sha512",
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "type": "package",
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Threading/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.4.0.10.nupkg",
+        "System.Threading.4.0.10.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.4.0.10.nupkg",
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    },
+    "xunit/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "NMFXV0ePe/GrfhMSPGAlWmiUZCzjaatpdAGcavf2B6vYTRyMTpyJT01LI6jemMV/VSDXLrtHp0Ov9xZyR1cLLg==",
+      "files": [
+        "xunit.2.1.0-beta3-build3029.nupkg",
+        "xunit.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.nuspec"
+      ]
+    },
+    "xunit.abstractions/2.0.0": {
+      "type": "package",
+      "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
+      "files": [
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
+        "xunit.abstractions.2.0.0.nupkg",
+        "xunit.abstractions.2.0.0.nupkg.sha512",
+        "xunit.abstractions.nuspec"
+      ]
+    },
+    "xunit.assert/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "AMS7Fv77DayXVRCBMmVEDwOXPcbxk8dCBA/iACsve+6+UQqopMtNyAynyIcXPFRK/peeitUKID4ChOXWisJmUw==",
+      "files": [
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.pdb",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.xml",
+        "xunit.assert.2.1.0-beta3-build3029.nupkg",
+        "xunit.assert.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.assert.nuspec"
+      ]
+    },
+    "xunit.core/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "uDUBbwZSRx226BMwj6VylzXQPVpEIelNIulT+LxbSEH52y2a4btR9d5ptQmkSVjmJXP5/hGCc4cu1DSCu0pgUA==",
+      "files": [
+        "build/_Desktop/xunit.execution.desktop.dll",
+        "build/monoandroid/xunit.core.props",
+        "build/monoandroid/xunit.execution.MonoAndroid.dll",
+        "build/monotouch/xunit.core.props",
+        "build/monotouch/xunit.execution.MonoTouch.dll",
+        "build/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.props",
+        "build/portable-win81+wpa81/xunit.core.props",
+        "build/portable-win81+wpa81/xunit.core.targets",
+        "build/portable-win81+wpa81/xunit.execution.universal.dll",
+        "build/portable-win81+wpa81/xunit.execution.universal.pri",
+        "build/wp8/xunit.core.props",
+        "build/wp8/xunit.core.targets",
+        "build/wp8/xunit.execution.wp8.dll",
+        "build/Xamarin.iOS/xunit.core.props",
+        "build/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
+        "xunit.core.2.1.0-beta3-build3029.nupkg",
+        "xunit.core.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.core.nuspec"
+      ]
+    },
+    "xunit.extensibility.core/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "lsPro5U3NLasHI/RwqjKzXiRlh9N0IOlR3cluwXYVtihXbGtySeSnU/Fh5MTcWYxh+MVpoNop5zDD0/A2nrHsA==",
+      "files": [
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll.tdnet",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.pdb",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.xml",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.tdnet.dll",
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll",
+        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg",
+        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.extensibility.core.nuspec"
+      ]
+    },
+    "xunit.extensibility.execution/2.1.0-beta3-build3029": {
+      "type": "package",
+      "sha512": "WuUYamK4RHrHxihvNuX7NkryMhQrpH1+ziJ/mPIQbm18zevSgre8BwUuVZvmLZa8uVob3xS4dvAah2+HCgLiXg==",
+      "files": [
+        "lib/dnx451/xunit.execution.dnx.dll",
+        "lib/dnx451/xunit.execution.dnx.pdb",
+        "lib/dnx451/xunit.execution.dnx.xml",
+        "lib/dnxcore50/xunit.execution.dnx.dll",
+        "lib/dnxcore50/xunit.execution.dnx.pdb",
+        "lib/dnxcore50/xunit.execution.dnx.xml",
+        "lib/monoandroid/xunit.execution.MonoAndroid.dll",
+        "lib/monoandroid/xunit.execution.MonoAndroid.pdb",
+        "lib/monoandroid/xunit.execution.MonoAndroid.xml",
+        "lib/monotouch/xunit.execution.MonoTouch.dll",
+        "lib/monotouch/xunit.execution.MonoTouch.pdb",
+        "lib/monotouch/xunit.execution.MonoTouch.xml",
+        "lib/net45/xunit.execution.desktop.dll",
+        "lib/net45/xunit.execution.desktop.pdb",
+        "lib/net45/xunit.execution.desktop.xml",
+        "lib/portable-wpa81+win81/xunit.execution.universal.dll",
+        "lib/portable-wpa81+win81/xunit.execution.universal.pdb",
+        "lib/portable-wpa81+win81/xunit.execution.universal.pri",
+        "lib/portable-wpa81+win81/xunit.execution.universal.xml",
+        "lib/wp8/xunit.execution.wp8.dll",
+        "lib/wp8/xunit.execution.wp8.pdb",
+        "lib/wp8/xunit.execution.wp8.xml",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.pdb",
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.xml",
+        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg",
+        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg.sha512",
+        "xunit.extensibility.execution.nuspec"
+      ]
+    },
+    "xunit.netcore.extensions/1.0.0-prerelease-00103": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "LpiPWwBRRp0JDLWtE590CGdYftvY9KV1XU5xJsylttjTx8vQHUliFL9R7rBoegUeFEs3y4uqA48TTdCZcoJb2w==",
+      "files": [
+        "lib/dotnet/Xunit.NetCore.Extensions.dll",
+        "xunit.netcore.extensions.1.0.0-prerelease-00103.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00103.nupkg.sha512",
+        "xunit.netcore.extensions.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Collections >= 4.0.10",
+      "System.Diagnostics.Debug >= 4.0.10",
+      "System.Globalization >= 4.0.10",
+      "System.Reflection >= 4.0.10",
+      "System.Runtime >= 4.0.20",
+      "System.Runtime.Extensions >= 4.0.10",
+      "System.Threading >= 4.0.10",
+      "System.Threading.Tasks >= 4.0.10",
+      "System.Diagnostics.DiagnosticSource >= 4.0.0-beta-*",
+      "xunit >= 2.1.0-beta3-*",
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
@@ -27,7 +27,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Tracing": "4.0.0",
@@ -396,15 +396,15 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uSNqrGOs66HTQxycuc2HuJ3PRej5HaeUDwSOkSvONJF4dJV4EKliDEg7xCAmxk0f8IwCr1jeTo2i/Rt2PGslQw==",
+      "sha512": "ZIzF+hsqa7Ujp+8chy8qRA5HuxanvltJ6/Kb/TxPCQ8thgQ3BlbED8MKeK7SWWeJijAlhKMw7MOd3LzX7cs8eA==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
       ]
     },

--- a/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
@@ -27,9 +27,10 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
+          "System.Diagnostics.Tracing": "4.0.0",
           "System.Runtime": "4.0.0",
           "System.Threading": "4.0.0"
         },
@@ -38,6 +39,15 @@
         },
         "runtime": {
           "lib/dotnet/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
         }
       },
       "System.Globalization/4.0.10": {
@@ -290,7 +300,7 @@
           "lib/dnxcore50/xunit.execution.dnx.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00103": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -386,18 +396,62 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23405": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Y2VYZb9pgMQgsJHIdYsmAtuv0JxUBi9qrzkmPDeqYjaD0nSAfxbueRQZJz9l8Gu97MPz004YhLEqJ85uyvztvQ==",
+      "sha512": "uSNqrGOs66HTQxycuc2HuJ3PRej5HaeUDwSOkSvONJF4dJV4EKliDEg7xCAmxk0f8IwCr1jeTo2i/Rt2PGslQw==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
-        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23405.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23409.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.0": {
+      "type": "package",
+      "sha512": "tzqQJPgD4bKs0eE5Gx9HEsxiHSBGcL42PImkjhwXTQK6iQbLTTB9mi+G7mUyEjlH8LUcm7F5QHEs+O+LpruOrQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/it/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/es/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/fr/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/it/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ja/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ko/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/ru/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/netcore50/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Diagnostics.Tracing.4.0.0.nupkg",
+        "System.Diagnostics.Tracing.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
@@ -980,14 +1034,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00103": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "LpiPWwBRRp0JDLWtE590CGdYftvY9KV1XU5xJsylttjTx8vQHUliFL9R7rBoegUeFEs3y4uqA48TTdCZcoJb2w==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00103.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00103.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
+++ b/src/System.Diagnostics.Tracing.Logger/tests/project.lock.json
@@ -27,7 +27,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
+      "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Tracing": "4.0.0",
@@ -396,15 +396,17 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23412": {
+    "System.Diagnostics.DiagnosticSource/4.0.0-beta-23413": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZIzF+hsqa7Ujp+8chy8qRA5HuxanvltJ6/Kb/TxPCQ8thgQ3BlbED8MKeK7SWWeJijAlhKMw7MOd3LzX7cs8eA==",
+      "sha512": "1iN7EMAvI5vEGHoOZv+6vC8r0Wf6ruA3p6jGvSdhOi9SX0utwR6DCRNNO+OctDXvOGElZblqa/OfbalX0bsAew==",
       "files": [
         "lib/dotnet/System.Diagnostics.DiagnosticSource.dll",
+        "lib/dotnet/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg",
-        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23412.nupkg.sha512",
+        "lib/portable-net45+win8+wp8+wpa81/System.Diagnostics.DiagnosticSource.xml",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg",
+        "System.Diagnostics.DiagnosticSource.4.0.0-beta-23413.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec"
       ]
     },


### PR DESCRIPTION
This is the new Logger API, that is intended to be used by the ASP.NET team.    See the comments in Logger.cs for why we need this in addition to EventSource.   

Because Logger is implemented using DiagnosticSource, it will leverage the (upcoming) bridge that allows all EventListeners (including ETW), to access data logged with DiagnosticSource (and thus Logger).   

This code is intended to replace a chunk of what is currently in Microsoft.Extensions.Logging (see https://github.com/aspnet/Logging).   Logger and ILogger however where moved into their on DLL in coreFX because it they are generally useful

This pull request is tentative.   It is here to get feedback from the ASP.NET team and others and as part of that feedback we may move things around.   
