### PR TITLE
Don't override dir.props' ECMA Key setting

### DIFF
--- a/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/System.IO.Compression/ref/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/ref/System.IO.Compression.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/System.Reflection.Context/ref/System.Reflection.Context.csproj
+++ b/src/System.Reflection.Context/ref/System.Reflection.Context.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/ref/System.Runtime.WindowsRuntime.UI.Xaml.csproj
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/ref/System.Runtime.WindowsRuntime.UI.Xaml.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <!-- 
          NOTE: Suppress false positive warning for the special case where we're building System.Runtime.WindowsRuntime itself
                at a version other than 4.0.0.0, which is referenced indirectly via the mscorlib.dll design-time facade, which


### PR DESCRIPTION
Due to https://github.com/dotnet/roslyn/issues/2444, we have disabled
ECMA signing when the host platform for our build is not Windows. This
is done by explicitly setting the property in our top level dir.props.
Some of the reference assemblies explicitly set UseECMAKey to true,
overwriting this value which leads to build breaks when building on non
Windows platforms.

Guard the setting of this property so that we don't override it if it
already set.

Fixes #3739