### PR TITLE
Fix ImmutableList<T> IList implementation for incompatible element types

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -1051,7 +1051,12 @@ namespace System.Collections.Immutable
             /// <exception cref="System.NotImplementedException"></exception>
             bool IList.Contains(object value)
             {
-                return this.Contains((T)value);
+                if (IsCompatibleObject(value))
+                {
+                    return this.Contains((T)value);
+                }
+
+                return false;
             }
 
             /// <summary>
@@ -1064,7 +1069,12 @@ namespace System.Collections.Immutable
             /// <exception cref="System.NotImplementedException"></exception>
             int IList.IndexOf(object value)
             {
-                return this.IndexOf((T)value);
+                if (IsCompatibleObject(value))
+                {
+                    return this.IndexOf((T)value);
+                }
+
+                return -1;
             }
 
             /// <summary>
@@ -1106,7 +1116,10 @@ namespace System.Collections.Immutable
             /// <exception cref="System.NotImplementedException"></exception>
             void IList.Remove(object value)
             {
-                this.Remove((T)value);
+                if (IsCompatibleObject(value))
+                {
+                    this.Remove((T)value);
+                }
             }
 
             /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -1272,7 +1272,12 @@ namespace System.Collections.Immutable
         /// <exception cref="System.NotImplementedException"></exception>
         bool IList.Contains(object value)
         {
-            return this.Contains((T)value);
+            if (IsCompatibleObject(value))
+            {
+                return this.Contains((T)value);
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -1285,7 +1290,12 @@ namespace System.Collections.Immutable
         /// <exception cref="System.NotImplementedException"></exception>
         int IList.IndexOf(object value)
         {
-            return this.IndexOf((T)value);
+            if (IsCompatibleObject(value))
+            {
+                return this.IndexOf((T)value);
+            }
+
+            return -1;
         }
 
         /// <summary>
@@ -1412,6 +1422,21 @@ namespace System.Collections.Immutable
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Tests whether a value is one that might be found in this collection.
+        /// </summary>
+        /// <param name="value">The value to test.</param>
+        /// <returns><c>true</c> if this value might appear in the collection.</returns>
+        /// <devremarks>
+        /// This implementation comes from <see cref="List{T}"/>.
+        /// </devremarks>
+        private static bool IsCompatibleObject(object value)
+        {
+            // Non-null values are fine.  Only accept nulls if T is a class or Nullable<U>.
+            // Note that default(T) is not equal to null for value types except when T is Nullable<U>. 
+            return ((value is T) || (value == null && default(T) == null));
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -301,6 +301,33 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void IList_Remove_NullArgument()
+        {
+            this.AssertIListBaseline(RemoveFunc, 1, null);
+            this.AssertIListBaseline(RemoveFunc, "item", null);
+            this.AssertIListBaseline(RemoveFunc, new int?(1), null);
+            this.AssertIListBaseline(RemoveFunc, new int?(), null);
+        }
+
+        [Fact]
+        public void IList_Remove_ArgTypeMismatch()
+        {
+            this.AssertIListBaseline(RemoveFunc, "first item", new object());
+            this.AssertIListBaseline(RemoveFunc, 1, 1.0);
+
+            this.AssertIListBaseline(RemoveFunc, new int?(1), 1);
+            this.AssertIListBaseline(RemoveFunc, new int?(1), new int?(1));
+            this.AssertIListBaseline(RemoveFunc, new int?(1), string.Empty);
+        }
+
+        [Fact]
+        public void IList_Remove_EqualsOverride()
+        {
+            this.AssertIListBaseline(RemoveFunc, new ProgrammaticEquals(v => v is string), "foo");
+            this.AssertIListBaseline(RemoveFunc, new ProgrammaticEquals(v => v is string), 3);
+        }
+
+        [Fact]
         public void DebuggerAttributesValid()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableList.CreateBuilder<int>());

--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -219,6 +219,30 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void IList_IndexOf_NullArgument()
+        {
+            this.AssertIndexOfBaseline(1, (string)null);
+            this.AssertIndexOfBaseline("item", (string)null);
+        }
+
+        [Fact]
+        public void IList_IndexOf_ArgTypeMismatch()
+        {
+            this.AssertIndexOfBaseline("first item", new object());
+            this.AssertIndexOfBaseline(1, 1.0);
+
+            this.AssertIndexOfBaseline("first item", (object)null);
+            this.AssertIndexOfBaseline(1, (string)null);
+        }
+
+        [Fact]
+        public void IList_IndexOf_EqualsOverride()
+        {
+            this.AssertIndexOfBaseline(new ProgrammaticEquals(v => v is string), "foo");
+            this.AssertIndexOfBaseline(new ProgrammaticEquals(v => v is string), 3);
+        }
+
+        [Fact]
         public void ConvertAllTest()
         {
             Assert.True(this.GetListQuery(ImmutableList<int>.Empty).ConvertAll<float>(n => n).IsEmpty);
@@ -419,6 +443,39 @@ namespace System.Collections.Immutable.Tests
             var expected = bclList.TrueForAll(test);
             var actual = this.GetListQuery(list).TrueForAll(test);
             Assert.Equal(expected, actual);
+        }
+
+        private void AssertIndexOfBaseline<T1, T2>(T1 item, T2 other)
+        {
+            IndexOfTests.SimpleIndexOfBaselineTest(
+                i => (IList)this.GetListQuery(ImmutableList.Create(i)),
+                item,
+                other);
+
+            IndexOfTests.SimpleIndexOfBaselineTest(
+                i => (IList)this.GetListQuery(ImmutableList.Create(i)),
+                other,
+                item);
+        }
+
+        private class ProgrammaticEquals
+        {
+            private readonly Func<object, bool> equalsCallback;
+
+            internal ProgrammaticEquals(Func<object, bool> equalsCallback)
+            {
+                this.equalsCallback = equalsCallback;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return this.equalsCallback(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/System.Collections.Immutable/tests/IndexOfTests.cs
+++ b/src/System.Collections.Immutable/tests/IndexOfTests.cs
@@ -9,16 +9,6 @@ namespace System.Collections.Immutable.Tests
 {
     public static class IndexOfTests
     {
-        public static void SimpleIndexOfBaselineTest<T>(Func<T, IList> collectionFactory, T item, object other)
-        {
-            IList bclList = new List<T> { item };
-            IList testedList = collectionFactory(item);
-
-            int expected = bclList.IndexOf(other);
-            int actual = testedList.IndexOf(other);
-            Assert.Equal(expected, actual);
-        }
-
         public static void IndexOfTest<TCollection>(
             Func<IEnumerable<int>, TCollection> factory,
             Func<TCollection, int, int> indexOfItem,

--- a/src/System.Collections.Immutable/tests/IndexOfTests.cs
+++ b/src/System.Collections.Immutable/tests/IndexOfTests.cs
@@ -9,6 +9,16 @@ namespace System.Collections.Immutable.Tests
 {
     public static class IndexOfTests
     {
+        public static void SimpleIndexOfBaselineTest<T>(Func<T, IList> collectionFactory, T item, object other)
+        {
+            IList bclList = new List<T> { item };
+            IList testedList = collectionFactory(item);
+
+            int expected = bclList.IndexOf(other);
+            int actual = testedList.IndexOf(other);
+            Assert.Equal(expected, actual);
+        }
+
         public static void IndexOfTest<TCollection>(
             Func<IEnumerable<int>, TCollection> factory,
             Func<TCollection, int, int> indexOfItem,


### PR DESCRIPTION
Add 15 unit tests to cover the `ImmutableList<T>` and `ImmutableList<T>+Builder` class's implementation of `IList.Contains`, `IList.Remove`, and `IList.IndexOf` for cases where the `object` argument is not of a compatible type with the type argument for the collection.

All 15 of the added unit tests fail. Until the final commit, which fixes all the issues the tests demonstrated.

Fix #1414