### PR TITLE
Adding original SSPI object model back to the Windows SslStream implementation

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
+++ b/src/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
@@ -18,7 +18,8 @@ namespace System.Net
                 return result;
             }
 
-            Interop.Crypt32.CERT_CONTEXT context = Marshal.PtrToStructure<Interop.Crypt32.CERT_CONTEXT>(certContext.DangerousGetHandle());
+                Interop.Crypt32.CERT_CONTEXT context =
+                    Marshal.PtrToStructure<Interop.Crypt32.CERT_CONTEXT>(certContext.DangerousGetHandle());
 
             if (context.hCertStore != IntPtr.Zero)
             {

--- a/src/Common/src/Interop/Windows/secur32/Bindings.cs
+++ b/src/Common/src/Interop/Windows/secur32/Bindings.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Bindings
+    {
+        // SecPkgContext_Bindings in sspi.h.
+        internal int BindingsLength;
+        internal IntPtr pBindings;
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/GlobalSSPI.cs
+++ b/src/Common/src/Interop/Windows/secur32/GlobalSSPI.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net
+{
+    internal static class GlobalSSPI
+    {
+        internal static SSPIInterface SSPIAuth = new SSPIAuthType();
+        internal static SSPIInterface SSPISecureChannel = new SSPISecureChannelType();
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/NegotiationInfo.cs
+++ b/src/Common/src/Interop/Windows/secur32/NegotiationInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    // SecPkgContext_NegotiationInfoW in sspi.h.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NegotiationInfo
+    {
+        // [MarshalAs(UnmanagedType.LPStruct)] internal SecurityPackageInfo PackageInfo;
+        internal IntPtr PackageInfo;
+        internal uint NegotiationState;
+        internal static readonly int Size = Marshal.SizeOf<NegotiationInfo>();
+        internal static readonly int NegotiationStateOffest = (int)Marshal.OffsetOf<NegotiationInfo>("NegotiationState");
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/NegotiationInfoClass.cs
+++ b/src/Common/src/Interop/Windows/secur32/NegotiationInfoClass.cs
@@ -26,13 +26,8 @@ namespace System.Net
             IntPtr packageInfo = safeHandle.DangerousGetHandle();
             GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8"));
 
-            const int SECPKG_NEGOTIATION_COMPLETE = 0;
-            const int SECPKG_NEGOTIATION_OPTIMISTIC = 1;
-            // const int SECPKG_NEGOTIATION_IN_PROGRESS     = 2;
-            // const int SECPKG_NEGOTIATION_DIRECT          = 3;
-            // const int SECPKG_NEGOTIATION_TRY_MULTICRED   = 4;
-
-            if (negotiationState == SECPKG_NEGOTIATION_COMPLETE || negotiationState == SECPKG_NEGOTIATION_OPTIMISTIC)
+            if (negotiationState == Interop.Secur32.SECPKG_NEGOTIATION_COMPLETE 
+                || negotiationState == Interop.Secur32.SECPKG_NEGOTIATION_OPTIMISTIC)
             {
                 IntPtr unmanagedString = Marshal.ReadIntPtr(packageInfo, SecurityPackageInfo.NameOffest);
                 string name = null;
@@ -43,7 +38,7 @@ namespace System.Net
 
                 GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8") + " name:" + Logging.ObjectToString(name));
 
-                // an optimization for future string comparisons
+                // An optimization for future string comparisons.
                 if (string.Compare(name, Kerberos, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     AuthenticationPackage = Kerberos;

--- a/src/Common/src/Interop/Windows/secur32/SSPIAuthType.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPIAuthType.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    // Authentication SSPI (Kerberos, NTLM, Negotiate and WDigest):
+    internal class SSPIAuthType : SSPIInterface
+    {
+        private static volatile SecurityPackageInfoClass[] s_securityPackages;
+
+        public SecurityPackageInfoClass[] SecurityPackages
+        {
+            get
+            {
+                return s_securityPackages;
+            }
+            set
+            {
+                s_securityPackages = value;
+            }
+        }
+
+        public int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray)
+        {
+            GlobalLog.Print("SSPIAuthType::EnumerateSecurityPackages()");
+            return SafeFreeContextBuffer.EnumeratePackages(out pkgnum, out pkgArray);
+        }
+
+        public int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref Interop.Secur32.AuthIdentity authdata, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
+        }
+
+        public int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref SafeSspiAuthDataHandle authdata, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
+        }
+
+        public int AcquireDefaultCredential(string moduleName, Interop.Secur32.CredentialUse usage, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireDefaultCredential(moduleName, usage, out outCredential);
+        }
+
+        public int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref Interop.Secur32.SecureCredential authdata, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
+        }
+
+        public int AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer inputBuffer, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.AcceptSecurityContext(ref credential, ref context, inFlags, endianness, inputBuffer, null, outputBuffer, ref outFlags);
+        }
+
+        public int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer[] inputBuffers, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.AcceptSecurityContext(ref credential, ref context, inFlags, endianness, null, inputBuffers, outputBuffer, ref outFlags);
+        }
+
+        public int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, inputBuffer, null, outputBuffer, ref outFlags);
+        }
+
+        public int InitializeSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, null, inputBuffers, outputBuffer, ref outFlags);
+        }
+
+        public int EncryptMessage(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            try
+            {
+                bool ignore = false;
+
+                context.DangerousAddRef(ref ignore);
+                return Interop.Secur32.EncryptMessage(ref context._handle, 0, inputOutput, sequenceNumber);
+            }
+            finally
+            {
+                context.DangerousRelease();
+            }
+        }
+
+        public unsafe int DecryptMessage(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            int status = (int)Interop.SecurityStatus.InvalidHandle;
+            uint qop = 0;
+
+            try
+            {
+                bool ignore = false;
+                context.DangerousAddRef(ref ignore);
+                status = Interop.Secur32.DecryptMessage(ref context._handle, inputOutput, sequenceNumber, &qop);
+            }
+            finally
+            {
+                context.DangerousRelease();
+            }
+
+            
+            if (status == 0 && qop == Interop.Secur32.SECQOP_WRAP_NO_ENCRYPT)
+            {
+                GlobalLog.Assert("Secur32.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
+                throw new InvalidOperationException(SR.net_auth_message_not_encrypted);
+            }
+
+
+            return status;
+        }
+
+        public int MakeSignature(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            try
+            {
+                bool ignore = false;
+
+                context.DangerousAddRef(ref ignore);
+                
+                return Interop.Secur32.EncryptMessage(ref context._handle, Interop.Secur32.SECQOP_WRAP_NO_ENCRYPT, inputOutput, sequenceNumber);
+            }
+            finally
+            {
+                context.DangerousRelease();
+            }
+        }
+
+        public unsafe int VerifySignature(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            try
+            {
+                bool ignore = false;
+                uint qop = 0;
+
+                context.DangerousAddRef(ref ignore);
+                return Interop.Secur32.DecryptMessage(ref context._handle, inputOutput, sequenceNumber, &qop);
+            }
+            finally
+            {
+                context.DangerousRelease();
+            }
+        }
+
+        public int QueryContextChannelBinding(SafeDeleteContext context, Interop.Secur32.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding binding)
+        {
+            // Querying an auth SSP for a CBT is not supported.
+            binding = null;
+            throw new NotSupportedException();
+        }
+
+        public unsafe int QueryContextAttributes(SafeDeleteContext context, Interop.Secur32.ContextAttribute attribute, byte[] buffer, Type handleType, out SafeHandle refHandle)
+        {
+            refHandle = null;
+            if (handleType != null)
+            {
+                if (handleType == typeof(SafeFreeContextBuffer))
+                {
+                    refHandle = SafeFreeContextBuffer.CreateEmptyHandle();
+                }
+                else if (handleType == typeof(SafeFreeCertContext))
+                {
+                    refHandle = new SafeFreeCertContext();
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Format(SR.SSPIInvalidHandleType, handleType.FullName), "handleType");
+                }
+            }
+
+            fixed (byte* bufferPtr = buffer)
+            {
+                return SafeFreeContextBuffer.QueryContextAttributes(context, attribute, bufferPtr, refHandle);
+            }
+        }
+
+        public int SetContextAttributes(SafeDeleteContext context, Interop.Secur32.ContextAttribute attribute, byte[] buffer)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
+
+        public int QuerySecurityContextToken(SafeDeleteContext phContext, out SecurityContextTokenHandle phToken)
+        {
+            return GetSecurityContextToken(phContext, out phToken);
+        }
+
+        public int CompleteAuthToken(ref SafeDeleteContext refContext, SecurityBuffer[] inputBuffers)
+        {
+            return SafeDeleteContext.CompleteAuthToken(ref refContext, inputBuffers);
+        }
+
+        private static int GetSecurityContextToken(SafeDeleteContext phContext, out SecurityContextTokenHandle safeHandle)
+        {
+            safeHandle = null;
+
+            try
+            {
+                bool ignore = false;
+                phContext.DangerousAddRef(ref ignore);
+                return Interop.Secur32.QuerySecurityContextToken(ref phContext._handle, out safeHandle);
+            }
+            finally
+            {
+                phContext.DangerousRelease();
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/SSPIInterface.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPIInterface.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    // Secur32 SSPI interface.
+    internal interface SSPIInterface
+    {
+        SecurityPackageInfoClass[] SecurityPackages { get; set; }
+        int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray);
+        int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref Interop.Secur32.AuthIdentity authdata, out SafeFreeCredentials outCredential);
+        int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref SafeSspiAuthDataHandle authdata, out SafeFreeCredentials outCredential);
+        int AcquireDefaultCredential(string moduleName, Interop.Secur32.CredentialUse usage, out SafeFreeCredentials outCredential);
+        int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref Interop.Secur32.SecureCredential authdata, out SafeFreeCredentials outCredential);
+        int AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer inputBuffer, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags);
+        int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer[] inputBuffers, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags);
+        int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags);
+        int InitializeSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags);
+        int EncryptMessage(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber);
+        int DecryptMessage(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber);
+        int MakeSignature(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber);
+        int VerifySignature(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber);
+
+        int QueryContextChannelBinding(SafeDeleteContext phContext, Interop.Secur32.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding refHandle);
+        int QueryContextAttributes(SafeDeleteContext phContext, Interop.Secur32.ContextAttribute attribute, byte[] buffer, Type handleType, out SafeHandle refHandle);
+        int SetContextAttributes(SafeDeleteContext phContext, Interop.Secur32.ContextAttribute attribute, byte[] buffer);
+        int QuerySecurityContextToken(SafeDeleteContext phContext, out SecurityContextTokenHandle phToken);
+        int CompleteAuthToken(ref SafeDeleteContext refContext, SecurityBuffer[] inputBuffers);
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/SSPISecureChannelType.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPISecureChannelType.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Security;
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    // Schannel SSPI interface.
+    internal class SSPISecureChannelType : SSPIInterface
+    {
+        private static volatile SecurityPackageInfoClass[] s_securityPackages;
+
+        public SecurityPackageInfoClass[] SecurityPackages
+        {
+            get
+            {
+                return s_securityPackages;
+            }
+            set
+            {
+                s_securityPackages = value;
+            }
+        }
+
+        public int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray)
+        {
+            GlobalLog.Print("SSPISecureChannelType::EnumerateSecurityPackages()");
+            return SafeFreeContextBuffer.EnumeratePackages(out pkgnum, out pkgArray);
+        }
+
+        public int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref Interop.Secur32.AuthIdentity authdata, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
+        }
+
+        public int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref SafeSspiAuthDataHandle authdata, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
+        }
+
+        public int AcquireDefaultCredential(string moduleName, Interop.Secur32.CredentialUse usage, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireDefaultCredential(moduleName, usage, out outCredential);
+        }
+
+        public int AcquireCredentialsHandle(string moduleName, Interop.Secur32.CredentialUse usage, ref Interop.Secur32.SecureCredential authdata, out SafeFreeCredentials outCredential)
+        {
+            return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
+        }
+
+        public int AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer inputBuffer, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.AcceptSecurityContext(ref credential, ref context, inFlags, endianness, inputBuffer, null, outputBuffer, ref outFlags);
+        }
+
+        public int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer[] inputBuffers, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.AcceptSecurityContext(ref credential, ref context, inFlags, endianness, null, inputBuffers, outputBuffer, ref outFlags);
+        }
+
+        public int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, inputBuffer, null, outputBuffer, ref outFlags);
+        }
+
+        public int InitializeSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness endianness, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, null, inputBuffers, outputBuffer, ref outFlags);
+        }
+
+        public int EncryptMessage(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            try
+            {
+                bool ignore = false;
+                context.DangerousAddRef(ref ignore);
+                return Interop.Secur32.EncryptMessage(ref context._handle, 0, inputOutput, sequenceNumber);
+            }
+            finally
+            {
+                context.DangerousRelease();
+            }
+        }
+
+        public unsafe int DecryptMessage(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput,
+            uint sequenceNumber)
+        {
+            try
+            {
+                bool ignore = false;
+                context.DangerousAddRef(ref ignore);
+                return Interop.Secur32.DecryptMessage(ref context._handle, inputOutput, sequenceNumber, null);
+            }
+            finally
+            {
+                context.DangerousRelease();
+            }
+        }
+
+        public int MakeSignature(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
+
+        public int VerifySignature(SafeDeleteContext context, Interop.Secur32.SecurityBufferDescriptor inputOutput, uint sequenceNumber)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
+
+        public unsafe int QueryContextChannelBinding(SafeDeleteContext phContext, Interop.Secur32.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding refHandle)
+        {
+            refHandle = SafeFreeContextBufferChannelBinding.CreateEmptyHandle();
+
+            // Bindings is on the stack, so there's no need for a fixed block.
+            Bindings bindings = new Bindings();
+            return SafeFreeContextBufferChannelBinding.QueryContextChannelBinding(phContext, attribute, &bindings, refHandle);
+        }
+
+        public unsafe int QueryContextAttributes(SafeDeleteContext phContext, Interop.Secur32.ContextAttribute attribute, byte[] buffer, Type handleType, out SafeHandle refHandle)
+        {
+            refHandle = null;
+            if (handleType != null)
+            {
+                if (handleType == typeof(SafeFreeContextBuffer))
+                {
+                    refHandle = SafeFreeContextBuffer.CreateEmptyHandle();
+                }
+                else if (handleType == typeof(SafeFreeCertContext))
+                {
+                    refHandle = new SafeFreeCertContext();
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Format(SR.SSPIInvalidHandleType, handleType.FullName), "handleType");
+                }
+            }
+            fixed (byte* bufferPtr = buffer)
+            {
+                return SafeFreeContextBuffer.QueryContextAttributes(phContext, attribute, bufferPtr, refHandle);
+            }
+        }
+
+        public int SetContextAttributes(SafeDeleteContext phContext, Interop.Secur32.ContextAttribute attribute, byte[] buffer)
+        {
+            return SafeFreeContextBuffer.SetContextAttributes(phContext, attribute, buffer);
+        }
+
+        public int QuerySecurityContextToken(SafeDeleteContext phContext, out SecurityContextTokenHandle phToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public int CompleteAuthToken(ref SafeDeleteContext refContext, SecurityBuffer[] inputBuffers)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
@@ -1,0 +1,678 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Globalization;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    internal static class SSPIWrapper
+    {
+        internal static SecurityPackageInfoClass[] EnumerateSecurityPackages(SSPIInterface secModule)
+        {
+            GlobalLog.Enter("EnumerateSecurityPackages");
+            if (secModule.SecurityPackages == null)
+            {
+                lock (secModule)
+                {
+                    if (secModule.SecurityPackages == null)
+                    {
+                        int moduleCount = 0;
+                        SafeFreeContextBuffer arrayBaseHandle = null;
+                        try
+                        {
+                            int errorCode = secModule.EnumerateSecurityPackages(out moduleCount, out arrayBaseHandle);
+                            GlobalLog.Print("SSPIWrapper::arrayBase: " + (arrayBaseHandle.DangerousGetHandle().ToString("x")));
+                            if (errorCode != 0)
+                            {
+                                throw new Win32Exception(errorCode);
+                            }
+
+                            SecurityPackageInfoClass[] securityPackages = new SecurityPackageInfoClass[moduleCount];
+                            if (Logging.On)
+                            {
+                                Logging.PrintInfo(Logging.Web, SR.net_log_sspi_enumerating_security_packages);
+                            }
+
+                            int i;
+                            for (i = 0; i < moduleCount; i++)
+                            {
+                                securityPackages[i] = new SecurityPackageInfoClass(arrayBaseHandle, i);
+                                if (Logging.On)
+                                {
+                                    Logging.PrintInfo(Logging.Web, "    " + securityPackages[i].Name);
+                                }
+                            }
+
+                            secModule.SecurityPackages = securityPackages;
+                        }
+                        finally
+                        {
+                            if (arrayBaseHandle != null)
+                            {
+                                arrayBaseHandle.Dispose();
+                            }
+                        }
+                    }
+                }
+            }
+
+            GlobalLog.Leave("EnumerateSecurityPackages");
+            return secModule.SecurityPackages;
+        }
+
+        internal static SecurityPackageInfoClass GetVerifyPackageInfo(SSPIInterface secModule, string packageName)
+        {
+            return GetVerifyPackageInfo(secModule, packageName, false);
+        }
+
+        internal static SecurityPackageInfoClass GetVerifyPackageInfo(SSPIInterface secModule, string packageName, bool throwIfMissing)
+        {
+            SecurityPackageInfoClass[] supportedSecurityPackages = EnumerateSecurityPackages(secModule);
+            if (supportedSecurityPackages != null)
+            {
+                for (int i = 0; i < supportedSecurityPackages.Length; i++)
+                {
+                    if (string.Compare(supportedSecurityPackages[i].Name, packageName, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        return supportedSecurityPackages[i];
+                    }
+                }
+            }
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_package_not_found, packageName));
+            }
+
+            if (throwIfMissing)
+            {
+                throw new NotSupportedException(SR.net_securitypackagesupport);
+            }
+
+            return null;
+        }
+
+        public static SafeFreeCredentials AcquireDefaultCredential(SSPIInterface secModule, string package, Interop.Secur32.CredentialUse intent)
+        {
+            GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): using " + package);
+            if (Logging.On)
+            {
+                Logging.PrintInfo(
+                    Logging.Web,
+                    "AcquireDefaultCredential(" +
+                    "package = " + package + ", " +
+                    "intent  = " + intent + ")");
+            }
+
+            SafeFreeCredentials outCredential = null;
+            int errorCode = secModule.AcquireDefaultCredential(package, intent, out outCredential);
+
+            if (errorCode != 0)
+            {
+#if TRACE_VERBOSE
+                GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): error " + Interop.MapSecurityStatus((uint)errorCode));
+#endif
+
+                if (Logging.On)
+                {
+                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireDefaultCredential()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                }
+
+                throw new Win32Exception(errorCode);
+            }
+            return outCredential;
+        }
+
+        public static SafeFreeCredentials AcquireCredentialsHandle(SSPIInterface secModule, string package, Interop.Secur32.CredentialUse intent, ref Interop.Secur32.AuthIdentity authdata)
+        {
+            GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): using " + package);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "AcquireCredentialsHandle(" +
+                    "package  = " + package + ", " +
+                    "intent   = " + intent + ", " +
+                    "authdata = " + authdata + ")");
+            }
+
+            SafeFreeCredentials credentialsHandle = null;
+            int errorCode = secModule.AcquireCredentialsHandle(package,
+                                                               intent,
+                                                               ref authdata,
+                                                               out credentialsHandle);
+
+            if (errorCode != 0)
+            {
+#if TRACE_VERBOSE
+                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): error " + Interop.MapSecurityStatus((uint)errorCode));
+#endif
+                if (Logging.On)
+                {
+                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                }
+
+                throw new Win32Exception(errorCode);
+            }
+            return credentialsHandle;
+        }
+
+        public static SafeFreeCredentials AcquireCredentialsHandle(SSPIInterface secModule, string package, Interop.Secur32.CredentialUse intent, ref SafeSspiAuthDataHandle authdata)
+        {
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "AcquireCredentialsHandle(" +
+                    "package  = " + package + ", " +
+                    "intent   = " + intent + ", " +
+                    "authdata = " + authdata + ")");
+            }
+
+            SafeFreeCredentials credentialsHandle = null;
+            int errorCode = secModule.AcquireCredentialsHandle(package, intent, ref authdata, out credentialsHandle);
+
+            if (errorCode != 0)
+            {
+                if (Logging.On)
+                {
+                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                }
+
+                throw new Win32Exception(errorCode);
+            }
+
+            return credentialsHandle;
+        }
+
+        public static SafeFreeCredentials AcquireCredentialsHandle(SSPIInterface secModule, string package, Interop.Secur32.CredentialUse intent, Interop.Secur32.SecureCredential scc)
+        {
+            GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): using " + package);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "AcquireCredentialsHandle(" +
+                    "package = " + package + ", " +
+                    "intent  = " + intent + ", " +
+                    "scc     = " + scc + ")");
+            }
+
+            SafeFreeCredentials outCredential = null;
+            int errorCode = secModule.AcquireCredentialsHandle(
+                                            package,
+                                            intent,
+                                            ref scc,
+                                            out outCredential);
+
+            if (errorCode != 0)
+            {
+#if TRACE_VERBOSE
+                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): error " + Interop.MapSecurityStatus((uint)errorCode));
+#endif
+
+                if (Logging.On)
+                {
+                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                }
+
+                throw new Win32Exception(errorCode);
+            }
+
+#if TRACE_VERBOSE
+            GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): cred handle = " + outCredential.ToString());
+#endif
+            return outCredential;
+        }
+
+        internal static int InitializeSecurityContext(SSPIInterface secModule, ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "InitializeSecurityContext(" +
+                    "credential = " + credential.ToString() + ", " +
+                    "context = " + Logging.ObjectToString(context) + ", " +
+                    "targetName = " + targetName + ", " +
+                    "inFlags = " + inFlags + ")");
+            }
+
+            int errorCode = secModule.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, datarep, inputBuffer, outputBuffer, ref outFlags);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffer, "InitializeSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+            }
+
+            return errorCode;
+        }
+
+        internal static int InitializeSecurityContext(SSPIInterface secModule, SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "InitializeSecurityContext(" +
+                    "credential = " + credential.ToString() + ", " +
+                    "context = " + Logging.ObjectToString(context) + ", " +
+                    "targetName = " + targetName + ", " +
+                    "inFlags = " + inFlags + ")");
+            }
+
+            int errorCode = secModule.InitializeSecurityContext(credential, ref context, targetName, inFlags, datarep, inputBuffers, outputBuffer, ref outFlags);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffers, "InitializeSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+            }
+
+            return errorCode;
+        }
+
+        internal static int AcceptSecurityContext(SSPIInterface secModule, ref SafeFreeCredentials credential, ref SafeDeleteContext context, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "AcceptSecurityContext(" +
+                    "credential = " + credential.ToString() + ", " +
+                    "context = " + Logging.ObjectToString(context) + ", " +
+                    "inFlags = " + inFlags + ")");
+            }
+
+            int errorCode = secModule.AcceptSecurityContext(ref credential, ref context, inputBuffer, inFlags, datarep, outputBuffer, ref outFlags);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffer, "AcceptSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+            }
+
+            return errorCode;
+        }
+
+        internal static int AcceptSecurityContext(SSPIInterface secModule, SafeFreeCredentials credential, ref SafeDeleteContext context, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
+        {
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web,
+                    "AcceptSecurityContext(" +
+                    "credential = " + credential.ToString() + ", " +
+                    "context = " + Logging.ObjectToString(context) + ", " +
+                    "inFlags = " + inFlags + ")");
+            }
+
+            int errorCode = secModule.AcceptSecurityContext(credential, ref context, inputBuffers, inFlags, datarep, outputBuffer, ref outFlags);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffers, "AcceptSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+            }
+
+            return errorCode;
+        }
+
+        internal static int CompleteAuthToken(SSPIInterface secModule, ref SafeDeleteContext context, SecurityBuffer[] inputBuffers)
+        {
+            int errorCode = secModule.CompleteAuthToken(ref context, inputBuffers);
+
+            if (Logging.On)
+            {
+                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_operation_returned_something, "CompleteAuthToken()", (Interop.SecurityStatus)errorCode));
+            }
+
+            return errorCode;
+        }
+
+        public static int QuerySecurityContextToken(SSPIInterface secModule, SafeDeleteContext context, out SecurityContextTokenHandle token)
+        {
+            return secModule.QuerySecurityContextToken(context, out token);
+        }
+
+        public static int EncryptMessage(SSPIInterface secModule, SafeDeleteContext context, SecurityBuffer[] input, uint sequenceNumber)
+        {
+            return EncryptDecryptHelper(OP.Encrypt, secModule, context, input, sequenceNumber);
+        }
+
+        public static int DecryptMessage(SSPIInterface secModule, SafeDeleteContext context, SecurityBuffer[] input, uint sequenceNumber)
+        {
+            return EncryptDecryptHelper(OP.Decrypt, secModule, context, input, sequenceNumber);
+        }
+
+        internal static int MakeSignature(SSPIInterface secModule, SafeDeleteContext context, SecurityBuffer[] input, uint sequenceNumber)
+        {
+            return EncryptDecryptHelper(OP.MakeSignature, secModule, context, input, sequenceNumber);
+        }
+
+        public static int VerifySignature(SSPIInterface secModule, SafeDeleteContext context, SecurityBuffer[] input, uint sequenceNumber)
+        {
+            return EncryptDecryptHelper(OP.VerifySignature, secModule, context, input, sequenceNumber);
+        }
+
+        private enum OP
+        {
+            Encrypt = 1,
+            Decrypt,
+            MakeSignature,
+            VerifySignature
+        }
+
+        private unsafe static int EncryptDecryptHelper(OP op, SSPIInterface secModule, SafeDeleteContext context, SecurityBuffer[] input, uint sequenceNumber)
+        {
+            Interop.Secur32.SecurityBufferDescriptor sdcInOut = new Interop.Secur32.SecurityBufferDescriptor(input.Length);
+            var unmanagedBuffer = new Interop.Secur32.SecurityBufferStruct[input.Length];
+
+            fixed (Interop.Secur32.SecurityBufferStruct* unmanagedBufferPtr = unmanagedBuffer)
+            {
+                sdcInOut.UnmanagedPointer = unmanagedBufferPtr;
+                GCHandle[] pinnedBuffers = new GCHandle[input.Length];
+                byte[][] buffers = new byte[input.Length][];
+                try
+                {
+                    for (int i = 0; i < input.Length; i++)
+                    {
+                        SecurityBuffer iBuffer = input[i];
+                        unmanagedBuffer[i].count = iBuffer.size;
+                        unmanagedBuffer[i].type = iBuffer.type;
+                        if (iBuffer.token == null || iBuffer.token.Length == 0)
+                        {
+                            unmanagedBuffer[i].token = IntPtr.Zero;
+                        }
+                        else
+                        {
+                            pinnedBuffers[i] = GCHandle.Alloc(iBuffer.token, GCHandleType.Pinned);
+                            unmanagedBuffer[i].token = Marshal.UnsafeAddrOfPinnedArrayElement(iBuffer.token, iBuffer.offset);
+                            buffers[i] = iBuffer.token;
+                        }
+                    }
+
+                    // The result is written in the input Buffer passed as type=BufferType.Data.
+                    int errorCode;
+                    switch (op)
+                    {
+                        case OP.Encrypt:
+                            errorCode = secModule.EncryptMessage(context, sdcInOut, sequenceNumber);
+                            break;
+
+                        case OP.Decrypt:
+                            errorCode = secModule.DecryptMessage(context, sdcInOut, sequenceNumber);
+                            break;
+
+                        case OP.MakeSignature:
+                            errorCode = secModule.MakeSignature(context, sdcInOut, sequenceNumber);
+                            break;
+
+                        case OP.VerifySignature:
+                            errorCode = secModule.VerifySignature(context, sdcInOut, sequenceNumber);
+                            break;
+
+                        default:
+                            GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
+                            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+                    }
+
+                    // Marshalling back returned sizes / data.
+                    for (int i = 0; i < input.Length; i++)
+                    {
+                        SecurityBuffer iBuffer = input[i];
+                        iBuffer.size = unmanagedBuffer[i].count;
+                        iBuffer.type = unmanagedBuffer[i].type;
+
+                        if (iBuffer.size == 0)
+                        {
+                            iBuffer.offset = 0;
+                            iBuffer.token = null;
+                        }
+                        else
+                        {
+                            checked
+                            {
+                                // Find the buffer this is inside of.  Usually they all point inside buffer 0.
+                                int j;
+                                for (j = 0; j < input.Length; j++)
+                                {
+                                    if (buffers[j] == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    byte* bufferAddress = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(buffers[j], 0);
+                                    if ((byte*)unmanagedBuffer[i].token >= bufferAddress &&
+                                        (byte*)unmanagedBuffer[i].token + iBuffer.size <= bufferAddress + buffers[j].Length)
+                                    {
+                                        iBuffer.offset = (int)((byte*)unmanagedBuffer[i].token - bufferAddress);
+                                        iBuffer.token = buffers[j];
+                                        break;
+                                    }
+                                }
+
+                                if (j >= input.Length)
+                                {
+                                    GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
+                                    iBuffer.size = 0;
+                                    iBuffer.offset = 0;
+                                    iBuffer.token = null;
+                                }
+                            }
+                        }
+                        
+                        // Backup validate the new sizes.
+                        GlobalLog.Assert(iBuffer.offset >= 0 && iBuffer.offset <= (iBuffer.token == null ? 0 : iBuffer.token.Length), "SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [{0}]", iBuffer.offset);
+                        GlobalLog.Assert(iBuffer.size >= 0 && iBuffer.size <= (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset), "SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [{0}]", iBuffer.size);
+                    }
+
+                    if (errorCode != 0 && Logging.On)
+                    {                         
+                        if (errorCode == Interop.Secur32.SEC_I_RENEGOTIATE)
+                        {
+                            Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_returned_something, op, "SEC_I_RENEGOTIATE"));
+                        }
+                        else
+                        {
+                            Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, op, String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                        }
+                    }
+
+                    return errorCode;
+                }
+                finally
+                {
+                    for (int i = 0; i < pinnedBuffers.Length; ++i)
+                    {
+                        if (pinnedBuffers[i].IsAllocated)
+                        {
+                            pinnedBuffers[i].Free();
+                        }
+                    }
+                }
+            }
+        }
+
+        public static SafeFreeContextBufferChannelBinding QueryContextChannelBinding(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.Secur32.ContextAttribute contextAttribute)
+        {
+            GlobalLog.Enter("QueryContextChannelBinding", contextAttribute.ToString());
+
+            SafeFreeContextBufferChannelBinding result;
+            int errorCode = secModule.QueryContextChannelBinding(securityContext, contextAttribute, out result);
+            if (errorCode != 0)
+            {
+                GlobalLog.Leave("QueryContextChannelBinding", "ERROR = " + ErrorDescription(errorCode));
+                return null;
+            }
+
+            GlobalLog.Leave("QueryContextChannelBinding", Logging.HashString(result));
+            return result;
+        }
+
+        public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.Secur32.ContextAttribute contextAttribute)
+        {
+            int errorCode;
+            return QueryContextAttributes(secModule, securityContext, contextAttribute, out errorCode);
+        }
+
+        public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.Secur32.ContextAttribute contextAttribute, out int errorCode)
+        {
+            GlobalLog.Enter("QueryContextAttributes", contextAttribute.ToString());
+
+            int nativeBlockSize = IntPtr.Size;
+            Type handleType = null;
+
+            switch (contextAttribute)
+            {
+                case Interop.Secur32.ContextAttribute.Sizes:
+                    nativeBlockSize = SecSizes.SizeOf;
+                    break;
+                case Interop.Secur32.ContextAttribute.StreamSizes:
+                    nativeBlockSize = StreamSizes.SizeOf;
+                    break;
+
+                case Interop.Secur32.ContextAttribute.Names:
+                    handleType = typeof(SafeFreeContextBuffer);
+                    break;
+
+                case Interop.Secur32.ContextAttribute.PackageInfo:
+                    handleType = typeof(SafeFreeContextBuffer);
+                    break;
+
+                case Interop.Secur32.ContextAttribute.NegotiationInfo:
+                    handleType = typeof(SafeFreeContextBuffer);
+                    nativeBlockSize = Marshal.SizeOf<NegotiationInfo>();
+                    break;
+
+                case Interop.Secur32.ContextAttribute.ClientSpecifiedSpn:
+                    handleType = typeof(SafeFreeContextBuffer);
+                    break;
+
+                case Interop.Secur32.ContextAttribute.RemoteCertificate:
+                    handleType = typeof(SafeFreeCertContext);
+                    break;
+
+                case Interop.Secur32.ContextAttribute.LocalCertificate:
+                    handleType = typeof(SafeFreeCertContext);
+                    break;
+
+                case Interop.Secur32.ContextAttribute.IssuerListInfoEx:
+                    nativeBlockSize = Marshal.SizeOf<Interop.Secur32.IssuerListInfoEx>();
+                    handleType = typeof(SafeFreeContextBuffer);
+                    break;
+
+                case Interop.Secur32.ContextAttribute.ConnectionInfo:
+                    nativeBlockSize = Marshal.SizeOf<SslConnectionInfo>();
+                    break;
+
+                default:
+                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, "ContextAttribute"), "contextAttribute");
+            }
+
+            SafeHandle sspiHandle = null;
+            object attribute = null;
+
+            try
+            {
+                byte[] nativeBuffer = new byte[nativeBlockSize];
+                errorCode = secModule.QueryContextAttributes(securityContext, contextAttribute, nativeBuffer, handleType, out sspiHandle);
+                if (errorCode != 0)
+                {
+                    GlobalLog.Leave("Win32:QueryContextAttributes", "ERROR = " + ErrorDescription(errorCode));
+                    return null;
+                }
+
+                switch (contextAttribute)
+                {
+                    case Interop.Secur32.ContextAttribute.Sizes:
+                        attribute = new SecSizes(nativeBuffer);
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.StreamSizes:
+                        attribute = new StreamSizes(nativeBuffer);
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.Names:
+                        attribute = Marshal.PtrToStringUni(sspiHandle.DangerousGetHandle());
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.PackageInfo:
+                        attribute = new SecurityPackageInfoClass(sspiHandle, 0);
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.NegotiationInfo:
+                        unsafe
+                        {
+                            fixed (void* ptr = nativeBuffer)
+                            {
+                                attribute = new NegotiationInfoClass(sspiHandle, Marshal.ReadInt32(new IntPtr(ptr), NegotiationInfo.NegotiationStateOffest));
+                            }
+                        }
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.ClientSpecifiedSpn:
+                        attribute = Marshal.PtrToStringUni(sspiHandle.DangerousGetHandle());
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.LocalCertificate:
+                        // Fall-through to RemoteCertificate is intentional.
+                    case Interop.Secur32.ContextAttribute.RemoteCertificate:
+                        attribute = sspiHandle;
+                        sspiHandle = null;
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.IssuerListInfoEx:
+                        attribute = new Interop.Secur32.IssuerListInfoEx(sspiHandle, nativeBuffer);
+                        sspiHandle = null;
+                        break;
+
+                    case Interop.Secur32.ContextAttribute.ConnectionInfo:
+                        attribute = new SslConnectionInfo(nativeBuffer);
+                        break;
+                    default:
+                        // Will return null.
+                        break;
+                }
+            }
+            finally
+            {
+                if (sspiHandle != null)
+                {
+                    sspiHandle.Dispose();
+                }
+            }
+            GlobalLog.Leave("QueryContextAttributes", Logging.ObjectToString(attribute));
+            return attribute;
+        }
+
+        public static string ErrorDescription(int errorCode)
+        {
+            if (errorCode == -1)
+            {
+                return "An exception when invoking Win32 API";
+            }
+
+            switch ((Interop.SecurityStatus)errorCode)
+            {
+                case Interop.SecurityStatus.InvalidHandle:
+                    return "Invalid handle";
+                case Interop.SecurityStatus.InvalidToken:
+                    return "Invalid token";
+                case Interop.SecurityStatus.ContinueNeeded:
+                    return "Continue needed";
+                case Interop.SecurityStatus.IncompleteMessage:
+                    return "Message incomplete";
+                case Interop.SecurityStatus.WrongPrincipal:
+                    return "Wrong principal";
+                case Interop.SecurityStatus.TargetUnknown:
+                    return "Target unknown";
+                case Interop.SecurityStatus.PackageNotFound:
+                    return "Package not found";
+                case Interop.SecurityStatus.BufferNotEnough:
+                    return "Buffer not enough";
+                case Interop.SecurityStatus.MessageAltered:
+                    return "Message altered";
+                case Interop.SecurityStatus.UntrustedRoot:
+                    return "Untrusted root";
+                default:
+                    return "0x" + errorCode.ToString("x", NumberFormatInfo.InvariantInfo);
+            }
+        }
+    } // class SSPIWrapper
+}

--- a/src/Common/src/Interop/Windows/secur32/SecurityPackageInfo.cs
+++ b/src/Common/src/Interop/Windows/secur32/SecurityPackageInfo.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecurityPackageInfo
+    {
+        // see SecPkgInfoW in <sspi.h>
+        internal int Capabilities;
+        internal short Version;
+        internal short RPCID;
+        internal int MaxToken;
+        internal IntPtr Name;
+        internal IntPtr Comment;
+
+        internal static readonly int Size = Marshal.SizeOf<SecurityPackageInfo>();
+        internal static readonly int NameOffest = (int)Marshal.OffsetOf<SecurityPackageInfo>("Name");
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/SecurityPackageInfoClass.cs
+++ b/src/Common/src/Interop/Windows/secur32/SecurityPackageInfoClass.cs
@@ -31,6 +31,7 @@ namespace System.Net
                 GlobalLog.Print("SecurityPackageInfoClass::.ctor() the pointer is invalid: " + (safeHandle.DangerousGetHandle()).ToString("x"));
                 return;
             }
+
             IntPtr unmanagedAddress = IntPtrHelper.Add(safeHandle.DangerousGetHandle(), SecurityPackageInfo.Size * index);
             GlobalLog.Print("SecurityPackageInfoClass::.ctor() unmanagedPointer: " + ((long)unmanagedAddress).ToString("x"));
 
@@ -65,8 +66,7 @@ namespace System.Net
                 + " RPCID:" + RPCID.ToString(NumberFormatInfo.InvariantInfo)
                 + " MaxToken:" + MaxToken.ToString(NumberFormatInfo.InvariantInfo)
                 + " Name:" + ((Name == null) ? "(null)" : Name)
-                + " Comment:" + ((Comment == null) ? "(null)" : Comment
-                );
+                + " Comment:" + ((Comment == null) ? "(null)" : Comment);
         }
     }
 }

--- a/src/Common/src/Interop/Windows/secur32/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/secur32/SecuritySafeHandles.cs
@@ -219,7 +219,6 @@ namespace System.Net.Security
         }
 #endif
 
-#if false //TODO if not used in Nego Stream as well, please remove it.
         public unsafe static int AcquireCredentialsHandle(
             string package,
             Interop.Secur32.CredentialUse intent,
@@ -327,7 +326,6 @@ namespace System.Net.Security
 
             return errorCode;
         }
-#endif
 
         public unsafe static int AcquireCredentialsHandle(
             string package,

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -125,7 +125,6 @@
     <Compile Include="System\Net\SslStreamPal.Windows.cs" />
     <Compile Include="System\Net\SecurityContextTokenHandle.cs" />
     <Compile Include="System\Net\CertificateValidationPal.Windows.cs" />
-    <Compile Include="System\Net\NegotiationInfo.Windows.cs" />
     
     <!-- Interop -->
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
@@ -146,26 +145,53 @@
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecurityStatus.cs">
       <Link>Interop\Windows\SChannel\Interop.SecurityStatus.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SslConnectionInfo.cs">
+      <Link>Interop\Windows\SChannel\SslConnectionInfo.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.cs">
       <Link>Interop\Windows\SChannel\UnmanagedCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecuritySafeHandles.cs">
-      <Link>Interop\Windows\secur32\SecuritySafeHandles.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\Bindings.cs">
+      <Link>Interop\Windows\secur32\Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\secur32\StreamSizes.cs">
-      <Link>Interop\Windows\secur32\StreamSizes.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\GlobalSSPI.cs">
+      <Link>Interop\Windows\secur32\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecurityPackageInfoClass.cs">
-      <Link>Interop\Windows\secur32\SecurityPackageInfoClass.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\Interop.SSPI.cs">
+      <Link>Interop\Windows\secur32\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SslConnectionInfo.cs">
-      <Link>Interop\Windows\SChannel\SslConnectionInfo.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\NegotiationInfo.cs">
+      <Link>Interop\Windows\secur32\NegotiationInfo.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\NegotiationInfoClass.cs">
+      <Link>Interop\Windows\secur32\NegotiationInfoClass.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecSizes.cs">
       <Link>Interop\Windows\secur32\SecSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\secur32\Interop.SSPI.cs">
-      <Link>Interop\Windows\secur32\Interop.SSPI.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecurityPackageInfo.cs">
+      <Link>Interop\Windows\secur32\SecurityPackageInfo.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecurityPackageInfoClass.cs">
+      <Link>Interop\Windows\secur32\SecurityPackageInfoClass.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecuritySafeHandles.cs">
+      <Link>Interop\Windows\secur32\SecuritySafeHandles.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPIAuthType.cs">
+      <Link>Interop\Windows\secur32\SSPIAuthType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPIInterface.cs">
+      <Link>Interop\Windows\secur32\SSPIInterface.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPISecureChannelType.cs">
+      <Link>Interop\Windows\secur32\SSPISecureChannelType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPIWrapper.cs">
+      <Link>Interop\Windows\secur32\SSPIWrapper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\StreamSizes.cs">
+      <Link>Interop\Windows\secur32\StreamSizes.cs</Link>
     </Compile>
   </ItemGroup>
   

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/_SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/_SslState.cs
@@ -861,6 +861,7 @@ namespace System.Net.Security
 
             StartReadFrame(buffer, readBytes, asyncRequest);
         }
+
         //
         private void StartReadFrame(byte[] buffer, int readBytes, AsyncProtocolRequest asyncRequest)
         {
@@ -1093,6 +1094,7 @@ namespace System.Net.Security
                 sslState.FinishHandshake(e, asyncRequest);
             }
         }
+
         //
         //
         private static void ReadFrameCallback(AsyncProtocolRequest asyncRequest)

--- a/src/System.Net.Security/src/System/Net/_SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/_SecureChannel.cs
@@ -17,10 +17,8 @@ using System.Security.Authentication;
 
 namespace System.Net.Security
 {
-    //
     // SecureChannel - a wrapper on SSPI based functionality. 
     // Provides an additional abstraction layer over SSPI for SslStream.
-    //
     internal class SecureChannel
     {
         // When reading a frame from the wire first read this many bytes for the header.
@@ -818,8 +816,7 @@ namespace System.Net.Security
                                       ref _securityContext,
                                       incomingSecurity,
                                       outgoingSecurity,
-                                      _remoteCertRequired
-                                      );
+                                      _remoteCertRequired);
                     }
                     else
                     {
@@ -830,8 +827,7 @@ namespace System.Net.Security
                                            ref _securityContext,
                                            _destination,
                                            incomingSecurity,
-                                           outgoingSecurity
-                                           );
+                                           outgoingSecurity);
                         }
                         else
                         {
@@ -840,8 +836,7 @@ namespace System.Net.Security
                                            ref _securityContext,
                                            _destination,
                                            incomingSecurityBuffers,
-                                           outgoingSecurity
-                                           );
+                                           outgoingSecurity);
                         }
                     }
                 } while (cachedCreds && _credentialsHandle == null);
@@ -892,7 +887,6 @@ namespace System.Net.Security
             GlobalLog.Enter("SecureChannel#" + Logging.HashString(this) + "::ProcessHandshakeSuccess");
 
             StreamSizes streamSizes;
-
             SslStreamPal.QueryContextStreamSizes(_securityContext, out streamSizes);
 
             if (streamSizes != null)
@@ -944,6 +938,7 @@ namespace System.Net.Security
                 {
                     throw new ArgumentOutOfRangeException("offset");
                 }
+
                 if (size < 0 || size > (buffer == null ? 0 : buffer.Length - offset))
                 {
                     throw new ArgumentOutOfRangeException("size");
@@ -960,6 +955,7 @@ namespace System.Net.Security
                 {
                     writeBuffer = new byte[bufferSizeNeeded];
                 }
+
                 Buffer.BlockCopy(buffer, offset, writeBuffer, _headerSize, size);
             }
             catch (Exception e)
@@ -968,6 +964,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert(false, "SecureChannel#" + Logging.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
+
                 throw;
             }
 
@@ -975,7 +972,7 @@ namespace System.Net.Security
 
             if (secStatus != SecurityStatusPal.OK)
             {
-                GlobalLog.Leave("SecureChannel#" + Logging.HashString(this) + "::Encrypt ERROR", secStatus.ToString("x"));
+                GlobalLog.Leave("SecureChannel#" + Logging.HashString(this) + "::Encrypt ERROR", secStatus.ToString());
             }
             else
             {
@@ -1048,11 +1045,7 @@ namespace System.Net.Security
                     {
                         chain.ChainPolicy.ExtraStore.AddRange(remoteCertificateStore);
                     }
-
-                    // Don't call chain.Build here in the common code, because the Windows version
-                    // is potentially going to check for GetLastWin32Error, and that call needs to be
-                    // guaranteed to be right after the call to chain.Build.
-
+                    
                     sslPolicyErrors |= CertificateValidationPal.VerifyCertificateProperties(
                         chain,
                         remoteCertificateEx,
@@ -1140,11 +1133,7 @@ namespace System.Net.Security
         }
     }
 
-    //
-    // ProtocolToken - used to process and handle the return codes
-    //   from the SSPI wrapper
-    //
-
+    // ProtocolToken - used to process and handle the return codes from the SSPI wrapper
     internal class ProtocolToken
     {
         internal SecurityStatusPal Status;

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -192,7 +192,7 @@ namespace System.Net.Security.Tests
                 using (SslStream sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
                     IAsyncResult async = sslStream.BeginAuthenticateAsClient("localhost", null, clientSslProtocols, false, null, null);
-                    Assert.True(async.AsyncWaitHandle.WaitOne(10000), "Timed Out");
+                    Assert.True(async.AsyncWaitHandle.WaitOne(TestConfiguration.TestTimeoutSeconds * 1000), "Timed Out");
                     sslStream.EndAuthenticateAsClient(async);
 
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",

--- a/src/System.Net.Security/tests/FunctionalTests/FakeNetworkStream.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/FakeNetworkStream.cs
@@ -1,4 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.IO;
+
 namespace System.Net.Security.Tests
 {
     internal class FakeNetworkStream : Stream

--- a/src/System.Net.Security/tests/FunctionalTests/MockNetwork.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/MockNetwork.cs
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using System.Threading;
+
 namespace System.Net.Security.Tests
 {
     internal class MockNetwork
@@ -9,10 +13,6 @@ namespace System.Net.Security.Tests
 
         private readonly SemaphoreSlim _clientDataAvailable = new SemaphoreSlim(0);
         private readonly SemaphoreSlim _serverDataAvailable = new SemaphoreSlim(0);
-
-        public MockNetwork()
-        {
-        }
 
         public void ReadFrame(bool server, out byte[] buffer)
         {
@@ -30,7 +30,7 @@ namespace System.Net.Security.Tests
                 packetQueue = _serverWriteQueue;
             }
 
-            semaphore.Wait();
+            semaphore.Wait(TestConfiguration.TestTimeoutSeconds * 1000);
             buffer = packetQueue.Dequeue();
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAPMExtensions.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAPMExtensions.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-/// <summary>
-/// Extensions that add the legacy APM Pattern (Begin/End) for generic Streams
-/// </summary>
-
-
 using System.Threading.Tasks;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;

--- a/src/System.Net.Security/tests/FunctionalTests/StreamAPMExtensions.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/StreamAPMExtensions.cs
@@ -3,13 +3,11 @@
 
 using System.Threading.Tasks;
 
-/// <summary>
-/// Extensions that add the legacy APM Pattern (Begin/End) for generic Streams
-/// </summary>
-
-
 namespace System.IO
 {
+    /// <summary>
+    /// Extensions that add the legacy APM Pattern (Begin/End) for generic Streams
+    /// </summary>
     public static class StreamAPMExtensions
     {
         public static IAsyncResult BeginRead(this Stream s, byte[] buffer, int offset, int count, AsyncCallback callback, object state)

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -4,12 +4,15 @@
 using System.IO;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+
 using Xunit;
 
 namespace System.Net.Security.Tests
 {
     internal static class TestConfiguration
     {
+        public const int TestTimeoutSeconds = 3; 
+        
         public const SslProtocols DefaultSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
 
         public static X509Certificate2 GetServerCertificate()


### PR DESCRIPTION
1. In preparation for NegotiateStream I'm adding back the original SSPI object model. Code was brought in from c74b6f2 with cosmetic or no modifications (simplest way to review is to diff against that). SslStreamPal.Windows has been updated to match the original code in SecureChannel.

2. Updated both Windows and Unix PAL to match the interface (a few methods got moved, no substantial changes in non-Windows code).

3. Adding common test timeout configuration.

@bartonjs @vijaykota @rajansingh10 PTAL
/cc: @DavidSh, @josguil @SidharthNabar @pgavlin @stephentoub 