### PR TITLE
WinHttpHandler uses async WinHTTP patterns

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -46,7 +46,7 @@ internal partial class Interop
             string acceptTypes,
             uint flags);
 
-        // NOTE: except for the return type, this refers to the same function as WinOpenRequest.
+        // NOTE: except for the return type, this refers to the same function as WinHttpOpenRequest.
         [DllImport(Interop.Libraries.WinHttp, EntryPoint = "WinHttpOpenRequest", CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern SafeWinHttpHandleWithCallback WinHttpOpenRequestWithCallback(
             SafeWinHttpHandle connectHandle,
@@ -106,6 +106,14 @@ internal partial class Interop
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpReadData(
+            SafeWinHttpHandle requestHandle,
+            IntPtr buffer,
+            uint bufferSize,
+            IntPtr parameterIgnoredAndShouldBeNullForAsync);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpQueryHeaders(
             SafeWinHttpHandle requestHandle,
             uint infoLevel,
@@ -155,6 +163,14 @@ internal partial class Interop
             IntPtr buffer,
             uint bufferSize,
             out uint bytesWritten);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpWriteData(
+            SafeWinHttpHandle requestHandle,
+            IntPtr buffer,
+            uint bufferSize,
+            IntPtr parameterIgnoredAndShouldBeNullForAsync);
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Common/src/System/Net/HttpVersion.cs
+++ b/src/Common/src/System/Net/HttpVersion.cs
@@ -7,6 +7,7 @@ namespace System.Net
 {
     internal static class HttpVersion
     {
+        public static readonly Version Unknown = new Version(0, 0);
         public static readonly Version Version10 = new Version(1, 0);
         public static readonly Version Version11 = new Version(1, 1);
         public static readonly Version Version20 = new Version(2, 0);

--- a/src/System.Net.Http.WinHttpHandler/System.Net.Http.WinHttpHandler.sln
+++ b/src/System.Net.Http.WinHttpHandler/System.Net.Http.WinHttpHandler.sln
@@ -6,7 +6,7 @@ Project("{BB2D2F6C-0445-43D4-84A9-DF5B4931FA19}") = "System.Net.Http.WinHttpHand
 EndProject
 Project("{BB2D2F6C-0445-43D4-84A9-DF5B4931FA19}") = "System.Net.Http.WinHttpHandler.Unit.Tests", "tests\UnitTests\System.Net.Http.WinHttpHandler.Unit.Tests.csproj", "{A2ECDEDB-12B7-402C-9230-152B7601179F}"
 EndProject
-Project("{BB2D2F6C-0445-43D4-84A9-DF5B4931FA19}") = "System.Net.Http.WinHttpHandler.Tests", "tests\FunctionalTests\System.Net.Http.WinHttpHandler.Tests.csproj", "{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}"
+Project("{BB2D2F6C-0445-43D4-84A9-DF5B4931FA19}") = "System.Net.Http.WinHttpHandler.Functional.Tests", "tests\FunctionalTests\System.Net.Http.WinHttpHandler.Functional.Tests.csproj", "{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}"
 EndProject
 
 Global

--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -141,10 +141,19 @@
   <data name="net_http_io_read" xml:space="preserve">
     <value>The read operation failed, see inner exception.</value>
   </data>
+  <data name="net_http_io_write" xml:space="preserve">
+    <value>The write operation failed, see inner exception.</value>
+  </data>
   <data name="net_http_chunked_not_allowed_with_empty_content" xml:space="preserve">
     <value>'Transfer-Encoding: chunked' header can not be used when content object is not specified.</value>
   </data>
   <data name="net_http_value_must_be_greater_than" xml:space="preserve">
     <value>The specified value must be greater than {0}.</value>
+  </data>
+  <data name="net_http_username_empty_string" xml:space="preserve">
+    <value>The username for a credential object cannot be null or empty.</value>
+  </data>
+  <data name="net_http_no_concurrent_io_allowed" xml:space="preserve">
+    <value>The stream does not support concurrent I/O read or write operations.</value>
   </data>
 </root>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -13,13 +13,20 @@
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.winhttp_types.cs" />
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.winhttp.cs" />
     <CompileItem Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\HttpVersion.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\UriScheme.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />
-    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\CertificateHelper.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpAuthHelper.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCertificateHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpChannelBinding.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpHandler.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestCallback.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestState.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestStream.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpResponseParser.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpResponseStream.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpTraceHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpTransportContext.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinInetProxyHelper.cs" />
   </ItemGroup>

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -1,0 +1,310 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
+
+namespace System.Net.Http
+{
+    internal class WinHttpAuthHelper
+    {
+        // TODO: Issue #2165. This looks messy but it is fast. Research a cleaner way
+        // to do this which keeps high performance lookup.
+        //
+        // Fast lookup table to convert WINHTTP_AUTH constants to strings.
+        // WINHTTP_AUTH_SCHEME_BASIC = 0x00000001;
+        // WINHTTP_AUTH_SCHEME_DIGEST = 0x00000008;
+        // WINHTTP_AUTH_SCHEME_NEGOTIATE = 0x00000010;
+        private static readonly string[] s_authSchemeStringMapping =
+        {
+            null,
+            "Basic",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Digest",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Negotiate"
+        };
+
+        private static readonly uint[] s_authSchemePriorityOrder =
+        {
+            Interop.WinHttp.WINHTTP_AUTH_SCHEME_NEGOTIATE,
+            Interop.WinHttp.WINHTTP_AUTH_SCHEME_DIGEST,
+            Interop.WinHttp.WINHTTP_AUTH_SCHEME_BASIC
+        };
+
+        // TODO: Issue #2165. This current design uses a handler-wide lock to Add/Retrieve
+        // from the cache.  Need to improve this for next iteration in order
+        // to boost performance and scalability.
+        private readonly CredentialCache _credentialCache = new CredentialCache();
+        private readonly object _credentialCacheLock = new object();
+        
+        public void CheckResponseForAuthentication(
+            WinHttpRequestState state,
+            ref uint proxyAuthScheme,
+            ref uint serverAuthScheme)
+        {
+            uint supportedSchemes = 0;
+            uint firstSchemeIgnored = 0;
+            uint authTarget = 0;
+            Uri uri = state.RequestMessage.RequestUri;
+
+            state.RetryRequest = false;
+
+            // Check the status code and retry the request applying credentials if needed.
+            var statusCode = (HttpStatusCode)WinHttpResponseParser.GetResponseHeaderNumberInfo(
+                state.RequestHandle,
+                Interop.WinHttp.WINHTTP_QUERY_STATUS_CODE);
+
+            switch (statusCode)
+            {
+                case HttpStatusCode.Unauthorized:
+                    if (state.ServerCredentials == null || state.LastStatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        // Either we don't have server credentials or we already tried 
+                        // to set the credentials and it failed before.
+                        // So we will let the 401 be the final status code returned.
+                        break;
+                    }
+                    
+                    state.LastStatusCode = statusCode;
+
+                    // Determine authorization scheme to use. We ignore the firstScheme
+                    // parameter which is included in the supportedSchemes flags already.
+                    // We pass the schemes to ChooseAuthScheme which will pick the scheme
+                    // based on most secure scheme to least secure scheme ordering.
+                    if (!Interop.WinHttp.WinHttpQueryAuthSchemes(
+                        state.RequestHandle,
+                        out supportedSchemes,
+                        out firstSchemeIgnored,
+                        out authTarget))
+                    {
+                        WinHttpException.ThrowExceptionUsingLastError();
+                    }
+
+                    // WinHTTP returns the proper authTarget based on the status code (401, 407).
+                    // But we can validate with assert.
+                    Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_SERVER);
+
+                    serverAuthScheme = ChooseAuthScheme(supportedSchemes);
+                    if (serverAuthScheme != 0)
+                    {
+                        SetWinHttpCredential(
+                            state.RequestHandle,
+                            state.ServerCredentials,
+                            uri,
+                            serverAuthScheme,
+                            authTarget);
+
+                        state.RetryRequest = true;
+                    }
+                    
+                    break;
+
+                case HttpStatusCode.ProxyAuthenticationRequired:
+                    if (state.LastStatusCode == HttpStatusCode.ProxyAuthenticationRequired)
+                    {
+                        // We tried already to set the credentials.
+                        break;
+                    }
+                    
+                    state.LastStatusCode = statusCode;
+
+                    // Determine authorization scheme to use. We ignore the firstScheme
+                    // parameter which is included in the supportedSchemes flags already.
+                    // We pass the schemes to ChooseAuthScheme which will pick the scheme
+                    // based on most secure scheme to least secure scheme ordering.
+                    if (!Interop.WinHttp.WinHttpQueryAuthSchemes(
+                        state.RequestHandle,
+                        out supportedSchemes,
+                        out firstSchemeIgnored,
+                        out authTarget))
+                    {
+                        WinHttpException.ThrowExceptionUsingLastError();
+                    }
+
+                    // WinHTTP returns the proper authTarget based on the status code (401, 407).
+                    // But we can validate with assert.
+                    Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY);
+
+                    proxyAuthScheme = ChooseAuthScheme(supportedSchemes);
+                    state.RetryRequest = true;
+                    break;
+
+                default:
+                    if (state.PreAuthenticate && serverAuthScheme != 0)
+                    {
+                        SaveServerCredentialsToCache(uri, serverAuthScheme, state.ServerCredentials);
+                    }
+                    break;
+            }
+        }
+
+        public void PreAuthenticateRequest(WinHttpRequestState state, uint proxyAuthScheme)
+        {
+            // Set proxy credentials if we have them.
+            // If a proxy authentication challenge was responded to, reset
+            // those credentials before each SendRequest, because the proxy  
+            // may require re-authentication after responding to a 401 or  
+            // to a redirect. If you don't, you can get into a 
+            // 407-401-407-401- loop.
+            if (proxyAuthScheme != 0)
+            {
+                SetWinHttpCredential(
+                    state.RequestHandle,
+                    state.Proxy == null ? state.DefaultProxyCredentials : state.Proxy.Credentials,
+                    state.RequestMessage.RequestUri,
+                    proxyAuthScheme,
+                    Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY);
+            }
+
+            // Apply pre-authentication headers for server authentication?
+            if (state.PreAuthenticate)
+            {
+                uint authScheme;
+                NetworkCredential serverCredentials;
+                if (GetServerCredentialsFromCache(
+                        state.RequestMessage.RequestUri,
+                        out authScheme,
+                        out serverCredentials))
+                {
+                    SetWinHttpCredential(
+                        state.RequestHandle,
+                        serverCredentials,
+                        state.RequestMessage.RequestUri,
+                        authScheme,
+                        Interop.WinHttp.WINHTTP_AUTH_TARGET_SERVER);
+                    state.LastStatusCode = HttpStatusCode.Unauthorized; // Remember we already set the creds.
+                }
+                
+                // No cached credential to use at this time. The request will first go out with no
+                // 'Authorization' header. Later, if a 401 occurs, we will be able to cache the credential
+                // since we will then know the proper auth scheme to use.
+                //
+                // TODO: Issue #2165. Adding logging to highlight the 'cache miss'.
+            }
+        }
+
+        // TODO: Issue #2165. Consider refactoring cache logic in separate class and avoid out parameters.
+        public bool GetServerCredentialsFromCache(
+            Uri uri,
+            out uint serverAuthScheme,
+            out NetworkCredential serverCredentials)
+        {
+            serverAuthScheme = 0;
+            serverCredentials = null;
+
+            NetworkCredential cred = null;
+
+            lock (_credentialCacheLock)
+            {
+                foreach (uint authScheme in s_authSchemePriorityOrder)
+                {
+                    cred = _credentialCache.GetCredential(uri, s_authSchemeStringMapping[authScheme]);
+                    if (cred != null)
+                    {
+                        serverAuthScheme = authScheme;
+                        serverCredentials = cred;
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public void SaveServerCredentialsToCache(Uri uri, uint authScheme, ICredentials serverCredentials)
+        {
+            string authType = s_authSchemeStringMapping[authScheme];
+            Debug.Assert(!string.IsNullOrEmpty(authType));
+
+            NetworkCredential cred = serverCredentials.GetCredential(uri, authType);
+            if (cred != null)
+            {
+                lock (_credentialCacheLock)
+                {
+                    try
+                    {
+                        _credentialCache.Add(uri, authType, cred);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // The credential was already added.
+                    }
+                }
+            }
+        }
+
+        private void SetWinHttpCredential(
+            SafeWinHttpHandle requestHandle,
+            ICredentials credentials,
+            Uri uri,
+            uint authScheme,
+            uint authTarget)
+        {
+            Debug.Assert(credentials != null);
+            Debug.Assert(authScheme != 0);
+            Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY || 
+                         authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_SERVER);
+
+            NetworkCredential networkCredential = credentials.GetCredential(uri, s_authSchemeStringMapping[authScheme]);
+
+            // Skip if no credentials or this is the default credential.
+            if (networkCredential == null || networkCredential == CredentialCache.DefaultNetworkCredentials)
+            {
+                return;
+            }
+
+            string userName = networkCredential.UserName;
+            string password = networkCredential.Password;
+            string domain = networkCredential.Domain;
+
+            // WinHTTP does not support a blank username.  So, we will throw an exception.
+            if (string.IsNullOrEmpty(userName))
+            {
+                throw new InvalidOperationException(SR.net_http_username_empty_string);
+            }
+
+            if (!string.IsNullOrEmpty(domain))
+            {
+                userName = domain + "\\" + userName;
+            }
+
+            if (!Interop.WinHttp.WinHttpSetCredentials(
+                requestHandle,
+                authTarget,
+                authScheme,
+                userName,
+                password,
+                IntPtr.Zero))
+            {
+                WinHttpException.ThrowExceptionUsingLastError();
+            }
+        }
+
+        private static uint ChooseAuthScheme(uint supportedSchemes)
+        {
+            foreach (uint authScheme in s_authSchemePriorityOrder)
+            {
+                if ((supportedSchemes & authScheme) != 0)
+                {
+                    return authScheme;
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Http
 {
-    // TODO: Move/rename to Common/System/Net as part of System.Private.Networking.dll refactor.
-    internal static class CertificateHelper
+    internal static class WinHttpCertificateHelper
     {
+        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+        
+        // TODO: Issue #2165. Merge with similar code used in System.Net.Security move to Common/src//System/Net.
         public static void BuildChain(
             X509Certificate2 certificate,
             string hostName,
@@ -68,10 +69,57 @@ namespace System.Net.Http
                     else
                     {
                         // Failure checking the policy. This is a rare error. We will assume the name check failed.
-                        // TODO: Log this error.
+                        // TODO: Issue #2165. Log this error or perhaps throw an exception instead.
                         sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNameMismatch;
                     }
                 }
+            }
+        }
+
+        public static X509Certificate2 GetEligibleClientCertificate()
+        {
+            // Get initial list of client certificates from the MY store.
+            X509Certificate2Collection candidateCerts;
+            using (var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                myStore.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+                candidateCerts = myStore.Certificates;
+            }
+            
+            return GetEligibleClientCertificate(candidateCerts);
+        }
+        
+        // TODO: Issue #3891. Get the Trusted Issuers List from WinHTTP and use that to help narrow down
+        // the list of eligible client certificates.
+        public static X509Certificate2 GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Reduce the set of certificates to match the proper 'Client Authentication' criteria.
+            candidateCerts = candidateCerts.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
+            candidateCerts = candidateCerts.Find(X509FindType.FindByApplicationPolicy, ClientAuthenticationOID, false);
+
+            // Build a new collection with certs that have a private key. Need to do this
+            // manually because there is no X509FindType to match this criteria.
+            var eligibleCerts = new X509Certificate2Collection();
+            foreach (X509Certificate2 cert in candidateCerts)
+            {
+                if (cert.HasPrivateKey)
+                {
+                    eligibleCerts.Add(cert);
+                }
+            }
+            
+            if (eligibleCerts.Count > 0)
+            {
+                return eligibleCerts[0];
+            }
+            else
+            {
+                return null;
             }
         }
     }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -1,0 +1,363 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+
+using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Static class containing the WinHttp global callback and associated routines.
+    /// </summary>
+    internal static class WinHttpRequestCallback
+    {
+        public static Interop.WinHttp.WINHTTP_STATUS_CALLBACK StaticCallbackDelegate =
+            new Interop.WinHttp.WINHTTP_STATUS_CALLBACK(WinHttpCallback);
+
+        public static void WinHttpCallback(
+            IntPtr handle,
+            IntPtr context,
+            uint internetStatus,
+            IntPtr statusInformation,
+            uint statusInformationLength)
+        {
+            bool invokeCallback = false;
+
+            if (Environment.HasShutdownStarted)
+            {
+                return;
+            }
+
+            if (context == IntPtr.Zero)
+            {
+                return;
+            }
+
+            WinHttpRequestState state = WinHttpRequestState.FromIntPtr(context);
+            if (state != null && 
+                state.RequestHandle != null &&
+                !state.RequestHandle.IsInvalid &&
+                state.RequestHandle.DangerousGetHandle() == handle)
+            {
+                invokeCallback = true;
+            }
+
+            WinHttpTraceHelper.TraceCallbackStatus("WinHttpCallback", handle, invokeCallback, internetStatus);
+
+            if (invokeCallback)
+            {
+                RequestCallback(handle, state, internetStatus, statusInformation, statusInformationLength);
+            }
+        }
+        
+        private static void RequestCallback(
+            IntPtr handle,
+            WinHttpRequestState state,
+            uint internetStatus,
+            IntPtr statusInformation,
+            uint statusInformationLength)
+        {
+            try
+            {
+                switch (internetStatus)
+                {
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE:
+                        OnRequestSendRequestComplete(state);
+                        return;
+                        
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
+                        OnRequestReadComplete(state, statusInformationLength);
+                        return;
+                        
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE:
+                        OnRequestWriteComplete(state);
+                        return;
+                        
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE:
+                        OnRequestReceiveResponseHeadersComplete(state);
+                        return;
+
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REDIRECT:
+                        string redirectUriString = Marshal.PtrToStringUni(statusInformation);
+                        var redirectUri = new Uri(redirectUriString);
+                        OnRequestRedirect(state, redirectUri);
+                        return;
+
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SENDING_REQUEST:
+                        OnRequestSendingRequest(state);
+                        return;
+
+                    case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REQUEST_ERROR:
+                        Debug.Assert(
+                            statusInformationLength == Marshal.SizeOf<Interop.WinHttp.WINHTTP_ASYNC_RESULT>(),
+                            "RequestCallback: statusInformationLength=" + statusInformationLength +
+                            " must be sizeof(WINHTTP_ASYNC_RESULT)=" + Marshal.SizeOf<Interop.WinHttp.WINHTTP_ASYNC_RESULT>());
+
+                        var asyncResult = Marshal.PtrToStructure<Interop.WinHttp.WINHTTP_ASYNC_RESULT>(statusInformation);
+                        OnRequestError(state, asyncResult);
+                        return;
+
+                    default:
+                        return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Interop.WinHttp.WinHttpCloseHandle(handle);
+                state.SavedException = ex;
+            }
+        }
+
+        private static void OnRequestSendRequestComplete(WinHttpRequestState state)
+        {
+            Debug.Assert(state != null, "OnRequestSendRequestComplete: state is null");
+            Debug.Assert(state.TcsSendRequest != null, "OnRequestSendRequestComplete: TcsSendRequest is null");
+            Debug.Assert(!state.TcsSendRequest.Task.IsCompleted, "OnRequestSendRequestComplete: TcsSendRequest.Task is completed");
+            
+            state.TcsSendRequest.TrySetResult(true);
+        }
+
+        private static void OnRequestReadComplete(WinHttpRequestState state, uint bytesRead)
+        {
+            Debug.Assert(state != null, "OnRequestReadComplete: state is null");
+            Debug.Assert(state.TcsReadFromResponseStream != null, "TcsReadFromResponseStream is null");
+            Debug.Assert(!state.TcsReadFromResponseStream.Task.IsCompleted, "TcsReadFromResponseStream.Task is completed");
+            
+            state.TcsReadFromResponseStream.TrySetResult((int)bytesRead);
+        }
+
+        private static void OnRequestWriteComplete(WinHttpRequestState state)
+        {
+            Debug.Assert(state != null, "OnRequestWriteComplete: state is null");
+            Debug.Assert(state.TcsInternalWriteDataToRequestStream != null, "TcsInternalWriteDataToRequestStream is null");
+            Debug.Assert(!state.TcsInternalWriteDataToRequestStream.Task.IsCompleted, "TcsInternalWriteDataToRequestStream.Task is completed");
+            
+            state.TcsInternalWriteDataToRequestStream.TrySetResult(true);
+        }
+
+        private static void OnRequestReceiveResponseHeadersComplete(WinHttpRequestState state)
+        {
+            Debug.Assert(state != null, "OnRequestReceiveResponseHeadersComplete: state is null");
+            Debug.Assert(state.TcsReceiveResponseHeaders != null, "TcsReceiveResponseHeaders is null");
+            Debug.Assert(!state.TcsReceiveResponseHeaders.Task.IsCompleted, "TcsReceiveResponseHeaders.Task is completed");
+
+            state.TcsReceiveResponseHeaders.TrySetResult(true);
+        }
+
+        private static void OnRequestRedirect(WinHttpRequestState state, Uri redirectUri)
+        {
+            const string EmptyCookieHeader = "Cookie:";
+
+            Debug.Assert(state != null, "OnRequestRedirect: state is null");
+            Debug.Assert(redirectUri != null, "OnRequestRedirect: redirectUri is null");
+            Debug.Assert(state.TcsReceiveResponseHeaders != null, "TcsReceiveResponseHeaders is null");
+            Debug.Assert(!state.TcsReceiveResponseHeaders.Task.IsCompleted, "TcsReceiveResponseHeaders.Task is completed");
+
+            // If we're manually handling cookies, we need to reset them based on the new URI.
+            if (state.Handler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer)
+            {
+                // Clear cookies.
+                if (!Interop.WinHttp.WinHttpAddRequestHeaders(
+                    state.RequestHandle,
+                    EmptyCookieHeader,
+                    (uint)EmptyCookieHeader.Length,
+                    Interop.WinHttp.WINHTTP_ADDREQ_FLAG_REPLACE))
+                {
+                    int lastError = Marshal.GetLastWin32Error();
+                    if (lastError != Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND)
+                    {
+                        throw WinHttpException.CreateExceptionUsingError(lastError);
+                    }
+                }
+
+                // Re-add cookies. The GetCookieHeader() method will return the correct set of
+                // cookies based on the redirectUri.
+                string cookieHeader = WinHttpHandler.GetCookieHeader(redirectUri, state.Handler.CookieContainer);
+                if (!string.IsNullOrEmpty(cookieHeader))
+                {
+                    if (!Interop.WinHttp.WinHttpAddRequestHeaders(
+                        state.RequestHandle,
+                        cookieHeader,
+                        (uint)cookieHeader.Length,
+                        Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
+                    {
+                        WinHttpException.ThrowExceptionUsingLastError();
+                    }
+                }
+            }
+
+            state.RequestMessage.RequestUri = redirectUri;
+            
+            // Redirection to a new uri may require a new connection through a potentially different proxy.
+            // If so, we will need to respond to additional 407 proxy auth demands and re-attach any
+            // proxy credentials. The ProcessResponse() method looks at the state.LastStatusCode
+            // before attaching proxy credentials and marking the HTTP request to be re-submitted.
+            // So we need to reset the LastStatusCode remembered. Otherwise, it will see additional 407
+            // responses as an indication that proxy auth failed and won't retry the HTTP request.
+            if (state.LastStatusCode == HttpStatusCode.ProxyAuthenticationRequired)
+            {
+                state.LastStatusCode = 0;
+            }
+
+            // For security reasons, we drop the server credential if it is a 
+            // NetworkCredential.  But we allow credentials in a CredentialCache
+            // since they are specifically tied to URI's.
+            if (!(state.ServerCredentials is CredentialCache))
+            {
+                state.ServerCredentials = null;
+            }
+        }
+        
+        private static void OnRequestSendingRequest(WinHttpRequestState state)
+        {
+            Debug.Assert(state != null, "OnRequestSendingRequest: state is null");
+            
+            if (state.RequestMessage.RequestUri.Scheme != UriScheme.Https)
+            {
+                // Not SSL/TLS.
+                return;
+            }
+
+            // Grab the channel binding token (CBT) information from the request handle and put it into
+            // the TransportContext object.
+            state.TransportContext.SetChannelBinding(state.RequestHandle);
+
+            if (state.ServerCertificateValidationCallback != null)
+            {
+                IntPtr certHandle = IntPtr.Zero;
+                uint certHandleSize = (uint)IntPtr.Size;
+
+                if (!Interop.WinHttp.WinHttpQueryOption(
+                    state.RequestHandle,
+                    Interop.WinHttp.WINHTTP_OPTION_SERVER_CERT_CONTEXT,
+                    ref certHandle,
+                    ref certHandleSize))
+                {
+                    int lastError = Marshal.GetLastWin32Error();
+                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                }
+                
+                // Create a managed wrapper around the certificate handle. Since this results in duplicating
+                // the handle, we will close the original handle after creating the wrapper.
+                var serverCertificate = new X509Certificate2(certHandle);
+                Interop.Crypt32.CertFreeCertificateContext(certHandle);
+
+                X509Chain chain = null;
+                SslPolicyErrors sslPolicyErrors;
+
+                try
+                {
+                    WinHttpCertificateHelper.BuildChain(
+                        serverCertificate,
+                        state.RequestMessage.RequestUri.Host,
+                        state.CheckCertificateRevocationList,
+                        out chain,
+                        out sslPolicyErrors);
+
+                    bool result = state.ServerCertificateValidationCallback(
+                        state.RequestMessage,
+                        serverCertificate,
+                        chain,
+                        sslPolicyErrors);
+                    if (!result)
+                    {
+                        throw WinHttpException.CreateExceptionUsingError(
+                            (int)Interop.WinHttp.ERROR_WINHTTP_SECURE_FAILURE);
+                    }
+                }
+                finally
+                {
+                    if (chain != null)
+                    {
+                        chain.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static void OnRequestError(WinHttpRequestState state, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult)
+        {
+            WinHttpTraceHelper.TraceAsyncError("OnRequestError", asyncResult);
+            
+            Debug.Assert(state != null, "OnRequestError: state is null");
+
+            var innerException = WinHttpException.CreateExceptionUsingError((int)asyncResult.dwError);
+
+            switch ((uint)asyncResult.dwResult.ToInt32())
+            {
+                case Interop.WinHttp.API_SEND_REQUEST:
+                    state.TcsSendRequest.TrySetException(innerException);
+                    break;
+                    
+                case Interop.WinHttp.API_RECEIVE_RESPONSE:
+                    if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_RESEND_REQUEST)
+                    {
+                        state.RetryRequest = true;
+                        state.TcsReceiveResponseHeaders.TrySetResult(false);
+                    }
+                    else if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED)
+                    {
+                        // WinHttp will automatically drop any client SSL certificates that we
+                        // have pre-set into the request handle including the NULL certificate
+                        // (which means we have no certs to send). For security reasons, we don't
+                        // allow the certificate to be re-applied. But we need to tell WinHttp
+                        // explicitly that we don't have any certificate to send.
+                        WinHttpHandler.SetNoClientCertificate(state.RequestHandle);
+                        state.RetryRequest = true;
+                        state.TcsReceiveResponseHeaders.TrySetResult(false);
+                    }
+                    else if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
+                    {
+                        state.TcsReceiveResponseHeaders.TrySetCanceled(state.CancellationToken);
+                    }
+                    else
+                    {
+                        state.TcsReceiveResponseHeaders.TrySetException(innerException);
+                    }
+                    break;
+
+                case Interop.WinHttp.API_READ_DATA:
+                    if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
+                    {
+                        // TODO: Issue #2165. We need to pass in the cancellation token from the
+                        // user's ReadAsync() call into the TrySetCanceled().
+                        Debug.WriteLine("RequestCallback: API_READ_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
+                        state.TcsReadFromResponseStream.TrySetCanceled();
+                    }
+                    else
+                    {
+                        state.TcsReadFromResponseStream.TrySetException(
+                            new IOException(SR.net_http_io_read, innerException));
+                    }
+                    break;
+
+                case Interop.WinHttp.API_WRITE_DATA:
+                    if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
+                    {
+                        // TODO: Issue #2165. We need to pass in the cancellation token from the
+                        // user's WriteAsync() call into the TrySetCanceled().
+                        Debug.WriteLine("RequestCallback: API_WRITE_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
+                        state.TcsInternalWriteDataToRequestStream.TrySetCanceled();
+                    }
+                    else
+                    {
+                        state.TcsInternalWriteDataToRequestStream.TrySetException(
+                            new IOException(SR.net_http_io_write, innerException));
+                    }
+                    break;
+
+                default:
+                    Debug.Fail(
+                        "OnRequestError: Result (" + asyncResult.dwResult + ") is not expected.",
+                        "Error code: " + asyncResult.dwError + " (" + innerException.Message + ")");
+                    break;
+            }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
+
+namespace System.Net.Http
+{
+    internal sealed class WinHttpRequestState : IDisposable
+    {
+        // TODO (Issue 2506): The current locking mechanism doesn't allow any two WinHttp functions executing at
+        // the same time for the same handle. Enahnce locking to prevent only WinHttpCloseHandle being called
+        // during other API execution. E.g. using a Reader/Writer model or, even better, Interlocked functions.
+
+        // The _lock object must be used during the execution of any WinHttp function to ensure no race conditions with 
+        // calling WinHttpCloseHandle.
+        private readonly object _lock = new object();
+
+        // A GCHandle for this operation object.
+        // This is owned by the callback and will be deallocated when the sessionHandle has been closed.
+        private GCHandle _operationHandle = new GCHandle();
+        
+        private volatile bool _disposed = false; // To detect redundant calls.
+        
+        public WinHttpRequestState()
+        {
+            TransportContext = new WinHttpTransportContext();
+            _operationHandle = GCHandle.Alloc(this);
+        }
+
+        public static WinHttpRequestState FromIntPtr(IntPtr gcHandle)
+        {
+            GCHandle stateHandle = GCHandle.FromIntPtr(gcHandle);
+            return (WinHttpRequestState)stateHandle.Target;
+        }        
+
+        public IntPtr ToIntPtr()
+        {
+            return GCHandle.ToIntPtr(_operationHandle);
+        }
+        
+        public object Lock
+        {
+            get
+            {
+                return _lock;
+            }
+        }
+
+        public TaskCompletionSource<HttpResponseMessage> Tcs { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
+
+        public HttpRequestMessage RequestMessage { get; set; }
+
+        public WinHttpHandler Handler { get; set; }
+
+        public SafeWinHttpHandle RequestHandle { get; set; }
+
+        public Exception SavedException { get; set; }
+
+        public bool CheckCertificateRevocationList { get; set; }
+
+        public Func<
+            HttpRequestMessage,
+            X509Certificate2,
+            X509Chain,
+            SslPolicyErrors,
+            bool> ServerCertificateValidationCallback { get; set; }
+
+        public WinHttpTransportContext TransportContext { get; private set; }
+
+        public WindowsProxyUsePolicy WindowsProxyUsePolicy { get; set; }
+
+        public IWebProxy Proxy { get; set; }
+
+        public ICredentials ServerCredentials { get; set; }
+
+        public ICredentials DefaultProxyCredentials { get; set; }
+
+        public bool PreAuthenticate { get; set; }
+        
+        public HttpStatusCode LastStatusCode { get; set; }
+
+        public bool RetryRequest { get; set; }
+        
+        // Important: do not hold _lock while signaling completion of any of below TaskCompletionSources.
+        public TaskCompletionSource<bool> TcsSendRequest { get; set; }
+        public TaskCompletionSource<bool> TcsWriteToRequestStream { get; set; }
+        public TaskCompletionSource<bool> TcsInternalWriteDataToRequestStream { get; set; }
+        public TaskCompletionSource<bool> TcsReceiveResponseHeaders { get; set; }
+        public TaskCompletionSource<int> TcsReadFromResponseStream { get; set; }
+        
+        #region IDisposable Members
+        private void Dispose(bool disposing)
+        {
+            // Since there is no finalizer and this class is sealed, the disposing parameter should be TRUE.
+            Debug.Assert(disposing, "WinHttpRequestState.Dispose() should have disposing=TRUE");
+            
+            if (_disposed)
+            {
+                return;
+            }
+            
+            _disposed = true;
+            
+            if (_operationHandle.IsAllocated)
+            {
+                _operationHandle.Free();
+            }
+        }
+
+        public void Dispose()
+        {
+            // No need to suppress finalization since the finalizer is not overridden and the class is sealed.
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 
@@ -15,13 +17,16 @@ namespace System.Net.Http
         private static byte[] s_crLfTerminator = new byte[] { 0x0d, 0x0a }; // "\r\n"
         private static byte[] s_endChunk = new byte[] { 0x30, 0x0d, 0x0a, 0x0d, 0x0a }; // "0\r\n\r\n"
 
-        private volatile bool _disposed = false;
-        private SafeWinHttpHandle _requestHandle = null;
-        private bool _chunkedMode = false;
+        private volatile bool _disposed;
+        private WinHttpRequestState _state;
+        private bool _chunkedMode;
 
-        internal WinHttpRequestStream(SafeWinHttpHandle requestHandle, bool chunkedMode)
+        // TODO (Issue 2505): temporary pinned buffer caches of 1 item. Will be replaced by PinnableBufferCache.
+        private GCHandle _cachedSendPinnedBuffer;
+
+        internal WinHttpRequestStream(WinHttpRequestState state, bool chunkedMode)
         {
-            _requestHandle = requestHandle;
+            _state = state;
             _chunkedMode = chunkedMode;
         }
 
@@ -75,9 +80,17 @@ namespace System.Net.Http
 
         public override void Flush()
         {
+            // Nothing to do.
         }
 
-        public override void Write(byte[] buffer, int offset, int count)
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                Task.CompletedTask;
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
             if (buffer == null)
             {
@@ -99,9 +112,27 @@ namespace System.Net.Http
                 throw new ArgumentException("buffer");
             }
 
+            if (token.IsCancellationRequested)
+            {
+                var tcs = new TaskCompletionSource<int>();
+                tcs.TrySetCanceled(token);
+                return tcs.Task;
+            }
+
             CheckDisposed();
 
-            WriteInternal(buffer, offset, count);
+            if (_state.TcsInternalWriteDataToRequestStream != null && 
+                !_state.TcsInternalWriteDataToRequestStream.Task.IsCompleted)
+            {
+                throw new InvalidOperationException(SR.net_http_no_concurrent_io_allowed);
+            }
+
+            return InternalWriteAsync(buffer, offset, count, token);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -122,11 +153,11 @@ namespace System.Net.Http
             throw new NotSupportedException();
         }
 
-        internal void EndUpload()
+        internal async Task EndUploadAsync(CancellationToken token)
         {
             if (_chunkedMode)
             {
-                WriteData(s_endChunk, 0, s_endChunk.Length);
+                await InternalWriteDataAsync(s_endChunk, 0, s_endChunk.Length, token);
             }
         }
         
@@ -135,6 +166,13 @@ namespace System.Net.Http
             if (!_disposed)
             {
                 _disposed = true;
+
+                // TODO (Issue 2508): Pinned buffers must be released in the callback, when it is guaranteed no further
+                // operations will be made to the send/receive buffers.
+                if (_cachedSendPinnedBuffer.IsAllocated)
+                {
+                    _cachedSendPinnedBuffer.Free();
+                }
             }
 
             base.Dispose(disposing);
@@ -148,38 +186,60 @@ namespace System.Net.Http
             }
         }
 
-        private void WriteInternal(byte[] buffer, int offset, int count)
+        private Task InternalWriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
-            if (_chunkedMode)
-            {
-                string chunkSizeString = String.Format("{0:x}\r\n", count);
-                byte[] chunkSize = Encoding.UTF8.GetBytes(chunkSizeString);
-
-                WriteData(chunkSize, 0, chunkSize.Length);
-
-                WriteData(buffer, offset, count);
-                WriteData(s_crLfTerminator, 0, s_crLfTerminator.Length);
-            }
-            else
-            {
-                WriteData(buffer, offset, count);
-            }
+            return _chunkedMode ?
+                InternalWriteChunkedModeAsync(buffer, offset, count, token) :
+                InternalWriteDataAsync(buffer, offset, count, token);            
         }
 
-        private void WriteData(byte[] buffer, int offset, int count)
+        private async Task InternalWriteChunkedModeAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
-            uint bytesWritten = 0;
-            GCHandle pinnedHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-            bool result = Interop.WinHttp.WinHttpWriteData(
-                _requestHandle,
-                Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
-                (uint)count,
-                out bytesWritten);
-            pinnedHandle.Free();
-            if (!result)
+            // WinHTTP does not fully support chunked uploads. It simply allows one to omit the 'Content-Length' header
+            // and instead use the 'Transfer-Encoding: chunked' header. The caller is still required to encode the
+            // request body according to chunking rules.
+            Debug.Assert(_chunkedMode);
+
+            string chunkSizeString = String.Format("{0:x}\r\n", count);
+            byte[] chunkSize = Encoding.UTF8.GetBytes(chunkSizeString);
+
+            await InternalWriteDataAsync(chunkSize, 0, chunkSize.Length, token);
+
+            await InternalWriteDataAsync(buffer, offset, count, token);
+            await InternalWriteDataAsync(s_crLfTerminator, 0, s_crLfTerminator.Length, token);
+        }
+
+        private Task<bool> InternalWriteDataAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        {
+            // TODO (Issue 2505): replace with PinnableBufferCache.
+            if (!_cachedSendPinnedBuffer.IsAllocated || _cachedSendPinnedBuffer.Target != buffer)
             {
-                throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                if (_cachedSendPinnedBuffer.IsAllocated)
+                {
+                    _cachedSendPinnedBuffer.Free();
+                }
+
+                _cachedSendPinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             }
+
+            _state.TcsInternalWriteDataToRequestStream = new TaskCompletionSource<bool>();
+            
+            lock (_state.Lock)
+            {
+                if (!Interop.WinHttp.WinHttpWriteData(
+                    _state.RequestHandle,
+                    Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
+                    (uint)count,
+                    IntPtr.Zero))
+                {
+                    _state.TcsInternalWriteDataToRequestStream.TrySetException(
+                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError()));
+                }
+            }
+
+            // TODO: Issue #2165. Register callback on cancellation token to cancel WinHTTP operation.
+
+            return _state.TcsInternalWriteDataToRequestStream.Task;
         }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
+
+namespace System.Net.Http
+{
+    internal static class WinHttpResponseParser
+    {
+        private const string EncodingNameDeflate = "DEFLATE";
+        private const string EncodingNameGzip = "GZIP";
+        private const string HeaderNameContentEncoding = "Content-Encoding";
+        private const string HeaderNameContentLength = "Content-Length";
+        private const string HeaderNameSetCookie = "Set-Cookie";
+        private static readonly string[] s_HttpHeadersSeparator = { "\r\n" };
+
+        public static HttpResponseMessage CreateResponseMessage(
+            WinHttpRequestState state,
+            bool doManualDecompressionCheck)
+        {
+            HttpRequestMessage request = state.RequestMessage;
+            SafeWinHttpHandle requestHandle = state.RequestHandle;
+            CookieUsePolicy cookieUsePolicy = state.Handler.CookieUsePolicy;
+            CookieContainer cookieContainer = state.Handler.CookieContainer;
+            var response = new HttpResponseMessage();
+            bool stripEncodingHeaders = false;
+
+            // Get HTTP version, status code, reason phrase from the response headers.
+            string version = GetResponseHeaderStringInfo(requestHandle, Interop.WinHttp.WINHTTP_QUERY_VERSION);
+            if (string.Compare("HTTP/1.1", version, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                response.Version = HttpVersion.Version11;
+            }
+            else if (string.Compare("HTTP/1.0", version, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                response.Version = HttpVersion.Version10;
+            }
+            else
+            {
+                response.Version = HttpVersion.Unknown;
+            }
+
+            response.StatusCode = (HttpStatusCode)GetResponseHeaderNumberInfo(
+                requestHandle,
+                Interop.WinHttp.WINHTTP_QUERY_STATUS_CODE);
+            response.ReasonPhrase = GetResponseHeaderStringInfo(
+                requestHandle,
+                Interop.WinHttp.WINHTTP_QUERY_STATUS_TEXT);
+
+            // Create response stream and wrap it in a StreamContent object.
+            var responseStream = new WinHttpResponseStream(state);
+            Stream decompressedStream = responseStream;
+
+            if (doManualDecompressionCheck)
+            {
+                string contentEncoding = GetResponseHeaderStringInfo(
+                    requestHandle,
+                    Interop.WinHttp.WINHTTP_QUERY_CONTENT_ENCODING);
+                if (!string.IsNullOrEmpty(contentEncoding))
+                {
+                    if (contentEncoding.IndexOf(EncodingNameDeflate, StringComparison.OrdinalIgnoreCase) > -1)
+                    {
+                        decompressedStream = new DeflateStream(responseStream, CompressionMode.Decompress);
+                        stripEncodingHeaders = true;
+                    }
+                    else if (contentEncoding.IndexOf(EncodingNameGzip, StringComparison.OrdinalIgnoreCase) > -1)
+                    {
+                        decompressedStream = new GZipStream(responseStream, CompressionMode.Decompress);
+                        stripEncodingHeaders = true;
+                    }
+                }
+            }
+
+            var content = new StreamContent(decompressedStream);
+
+            response.Content = content;
+            response.RequestMessage = request;
+
+            // Parse raw response headers and place them into response message.
+            ParseResponseHeaders(requestHandle, response, stripEncodingHeaders);
+
+            // Store response header cookies into custom CookieContainer.
+            if (cookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer)
+            {
+                Debug.Assert(cookieContainer != null);
+
+                if (response.Headers.Contains(HeaderNameSetCookie))
+                {
+                    IEnumerable<string> cookieHeaders = response.Headers.GetValues(HeaderNameSetCookie);
+                    foreach (var cookieHeader in cookieHeaders)
+                    {
+                        try
+                        {
+                            cookieContainer.SetCookies(request.RequestUri, cookieHeader);
+                        }
+                        catch (CookieException)
+                        {
+                            // We ignore malformed cookies in the response.
+                        }
+                    }
+                }
+            }
+
+            return response;
+        }
+
+        public static uint GetResponseHeaderNumberInfo(SafeWinHttpHandle requestHandle, uint infoLevel)
+        {
+            uint result = 0;
+            uint resultSize = sizeof(uint);
+
+            if (!Interop.WinHttp.WinHttpQueryHeaders(
+                requestHandle,
+                infoLevel | Interop.WinHttp.WINHTTP_QUERY_FLAG_NUMBER,
+                Interop.WinHttp.WINHTTP_HEADER_NAME_BY_INDEX,
+                ref result,
+                ref resultSize,
+                IntPtr.Zero))
+            {
+                WinHttpException.ThrowExceptionUsingLastError();
+            }
+
+            return result;
+        }
+
+        private static string GetResponseHeaderStringInfo(SafeWinHttpHandle requestHandle, uint infoLevel)
+        {
+            uint bytesNeeded = 0;
+            bool results = false;
+
+            // Call WinHttpQueryHeaders once to obtain the size of the buffer needed.  The size is returned in
+            // bytes but the API actually returns Unicode characters.
+            if (!Interop.WinHttp.WinHttpQueryHeaders(
+                requestHandle,
+                infoLevel,
+                Interop.WinHttp.WINHTTP_HEADER_NAME_BY_INDEX,
+                null,
+                ref bytesNeeded,
+                IntPtr.Zero))
+            {
+                int lastError = Marshal.GetLastWin32Error();
+                if (lastError == Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND)
+                {
+                    return null;
+                }
+
+                if (lastError != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER)
+                {
+                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                }
+            }
+
+            // Allocate space for the buffer.
+            int charsNeeded = (int)bytesNeeded / 2;
+            var buffer = new StringBuilder(charsNeeded, charsNeeded);
+
+            results = Interop.WinHttp.WinHttpQueryHeaders(
+                requestHandle,
+                infoLevel,
+                Interop.WinHttp.WINHTTP_HEADER_NAME_BY_INDEX,
+                buffer,
+                ref bytesNeeded,
+                IntPtr.Zero);
+            if (!results)
+            {
+                WinHttpException.ThrowExceptionUsingLastError();
+            }
+
+            return buffer.ToString();
+        }
+
+        private static void ParseResponseHeaders(
+            SafeWinHttpHandle requestHandle,
+            HttpResponseMessage response,
+            bool stripEncodingHeaders)
+        {
+            string rawResponseHeaders = GetResponseHeaderStringInfo(
+                requestHandle,
+                Interop.WinHttp.WINHTTP_QUERY_RAW_HEADERS_CRLF);
+            string[] responseHeaderArray = rawResponseHeaders.Split(
+                s_HttpHeadersSeparator,
+                StringSplitOptions.RemoveEmptyEntries);
+
+            // Parse the array of headers and split them between Content headers and Response headers.
+            // Skip the first line which contains status code, etc. information that we already parsed.
+            for (int i = 1; i < responseHeaderArray.Length; i++)
+            {
+                int colonIndex = responseHeaderArray[i].IndexOf(':');
+
+                // Skip malformed header lines that are missing the colon character.
+                if (colonIndex > 0)
+                {
+                    string headerName = responseHeaderArray[i].Substring(0, colonIndex);
+                    string headerValue = responseHeaderArray[i].Substring(colonIndex + 1).Trim(); // Normalize header value by trimming white space.
+
+                    if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
+                    {
+                        if (stripEncodingHeaders)
+                        {
+                            // Remove Content-Length and Content-Encoding headers if we are
+                            // decompressing the response stream in the handler (due to 
+                            // WINHTTP not supporting it in a particular downlevel platform). 
+                            // This matches the behavior of WINHTTP when it does decompression iself.
+                            if (string.Equals(
+                                HeaderNameContentLength,
+                                headerName,
+                                StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+
+                            if (string.Equals(
+                                HeaderNameContentEncoding,
+                                headerName,
+                                StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+                        }
+
+                        // TODO: Issue #2165. Should we log if there is an error here?
+                        response.Content.Headers.TryAddWithoutValidation(headerName, headerValue);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 
@@ -11,12 +12,15 @@ namespace System.Net.Http
 {
     internal class WinHttpResponseStream : Stream
     {
-        private volatile bool _disposed = false;
-        private SafeWinHttpHandle _requestHandle = null;
+        private volatile bool _disposed;
+        private readonly WinHttpRequestState _state;
+        
+        // TODO (Issue 2505): temporary pinned buffer caches of 1 item. Will be replaced by PinnableBufferCache.
+        private GCHandle _cachedReceivePinnedBuffer = new GCHandle();
 
-        internal WinHttpResponseStream(SafeWinHttpHandle requestHandle)
+        internal WinHttpResponseStream(WinHttpRequestState state)
         {
-            _requestHandle = requestHandle;
+            _state = state;
         }
 
         public override bool CanRead
@@ -72,7 +76,14 @@ namespace System.Net.Http
             // Nothing to do.
         }
 
-        public override int Read(byte[] buffer, int offset, int count)
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                Task.CompletedTask;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
             if (buffer == null)
             {
@@ -94,22 +105,52 @@ namespace System.Net.Http
                 throw new ArgumentException("buffer");
             }
 
-            CheckDisposed();
-
-            uint bytesRead = 0;
-            GCHandle pinnedHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-            bool result = Interop.WinHttp.WinHttpReadData(
-                _requestHandle,
-                Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
-                (uint)count,
-                out bytesRead);
-            pinnedHandle.Free();
-            if (!result)
+            if (token.IsCancellationRequested)
             {
-                throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                return Task.FromCanceled<int>(token);
             }
 
-            return (int)bytesRead;
+            CheckDisposed();
+
+            if (_state.TcsReadFromResponseStream != null && !_state.TcsReadFromResponseStream.Task.IsCompleted)
+            {
+                throw new InvalidOperationException(SR.net_http_no_concurrent_io_allowed);
+            }
+
+            // TODO (Issue 2505): replace with PinnableBufferCache.
+            if (!_cachedReceivePinnedBuffer.IsAllocated || _cachedReceivePinnedBuffer.Target != buffer)
+            {
+                if (_cachedReceivePinnedBuffer.IsAllocated)
+                {
+                    _cachedReceivePinnedBuffer.Free();
+                }
+
+                _cachedReceivePinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            }
+
+            _state.TcsReadFromResponseStream = new TaskCompletionSource<int>();
+
+            lock (_state.Lock)
+            {
+                if (!Interop.WinHttp.WinHttpReadData(
+                    _state.RequestHandle,
+                    Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
+                    (uint)count,
+                    IntPtr.Zero))
+                {
+                    _state.TcsReadFromResponseStream.TrySetException(
+                        new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError()));
+                }
+            }
+
+            // TODO: Issue #2165. Register callback on cancellation token to cancel WinHTTP operation.
+
+            return _state.TcsReadFromResponseStream.Task;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -136,9 +177,22 @@ namespace System.Net.Http
             {
                 _disposed = true;
 
-                if (disposing && _requestHandle != null)
+                if (disposing)
                 {
-                    SafeWinHttpHandle.DisposeAndClearHandle(ref _requestHandle);
+                    // TODO (Issue 2508): Pinned buffers must be released in the callback, when it is guaranteed no further
+                    // operations will be made to the send/receive buffers.
+                    if (_cachedReceivePinnedBuffer.IsAllocated)
+                    {
+                        _cachedReceivePinnedBuffer.Free();
+                    }
+
+                    if (_state.RequestHandle != null)
+                    {
+                        _state.RequestHandle.Dispose();
+                        _state.RequestHandle = null;
+                    }
+                    
+                    _state.Dispose();
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+namespace System.Net.Http
+{
+    internal static class WinHttpTraceHelper
+    {
+        private const string WinHtpTraceEnvironmentVariable = "WINHTTPHANDLER_TRACE";
+        private static bool s_TraceEnabled;
+
+        static WinHttpTraceHelper()
+        {
+            string env;
+            try
+            {
+                env = Environment.GetEnvironmentVariable(WinHtpTraceEnvironmentVariable);
+            }
+            catch (SecurityException)
+            {
+                env = null;
+            }
+
+            s_TraceEnabled = !string.IsNullOrEmpty(env);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsTraceEnabled()
+        {
+            return s_TraceEnabled;
+        }
+
+        public static void TraceCallbackStatus(string message, IntPtr handle, bool invokeCallback, uint status)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+
+            Debug.WriteLine(
+                "{0}: handle=0x{1:X}, {2}, {3}",
+                message,
+                handle,
+                invokeCallback ? "processing" : "skipping",
+                GetStringFromInternetStatus(status));
+        }
+
+        public static void TraceAsyncError(string message, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+
+            uint apiIndex = (uint)asyncResult.dwResult.ToInt32();
+            uint error = asyncResult.dwError;
+
+            Debug.WriteLine(
+                "{0}: api={1}, error={2}({3}) \"{4}\"",
+                message,
+                GetNameFromApiIndex(apiIndex),
+                GetNameFromError(error),
+                error,
+                WinHttpException.GetErrorMessage((int)error));
+        }
+
+        private static string GetNameFromApiIndex(uint index)
+        {
+            switch (index)
+            {
+                case Interop.WinHttp.API_RECEIVE_RESPONSE:
+                    return "API_RECEIVE_RESPONSE";
+
+                case Interop.WinHttp.API_QUERY_DATA_AVAILABLE:
+                    return "API_QUERY_DATA_AVAILABLE";
+
+                case Interop.WinHttp.API_READ_DATA:
+                    return "API_READ_DATA";
+
+                case Interop.WinHttp.API_WRITE_DATA:
+                    return "API_WRITE_DATA";
+
+                case Interop.WinHttp.API_SEND_REQUEST:
+                    return "API_SEND_REQUEST";
+
+                default:
+                    return index.ToString();
+            }
+        }
+
+        private static string GetNameFromError(uint error)
+        {
+            switch (error)
+            {
+                case Interop.WinHttp.ERROR_FILE_NOT_FOUND:
+                    return "ERROR_FILE_NOT_FOUND";
+
+                case Interop.WinHttp.ERROR_INVALID_HANDLE:
+                    return "ERROR_INVALID_HANDLE";
+
+                case Interop.WinHttp.ERROR_INVALID_PARAMETER:
+                    return "ERROR_INVALID_PARAMETER";
+
+                case Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER:
+                    return "ERROR_INSUFFICIENT_BUFFER";
+
+                case Interop.WinHttp.ERROR_NOT_FOUND:
+                    return "ERROR_NOT_FOUND";
+
+                case Interop.WinHttp.ERROR_WINHTTP_INVALID_OPTION:
+                    return "WINHTTP_INVALID_OPTION";
+
+                case Interop.WinHttp.ERROR_WINHTTP_LOGIN_FAILURE:
+                    return "WINHTTP_LOGIN_FAILURE";
+
+                case Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED:
+                    return "WINHTTP_OPERATION_CANCELLED";
+
+                case Interop.WinHttp.ERROR_WINHTTP_INCORRECT_HANDLE_STATE:
+                    return "WINHTTP_INCORRECT_HANDLE_STATE";
+
+                case Interop.WinHttp.ERROR_WINHTTP_CONNECTION_ERROR:
+                    return "WINHTTP_CONNECTION_ERROR";
+
+                case Interop.WinHttp.ERROR_WINHTTP_RESEND_REQUEST:
+                    return "WINHTTP_RESEND_REQUEST";
+
+                case Interop.WinHttp.ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED:
+                    return "WINHTTP_CLIENT_AUTH_CERT_NEEDED";
+
+                case Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND:
+                    return "WINHTTP_HEADER_NOT_FOUND";
+
+                case Interop.WinHttp.ERROR_WINHTTP_SECURE_FAILURE:
+                    return "WINHTTP_SECURE_FAILURE";
+
+                case Interop.WinHttp.ERROR_WINHTTP_AUTODETECTION_FAILED:
+                    return "WINHTTP_AUTODETECTION_FAILED";
+
+                 default:
+                    return error.ToString();
+            }
+        }
+
+        private static string GetStringFromInternetStatus(uint status)
+        {
+            switch (status)
+            {
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_RESOLVING_NAME:
+                    return "STATUS_RESOLVING_NAME";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_NAME_RESOLVED:
+                    return "STATUS_NAME_RESOLVED";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CONNECTING_TO_SERVER:
+                    return "STATUS_CONNECTING_TO_SERVER";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CONNECTED_TO_SERVER:
+                    return "STATUS_CONNECTED_TO_SERVER";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SENDING_REQUEST:
+                    return "STATUS_SENDING_REQUEST";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REQUEST_SENT:
+                    return "STATUS_REQUEST_SENT";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_RECEIVING_RESPONSE:
+                    return "STATUS_RECEIVING_RESPONSE"; 
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_RESPONSE_RECEIVED:
+                    return "STATUS_RESPONSE_RECEIVED";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CLOSING_CONNECTION:
+                    return "STATUS_CLOSING_CONNECTION";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CONNECTION_CLOSED:
+                    return "STATUS_CONNECTION_CLOSED";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_HANDLE_CREATED:
+                    return "STATUS_HANDLE_CREATED";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING:
+                    return "STATUS_HANDLE_CLOSING";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_DETECTING_PROXY:
+                    return "STATUS_DETECTING_PROXY";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REDIRECT:
+                    return "STATUS_REDIRECT";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_INTERMEDIATE_RESPONSE:
+                    return "STATUS_INTERMEDIATE_RESPONSE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SECURE_FAILURE:
+                    return "STATUS_SECURE_FAILURE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE:
+                    return "STATUS_HEADERS_AVAILABLE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_DATA_AVAILABLE:
+                    return "STATUS_DATA_AVAILABLE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
+                    return "STATUS_READ_COMPLETE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE:
+                    return "STATUS_WRITE_COMPLETE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REQUEST_ERROR:
+                    return "STATUS_REQUEST_ERROR";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE:
+                    return "STATUS_SENDREQUEST_COMPLETE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_GETPROXYFORURL_COMPLETE:
+                    return "STATUS_GETPROXYFORURL_COMPLETE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CLOSE_COMPLETE:
+                    return "STATUS_CLOSE_COMPLETE";
+
+                case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SHUTDOWN_COMPLETE:
+                    return "STATUS_SHUTDOWN_COMPLETE";
+
+                default:
+                    return string.Format("0x{0:X}", status);
+            }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -21,6 +21,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers2.cs">
+      <Link>Common\System\Net\HttpTestServers2.cs</Link>
+    </Compile>
     <Compile Include="ServerCertificateTest.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -19,6 +19,9 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
     // to separately Dispose (or have a 'using' statement) for the handler.
     public class WinHttpHandlerTest
     {
+        // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
+        private const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
+        
         readonly ITestOutputHelper _output;
 
         public WinHttpHandlerTest(ITestOutputHelper output)
@@ -37,6 +40,38 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 var responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 _output.WriteLine(responseContent);
+            }
+        }
+
+        [Fact]
+        [OuterLoop]
+        public async Task SendAsync_SlowServerAndCancel_ThrowsTaskCanceledException()
+        {
+            var handler = new WinHttpHandler();
+            using (var client = new HttpClient(handler))
+            {
+                var cts = new CancellationTokenSource();
+                Task<HttpResponseMessage> t = client.GetAsync(SlowServer, cts.Token);
+
+                await Task.Delay(500);
+                cts.Cancel();
+                
+                AggregateException ag = Assert.Throws<AggregateException>(() => t.Wait());
+                Assert.IsType<TaskCanceledException>(ag.InnerException);
+            }
+        }        
+        
+        [Fact]
+        [OuterLoop]
+        public void SendAsync_SlowServerRespondsAfterDefaultReceiveTimeout_ThrowsHttpRequestException()
+        {
+            var handler = new WinHttpHandler();
+            using (var client = new HttpClient(handler))
+            {
+                Task<HttpResponseMessage> t = client.GetAsync(SlowServer);
+                
+                AggregateException ag = Assert.Throws<AggregateException>(() => t.Wait());
+                Assert.IsType<HttpRequestException>(ag.InnerException);
             }
         }
     }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -58,7 +58,7 @@ internal static partial class Interop
             string proxyBypass,
             uint flags)
         {
-            if (TestControl.Fail.WinHttpOpen)
+            if (TestControl.WinHttpOpen.ErrorWithApiCall)
             {
                 TestControl.LastWin32Error = (int)Interop.WinHttp.ERROR_INVALID_HANDLE;
                 return new FakeSafeWinHttpHandle(false);
@@ -135,17 +135,37 @@ internal static partial class Interop
             uint totalLength,
             IntPtr context)
         {
+            Task.Run(() => {
+                var fakeHandle = (FakeSafeWinHttpHandle)requestHandle;
+                fakeHandle.Context = context;
+                fakeHandle.InvokeCallback(Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE, IntPtr.Zero, 0);
+            });
+
             return true;
         }
 
         public static bool WinHttpReceiveResponse(SafeWinHttpHandle requestHandle, IntPtr reserved)
         {
-            if (TestControl.ResponseDelayTime > 0)
-            {
-                TestControl.ResponseDelayCompletedEvent.Reset();
-                Thread.Sleep(TestControl.ResponseDelayTime);
-                TestControl.ResponseDelayCompletedEvent.Set();
-            }
+            Task.Run(() => {
+                var fakeHandle = (FakeSafeWinHttpHandle)requestHandle;
+                bool aborted = !fakeHandle.DelayOperation(TestControl.WinHttpReceiveResponse.Delay);
+
+                if (aborted || TestControl.WinHttpReadData.ErrorOnCompletion)
+                {
+                    Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult;
+                    asyncResult.dwResult = new IntPtr((int)Interop.WinHttp.API_RECEIVE_RESPONSE);
+                    asyncResult.dwError = aborted ? Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED :
+                        Interop.WinHttp.ERROR_WINHTTP_CONNECTION_ERROR;
+
+                    TestControl.WinHttpReadData.Wait();
+                    fakeHandle.InvokeCallback(Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REQUEST_ERROR, asyncResult);
+                }
+                else
+                {
+                    TestControl.WinHttpReceiveResponse.Wait();
+                    fakeHandle.InvokeCallback(Interop.WinHttp.WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE, IntPtr.Zero, 0);
+                }
+            });
 
             return true;
         }
@@ -160,16 +180,42 @@ internal static partial class Interop
             SafeWinHttpHandle requestHandle,
             IntPtr buffer,
             uint bufferSize,
-            out uint bytesRead)
+            IntPtr bytesReadShouldBeNullForAsync)
         {
-            bytesRead = 0;
-
-            if (TestControl.Fail.WinHttpReadData)
+            if (bytesReadShouldBeNullForAsync != IntPtr.Zero)
             {
                 return false;
             }
 
+            if (TestControl.WinHttpReadData.ErrorWithApiCall)
+            {
+                return false;
+            }
+
+            uint bytesRead;
             TestServer.ReadFromResponseBody(buffer, bufferSize, out bytesRead);
+
+            Task.Run(() => {
+                var fakeHandle = (FakeSafeWinHttpHandle)requestHandle;
+                bool aborted = !fakeHandle.DelayOperation(TestControl.WinHttpReadData.Delay);
+
+                if (aborted || TestControl.WinHttpReadData.ErrorOnCompletion)
+                {
+                    Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult;
+                    asyncResult.dwResult = new IntPtr((int)Interop.WinHttp.API_READ_DATA);
+                    asyncResult.dwError = aborted ? Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED :
+                        Interop.WinHttp.ERROR_WINHTTP_CONNECTION_ERROR;
+
+                    TestControl.WinHttpReadData.Wait();
+                    fakeHandle.InvokeCallback(Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REQUEST_ERROR, asyncResult);
+                }
+                else
+                {
+                    TestControl.WinHttpReadData.Wait();
+                    fakeHandle.InvokeCallback(Interop.WinHttp.WINHTTP_CALLBACK_STATUS_READ_COMPLETE, buffer, bytesRead);
+                }
+            });
+
             return true;
         }
 
@@ -320,16 +366,43 @@ internal static partial class Interop
             SafeWinHttpHandle requestHandle,
             IntPtr buffer,
             uint bufferSize,
-            out uint bytesWritten)
+            IntPtr bytesWrittenShouldBeNullForAsync)
         {
-            if (TestControl.Fail.WinHttpWriteData)
+            if (bytesWrittenShouldBeNullForAsync != IntPtr.Zero)
             {
-                bytesWritten = 0;
                 return false;
             }
 
+            if (TestControl.WinHttpWriteData.ErrorWithApiCall)
+            {
+                return false;
+            }
+
+            uint bytesWritten;
             TestServer.WriteToRequestBody(buffer, bufferSize);
             bytesWritten = bufferSize;
+
+            Task.Run(() => {
+                var fakeHandle = (FakeSafeWinHttpHandle)requestHandle;
+                bool aborted = !fakeHandle.DelayOperation(TestControl.WinHttpWriteData.Delay);
+
+                if (aborted || TestControl.WinHttpWriteData.ErrorOnCompletion)
+                {
+                    Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult;
+                    asyncResult.dwResult = new IntPtr((int)Interop.WinHttp.API_WRITE_DATA);
+                    asyncResult.dwError = Interop.WinHttp.ERROR_WINHTTP_CONNECTION_ERROR;
+
+                    TestControl.WinHttpWriteData.Wait();
+                    fakeHandle.InvokeCallback(aborted ? Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED :
+                        Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REQUEST_ERROR, asyncResult);
+                }
+                else
+                {
+                    TestControl.WinHttpWriteData.Wait();
+                    fakeHandle.InvokeCallback(Interop.WinHttp.WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE, IntPtr.Zero, 0);
+                }
+            });
+
             return true;
         }
 
@@ -513,6 +586,9 @@ internal static partial class Interop
             {
                 throw new ArgumentNullException("handle");
             }
+            
+            var fakeHandle = (FakeSafeWinHttpHandle)handle;
+            fakeHandle.Callback = callback;
             
             return IntPtr.Zero;
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeSafeWinHttpHandle.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeSafeWinHttpHandle.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Diagnostics;
+using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
@@ -11,6 +14,9 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
     {
         private static int s_HandlesOpen = 0;
 
+        private Interop.WinHttp.WINHTTP_STATUS_CALLBACK _callback = null;
+        private IntPtr _context = IntPtr.Zero;
+        
         public FakeSafeWinHttpHandle(bool markAsValid)
         {
             if (markAsValid)
@@ -34,6 +40,74 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             {
                 return s_HandlesOpen;
             }
+        }
+
+        public Interop.WinHttp.WINHTTP_STATUS_CALLBACK Callback
+        {
+            get
+            {
+                return _callback;
+            }
+            
+            set
+            {
+                _callback = value;
+            }
+        }
+
+        public IntPtr Context
+        {
+            get
+            {
+                return _context;
+            }
+            
+            set
+            {
+                _context = value;
+            }
+        }
+
+        public bool DelayOperation(int delay)
+        {
+            if (delay <= 0)
+            {
+                return true;
+            }
+            
+            // Sleep for delay time specified.  Abort if handle becomes closed.
+            var sw = new Stopwatch();
+            sw.Start();
+            while (sw.ElapsedMilliseconds <= delay)
+            {
+                if (IsClosed)
+                {
+                    sw.Stop();
+                    return false;
+                }
+                
+                Thread.Sleep(1);
+            }
+
+            sw.Stop();
+            
+            return true;
+        }
+        
+        public void InvokeCallback(uint internetStatus, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult)
+        {
+            GCHandle pinnedAsyncResult = GCHandle.Alloc(asyncResult, GCHandleType.Pinned);
+            IntPtr statusInformation = pinnedAsyncResult.AddrOfPinnedObject();
+            uint statusInformationLength = (uint)Marshal.SizeOf<Interop.WinHttp.WINHTTP_ASYNC_RESULT>();
+
+            InvokeCallback(internetStatus, statusInformation, statusInformationLength);
+
+            pinnedAsyncResult.Free();
+        }
+
+        public void InvokeCallback(uint internetStatus, IntPtr statusInformation, uint statusInformationLength)
+        {
+            _callback(DangerousGetHandle(), _context, internetStatus, statusInformation, statusInformationLength);
         }
 
         protected override bool ReleaseHandle()

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeX509Certificates.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeX509Certificates.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Net.Http.WinHttpHandlerUnitTests;
 using System.Security.Cryptography.X509Certificates;
 
@@ -10,8 +11,10 @@ namespace System.Net.Http
     {
         private bool _disposed;
         
-        public X509Store()
+        public X509Store(StoreName storeName, StoreLocation storeLocation)
         {
+            Debug.Assert(storeName == StoreName.My);
+            Debug.Assert(storeLocation == StoreLocation.CurrentUser);
         }
 
         public X509Certificate2Collection Certificates

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -38,11 +38,20 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
+      <Link>Common\System\Net\HttpVersion.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+      <Link>Common\System\Net\UriScheme.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\System\Net\Http\CertificateHelper.cs">
-      <Link>ProductionCode\CertificateHelper.cs</Link>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpAuthHelper.cs">
+      <Link>ProductionCode\WinHttpAuthHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpCertificateHelper.cs">
+      <Link>ProductionCode\WinHttpCertificateHelper.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpChannelBinding.cs">
       <Link>ProductionCode\WinHttpChannelBinding.cs</Link>
@@ -53,11 +62,23 @@
     <Compile Include="..\..\src\System\Net\Http\WinHttpHandler.cs">
       <Link>ProductionCode\WinHttpHandler.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpRequestCallback.cs">
+      <Link>ProductionCode\WinHttpRequestCallback.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpRequestState.cs">
+      <Link>ProductionCode\WinHttpRequestState.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpRequestStream.cs">
       <Link>ProductionCode\WinHttpRequestStream.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpResponseParser.cs">
+      <Link>ProductionCode\WinHttpResponseParser.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpResponseStream.cs">
       <Link>ProductionCode\WinHttpResponseStream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpTraceHelper.cs">
+      <Link>ProductionCode\WinHttpTraceHelper.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpTransportContext.cs">
       <Link>ProductionCode\WinHttpTransportContext.cs</Link>

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
@@ -17,18 +18,13 @@ using Xunit;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class WinHttpHandlerTest : IDisposable
+    public class WinHttpHandlerTest
     {
         private const string FakeProxy = "http://proxy.contoso.com";
-
+        
         public WinHttpHandlerTest()
         {
             TestControl.ResetAll();
-        }
-
-        public void Dispose()
-        {
-            TestControl.ResponseDelayCompletedEvent.WaitOne();
         }
 
         [Fact]
@@ -160,7 +156,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
-        public async Task CookieUsePolicy_UseSpecifiedCookieContainerAndNullContainer_ThrowsInvalidOperationException()
+        public async void CookieUsePolicy_UseSpecifiedCookieContainerAndNullContainer_ThrowsInvalidOperationException()
         {
             var handler = new WinHttpHandler();
             Assert.Null(handler.CookieContainer);
@@ -794,8 +790,8 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public async Task SendAsync_SlowPostRequestWithTimedCancellation_ExpectTaskCanceledException()
         {
             var handler = new WinHttpHandler();
-            TestControl.ResponseDelayTime = 500;
-            CancellationTokenSource cts = new CancellationTokenSource(100);
+            TestControl.WinHttpReceiveResponse.Delay = 5000;
+            CancellationTokenSource cts = new CancellationTokenSource(50);
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Post, TestServer.FakeServerEndpoint);
             var content = new StringContent(new String('a', 1000));
@@ -809,8 +805,8 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public async Task SendAsync_SlowGetRequestWithTimedCancellation_ExpectTaskCanceledException()
         {
             var handler = new WinHttpHandler();
-            TestControl.ResponseDelayTime = 500;
-            CancellationTokenSource cts = new CancellationTokenSource(100);
+            TestControl.WinHttpReceiveResponse.Delay = 5000;
+            CancellationTokenSource cts = new CancellationTokenSource(50);
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Get, TestServer.FakeServerEndpoint);
             
@@ -838,7 +834,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Get, TestServer.FakeServerEndpoint);
 
-            TestControl.Fail.WinHttpOpen = true;
+            TestControl.WinHttpOpen.ErrorWithApiCall = true;
 
             Exception ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
             Assert.Equal(typeof(WinHttpException), ex.InnerException.GetType());

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -66,7 +66,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<NotSupportedException>(() => { long result = stream.Length; });
+            Assert.Throws<NotSupportedException>(() => stream.Length);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { long result = stream.Length; });
+            Assert.Throws<ObjectDisposedException>(() => stream.Length);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<NotSupportedException>(() => { long result = stream.Position; });
+            Assert.Throws<NotSupportedException>(() => stream.Position);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { long result = stream.Position; });
+            Assert.Throws<ObjectDisposedException>(() => stream.Position);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.Position = 0; });
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Position = 0; });
+            Assert.Throws<ObjectDisposedException>(() => stream.Position = 0);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.Seek(0, SeekOrigin.Begin); });
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Seek(0, SeekOrigin.Begin); });
+            Assert.Throws<ObjectDisposedException>(() => stream.Seek(0, SeekOrigin.Begin));
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.SetLength(0); });
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.SetLength(0); });
+            Assert.Throws<ObjectDisposedException>(() => stream.SetLength(0));
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.Read(new byte[1], 0, 1); });
+            Assert.Throws<NotSupportedException>(() => stream.Read(new byte[1], 0, 1));
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Read(new byte[1], 0, 1); });
+            Assert.Throws<ObjectDisposedException>(() => stream.Read(new byte[1], 0, 1));
         }
 
         [Fact]
@@ -168,7 +168,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<ArgumentNullException>(() => { stream.Write(null, 0, 1); });
+            Assert.Throws<ArgumentNullException>(() => stream.Write(null, 0, 1));
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { stream.Write(new byte[1], -1, 1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(new byte[1], -1, 1));
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { stream.Write(new byte[1], 0, -1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(new byte[1], 0, -1));
         }
 
         [Fact]
@@ -192,7 +192,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<ArgumentException>(() => { stream.Write(new byte[1], 0, 3); });
+            Assert.Throws<ArgumentException>(() => stream.Write(new byte[1], 0, 3));
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            Assert.Throws<ArgumentException>(() => { stream.Write(new byte[1], int.MaxValue, int.MaxValue); });
+            Assert.Throws<ArgumentException>(() => stream.Write(new byte[1], int.MaxValue, int.MaxValue));
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeRequestStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Write(new byte[1], 0, 1); });
+            Assert.Throws<ObjectDisposedException>(() => stream.Write(new byte[1], 0, 1));
         }
 
         [Fact]
@@ -217,9 +217,9 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeRequestStream();
 
-            TestControl.Fail.WinHttpWriteData = true;
-            
-            Assert.Throws<IOException>(() => { stream.Write(new byte[1], 0, 1); });
+            TestControl.WinHttpWriteData.ErrorOnCompletion = true;
+
+            Assert.Throws<IOException>(() => stream.Write(new byte[1], 0, 1));
         }
 
         [Fact]
@@ -232,7 +232,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             stream.Write(buffer, 0, buffer.Length);
 
             byte[] serverBytes = TestServer.RequestBody;
-            Assert.True(ByteArraysEqual(buffer, 0, buffer.Length, serverBytes, 0, serverBytes.Length));
+            Assert.Equal(buffer, serverBytes);
         }
 
         [Fact]
@@ -246,32 +246,72 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             stream.Write(buffer, offset, buffer.Length - offset);
 
             byte[] serverBytes = TestServer.RequestBody;
-            Assert.True(ByteArraysEqual(buffer, offset, buffer.Length - offset, serverBytes, 0, serverBytes.Length));
+            Assert.Equal(
+                new ArraySegment<byte>(buffer, offset, buffer.Length - offset),
+                new ArraySegment<byte>(serverBytes, 0, serverBytes.Length));
+        }
+
+        [Fact]
+        public void WriteAsync_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            Stream stream = MakeRequestStream();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(new byte[1], -1, 1); });
+        }
+
+        [Fact]
+        public async Task WriteAsync_NetworkFails_TaskIsFaultedWithIOException()
+        {
+            Stream stream = MakeRequestStream();
+
+            TestControl.WinHttpWriteData.ErrorOnCompletion = true;
+
+            await Assert.ThrowsAsync<IOException>(() => stream.WriteAsync(new byte[1], 0, 1));
+        }
+
+        [Fact]
+        public void WriteAsync_TokenIsAlreadyCanceled_TaskIsCanceled()
+        {
+            Stream stream = MakeRequestStream();
+
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            Task t = stream.WriteAsync(new byte[1], 0, 1, cts.Token);
+            Assert.True(t.IsCanceled);
+        }
+
+        [Fact]
+        public void WtiteAsync_WhenDisposed_ThrowsObjectDisposedException()
+        {
+            Stream stream = MakeRequestStream();
+            stream.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { Task t = stream.WriteAsync(new byte[1], 0, 1); });
+        }
+
+        [Fact]
+        public void WriteAsync_PriorWriteInProgress_ThrowsInvalidOperationException()
+        {
+            Stream stream = MakeRequestStream();
+            
+            TestControl.WinHttpWriteData.Pause();
+            Task t1 = stream.WriteAsync(new byte[1], 0, 1);
+
+            Assert.Throws<InvalidOperationException>(() => { Task t2 = stream.WriteAsync(new byte[1], 0, 1); });
+            
+            TestControl.WinHttpWriteData.Resume();
+            t1.Wait();
         }
 
         internal Stream MakeRequestStream()
         {
-            SafeWinHttpHandle requestHandle = new FakeSafeWinHttpHandle(true);
+            var state = new WinHttpRequestState();
+            var handle = new FakeSafeWinHttpHandle(true);
+            handle.Callback = WinHttpRequestCallback.StaticCallbackDelegate;
+            handle.Context = state.ToIntPtr();
+            state.RequestHandle = handle;
 
-            return new WinHttpRequestStream(requestHandle, false);
-        }
-
-        private bool ByteArraysEqual(byte[] array1, int offset1, int length1, byte[] array2, int offset2, int length2)
-        {
-            if (length1 != length2)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < length1; i++)
-            {
-                if (array1[offset1 + i] != array2[offset2 + i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return new WinHttpRequestStream(state, false);
         }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Net.Http;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -63,7 +63,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<NotSupportedException>(() => { long result = stream.Length; });
+            Assert.Throws<NotSupportedException>(() => stream.Length);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { long result = stream.Length; });
+            Assert.Throws<ObjectDisposedException>(() => stream.Length);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<NotSupportedException>(() => { long result = stream.Position; });
+            Assert.Throws<NotSupportedException>(() => stream.Position);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { long result = stream.Position; });
+            Assert.Throws<ObjectDisposedException>(() => stream.Position);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.Position = 0; });
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Position = 0; });
+            Assert.Throws<ObjectDisposedException>(() => stream.Position = 0);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.Seek(0, SeekOrigin.Begin); });
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Seek(0, SeekOrigin.Begin); });
+            Assert.Throws<ObjectDisposedException>(() => stream.Seek(0, SeekOrigin.Begin));
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.SetLength(0); });
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.SetLength(0); });
+            Assert.Throws<ObjectDisposedException>(() => stream.SetLength(0));
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<NotSupportedException>(() => { stream.Write(new byte[1], 0, 1); });
+            Assert.Throws<NotSupportedException>(() => stream.Write(new byte[1], 0, 1));
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Write(new byte[1], 0, 1); });
+            Assert.Throws<ObjectDisposedException>(() => stream.Write(new byte[1], 0, 1));
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<ArgumentNullException>(() => { stream.Read(null, 0, 1); });
+            Assert.Throws<ArgumentNullException>(() => stream.Read(null, 0, 1));
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { stream.Read(new byte[1], -1, 1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Read(new byte[1], -1, 1));
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { stream.Read(new byte[1], 0, -1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Read(new byte[1], 0, -1));
         }
 
         [Fact]
@@ -189,7 +189,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            Assert.Throws<ArgumentException>(() => { stream.Read(new byte[1], int.MaxValue, int.MaxValue); });
+            Assert.Throws<ArgumentException>(() => stream.Read(new byte[1], int.MaxValue, int.MaxValue));
         }
 
         [Fact]
@@ -198,7 +198,61 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Stream stream = MakeResponseStream();
             stream.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => { stream.Read(new byte[1], 0, 1); });
+            Assert.Throws<ObjectDisposedException>(() => stream.Read(new byte[1], 0, 1));
+        }
+
+        [Fact]
+        public void ReadAsync_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            Stream stream = MakeResponseStream();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.ReadAsync(new byte[1], -1, 1); });
+        }
+
+        [Fact]
+        public void ReadAsync_NetworkFails_TaskIsFaultedWithIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpReadData.ErrorOnCompletion = true;
+            
+            Task t = stream.ReadAsync(new byte[1], 0, 1);
+            AggregateException ex = Assert.Throws<AggregateException>(() => t.Wait());
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void ReadAsync_TokenIsAlreadyCanceled_TaskIsCanceled()
+        {
+            Stream stream = MakeResponseStream();
+
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            Task t = stream.ReadAsync(new byte[1], 0, 1, cts.Token);
+            Assert.True(t.IsCanceled);
+        }
+
+        [Fact]
+        public void ReadAsync_WhenDisposed_ThrowsObjectDisposedException()
+        {
+            Stream stream = MakeResponseStream();
+            stream.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { Task t = stream.ReadAsync(new byte[1], 0, 1); });
+        }
+
+        [Fact]
+        public void ReadAsync_PriorReadInProgress_ThrowsInvalidOperationException()
+        {
+            Stream stream = MakeResponseStream();
+            
+            TestControl.WinHttpReadData.Pause();
+            Task t1 = stream.ReadAsync(new byte[1], 0, 1);
+
+            Assert.Throws<InvalidOperationException>(() => { Task t2 = stream.ReadAsync(new byte[1], 0, 1); });
+            
+            TestControl.WinHttpReadData.Resume();
+            t1.Wait();
         }
 
         [Fact]
@@ -206,7 +260,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             Stream stream = MakeResponseStream();
 
-            TestControl.Fail.WinHttpReadData = true;
+            TestControl.WinHttpReadData.ErrorOnCompletion = true;
             Assert.Throws<IOException>(() => { stream.Read(new byte[1], 0, 1); });
         }
 
@@ -252,9 +306,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
         internal Stream MakeResponseStream()
         {
-            var requestHandle = new FakeSafeWinHttpHandle(true);
+            var state = new WinHttpRequestState();
+            var handle = new FakeSafeWinHttpHandle(true);
+            handle.Callback = WinHttpRequestCallback.StaticCallbackDelegate;
+            handle.Context = state.ToIntPtr();
+            state.RequestHandle = handle;
 
-            return new WinHttpResponseStream(requestHandle);
+            return new WinHttpResponseStream(state);
         }
     }
 }

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -252,6 +252,9 @@
   <data name="net_http_io_read" xml:space="preserve">
     <value>The read operation failed, see inner exception.</value>
   </data>
+  <data name="net_http_io_write" xml:space="preserve">
+    <value>The write operation failed, see inner exception.</value>
+  </data>
   <data name="net_http_chunked_not_allowed_with_empty_content" xml:space="preserve">
     <value>'Transfer-Encoding: chunked' header can not be used when content object is not specified.</value>
   </data>
@@ -335,5 +338,11 @@
   </data>
   <data name="net_http_content_no_concurrent_reads" xml:space="preserve">
     <value>The stream does not support concurrent read operations.</value>
+  </data>
+  <data name="net_http_username_empty_string" xml:space="preserve">
+    <value>The username for a credential object cannot be null or empty.</value>
+  </data>
+  <data name="net_http_no_concurrent_io_allowed" xml:space="preserve">
+    <value>The stream does not support concurrent I/O read or write operations.</value>
   </data>
 </root>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -95,7 +95,6 @@
 
     <!-- TODO: Must be moved to the Common/System/Net folder -->
     <Compile Include="Internal\ICloneable.cs" />
-    <Compile Include="Internal\HttpVersion.cs" />
     <Compile Include="Internal\HttpStatusDescription.cs" />
     <Compile Include="Internal\MailAddress.cs" />
     <Compile Include="Internal\Mail\DomainLiteralReader.cs" />
@@ -211,6 +210,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
+      <Link>Common\System\Net\HttpVersion.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -31,9 +31,6 @@
     <Compile Include="..\..\src\Internal\HttpStatusDescription.cs">
       <Link>ProductionCode\Internal\HttpStatusDescription.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\Internal\HttpVersion.cs">
-      <Link>ProductionCode\Internal\HttpVersion.cs</Link>
-    </Compile>
     <Compile Include="..\..\src\Internal\ICloneable.cs">
       <Link>ProductionCode\Internal\ICloneable.cs</Link>
     </Compile>
@@ -318,6 +315,9 @@
 
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>ProductionCode\HttpKnownHeaderNames.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
+      <Link>Common\System\Net\HttpVersion.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging.cs">
       <Link>ProductionCode\Logging.cs</Link>


### PR DESCRIPTION
This is a large PR and addresses work item #3000. I apologize for not being able to structure it in a series of smaller commits.

The bulk of this PR is switching WinHttpHandler to use the async pattern of calling WinHTTP APIs. This involved a significant restructuring of the code. As part of that, I split up the large WinHttpHandler class into multiple, smaller, helper classes.

While the intent of using async WinHTTP calls is better performance and cancel-ability, this PR has not been fully optimized yet. Due to the schedule of RC1 code complete next week, it's important that this PR get in and get mileage on it in the next few weeks.

There are several TODO items that will be done in later PR's. There is still work being tracked in #2165 for various follow-up items. For example, re-conciling the best SafeHandle pattern to use for WinHTTP between WebSockets.Client and WinHttpHandler.

I'm currently using a simple Debug.WriteLine for verbose debug logging which can be turned on/off via environment variable. I plan to switch this to System.Net ETW trace loggers in the next commit and/or PR. But the logging has proved very useful in diagnosing issues.

Please provide feedback. Depending on the feedback, some of it will be marked as follow-up items for future PRs.