### PR TITLE
Remove internal Validation namespace

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/DictionaryEnumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/DictionaryEnumerator.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Comparers.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Comparers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+DebuggerProxy.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+DebuggerProxy.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+MutationResult.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+MutationResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Validation;
-
 namespace System.Collections.Immutable
 {
     /// <content>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
-using BCL = System.Collections.Generic;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+Builder.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+DebuggerProxy.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+DebuggerProxy.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+HashBucket.cs
@@ -360,7 +360,7 @@ namespace System.Collections.Immutable
                 {
                     if (_disposed)
                     {
-                        Validation.Requires.FailObjectDisposed(this);
+                        Requires.FailObjectDisposed(this);
                     }
                 }
             }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationInput.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationInput.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationResult.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Validation;
-
 namespace System.Collections.Immutable
 {
     /// <content>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+NodeEnumerable.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+NodeEnumerable.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {
@@ -1729,7 +1728,7 @@ namespace System.Collections.Immutable
 
                 if (_root == null || (_stack != null && !_stack.IsOwned(ref this)))
                 {
-                    Validation.Requires.FailObjectDisposed(this);
+                    Requires.FailObjectDisposed(this);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue`1.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {
@@ -478,7 +477,7 @@ namespace System.Collections.Immutable
             {
                 if (_disposed)
                 {
-                    Validation.Requires.FailObjectDisposed(this);
+                    Requires.FailObjectDisposed(this);
                 }
             }
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {
@@ -1114,7 +1113,7 @@ namespace System.Collections.Immutable
 
                 if (_root == null || (_stack != null && !_stack.IsOwned(ref this)))
                 {
-                    Validation.Requires.FailObjectDisposed(this);
+                    Requires.FailObjectDisposed(this);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {
@@ -1346,7 +1345,7 @@ namespace System.Collections.Immutable
 
                 if (_root == null || (_stack != null && !_stack.IsOwned(ref this)))
                 {
-                    Validation.Requires.FailObjectDisposed(this);
+                    Requires.FailObjectDisposed(this);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 
 namespace System.Collections.Immutable
 {
@@ -411,7 +410,7 @@ namespace System.Collections.Immutable
             {
                 if (_disposed)
                 {
-                    Validation.Requires.FailObjectDisposed(this);
+                    Requires.FailObjectDisposed(this);
                 }
             }
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SecureObjectPool.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SecureObjectPool.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Validation;
 
 namespace System.Collections.Immutable
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using Validation;
 
 namespace System.Collections.Immutable
 {
@@ -774,7 +773,7 @@ namespace System.Collections.Immutable
 
                 if (_root == null || (_stack != null && !_stack.IsOwned(ref this)))
                 {
-                    Validation.Requires.FailObjectDisposed(this);
+                    Requires.FailObjectDisposed(this);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -7,7 +7,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using Validation;
 
 namespace System.Linq
 // ReSharper restore CheckNamespace

--- a/src/System.Collections.Immutable/src/Validation/Requires.cs
+++ b/src/System.Collections.Immutable/src/Validation/Requires.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-namespace Validation
+namespace System.Collections.Immutable
 {
     /// <summary>
     /// Common runtime checks that throw <see cref="ArgumentException"/> upon failure.

--- a/src/System.Collections.Immutable/src/Validation/ValidatedNotNullAttribute.cs
+++ b/src/System.Collections.Immutable/src/Validation/ValidatedNotNullAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Validation
+namespace System.Collections.Immutable
 {
     /// <summary>
     /// Indicates to Code Analysis that a method validates a particular parameter.

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests

--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using Validation;
 using System.Diagnostics;
 
 namespace System.Collections.Immutable.Tests

--- a/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Validation;
 using Xunit;
 using SetTriad = System.Tuple<System.Collections.Generic.IEnumerable<int>, System.Collections.Generic.IEnumerable<int>, bool>;
 

--- a/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using Validation;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests

--- a/src/System.Collections.Immutable/tests/RequiresTests.cs
+++ b/src/System.Collections.Immutable/tests/RequiresTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Validation;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests

--- a/src/System.Collections.Immutable/tests/TestExtensionsMethods.cs
+++ b/src/System.Collections.Immutable/tests/TestExtensionsMethods.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Validation;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests


### PR DESCRIPTION
This moves the two internal types in the "Validation" namespace into the System.Collections.Immutable namespace so that we don't have any 'internal only' namespaces in the assembly.

Fix #2278