### PR TITLE
Add tests for unbox expressions and remove incorrect assertion

### DIFF
--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Unary\UnaryOnesComplementTests.cs" />
     <Compile Include="Unary\UnaryUnaryPlusTests.cs" />
     <Compile Include="Visitor\ExpressionVisitorTests.cs" />
+    <Compile Include="Unary\UnboxTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">

--- a/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class UnboxTests
+    {
+        [Theory]
+        [MemberData("UnboxableFromObject")]
+        [MemberData("NullableUnboxableFromObject")]
+        [MemberData("UnboxableFromIComparable")]
+        [MemberData("NullableUnboxableFromIComparable")]
+        [MemberData("UnboxableFromIComparableT")]
+        [MemberData("NullableUnboxableFromIComparableT")]
+        public void CanUnbox(object value, Type type, Type boxedType)
+        {
+            Expression expression = Expression.Constant(value, boxedType);
+            UnaryExpression unbox = Expression.Unbox(expression, type);
+            Assert.Equal(type, unbox.Type);
+            BinaryExpression isEqual = Expression.Equal(Expression.Constant(value, type), unbox);
+            Assert.True(Expression.Lambda<Func<bool>>(isEqual).Compile()());
+        }
+
+        [Theory]
+        [MemberData("UnboxableFromObject")]
+        [MemberData("NullableUnboxableFromObject")]
+        [MemberData("UnboxableFromIComparable")]
+        [MemberData("NullableUnboxableFromIComparable")]
+        [MemberData("UnboxableFromIComparableT")]
+        [MemberData("NullableUnboxableFromIComparableT")]
+        public void CanUnboxFromMake(object value, Type type, Type boxedType)
+        {
+            Expression expression = Expression.Constant(value, boxedType);
+            UnaryExpression unbox = Expression.MakeUnary(ExpressionType.Unbox, expression, type);
+            Assert.Equal(type, unbox.Type);
+            BinaryExpression isEqual = Expression.Equal(Expression.Constant(value, type), unbox);
+            Assert.True(Expression.Lambda<Func<bool>>(isEqual).Compile()());
+        }
+
+        public static IEnumerable<object[]> UnboxableFromObject()
+        {
+            yield return new object[] { 1, typeof(int), typeof(object) };
+            yield return new object[] { 42, typeof(int), typeof(object) };
+            yield return new object[] { DateTime.MinValue, typeof(DateTime), typeof(object) };
+            yield return new object[] { DateTimeOffset.MinValue, typeof(DateTimeOffset), typeof(object) };
+            yield return new object[] { 42L, typeof(long), typeof(object) };
+            yield return new object[] { 13m, typeof(decimal), typeof(object) };
+            yield return new object[] { ExpressionType.Unbox, typeof(ExpressionType), typeof(object) };
+        }
+
+        public static IEnumerable<object[]> NullableUnboxableFromObject()
+        {
+            yield return new object[] { 1, typeof(int?), typeof(object) };
+            yield return new object[] { 42, typeof(int?), typeof(object) };
+            yield return new object[] { DateTime.MinValue, typeof(DateTime?), typeof(object) };
+            yield return new object[] { DateTimeOffset.MinValue, typeof(DateTimeOffset?), typeof(object) };
+            yield return new object[] { 42L, typeof(long?), typeof(object) };
+            yield return new object[] { 13m, typeof(decimal?), typeof(object) };
+            yield return new object[] { ExpressionType.Unbox, typeof(ExpressionType?), typeof(object) };
+        }
+
+        public static IEnumerable<object[]> UnboxableFromIComparable()
+        {
+            yield return new object[] { 1, typeof(int), typeof(IComparable) };
+            yield return new object[] { 42, typeof(int), typeof(IComparable) };
+            yield return new object[] { DateTime.MinValue, typeof(DateTime), typeof(IComparable) };
+            yield return new object[] { DateTimeOffset.MinValue, typeof(DateTimeOffset), typeof(IComparable) };
+            yield return new object[] { 42L, typeof(long), typeof(IComparable) };
+            yield return new object[] { 13m, typeof(decimal), typeof(IComparable) };
+            yield return new object[] { ExpressionType.Unbox, typeof(ExpressionType), typeof(IComparable) };
+        }
+
+        public static IEnumerable<object[]> NullableUnboxableFromIComparable()
+        {
+            yield return new object[] { 1, typeof(int?), typeof(IComparable) };
+            yield return new object[] { 42, typeof(int?), typeof(IComparable) };
+            yield return new object[] { DateTime.MinValue, typeof(DateTime?), typeof(IComparable) };
+            yield return new object[] { DateTimeOffset.MinValue, typeof(DateTimeOffset?), typeof(IComparable) };
+            yield return new object[] { 42L, typeof(long?), typeof(IComparable) };
+            yield return new object[] { 13m, typeof(decimal?), typeof(IComparable) };
+            yield return new object[] { ExpressionType.Unbox, typeof(ExpressionType?), typeof(IComparable) };
+        }
+
+        public static IEnumerable<object[]> UnboxableFromIComparableT()
+        {
+            yield return new object[] { 1, typeof(int), typeof(IComparable<int>) };
+            yield return new object[] { 42, typeof(int), typeof(IComparable<int>) };
+            yield return new object[] { DateTime.MinValue, typeof(DateTime), typeof(IComparable<DateTime>) };
+            yield return new object[] { DateTimeOffset.MinValue, typeof(DateTimeOffset), typeof(IComparable<DateTimeOffset>) };
+            yield return new object[] { 42L, typeof(long), typeof(IComparable<long>) };
+            yield return new object[] { 13m, typeof(decimal), typeof(IComparable<decimal>) };
+        }
+
+        public static IEnumerable<object[]> NullableUnboxableFromIComparableT()
+        {
+            yield return new object[] { 1, typeof(int?), typeof(IComparable<int>) };
+            yield return new object[] { 42, typeof(int?), typeof(IComparable<int>) };
+            yield return new object[] { DateTime.MinValue, typeof(DateTime?), typeof(IComparable<DateTime>) };
+            yield return new object[] { DateTimeOffset.MinValue, typeof(DateTimeOffset?), typeof(IComparable<DateTimeOffset>) };
+            yield return new object[] { 42L, typeof(long?), typeof(IComparable<long>) };
+            yield return new object[] { 13m, typeof(decimal?), typeof(IComparable<decimal>) };
+        }
+
+        public static IEnumerable<object[]> NullableTypes()
+        {
+            yield return new object[] { typeof(int?) };
+            yield return new object[] { typeof(DateTime?) };
+            yield return new object[] { typeof(DateTimeKind?) };
+            yield return new object[] { typeof(DateTimeOffset?) };
+            yield return new object[] { typeof(long?) };
+            yield return new object[] { typeof(decimal?) };
+        }
+
+        [Theory]
+        [MemberData("NullableTypes")]
+        public void NullNullable(Type type)
+        {
+            UnaryExpression unbox = Expression.Unbox(Expression.Default(typeof(object)), type);
+            Func<bool> isNull = Expression.Lambda<Func<bool>>(Expression.Equal(Expression.Default(type), unbox)).Compile();
+            Assert.True(isNull());
+        }
+
+        [Fact]
+        public void CannotUnboxToNonInterfaceExceptObject()
+        {
+            Expression value = Expression.Constant(0);
+            Assert.Throws<ArgumentException>(() => Expression.Unbox(value, typeof(int)));
+        }
+
+        [Fact]
+        public void CannotUnboxReferenceType()
+        {
+            Expression value = Expression.Constant("", typeof(IComparable<string>));
+            Assert.Throws<ArgumentException>(() => Expression.Unbox(value, typeof(string)));
+        }
+
+        private static class Unreadable
+        {
+            public static object WriteOnly
+            {
+                set { }
+            }
+        }
+
+        [Fact]
+        public void CannotUnboxUnreadable()
+        {
+            Expression value = Expression.Property(null, typeof(Unreadable), "WriteOnly");
+            Assert.Throws<ArgumentException>("expression", () => Expression.Unbox(value, typeof(int)));
+        }
+
+        [Fact]
+        public void ExpressionNull()
+        {
+            Assert.Throws<ArgumentNullException>("expression", () => Expression.Unbox(null, typeof(int)));
+        }
+
+        [Fact]
+        public void TypeNull()
+        {
+            Expression value = Expression.Constant(0, typeof(object));
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Unbox(value, null));
+        }
+
+        [Fact]
+        public void MistmatchFailsOnRuntime()
+        {
+            Expression unbox = Expression.Unbox(Expression.Constant(0, typeof(object)), typeof(long));
+            Func<long> del = Expression.Lambda<Func<long>>(unbox).Compile();
+            Assert.Throws<InvalidCastException>(() => del());
+        }
+
+        [Fact]
+        public void CannotReduce()
+        {
+            Expression unbox = Expression.Unbox(Expression.Constant(0, typeof(object)), typeof(int));
+            Assert.False(unbox.CanReduce);
+            Assert.Same(unbox, unbox.Reduce());
+            Assert.Throws<ArgumentException>(() => unbox.ReduceAndCheck());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3873 as the incorrect assertions would cause these tests to fail
incorrectly, and the assertions should only affect such tests.