### PR TITLE
Re-enable test on *Nix

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -392,7 +392,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(3343, PlatformID.AnyUnix)]
         public async Task ReadAsStringAsync_SetInvalidCharset_ThrowsInvalidOperationException()
         {
             string sourceString = "some string";


### PR DESCRIPTION
HttpContentTest.ReadAsStringAsync_SetInvalidCharset_ThrowsInvalidOperationException
can be re-enabled due to fixes in the CoreCLR for System.Text.Encoding on
*Nix.

This fixes #3343.