### PR TITLE
Respond to PR feedback from Jeremy.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Ext.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Ext.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative)]
         internal static extern SafeX509ExtensionHandle X509ExtensionCreateByObj(
             SafeAsn1ObjectHandle oid,
+            [MarshalAs(UnmanagedType.Bool)] bool isCritical,
             SafeAsn1OctetStringHandle data);
 
         [DllImport(Libraries.CryptoNative)]

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
@@ -5,9 +5,9 @@
 
 #include <assert.h>
 
-extern "C" X509_EXTENSION* X509ExtensionCreateByObj(ASN1_OBJECT* obj, ASN1_OCTET_STRING* data)
+extern "C" X509_EXTENSION* X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data)
 {
-    return X509_EXTENSION_create_by_OBJ(nullptr, obj, /*crit*/ false, data);
+    return X509_EXTENSION_create_by_OBJ(nullptr, obj, isCritical, data);
 }
 
 extern "C" void X509ExtensionDestroy(X509_EXTENSION* a)
@@ -30,6 +30,11 @@ extern "C" int32_t DecodeX509BasicConstraints2Extension(
     int32_t* hasPathLengthConstraint,
     int32_t* pathLengthConstraint)
 {
+    if (!certificateAuthority || !hasPathLengthConstraint || !pathLengthConstraint)
+    {
+        return false;
+    }
+
     *certificateAuthority = false;
     *hasPathLengthConstraint = false;
     *pathLengthConstraint = 0;

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.h
@@ -12,7 +12,7 @@ Implemented by calling X509_EXTENSION_create_by_OBJ
 
 Returns new X509_EXTENSION on success, nullptr on failure.
 */
-extern "C" X509_EXTENSION* X509ExtensionCreateByObj(ASN1_OBJECT* obj, ASN1_OCTET_STRING* data);
+extern "C" X509_EXTENSION* X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data);
 
 /*
 Cleans up and deletes an X509_EXTENSION instance.

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OpenSslAsnFormatter.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OpenSslAsnFormatter.cs
@@ -36,7 +36,7 @@ namespace Internal.Cryptography
                 }
 
                 using (SafeBioHandle bio = Interop.Crypto.CreateMemoryBio())
-                using (SafeX509ExtensionHandle x509Ext = Interop.Crypto.X509ExtensionCreateByObj(asnOid, octetString))
+                using (SafeX509ExtensionHandle x509Ext = Interop.Crypto.X509ExtensionCreateByObj(asnOid, false, octetString))
                 {
                     if (bio.IsInvalid || x509Ext.IsInvalid)
                     {


### PR DESCRIPTION
Adding 'isCritical' to the X509ExtensionCreateByObj method.
Checking for NULL before dereferencing pointers.

@bartonjs 