### PR TITLE
Accept null comparers and update docs around these parameters

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -116,6 +116,7 @@ namespace System.Collections.Immutable
         /// <param name="value">The value to remove.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>A new list with the element removed, or this list if the element is not in this list.</returns>
         [Pure]

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -42,6 +42,7 @@ namespace System.Collections.Immutable
         /// </param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>
         /// The zero-based index of the first occurrence of item within the range of
@@ -65,6 +66,7 @@ namespace System.Collections.Immutable
         /// <param name="count">The number of elements in the section to search.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>
         /// The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Immutable
     public interface IImmutableList<T> : IReadOnlyList<T>
     {
         /// <summary>
-        /// Gets an empty list that retains the same sort or unordered semantics that this instance has.
+        /// Gets an empty list that retains the same sort semantics that this instance has.
         /// </summary>
         [Pure]
         IImmutableList<T> Clear();

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -185,6 +185,7 @@ namespace System.Collections.Immutable
         /// <param name="newValue">The element to replace the old element with.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>The new list -- even if the value being replaced is equal to the new value for that position.</returns>
         /// <exception cref="ArgumentException">Thrown when the old value does not exist in the list.</exception>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -141,6 +141,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The items to remove if matches are found in this list.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>
         /// A new list with the elements removed.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -481,13 +481,14 @@ namespace System.Collections.Immutable
             /// <param name="item">The item to search for.</param>
             /// <param name="startIndex">The index at which to begin the search.</param>
             /// <param name="count">The number of elements to search.</param>
-            /// <param name="equalityComparer">The equality comparer to use in the search.</param>
+            /// <param name="equalityComparer">
+            /// The equality comparer to use in the search.
+            /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
+            /// </param>
             /// <returns>The 0-based index into the array where the item was found; or -1 if it could not be found.</returns>
             [Pure]
             public int IndexOf(T item, int startIndex, int count, IEqualityComparer<T> equalityComparer)
             {
-                Requires.NotNull(equalityComparer, "equalityComparer");
-
                 if (count == 0 && startIndex == 0)
                 {
                     return -1;
@@ -496,6 +497,7 @@ namespace System.Collections.Immutable
                 Requires.Range(startIndex >= 0 && startIndex < this.Count, "startIndex");
                 Requires.Range(count >= 0 && startIndex + count <= this.Count, "count");
 
+                equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 if (equalityComparer == EqualityComparer<T>.Default)
                 {
                     return Array.IndexOf(_elements, item, startIndex, count);
@@ -573,8 +575,6 @@ namespace System.Collections.Immutable
             [Pure]
             public int LastIndexOf(T item, int startIndex, int count, IEqualityComparer<T> equalityComparer)
             {
-                Requires.NotNull(equalityComparer, "equalityComparer");
-
                 if (count == 0 && startIndex == 0)
                 {
                     return -1;
@@ -583,6 +583,7 @@ namespace System.Collections.Immutable
                 Requires.Range(startIndex >= 0 && startIndex < this.Count, "startIndex");
                 Requires.Range(count >= 0 && startIndex - count + 1 >= 0, "count");
 
+                equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 if (equalityComparer == EqualityComparer<T>.Default)
                 {
                     return Array.LastIndexOf(_elements, item, startIndex, count);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -788,6 +788,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The items to remove if matches are found in this list.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>
         /// A new list with the elements removed.
@@ -798,7 +799,6 @@ namespace System.Collections.Immutable
             var self = this;
             self.ThrowNullRefIfNotInitialized();
             Requires.NotNull(items, "items");
-            Requires.NotNull(equalityComparer, "equalityComparer");
 
             var indexesToRemove = new SortedSet<int>();
             foreach (var item in items)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -686,6 +686,7 @@ namespace System.Collections.Immutable
         /// <param name="newValue">The element to replace the old element with.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>The new list -- even if the value being replaced is equal to the new value for that position.</returns>
         /// <exception cref="ArgumentException">Thrown when the old value does not exist in the list.</exception>
@@ -1301,7 +1302,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
             var self = this;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -329,14 +329,16 @@ namespace System.Collections.Immutable
         /// <param name="item">The item to search for.</param>
         /// <param name="startIndex">The index at which to begin the search.</param>
         /// <param name="count">The number of elements to search.</param>
-        /// <param name="equalityComparer">The equality comparer to use in the search.</param>
+        /// <param name="equalityComparer">
+        /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
+        /// </param>
         /// <returns>The 0-based index into the array where the item was found; or -1 if it could not be found.</returns>
         [Pure]
         public int IndexOf(T item, int startIndex, int count, IEqualityComparer<T> equalityComparer)
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(equalityComparer, "equalityComparer");
 
             if (count == 0 && startIndex == 0)
             {
@@ -346,6 +348,7 @@ namespace System.Collections.Immutable
             Requires.Range(startIndex >= 0 && startIndex < self.Length, "startIndex");
             Requires.Range(count >= 0 && startIndex + count <= self.Length, "count");
 
+            equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
             if (equalityComparer == EqualityComparer<T>.Default)
             {
                 return Array.IndexOf(self.array, item, startIndex, count);
@@ -425,7 +428,6 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(equalityComparer, "equalityComparer");
 
             if (startIndex == 0 && count == 0)
             {
@@ -435,6 +437,7 @@ namespace System.Collections.Immutable
             Requires.Range(startIndex >= 0 && startIndex < self.Length, "startIndex");
             Requires.Range(count >= 0 && startIndex - count + 1 >= 0, "count");
 
+            equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
             if (equalityComparer == EqualityComparer<T>.Default)
             {
                 return Array.LastIndexOf(self.array, item, startIndex, count);
@@ -948,7 +951,7 @@ namespace System.Collections.Immutable
                 {
                     comparer = Comparer<T>.Default;
                 }
-            
+
                 // Avoid copying the entire array when the array is already sorted.
                 bool outOfOrder = false;
                 for (int i = index + 1; i < index + count; i++)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -721,6 +721,7 @@ namespace System.Collections.Immutable
         /// <param name="item">The item to remove.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>The new array.</returns>
         [Pure]

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -639,7 +639,10 @@ namespace System.Collections.Immutable
             /// <param name="count">
             /// The number of elements in the section to search.
             /// </param>
-            /// <param name="equalityComparer">The equality comparer to use in the search.</param>
+            /// <param name="equalityComparer">
+            /// The equality comparer to use in the search.
+            /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
+            /// </param>
             /// <returns>
             /// The zero-based index of the first occurrence of item within the range of
             /// elements in the ImmutableList&lt;T&gt; that starts at index and
@@ -648,8 +651,6 @@ namespace System.Collections.Immutable
             [Pure]
             public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
             {
-                Requires.NotNull(equalityComparer, "equalityComparer");
-
                 return _root.IndexOf(item, index, count, equalityComparer);
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -868,8 +868,9 @@ namespace System.Collections.Immutable
             /// the specified System.Comparison&lt;T&gt;.
             /// </summary>
             /// <param name="comparison">
-            /// The System.Comparison&lt;T&gt; to use when comparing elements.
+            /// The <see cref="Comparison{T}"/> to use when comparing elements.
             /// </param>
+            /// <exception cref="ArgumentNullException"><paramref name="comparison"/> is null.</exception>
             public void Sort(Comparison<T> comparison)
             {
                 Requires.NotNull(comparison, "comparison");
@@ -881,12 +882,11 @@ namespace System.Collections.Immutable
             /// the specified comparer.
             /// </summary>
             /// <param name="comparer">
-            /// The System.Collections.Generic.IComparer&lt;T&gt; implementation to use when comparing
-            /// elements, or null to use the default comparer System.Collections.Generic.Comparer&lt;T&gt;.Default.
+            /// The <see cref="IComparer{T}"/> implementation to use when comparing
+            /// elements, or null to use <see cref="Comparer{T}.Default"/>.
             /// </param>
             public void Sort(IComparer<T> comparer)
             {
-                Requires.NotNull(comparer, "comparer");
                 this.Root = this.Root.Sort(comparer);
             }
 
@@ -901,15 +901,14 @@ namespace System.Collections.Immutable
             /// The length of the range to sort.
             /// </param>
             /// <param name="comparer">
-            /// The System.Collections.Generic.IComparer&lt;T&gt; implementation to use when comparing
-            /// elements, or null to use the default comparer System.Collections.Generic.Comparer&lt;T&gt;.Default.
+            /// The <see cref="IComparer{T}"/> implementation to use when comparing
+            /// elements, or null to use <see cref="Comparer{T}.Default"/>.
             /// </param>
             public void Sort(int index, int count, IComparer<T> comparer)
             {
                 Requires.Range(index >= 0, "index");
                 Requires.Range(count >= 0, "count");
                 Requires.Range(index + count <= this.Count, "count");
-                Requires.NotNull(comparer, "comparer");
                 this.Root = this.Root.Sort(index, count, comparer);
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -521,6 +521,7 @@ namespace System.Collections.Immutable
         /// The <see cref="Comparison{T}"/> to use when comparing elements.
         /// </param>
         /// <returns>The sorted list.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="comparison"/> is null.</exception>
         [Pure]
         public ImmutableList<T> Sort(Comparison<T> comparison)
         {
@@ -541,7 +542,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Sort(IComparer<T> comparer)
         {
-            Requires.NotNull(comparer, "comparer");
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             return this.Wrap(_root.Sort(comparer));
         }
@@ -567,7 +567,6 @@ namespace System.Collections.Immutable
             Requires.Range(index >= 0, "index");
             Requires.Range(count >= 0, "count");
             Requires.Range(index + count <= this.Count, "count");
-            Requires.NotNull(comparer, "comparer");
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             return this.Wrap(_root.Sort(index, count, comparer));
@@ -2331,7 +2330,6 @@ namespace System.Collections.Immutable
             /// <returns>The sorted list.</returns>
             internal Node Sort(IComparer<T> comparer)
             {
-                Requires.NotNull(comparer, "comparer");
                 Contract.Ensures(Contract.Result<Node>() != null);
                 return this.Sort(0, this.Count, comparer);
             }
@@ -2356,7 +2354,6 @@ namespace System.Collections.Immutable
                 Requires.Range(index >= 0, "index");
                 Requires.Range(count >= 0, "count");
                 Requires.Argument(index + count <= this.Count);
-                Requires.NotNull(comparer, "comparer");
 
                 // PERF: Eventually this might be reimplemented in a way that does not require allocating an array.
                 var array = new T[this.Count];

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -467,7 +467,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
-            Requires.NotNull(equalityComparer, "equalityComparer");
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count);
 
@@ -1097,10 +1096,10 @@ namespace System.Collections.Immutable
         /// <param name="newValue">The element to replace the old element with.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>The new list.</returns>
         /// <exception cref="ArgumentException">Thrown when the old value does not exist in the list.</exception>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
             return this.Replace(oldValue, newValue, equalityComparer);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -2485,7 +2485,10 @@ namespace System.Collections.Immutable
             /// <param name="count">
             /// The number of elements in the section to search.
             /// </param>
-            /// <param name="equalityComparer">The equality comparer to use for testing the match of two elements.</param>
+            /// <param name="equalityComparer">
+            /// The equality comparer to use in the search.
+            /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
+            /// </param>
             /// <returns>
             /// The zero-based index of the first occurrence of <paramref name="item"/> within the range of
             /// elements in the <see cref="ImmutableList{T}"/> that starts at <paramref name="index"/> and
@@ -2498,8 +2501,8 @@ namespace System.Collections.Immutable
                 Requires.Range(count >= 0, "count");
                 Requires.Range(count <= this.Count, "count");
                 Requires.Range(index + count <= this.Count, "count");
-                Requires.NotNull(equalityComparer, "equalityComparer");
 
+                equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 using (var enumerator = new Enumerator(this, startIndex: index, count: count))
                 {
                     while (enumerator.MoveNext())
@@ -2537,11 +2540,11 @@ namespace System.Collections.Immutable
             [Pure]
             internal int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
             {
-                Requires.NotNull(equalityComparer, "ValueComparer");
                 Requires.Range(index >= 0, "index");
                 Requires.Range(count >= 0 && count <= this.Count, "count");
                 Requires.Argument(index - count + 1 >= 0);
 
+                equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 using (var enumerator = new Enumerator(this, startIndex: index, count: count, reversed: true))
                 {
                     while (enumerator.MoveNext())

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -377,6 +377,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The items to remove if matches are found in this list.</param>
         /// <param name="equalityComparer">
         /// The equality comparer to use in the search.
+        /// If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
         /// </param>
         /// <returns>
         /// A new list with the elements removed.
@@ -385,7 +386,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
         {
             Requires.NotNull(items, "items");
-            Requires.NotNull(equalityComparer, "equalityComparer");
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             Contract.Ensures(Contract.Result<ImmutableList<T>>().Count <= this.Count);
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -287,10 +287,15 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void SortNullComparer()
         {
-            var builder = new ImmutableArray<int>.Builder();
-            builder.AddRange(2, 4, 1, 3);
+            var template = ImmutableArray.Create(2, 4, 1, 3);
+
+            var builder = template.ToBuilder();
             builder.Sort(null);
             Assert.Equal(new[] { 1, 2, 3, 4 }, builder);
+
+            builder = template.ToBuilder();
+            builder.Sort(1, 2, null);
+            Assert.Equal(new[] { 2, 1, 4, 3 }, builder);
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1165,6 +1165,7 @@ namespace System.Collections.Immutable.Tests
         {
             var array = ImmutableArray.Create(2, 4, 1, 3);
             Assert.Equal(new[] { 1, 2, 3, 4 }, array.Sort(null));
+            Assert.Equal(new[] { 2, 1, 4, 3 }, array.Sort(1, 2, null));
             Assert.Equal(new[] { 2, 4, 1, 3 }, array); // original array unaffected.
         }
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1005,6 +1005,18 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void ReplaceWithEqualityComparerTest()
+        {
+            var updatedArray = s_manyElements.Replace(2, 10, null);
+            Assert.Equal(new[] { 1, 10, 3 }, updatedArray);
+
+            // Finally, try one last time using the interface implementation.
+            IImmutableList<int> iface = s_manyElements;
+            var updatedIFace = iface.Replace(2, 10, null);
+            Assert.Equal(new[] { 1, 10, 3 }, updatedIFace);
+        }
+
+        [Fact]
         public void ReplaceMissingThrowsTest()
         {
             Assert.Throws<ArgumentException>(() => s_empty.Replace(5, 3));

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -837,6 +837,18 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void Remove_NullEqualityComparer()
+        {
+            var modified = s_manyElements.Remove(2, null);
+            Assert.Equal(new[] { 1, 3 }, modified);
+
+            // Try again through the explicit interface implementation.
+            IImmutableList<int> boxedCollection = s_manyElements;
+            var modified2 = boxedCollection.Remove(2, null);
+            Assert.Equal(new[] { 1, 3 }, modified2);
+        }
+
+        [Fact]
         public void Remove()
         {
             Assert.Throws<NullReferenceException>(() => s_emptyDefault.Remove(5));
@@ -1316,11 +1328,11 @@ namespace System.Collections.Immutable.Tests
             Assert.Throws<ArgumentNullException>(() => ImmutableArray.BinarySearch(default(ImmutableArray<int>), value));
 
             Assert.Equal(
-                Array.BinarySearch(array, value), 
+                Array.BinarySearch(array, value),
                 ImmutableArray.BinarySearch(ImmutableArray.Create(array), value));
 
             Assert.Equal(
-                Array.BinarySearch(array, value, Comparer<int>.Default), 
+                Array.BinarySearch(array, value, Comparer<int>.Default),
                 ImmutableArray.BinarySearch(ImmutableArray.Create(array), value, Comparer<int>.Default));
 
             Assert.Equal(

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -915,6 +915,15 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void RemoveRange_EnumerableEqualityComparer_AcceptsNullEQ()
+        {
+            var array = ImmutableArray.Create(1, 2, 3);
+            var removed2eq = array.RemoveRange(new[] { 2 }, null);
+            Assert.Equal(2, removed2eq.Length);
+            Assert.Equal(new[] { 1, 3 }, removed2eq);
+        }
+
+        [Fact]
         public void RemoveRangeEnumerableTest()
         {
             var list = ImmutableArray.Create(1, 2, 3);

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -317,6 +317,19 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void Remove_NullEqualityComparer()
+        {
+            var collection = ImmutableList.Create(1, 2, 3);
+            var modified = collection.Remove(2, null);
+            Assert.Equal(new[] { 1, 3 }, modified);
+
+            // Try again through the explicit interface implementation.
+            IImmutableList<int> collectionIface = collection;
+            var modified2 = collectionIface.Remove(2, null);
+            Assert.Equal(new[] { 1, 3 }, modified2);
+        }
+
+        [Fact]
         public void RemoveTest()
         {
             ImmutableList<int> list = ImmutableList<int>.Empty;

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -594,6 +594,15 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void RemoveRange_EnumerableEqualityComparer_AcceptsNullEQ()
+        {
+            var list = ImmutableList.Create(1, 2, 3);
+            var removed2eq = list.RemoveRange(new[] { 2 }, null);
+            Assert.Equal(2, removed2eq.Count);
+            Assert.Equal(new[] { 1, 3 }, removed2eq);
+        }
+
+        [Fact]
         public void RemoveRangeEnumerableTest()
         {
             var list = ImmutableList.Create(1, 2, 3);

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -535,6 +535,15 @@ namespace System.Collections.Immutable.Tests
             var newAge = new Person { Name = "Andrew", Age = 21 };
             var updatedList = list.Replace(newAge, newAge, new NameOnlyEqualityComparer());
             Assert.Equal(newAge.Age, updatedList[0].Age);
+
+            // Try again with a null equality comparer, which should use the default EQ.
+            updatedList = list.Replace(list[0], newAge);
+            Assert.NotSame(list, updatedList);
+
+            // Finally, try one last time using the interface implementation.
+            IImmutableList<Person> iface = list;
+            var updatedIface = iface.Replace(list[0], newAge);
+            Assert.NotSame(iface, updatedIface);
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -282,6 +282,12 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void Sort_NullComparison_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => this.SortTestHelper(ImmutableList<int>.Empty, (Comparison<int>)null));
+        }
+
+        [Fact]
         public void SortTest()
         {
             var scenarios = new[] {
@@ -304,7 +310,13 @@ namespace System.Collections.Immutable.Tests
                 Assert.Equal<int>(expected, actual);
 
                 expected = scenario.ToList();
-                IComparer<int> comparer = Comparer<int>.Default;
+                IComparer<int> comparer = null;
+                expected.Sort(comparer);
+                actual = this.SortTestHelper(scenario, comparer);
+                Assert.Equal<int>(expected, actual);
+
+                expected = scenario.ToList();
+                comparer = new CustomComparer<int>(comparison);
                 expected.Sort(comparer);
                 actual = this.SortTestHelper(scenario, comparer);
                 Assert.Equal<int>(expected, actual);
@@ -314,7 +326,7 @@ namespace System.Collections.Immutable.Tests
                     for (int j = 0; j < scenario.Count - i; j++)
                     {
                         expected = scenario.ToList();
-                        comparer = Comparer<int>.Default;
+                        comparer = null;
                         expected.Sort(i, j, comparer);
                         actual = this.SortTestHelper(scenario, i, j, comparer);
                         Assert.Equal<int>(expected, actual);
@@ -418,6 +430,21 @@ namespace System.Collections.Immutable.Tests
             var expected = bclList.TrueForAll(test);
             var actual = this.GetListQuery(list).TrueForAll(test);
             Assert.Equal(expected, actual);
+        }
+
+        private class CustomComparer<T> : IComparer<T>
+        {
+            private readonly Comparison<T> comparison;
+
+            internal CustomComparer(Comparison<T> comparison)
+            {
+                this.comparison = comparison;
+            }
+
+            public int Compare(T x, T y)
+            {
+                return this.comparison(x, y);
+            }
         }
     }
 }

--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -316,7 +316,7 @@ namespace System.Collections.Immutable.Tests
                 Assert.Equal<int>(expected, actual);
 
                 expected = scenario.ToList();
-                comparer = new CustomComparer<int>(comparison);
+                comparer = Comparer<int>.Create(comparison);
                 expected.Sort(comparer);
                 actual = this.SortTestHelper(scenario, comparer);
                 Assert.Equal<int>(expected, actual);
@@ -430,21 +430,6 @@ namespace System.Collections.Immutable.Tests
             var expected = bclList.TrueForAll(test);
             var actual = this.GetListQuery(list).TrueForAll(test);
             Assert.Equal(expected, actual);
-        }
-
-        private class CustomComparer<T> : IComparer<T>
-        {
-            private readonly Comparison<T> comparison;
-
-            internal CustomComparer(Comparison<T> comparison)
-            {
-                this.comparison = comparison;
-            }
-
-            public int Compare(T x, T y)
-            {
-                return this.comparison(x, y);
-            }
         }
     }
 }

--- a/src/System.Collections.Immutable/tests/IndexOfTests.cs
+++ b/src/System.Collections.Immutable/tests/IndexOfTests.cs
@@ -39,6 +39,7 @@ namespace System.Collections.Immutable.Tests
             var list = ImmutableList<int>.Empty.AddRange(Enumerable.Range(100, 5).Concat(Enumerable.Range(100, 5)));
             var bclList = list.ToList();
             Assert.Equal(-1, indexOfItem(factory(list), 6));
+            Assert.Equal(2, indexOfItemIndexCountEQ(factory(list), 102, 0, 4, null));
 
             if (factory(list) is IList)
             {
@@ -106,6 +107,7 @@ namespace System.Collections.Immutable.Tests
             var list = ImmutableList<int>.Empty.AddRange(Enumerable.Range(100, 5).Concat(Enumerable.Range(100, 5)));
             var bclList = list.ToList();
             Assert.Equal(-1, lastIndexOfItem(factory(list), 6));
+            Assert.Equal(2, lastIndexOfItemIndexCountEQ(factory(list), 102, 6, 5, null));
 
             for (int idx = 0; idx < list.Count; idx++)
             {


### PR DESCRIPTION
Follow .NET BCL patterns more closely with regard to accepting `IEqualityComparer<T>` and `IComparer<T>` parameters that have null arguments.

Fixes #2036 