### PR TITLE
Unix SslStream: Implement RFC2812 IP Address matching for HTTP over TLS.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -121,6 +121,9 @@ internal static partial class Interop
             [MarshalAs(UnmanagedType.Bool)] bool isDst);
 
         [DllImport(Libraries.CryptoNative)]
+        internal static extern int CheckX509IpAddress(SafeX509Handle x509, [In]byte[] addressBytes, int addressLen, string hostname, int cchHostname);
+
+        [DllImport(Libraries.CryptoNative)]
         internal static extern int CheckX509Hostname(SafeX509Handle x509, string hostname, int cchHostname);
 
         internal static byte[] GetAsn1StringBytes(IntPtr asn1)

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -41,7 +41,23 @@ namespace System.Net
 
                     using (SafeX509Handle certHandle = Interop.libcrypto.X509_dup(certificate.Handle))
                     {
-                        hostnameMatch = Interop.Crypto.CheckX509Hostname(certHandle, hostName, hostName.Length);
+                        IPAddress hostnameAsIp;
+
+                        if (IPAddress.TryParse(hostName, out hostnameAsIp))
+                        {
+                            byte[] addressBytes = hostnameAsIp.GetAddressBytes();
+
+                            hostnameMatch = Interop.Crypto.CheckX509IpAddress(
+                                certHandle,
+                                addressBytes,
+                                addressBytes.Length,
+                                hostName,
+                                hostName.Length);
+                        }
+                        else
+                        {
+                            hostnameMatch = Interop.Crypto.CheckX509Hostname(certHandle, hostName, hostName.Length);
+                        }
                     }
 
                     if (hostnameMatch != 1)


### PR DESCRIPTION
If the hostname looks like an IP Address then do exact matches against GEN_IPADDR Subject Alternative Name entries.  Unlike the GEN_DNS matching of text hostnames, the IP Address form always falls back to the CN text comparison if no other match has been found.

Fixes #3445.

cc: @vijaykota @stephentoub @rajansingh10 @shrutigarg @CIPop @davidsh 