### PR TITLE
Add more tests for binary expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -184,8 +184,7 @@ namespace System.Linq.Expressions
                 case ExpressionType.ExclusiveOrAssign:
                     return ExpressionType.ExclusiveOr;
                 default:
-                    // must be an error
-                    throw Error.InvalidOperation("op");
+                    throw ContractUtils.Unreachable;
             }
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -920,5 +920,83 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Add(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void CannotReduceChecked()
+        {
+            Expression exp = Expression.AddChecked(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Add(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Add(Expression.Constant(""), null));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.AddChecked(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.AddChecked(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Add(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Add(Expression.Constant(1), value));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.AddChecked(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Add(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -617,5 +617,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Divide(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Divide(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Divide(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Divide(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Divide(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -617,5 +617,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Modulo(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Modulo(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Modulo(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Modulo(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Modulo(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -920,5 +920,83 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Multiply(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void CannotReduceChecked()
+        {
+            Expression exp = Expression.MultiplyChecked(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Multiply(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Multiply(Expression.Constant(""), null));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.MultiplyChecked(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.MultiplyChecked(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Multiply(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Multiply(Expression.Constant(1), value));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.MultiplyChecked(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.MultiplyChecked(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -602,5 +602,83 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduceLeft()
+        {
+            Expression exp = Expression.LeftShift(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void CannotReduceRight()
+        {
+            Expression exp = Expression.RightShift(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void LeftThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.LeftShift(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void LeftThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.LeftShift(Expression.Constant(""), null));
+        }
+
+        [Fact]
+        public static void RightThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.RightShift(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void RightThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.RightShift(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void LeftThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.LeftShift(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void LeftThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.LeftShift(Expression.Constant(1), value));
+        }
+
+        [Fact]
+        public static void RightThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.RightShift(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void RightThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.RightShift(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -905,5 +905,83 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Subtract(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void CannotReduceChecked()
+        {
+            Expression exp = Expression.SubtractChecked(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Subtract(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Subtract(Expression.Constant(""), null));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.SubtractChecked(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.SubtractChecked(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Subtract(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Subtract(Expression.Constant(1), value));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.SubtractChecked(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void CheckedThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.SubtractChecked(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class Assign
+    {
+        [Fact]
+        public void SimpleAssignment()
+        {
+            ParameterExpression variable = Expression.Variable(typeof(int));
+            LabelTarget target = Expression.Label(typeof(int));
+            Expression exp = Expression.Block(
+                new ParameterExpression[] {variable},
+                Expression.Assign(variable, Expression.Constant(42)),
+                Expression.Return(target, variable),
+                Expression.Label(target, Expression.Default(typeof(int)))
+                );
+            Assert.Equal(42, Expression.Lambda<Func<int>>(exp).Compile()());
+        }
+
+        [Fact]
+        public void AssignmentHasValueItself()
+        {
+            ParameterExpression variable = Expression.Variable(typeof(int));
+            Expression exp = Expression.Block(
+                new ParameterExpression[] { variable },
+                Expression.Assign(variable, Expression.Constant(42))
+                );
+            Assert.Equal(42, Expression.Lambda<Func<int>>(exp).Compile()());
+        }
+
+        [Fact]
+        public void CannotReduce()
+        {
+            Expression exp = Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Assign(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Assign(Expression.Variable(typeof(int)), null));
+        }
+
+        [Fact]
+        public void LeftMustBeWritable()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Constant(0), Expression.Constant(1)));
+        }
+
+        [Fact]
+        public void MismatchTypes()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant("Hello")));
+        }
+
+        [Fact]
+        public void AssignableButOnlyWithConversion()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Variable(typeof(long)), Expression.Constant(1)));
+        }
+
+        [Fact]
+        public void ReferenceAssignable()
+        {
+            ParameterExpression variable = Expression.Variable(typeof(object));
+            LabelTarget target = Expression.Label(typeof(object));
+            Expression exp = Expression.Block(
+                new ParameterExpression[] { variable },
+                Expression.Assign(variable, Expression.Constant("Hello")),
+                Expression.Return(target, variable),
+                Expression.Label(target, Expression.Default(typeof(object)))
+                );
+            Assert.Equal("Hello", Expression.Lambda<Func<object>>(exp).Compile()());
+        }
+
+        [Fact]
+        public void AttemptToAssignToNonWritable()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Default(typeof(int)), Expression.Default(typeof(int))));
+        }
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void AttemptToAssignFromNonReadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            ParameterExpression variable = Expression.Variable(typeof(int));
+            Assert.Throws<ArgumentException>("right", () => Expression.Assign(variable, value));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -1,0 +1,284 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class OpAssign
+    {
+        [Theory]
+        [MemberData("AssignAndEquivalentMethods")]
+        public void AssignmentEquivalents(MethodInfo nonAssign, MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withoutAssignment = (Func<Expression, Expression, Expression>)nonAssign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            foreach (object x in new[] { 0, -1, 1, 10 }.Select(i => Convert.ChangeType(i, type)))
+                foreach (object y in new[] { -1, 1, 10 }.Select(i => Convert.ChangeType(i, type)))
+                {
+                    ConstantExpression xExp = Expression.Constant(x);
+                    ConstantExpression yExp = Expression.Constant(y);
+                    Expression woAssign = withoutAssignment(xExp, yExp);
+                    ParameterExpression variable = Expression.Variable(type);
+                    Expression initAssign = Expression.Assign(variable, xExp);
+                    Expression assignment = withAssignment(variable, yExp);
+                    Expression wAssign = Expression.Block(
+                        new ParameterExpression[] { variable },
+                        initAssign,
+                        assignment
+                        );
+                    Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(woAssign, wAssign)).Compile()());
+                    LabelTarget target = Expression.Label(type);
+                    Expression wAssignReturningVariable = Expression.Block(
+                        new ParameterExpression[] { variable },
+                        initAssign,
+                        assignment,
+                        Expression.Return(target, variable),
+                        Expression.Label(target, Expression.Default(type))
+                        );
+                    Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(woAssign, wAssignReturningVariable)).Compile()());
+                }
+        }
+
+        private class Box<T>
+        {
+            public T Value { get; set; }
+            public T this[int index]
+            {
+                get
+                {
+                    return Value;
+                }
+                set
+                {
+                    Value = value;
+                }
+            }
+            public Box(T value)
+            {
+                Value = value;
+            }
+        }
+
+        [Theory]
+        [MemberData("AssignAndEquivalentMethods")]
+        public void AssignmentEquivalentsWithMemberAccess(MethodInfo nonAssign, MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withoutAssignment = (Func<Expression, Expression, Expression>)nonAssign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            foreach (object x in new[] { 0, -1, 1, 10 }.Select(i => Convert.ChangeType(i, type)))
+                foreach (object y in new[] { -1, 1, 10 }.Select(i => Convert.ChangeType(i, type)))
+                {
+                    ConstantExpression xExp = Expression.Constant(x);
+                    ConstantExpression yExp = Expression.Constant(y);
+                    Expression woAssign = withoutAssignment(xExp, yExp);
+                    Type boxType = typeof(Box<>).MakeGenericType(type);
+                    object box = boxType.GetConstructor(new[] { type }).Invoke(new object[] { x });
+                    Expression boxExp = Expression.Constant(box);
+                    Expression property = Expression.Property(boxExp, boxType.GetProperty("Value"));
+                    Expression assignment = withAssignment(property, yExp);
+                    Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(woAssign, assignment)).Compile()());
+                    LabelTarget target = Expression.Label(type);
+                    box = boxType.GetConstructor(new[] { type }).Invoke(new object[] { x });
+                    boxExp = Expression.Constant(box);
+                    property = Expression.Property(boxExp, boxType.GetProperty("Value"));
+                    assignment = withAssignment(property, yExp);
+                    Expression wAssignReturningVariable = Expression.Block(
+                        assignment,
+                        Expression.Return(target, property),
+                        Expression.Label(target, Expression.Default(type))
+                        );
+                    Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(woAssign, wAssignReturningVariable)).Compile()());
+                }
+        }
+
+        [Theory]
+        [MemberData("AssignAndEquivalentMethods")]
+        public void AssignmentEquivalentsWithIndexAccess(MethodInfo nonAssign, MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withoutAssignment = (Func<Expression, Expression, Expression>)nonAssign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            foreach (object x in new[] { 0, -1, 1, 10 }.Select(i => Convert.ChangeType(i, type)))
+                foreach (object y in new[] { -1, 1, 10 }.Select(i => Convert.ChangeType(i, type)))
+                {
+                    ConstantExpression xExp = Expression.Constant(x);
+                    ConstantExpression yExp = Expression.Constant(y);
+                    Expression woAssign = withoutAssignment(xExp, yExp);
+                    Type boxType = typeof(Box<>).MakeGenericType(type);
+                    object box = boxType.GetConstructor(new[] { type }).Invoke(new object[] { x });
+                    Expression boxExp = Expression.Constant(box);
+                    Expression property = Expression.Property(boxExp, boxType.GetProperty("Item"), Expression.Constant(0));
+                    Expression assignment = withAssignment(property, yExp);
+                    Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(woAssign, assignment)).Compile()());
+                    LabelTarget target = Expression.Label(type);
+                    box = boxType.GetConstructor(new[] { type }).Invoke(new object[] { x });
+                    boxExp = Expression.Constant(box);
+                    property = Expression.Property(boxExp, boxType.GetProperty("Item"), Expression.Constant(0));
+                    assignment = withAssignment(property, yExp);
+                    Expression wAssignReturningVariable = Expression.Block(
+                        assignment,
+                        Expression.Return(target, property),
+                        Expression.Label(target, Expression.Default(type))
+                        );
+                    Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(woAssign, wAssignReturningVariable)).Compile()());
+                }
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethods")]
+        public void AssignmentReducable(MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            ParameterExpression variable = Expression.Variable(type);
+            Expression assignment = withAssignment(variable, Expression.Default(type));
+            Assert.True(assignment.CanReduce);
+            Assert.NotSame(assignment, assignment.ReduceAndCheck());
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethods")]
+        public void CannotAssignToNonWritable(MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            Assert.Throws<ArgumentException>(() => withAssignment(Expression.Default(type), Expression.Default(type)));
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethods")]
+        public void AssignmentWithMemberAccessReducable(MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            Type boxType = typeof(Box<>).MakeGenericType(type);
+            object box = boxType.GetConstructor(new[] { type }).Invoke(new object[] { Convert.ChangeType(0, type) });
+            Expression boxExp = Expression.Constant(box);
+            Expression property = Expression.Property(boxExp, boxType.GetProperty("Value"));
+            Expression assignment = withAssignment(property, Expression.Default(type));
+            Assert.True(assignment.CanReduce);
+            Assert.NotSame(assignment, assignment.ReduceAndCheck());
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethods")]
+        public void AssignmentWithIndexAccessReducable(MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            Type boxType = typeof(Box<>).MakeGenericType(type);
+            object box = boxType.GetConstructor(new[] { type }).Invoke(new object[] { Convert.ChangeType(0, type) });
+            Expression boxExp = Expression.Constant(box);
+            Expression property = Expression.Property(boxExp, boxType.GetProperty("Item"), Expression.Constant(0));
+            Expression assignment = withAssignment(property, Expression.Default(type));
+            Assert.True(assignment.CanReduce);
+            Assert.NotSame(assignment, assignment.ReduceAndCheck());
+        }
+
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethods")]
+        public static void ThrowsOnLeftUnreadable(MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            Type unreadableType = typeof(Unreadable<>).MakeGenericType(type);
+            Expression property = Expression.Property(null, unreadableType.GetProperty("WriteOnly"));
+            Assert.Throws<ArgumentException>(() => withAssignment(property, Expression.Default(type)));
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethods")]
+        public static void ThrowsOnRightUnreadable(MethodInfo assign, Type type)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            Type unreadableType = typeof(Unreadable<>).MakeGenericType(type);
+            Expression property = Expression.Property(null, unreadableType.GetProperty("WriteOnly"));
+            Expression variable = Expression.Variable(type);
+            Assert.Throws<ArgumentException>(() => withAssignment(variable, property));
+        }
+
+        [Theory]
+        [MemberData("AssignmentMethodsWithoutTypes")]
+        public void ThrowIfNoSuchBinaryOperation(MethodInfo assign)
+        {
+            Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
+
+            ParameterExpression variable = Expression.Variable(typeof(string));
+            Expression value = Expression.Default(typeof(string));
+            Assert.Throws<InvalidOperationException>(() => withAssignment(variable, value));
+        }
+
+        private static IEnumerable<object[]> AssignmentMethods()
+        {
+            MethodInfo[] expressionMethods = typeof(Expression).GetMethods().Where(mi => mi.GetParameters().Length == 2).ToArray();
+            foreach (Tuple<string, string> names in AssignAndEquivalentMethodNames(true))
+                yield return new object[] { expressionMethods.First(mi => mi.Name == names.Item2), typeof(int) };
+            foreach (Tuple<string, string> names in AssignAndEquivalentMethodNames(false))
+                yield return new object[] { expressionMethods.First(mi => mi.Name == names.Item2), typeof(double) };
+        }
+
+        private static IEnumerable<object[]> AssignmentMethodsWithoutTypes()
+        {
+            MethodInfo[] expressionMethods = typeof(Expression).GetMethods().Where(mi => mi.GetParameters().Length == 2).ToArray();
+            return AssignAndEquivalentMethodNames(true).Concat(AssignAndEquivalentMethodNames(false))
+                .Select(i => i.Item2)
+                .Distinct()
+                .Select(i => new object[] { expressionMethods.First(mi => mi.Name == i) });
+        }
+
+        private static IEnumerable<object[]> AssignAndEquivalentMethods()
+        {
+            MethodInfo[] expressionMethods = typeof(Expression).GetMethods().Where(mi => mi.GetParameters().Length == 2).ToArray();
+            foreach (Tuple<string, string> names in AssignAndEquivalentMethodNames(true))
+                yield return new object[] {
+                    expressionMethods.First(mi => mi.Name == names.Item1),
+                    expressionMethods.First(mi => mi.Name == names.Item2),
+                    typeof(int)
+                };
+            foreach (Tuple<string, string> names in AssignAndEquivalentMethodNames(false))
+                yield return new object[] {
+                    expressionMethods.First(mi => mi.Name == names.Item1),
+                    expressionMethods.First(mi => mi.Name == names.Item2),
+                    typeof(double)
+                };
+        }
+
+        private static IEnumerable<Tuple<string, string>> AssignAndEquivalentMethodNames(bool integral)
+        {
+            yield return Tuple.Create("Add", "AddAssign");
+            yield return Tuple.Create("AddChecked", "AddAssignChecked");
+            yield return Tuple.Create("Divide", "DivideAssign");
+            yield return Tuple.Create("Modulo", "ModuloAssign");
+            yield return Tuple.Create("Multiply", "MultiplyAssign");
+            yield return Tuple.Create("MultiplyChecked", "MultiplyAssignChecked");
+            yield return Tuple.Create("Subtract", "SubtractAssign");
+            yield return Tuple.Create("SubtractChecked", "SubtractAssignChecked");
+            if (integral)
+            {
+                yield return Tuple.Create("And", "AndAssign");
+                yield return Tuple.Create("ExclusiveOr", "ExclusiveOrAssign");
+                yield return Tuple.Create("LeftShift", "LeftShiftAssign");
+                yield return Tuple.Create("Or", "OrAssign");
+                yield return Tuple.Create("RightShift", "RightShiftAssign");
+            }
+            else
+                yield return Tuple.Create("Power", "PowerAssign");
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -497,5 +497,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.And(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.And(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.And(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.And(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.And(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -497,5 +497,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.ExclusiveOr(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.ExclusiveOr(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.ExclusiveOr(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.ExclusiveOr(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.ExclusiveOr(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -497,5 +497,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Or(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Or(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Or(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Or(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Or(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -2144,5 +2144,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Coalesce(Expression.Constant(0, typeof(int?)), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Coalesce(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Coalesce(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Coalesce(value, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Coalesce(Expression.Constant(""), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
@@ -797,5 +797,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.Equal(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.Equal(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.Equal(Expression.Constant(""), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.Equal(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.Equal(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
@@ -737,5 +737,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.GreaterThanOrEqual(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.GreaterThanOrEqual(null, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.GreaterThanOrEqual(Expression.Constant(0), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.GreaterThanOrEqual(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.GreaterThanOrEqual(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
@@ -737,5 +737,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.GreaterThan(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.GreaterThan(null, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.GreaterThan(Expression.Constant(0), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.GreaterThan(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.GreaterThan(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
@@ -737,5 +737,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.LessThanOrEqual(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.LessThanOrEqual(null, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.LessThanOrEqual(Expression.Constant(0), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.LessThanOrEqual(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.LessThanOrEqual(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
@@ -737,5 +737,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.LessThan(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.LessThan(null, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.LessThan(Expression.Constant(0), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.LessThan(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.LessThan(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
@@ -797,5 +797,48 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduce()
+        {
+            Expression exp = Expression.NotEqual(Expression.Constant(0), Expression.Constant(0));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.NotEqual(null, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.NotEqual(Expression.Constant(0), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.NotEqual(value, Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.NotEqual(Expression.Constant(1), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class GeneralBinaryTests
+    {
+        private static readonly ExpressionType[] BinaryTypes =
+        {
+            ExpressionType.Add, ExpressionType.AddChecked, ExpressionType.Subtract, ExpressionType.SubtractChecked,
+            ExpressionType.Multiply, ExpressionType.MultiplyChecked, ExpressionType.Divide, ExpressionType.Modulo,
+            ExpressionType.Power, ExpressionType.And, ExpressionType.AndAlso, ExpressionType.Or, ExpressionType.OrElse,
+            ExpressionType.LessThan, ExpressionType.LessThanOrEqual, ExpressionType.GreaterThan, ExpressionType.GreaterThanOrEqual,
+            ExpressionType.Equal, ExpressionType.NotEqual, ExpressionType.ExclusiveOr, ExpressionType.Coalesce,
+            ExpressionType.ArrayIndex, ExpressionType.RightShift, ExpressionType.LeftShift, ExpressionType.Assign,
+            ExpressionType.AddAssign, ExpressionType.AndAssign, ExpressionType.DivideAssign, ExpressionType.ExclusiveOrAssign,
+            ExpressionType.LeftShiftAssign, ExpressionType.ModuloAssign, ExpressionType.MultiplyAssign, ExpressionType.OrAssign,
+            ExpressionType.PowerAssign, ExpressionType.RightShiftAssign, ExpressionType.SubtractAssign,
+            ExpressionType.AddAssignChecked, ExpressionType.SubtractAssignChecked, ExpressionType.MultiplyAssignChecked
+        };
+
+        public static IEnumerable<object[]> BinaryTypesData()
+        {
+            return BinaryTypes.Select(i => new object[] { i });
+        }
+
+        private static ExpressionType[] NonBinaryTypes = ((ExpressionType[])Enum.GetValues(typeof(ExpressionType)))
+            .Except(BinaryTypes)
+            .ToArray();
+
+        public static IEnumerable<ExpressionType> NonBinaryTypesIncludingInvalid = NonBinaryTypes.Concat(Enumerable.Repeat((ExpressionType)(-1), 1));
+
+        public static IEnumerable<object[]> NonBinaryTypesIncludingInvalidData()
+        {
+            return NonBinaryTypesIncludingInvalid.Select(i => new object[] { i });
+        }
+
+        [Theory]
+        [MemberData("NonBinaryTypesIncludingInvalidData")]
+        public void MakeBinaryInvalidType(ExpressionType type)
+        {
+            Assert.Throws<ArgumentException>(() => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null));
+            Assert.Throws<ArgumentException>(() => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null, null));
+        }
+
+        [Theory]
+        [MemberData("BinaryTypesData")]
+        public void MakeBinaryLeftNull(ExpressionType type)
+        {
+            Assert.Throws<ArgumentNullException>(() => Expression.MakeBinary(type, null, Expression.Constant(0)));
+            Assert.Throws<ArgumentNullException>(() => Expression.MakeBinary(type, null, Expression.Constant(0), false, null));
+            Assert.Throws<ArgumentNullException>(() => Expression.MakeBinary(type, null, Expression.Constant(0), false, null, null));
+        }
+
+        [Theory]
+        [MemberData("BinaryTypesData")]
+        public void MakeBinaryRightNull(ExpressionType type)
+        {
+            Assert.Throws<ArgumentNullException>(() => Expression.MakeBinary(type, Expression.Variable(typeof(object)), null));
+            Assert.Throws<ArgumentNullException>(() => Expression.MakeBinary(type, Expression.Variable(typeof(object)), null, false, null));
+            Assert.Throws<ArgumentNullException>(() => Expression.MakeBinary(type, Expression.Variable(typeof(object)), null, false, null, null));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -257,5 +257,83 @@ namespace Tests.ExpressionCompiler.Binary
         }
 
         #endregion
+
+        [Fact]
+        public static void CannotReduceAndAlso()
+        {
+            Expression exp = Expression.AndAlso(Expression.Constant(true), Expression.Constant(false));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void CannotReduceOrElse()
+        {
+            Expression exp = Expression.OrElse(Expression.Constant(true), Expression.Constant(false));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public static void AndAlsoThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.AndAlso(null, Expression.Constant(true)));
+        }
+
+        [Fact]
+        public static void AndAlsoThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.AndAlso(Expression.Constant(true), null));
+        }
+
+        [Fact]
+        public static void OrElseThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.OrElse(null, Expression.Constant(true)));
+        }
+
+        [Fact]
+        public static void OrElseThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.OrElse(Expression.Constant(true), null));
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public static void AndAlsoThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<bool>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.AndAlso(value, Expression.Constant(true)));
+        }
+
+        [Fact]
+        public static void AndAlsoThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<bool>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.AndAlso(Expression.Constant(true), value));
+        }
+
+        [Fact]
+        public static void OrElseThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<bool>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.OrElse(value, Expression.Constant(true)));
+        }
+
+        [Fact]
+        public static void OrElseThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<bool>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.OrElse(Expression.Constant(false), value));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ReferenceEqual : ReferenceEqualityTests
+    {
+        [Theory]
+        [MemberData("ReferenceObjectsData")]
+        public void TrueOnSame(object item)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                    Expression.Constant(item, item.GetType()),
+                    Expression.Constant(item, item.GetType())
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ReferenceTypesData")]
+        public void TrueOnBothNull(Type type)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                Expression.Constant(null, type),
+                Expression.Constant(null, type)
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ReferenceObjectsData")]
+        public void FalseIfLeftNull(object item)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                    Expression.Constant(null, item.GetType()),
+                    Expression.Constant(item, item.GetType())
+                );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ReferenceObjectsData")]
+        public void FalseIfRightNull(object item)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                    Expression.Constant(item, item.GetType()),
+                    Expression.Constant(null, item.GetType())
+                );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("DifferentObjects")]
+        public void FalseIfDifferentObjectsAsObject(object x, object y)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                    Expression.Constant(x, typeof(object)),
+                    Expression.Constant(y, typeof(object))
+                );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("DifferentObjects")]
+        public void FalseIfDifferentObjectsOwnType(object x, object y)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                    Expression.Constant(x),
+                    Expression.Constant(y)
+                );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("LeftValueType")]
+        [MemberData("RightValueType")]
+        [MemberData("BothValueType")]
+        public void ThrowsOnValueTypeArguments(object x, object y)
+        {
+            Expression xExp = Expression.Constant(x);
+            Expression yExp = Expression.Constant(y);
+            Assert.Throws<InvalidOperationException>(() => Expression.ReferenceEqual(xExp, yExp));
+        }
+
+        [Theory]
+        [MemberData("UnassignablePairs")]
+        public void ThrowsOnUnassignablePairs(object x, object y)
+        {
+            Expression xExp = Expression.Constant(x);
+            Expression yExp = Expression.Constant(y);
+            Assert.Throws<InvalidOperationException>(() => Expression.ReferenceEqual(xExp, yExp));
+        }
+
+        [Theory]
+        [MemberData("ComparableValuesData")]
+        public void TrueOnSameViaInterface(object item)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                Expression.Constant(item, typeof(IComparable)),
+                Expression.Constant(item, typeof(IComparable))
+            );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("DifferentComparableValues")]
+        public void FalseOnDifferentViaInterface(object x, object y)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                Expression.Constant(x, typeof(IComparable)),
+                Expression.Constant(y, typeof(IComparable))
+            );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ComparableReferenceTypesData")]
+        public void TrueOnSameLeftViaInterface(object item)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                Expression.Constant(item, typeof(IComparable)),
+                Expression.Constant(item)
+            );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ComparableReferenceTypesData")]
+        public void TrueOnSameRightViaInterface(object item)
+        {
+            Expression exp = Expression.ReferenceEqual(
+                Expression.Constant(item),
+                Expression.Constant(item, typeof(IComparable))
+            );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Fact]
+        public void CannotReduce()
+        {
+            Expression exp = Expression.ReferenceEqual(Expression.Constant(""), Expression.Constant(""));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.ReferenceEqual(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.ReferenceEqual(Expression.Constant(""), null));
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.ReferenceEqual(value, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.ReferenceEqual(Expression.Constant(""), value));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqualityTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqualityTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.Linq.Expressions.Tests
+{
+    public abstract class ReferenceEqualityTests
+    {
+        protected static IEnumerable<object[]> ReferenceObjectsData()
+        {
+            return ReferenceObjects().Select(i => new[] { i });
+        }
+
+        protected static IEnumerable<object[]> DifferentObjects()
+        {
+            return from x in ReferenceObjects()
+                   from y in ReferenceObjects()
+                   where !ReferenceEquals(x, y)
+                   && (x.GetType().IsAssignableFrom(y.GetType()) || y.GetType().IsAssignableFrom(x.GetType()))
+                   select new[] { x, y };
+        }
+
+        protected static IEnumerable<object[]> ComparableValuesData()
+        {
+            return ComparableValues().Select(i => new object[] { i });
+        }
+
+        protected static IEnumerable<object[]> DifferentComparableValues()
+        {
+            return from x in ComparableValues()
+                   from y in ComparableValues()
+                   where !(ReferenceEquals(x, y))
+                   select new[] { x, y };
+        }
+
+        protected static IEnumerable<object[]> ComparableReferenceTypesData()
+        {
+            return ComparableReferenceTypes().Select(i => new object[] { i });
+        }
+
+        protected static IEnumerable<object[]> LeftValueType()
+        {
+            return from x in ReferenceObjects()
+                   from y in ValueTypeObjects()
+                   select new[] { y, x };
+        }
+
+        protected static IEnumerable<object[]> RightValueType()
+        {
+            return from x in ReferenceObjects()
+                   from y in ValueTypeObjects()
+                   select new[] { x, y };
+        }
+
+        protected static IEnumerable<object[]> BothValueType()
+        {
+            return from x in ValueTypeObjects()
+                   from y in ValueTypeObjects()
+                   select new[] { x, y };
+        }
+
+        protected static IEnumerable<object[]> UnassignablePairs()
+        {
+            return from x in ReferenceObjects()
+                   from y in ReferenceObjects()
+                   where !x.GetType().IsAssignableFrom(y.GetType()) && !y.GetType().IsAssignableFrom(x.GetType())
+                   select new[] { x, y };
+        }
+
+        protected static IEnumerable<object> ReferenceObjects()
+        {
+            yield return new object();
+            yield return "";
+            yield return "Hello";
+            yield return new Uri("http://example.net/");
+            yield return new Uri("http://example.net/");
+        }
+
+        protected static IEnumerable<IComparable> ComparableValues()
+        {
+            yield return 1;
+            yield return DateTime.MinValue;
+            foreach (IComparable value in ComparableReferenceTypes())
+                yield return value;
+        }
+
+        protected static IEnumerable<IComparable> ComparableReferenceTypes()
+        {
+            yield return "abc";
+            yield return "";
+            yield return "Hello";
+        }
+
+        protected static IEnumerable<object> ValueTypeObjects()
+        {
+            yield return 0;
+            yield return 0m;
+            yield return DateTime.MinValue;
+        }
+
+        protected static IEnumerable<object[]> ReferenceTypesData()
+        {
+            return ReferenceTypes().Select(i => new object[] { i });
+        }
+
+        protected static IEnumerable<Type> ReferenceTypes()
+        {
+            yield return typeof(object);
+            yield return typeof(string);
+            yield return typeof(ReferenceEqual);
+        }
+
+        protected static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ReferenceNotEqual : ReferenceEqualityTests
+    {
+        [Theory]
+        [MemberData("ReferenceObjectsData")]
+        public void FalseOnSame(object item)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                    Expression.Constant(item, item.GetType()),
+                    Expression.Constant(item, item.GetType())
+                );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ReferenceTypesData")]
+        public void FalseOnBothNull(Type type)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                Expression.Constant(null, type),
+                Expression.Constant(null, type)
+                );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ReferenceObjectsData")]
+        public void TrueIfLeftNull(object item)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                    Expression.Constant(null, item.GetType()),
+                    Expression.Constant(item, item.GetType())
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ReferenceObjectsData")]
+        public void TrueIfRightNull(object item)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                    Expression.Constant(item, item.GetType()),
+                    Expression.Constant(null, item.GetType())
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("DifferentObjects")]
+        public void TrueIfDifferentObjectsAsObject(object x, object y)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                    Expression.Constant(x, typeof(object)),
+                    Expression.Constant(y, typeof(object))
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("DifferentObjects")]
+        public void TrueIfDifferentObjectsOwnType(object x, object y)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                    Expression.Constant(x),
+                    Expression.Constant(y)
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("LeftValueType")]
+        [MemberData("RightValueType")]
+        [MemberData("BothValueType")]
+        public void ThrowsOnValueTypeArguments(object x, object y)
+        {
+            Expression xExp = Expression.Constant(x);
+            Expression yExp = Expression.Constant(y);
+            Assert.Throws<InvalidOperationException>(() => Expression.ReferenceNotEqual(xExp, yExp));
+        }
+
+        [Theory]
+        [MemberData("UnassignablePairs")]
+        public void ThrowsOnUnassignablePairs(object x, object y)
+        {
+            Expression xExp = Expression.Constant(x);
+            Expression yExp = Expression.Constant(y);
+            Assert.Throws<InvalidOperationException>(() => Expression.ReferenceNotEqual(xExp, yExp));
+        }
+
+        [Theory]
+        [MemberData("ComparableValuesData")]
+        public void FalseOnSameViaInterface(object item)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                Expression.Constant(item, typeof(IComparable)),
+                Expression.Constant(item, typeof(IComparable))
+            );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("DifferentComparableValues")]
+        public void TrueOnDifferentViaInterface(object x, object y)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                Expression.Constant(x, typeof(IComparable)),
+                Expression.Constant(y, typeof(IComparable))
+            );
+            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ComparableReferenceTypesData")]
+        public void FalseOnSameLeftViaInterface(object item)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                Expression.Constant(item, typeof(IComparable)),
+                Expression.Constant(item)
+            );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ComparableReferenceTypesData")]
+        public void FalseOnSameRightViaInterface(object item)
+        {
+            Expression exp = Expression.ReferenceNotEqual(
+                Expression.Constant(item),
+                Expression.Constant(item, typeof(IComparable))
+            );
+            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+        }
+
+        [Fact]
+        public void CannotReduce()
+        {
+            Expression exp = Expression.ReferenceNotEqual(Expression.Constant(""), Expression.Constant(""));
+            Assert.False(exp.CanReduce);
+            Assert.Same(exp, exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+        }
+
+        [Fact]
+        public void ThrowsOnLeftNull()
+        {
+            Assert.Throws<ArgumentNullException>("left", () => Expression.ReferenceNotEqual(null, Expression.Constant("")));
+        }
+
+        [Fact]
+        public void ThrowsOnRightNull()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Expression.ReferenceNotEqual(Expression.Constant(""), null));
+        }
+
+        [Fact]
+        public static void ThrowsOnLeftUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
+            Assert.Throws<ArgumentException>("left", () => Expression.ReferenceNotEqual(value, Expression.Constant("")));
+        }
+
+        [Fact]
+        public static void ThrowsOnRightUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
+            Assert.Throws<ArgumentException>("right", () => Expression.ReferenceNotEqual(Expression.Constant(""), value));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -44,6 +44,8 @@
     <Compile Include="BinaryOperators\Arithmetic\BinaryNullablePowerTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinaryNullableSubtractTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinarySubtractTests.cs" />
+    <Compile Include="BinaryOperators\Assignment\Assign.cs" />
+    <Compile Include="BinaryOperators\Assignment\OpAssign.cs" />
     <Compile Include="BinaryOperators\Bitwise\BinaryAndTests.cs" />
     <Compile Include="BinaryOperators\Bitwise\BinaryExclusiveOrTests.cs" />
     <Compile Include="BinaryOperators\Bitwise\BinaryNullableAndTests.cs" />
@@ -64,8 +66,12 @@
     <Compile Include="BinaryOperators\Comparison\BinaryNullableLessThanOrEqualTests.cs" />
     <Compile Include="BinaryOperators\Comparison\BinaryNullableLessThanTests.cs" />
     <Compile Include="BinaryOperators\Comparison\BinaryNullableNotEqualTests.cs" />
+    <Compile Include="BinaryOperators\GeneralBinaryTests.cs" />
     <Compile Include="BinaryOperators\Logical\BinaryLogicalTests.cs" />
     <Compile Include="BinaryOperators\Logical\BinaryNullableLogicalTests.cs" />
+    <Compile Include="BinaryOperators\ReferenceComparison\ReferenceEqual.cs" />
+    <Compile Include="BinaryOperators\ReferenceComparison\ReferenceEqualityTests.cs" />
+    <Compile Include="BinaryOperators\ReferenceComparison\ReferenceNotEqual.cs" />
     <Compile Include="Block\BlockFactoryTests.cs" />
     <Compile Include="Call\CallFactoryTests.cs" />
     <Compile Include="Cast\AsNullable.cs" />


### PR DESCRIPTION
Filling in checks for correct behaviour on Reduce, CanReduce and null arguments
to existing tests. Adding tests for assigning expressions.

A start on making some inroads on #1198

