### PR TITLE
Removing some dead code in the expression interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -265,24 +265,6 @@ namespace System.Linq.Expressions.Interpreter
             _pendingContinuation = (int)Pop();
         }
 
-        private static MethodInfo s_goto;
-        private static MethodInfo s_voidGoto;
-
-        internal static MethodInfo GotoMethod
-        {
-            get { return s_goto ?? (s_goto = typeof(InterpretedFrame).GetMethod("Goto")); }
-        }
-
-        internal static MethodInfo VoidGotoMethod
-        {
-            get { return s_voidGoto ?? (s_voidGoto = typeof(InterpretedFrame).GetMethod("VoidGoto")); }
-        }
-
-        public int VoidGoto(int labelIndex)
-        {
-            return Goto(labelIndex, Interpreter.NoValue, gotoExceptionHandler: false);
-        }
-
         public int Goto(int labelIndex, object value, bool gotoExceptionHandler)
         {
             // TODO: we know this at compile time (except for compiled loop):

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -16,16 +16,6 @@ using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Linq.Expressions.Interpreter
 {
-    internal sealed class LightLambdaCompileEventArgs : EventArgs
-    {
-        public Delegate Compiled { get; private set; }
-
-        internal LightLambdaCompileEventArgs(Delegate compiled)
-        {
-            Compiled = compiled;
-        }
-    }
-
     public partial class LightLambda
     {
         private readonly IStrongBox[] _closure;


### PR DESCRIPTION
This addresses issue #3836. More may be found later.