### PR TITLE
Fix exception documentation on System.Collections.Immutable

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -311,7 +311,6 @@ namespace System.Collections.Immutable
             /// <returns>
             /// An <see cref="IDictionaryEnumerator"/> object for the <see cref="IDictionary"/> object.
             /// </returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             IDictionaryEnumerator IDictionary.GetEnumerator()
             {
                 return new DictionaryEnumerator<TKey, TValue>(this.GetEnumerator());

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -738,7 +738,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// An <see cref="IDictionaryEnumerator"/> object for the <see cref="IDictionary"/> object.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
             return new DictionaryEnumerator<TKey, TValue>(this.GetEnumerator());

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -1025,7 +1025,6 @@ namespace System.Collections.Immutable
             /// <returns>
             /// The position into which the new element was inserted, or -1 to indicate that the item was not inserted into the collection,
             /// </returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             int IList.Add(object value)
             {
                 this.Add((T)value);
@@ -1035,7 +1034,6 @@ namespace System.Collections.Immutable
             /// <summary>
             /// Clears this instance.
             /// </summary>
-            /// <exception cref="System.NotImplementedException"></exception>
             void IList.Clear()
             {
                 this.Clear();
@@ -1048,7 +1046,6 @@ namespace System.Collections.Immutable
             /// <returns>
             /// true if the <see cref="object"/> is found in the <see cref="IList"/>; otherwise, false.
             /// </returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             bool IList.Contains(object value)
             {
                 return this.Contains((T)value);
@@ -1061,7 +1058,6 @@ namespace System.Collections.Immutable
             /// <returns>
             /// The index of <paramref name="value"/> if found in the list; otherwise, -1.
             /// </returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             int IList.IndexOf(object value)
             {
                 return this.IndexOf((T)value);
@@ -1072,7 +1068,6 @@ namespace System.Collections.Immutable
             /// </summary>
             /// <param name="index">The zero-based index at which <paramref name="value"/> should be inserted.</param>
             /// <param name="value">The object to insert into the <see cref="IList"/>.</param>
-            /// <exception cref="System.NotImplementedException"></exception>
             void IList.Insert(int index, object value)
             {
                 this.Insert(index, (T)value);
@@ -1082,7 +1077,6 @@ namespace System.Collections.Immutable
             /// Gets a value indicating whether the <see cref="IList"/> has a fixed size.
             /// </summary>
             /// <returns>true if the <see cref="IList"/> has a fixed size; otherwise, false.</returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             bool IList.IsFixedSize
             {
                 get { return false; }
@@ -1093,7 +1087,6 @@ namespace System.Collections.Immutable
             /// </summary>
             /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false.
             ///   </returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             bool IList.IsReadOnly
             {
                 get { return false; }
@@ -1103,7 +1096,6 @@ namespace System.Collections.Immutable
             /// Removes the first occurrence of a specific object from the <see cref="IList"/>.
             /// </summary>
             /// <param name="value">The object to remove from the <see cref="IList"/>.</param>
-            /// <exception cref="System.NotImplementedException"></exception>
             void IList.Remove(object value)
             {
                 this.Remove((T)value);
@@ -1117,7 +1109,6 @@ namespace System.Collections.Immutable
             /// </value>
             /// <param name="index">The index.</param>
             /// <returns></returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             object IList.this[int index]
             {
                 get { return this[index]; }
@@ -1133,7 +1124,6 @@ namespace System.Collections.Immutable
             /// </summary>
             /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the elements copied from <see cref="ICollection"/>. The <see cref="Array"/> must have zero-based indexing.</param>
             /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-            /// <exception cref="System.NotImplementedException"></exception>
             void ICollection.CopyTo(Array array, int arrayIndex)
             {
                 this.Root.CopyTo(array, arrayIndex);
@@ -1143,7 +1133,6 @@ namespace System.Collections.Immutable
             /// Gets a value indicating whether access to the <see cref="ICollection"/> is synchronized (thread safe).
             /// </summary>
             /// <returns>true if access to the <see cref="ICollection"/> is synchronized (thread safe); otherwise, false.</returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             bool ICollection.IsSynchronized
             {
@@ -1154,7 +1143,6 @@ namespace System.Collections.Immutable
             /// Gets an object that can be used to synchronize access to the <see cref="ICollection"/>.
             /// </summary>
             /// <returns>An object that can be used to synchronize access to the <see cref="ICollection"/>.</returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             object ICollection.SyncRoot
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -210,6 +210,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The 0-based index of the element in the set to return.</param>
         /// <returns>The element at the given position.</returns>
+        /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
         public T this[int index]
         {
             get
@@ -1145,7 +1146,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The index.</param>
         /// <param name="item">The item.</param>
-        /// <exception cref="System.NotSupportedException"></exception>
+        /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         void IList<T>.Insert(int index, T item)
         {
             throw new NotSupportedException();
@@ -1155,7 +1156,7 @@ namespace System.Collections.Immutable
         /// Removes the value at the specified index.
         /// </summary>
         /// <param name="index">The index.</param>
-        /// <exception cref="System.NotSupportedException"></exception>
+        /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         void IList<T>.RemoveAt(int index)
         {
             throw new NotSupportedException();
@@ -1164,6 +1165,8 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Gets or sets the value at the specified index.
         /// </summary>
+        /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
+        /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         T IList<T>.this[int index]
         {
             get { return this[index]; }
@@ -1178,6 +1181,7 @@ namespace System.Collections.Immutable
         /// Adds the specified item.
         /// </summary>
         /// <param name="item">The item.</param>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void ICollection<T>.Add(T item)
         {
             throw new NotSupportedException();
@@ -1186,7 +1190,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Clears this instance.
         /// </summary>
-        /// <exception cref="System.NotSupportedException"></exception>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void ICollection<T>.Clear()
         {
             throw new NotSupportedException();
@@ -1206,8 +1210,8 @@ namespace System.Collections.Immutable
         /// Removes the specified item.
         /// </summary>
         /// <param name="item">The item.</param>
-        /// <returns></returns>
-        /// <exception cref="System.NotSupportedException"></exception>
+        /// <returns>Nothing. An exception is always thrown.</returns>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         bool ICollection<T>.Remove(T item)
         {
             throw new NotSupportedException();
@@ -1234,8 +1238,9 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="value">The object to add to the <see cref="IList"/>.</param>
         /// <returns>
-        /// The position into which the new element was inserted, or -1 to indicate that the item was not inserted into the collection,
+        /// Nothing. An exception is always thrown.
         /// </returns>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         int IList.Add(object value)
         {
             throw new NotSupportedException();
@@ -1245,7 +1250,7 @@ namespace System.Collections.Immutable
         /// Removes the <see cref="IList"/> item at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index of the item to remove.</param>
-        /// <exception cref="System.NotSupportedException"></exception>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void IList.RemoveAt(int index)
         {
             throw new NotSupportedException();
@@ -1254,6 +1259,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Clears this instance.
         /// </summary>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void IList.Clear()
         {
             throw new NotSupportedException();
@@ -1288,6 +1294,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The zero-based index at which <paramref name="value"/> should be inserted.</param>
         /// <param name="value">The object to insert into the <see cref="IList"/>.</param>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void IList.Insert(int index, object value)
         {
             throw new NotSupportedException();
@@ -1316,6 +1323,7 @@ namespace System.Collections.Immutable
         /// Removes the first occurrence of a specific object from the <see cref="IList"/>.
         /// </summary>
         /// <param name="value">The object to remove from the <see cref="IList"/>.</param>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void IList.Remove(object value)
         {
             throw new NotSupportedException();
@@ -1328,7 +1336,9 @@ namespace System.Collections.Immutable
         /// The <see cref="System.Object"/>.
         /// </value>
         /// <param name="index">The index.</param>
-        /// <returns></returns>
+        /// <returns>The value at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
+        /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         object IList.this[int index]
         {
             get { return this[index]; }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -1146,7 +1146,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The index.</param>
         /// <param name="item">The item.</param>
-        /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void IList<T>.Insert(int index, T item)
         {
             throw new NotSupportedException();
@@ -1156,7 +1156,7 @@ namespace System.Collections.Immutable
         /// Removes the value at the specified index.
         /// </summary>
         /// <param name="index">The index.</param>
-        /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         void IList<T>.RemoveAt(int index)
         {
             throw new NotSupportedException();

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -1178,7 +1178,6 @@ namespace System.Collections.Immutable
         /// Adds the specified item.
         /// </summary>
         /// <param name="item">The item.</param>
-        /// <exception cref="System.NotImplementedException"></exception>
         void ICollection<T>.Add(T item)
         {
             throw new NotSupportedException();
@@ -1237,7 +1236,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// The position into which the new element was inserted, or -1 to indicate that the item was not inserted into the collection,
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         int IList.Add(object value)
         {
             throw new NotSupportedException();
@@ -1256,7 +1254,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Clears this instance.
         /// </summary>
-        /// <exception cref="System.NotImplementedException"></exception>
         void IList.Clear()
         {
             throw new NotSupportedException();
@@ -1269,7 +1266,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// true if the <see cref="object"/> is found in the <see cref="IList"/>; otherwise, false.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         bool IList.Contains(object value)
         {
             return this.Contains((T)value);
@@ -1282,7 +1278,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// The index of <paramref name="value"/> if found in the list; otherwise, -1.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         int IList.IndexOf(object value)
         {
             return this.IndexOf((T)value);
@@ -1293,7 +1288,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The zero-based index at which <paramref name="value"/> should be inserted.</param>
         /// <param name="value">The object to insert into the <see cref="IList"/>.</param>
-        /// <exception cref="System.NotImplementedException"></exception>
         void IList.Insert(int index, object value)
         {
             throw new NotSupportedException();
@@ -1303,7 +1297,6 @@ namespace System.Collections.Immutable
         /// Gets a value indicating whether the <see cref="IList"/> has a fixed size.
         /// </summary>
         /// <returns>true if the <see cref="IList"/> has a fixed size; otherwise, false.</returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         bool IList.IsFixedSize
         {
             get { return true; }
@@ -1314,7 +1307,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false.
         ///   </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         bool IList.IsReadOnly
         {
             get { return true; }
@@ -1324,7 +1316,6 @@ namespace System.Collections.Immutable
         /// Removes the first occurrence of a specific object from the <see cref="IList"/>.
         /// </summary>
         /// <param name="value">The object to remove from the <see cref="IList"/>.</param>
-        /// <exception cref="System.NotImplementedException"></exception>
         void IList.Remove(object value)
         {
             throw new NotSupportedException();
@@ -1338,7 +1329,6 @@ namespace System.Collections.Immutable
         /// </value>
         /// <param name="index">The index.</param>
         /// <returns></returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         object IList.this[int index]
         {
             get { return this[index]; }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
@@ -375,7 +375,6 @@ namespace System.Collections.Immutable
             /// <returns>
             /// An <see cref="IDictionaryEnumerator"/> object for the <see cref="IDictionary"/> object.
             /// </returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             IDictionaryEnumerator IDictionary.GetEnumerator()
             {
                 return new DictionaryEnumerator<TKey, TValue>(this.GetEnumerator());

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -646,7 +646,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// An <see cref="IDictionaryEnumerator"/> object for the <see cref="IDictionary"/> object.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
             return new DictionaryEnumerator<TKey, TValue>(this.GetEnumerator());

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
@@ -450,7 +450,6 @@ namespace System.Collections.Immutable
             /// </summary>
             /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the elements copied from <see cref="ICollection"/>. The <see cref="Array"/> must have zero-based indexing.</param>
             /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-            /// <exception cref="System.NotImplementedException"></exception>
             void ICollection.CopyTo(Array array, int arrayIndex)
             {
                 this.Root.CopyTo(array, arrayIndex);
@@ -460,7 +459,6 @@ namespace System.Collections.Immutable
             /// Gets a value indicating whether access to the <see cref="ICollection"/> is synchronized (thread safe).
             /// </summary>
             /// <returns>true if access to the <see cref="ICollection"/> is synchronized (thread safe); otherwise, false.</returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             bool ICollection.IsSynchronized
             {
@@ -471,7 +469,6 @@ namespace System.Collections.Immutable
             /// Gets an object that can be used to synchronize access to the <see cref="ICollection"/>.
             /// </summary>
             /// <returns>An object that can be used to synchronize access to the <see cref="ICollection"/>.</returns>
-            /// <exception cref="System.NotImplementedException"></exception>
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             object ICollection.SyncRoot
             {


### PR DESCRIPTION
I noticed in making another change that a bunch of incorrect xml docs describing exceptions existed. This fixes those up by removing the invalid ones and adding explanations for the valid ones.