### PR TITLE
Exclude unreachable members in System.Linq.Expressions from coverage.

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -17,6 +17,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\CacheDict.cs">
       <Link>Common\System\Dynamic\Utils\CacheDict.cs</Link>
     </Compile>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Threading;
 
@@ -96,11 +97,13 @@ namespace System.Linq.Expressions
             return Expression.Block(Type, variables, expressions);
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual Expression GetExpression(int index)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual int ExpressionCount
         {
             get
@@ -109,11 +112,13 @@ namespace System.Linq.Expressions
             }
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual ReadOnlyCollection<Expression> GetOrMakeExpressions()
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual ParameterExpression GetVariable(int index)
         {
             throw ContractUtils.Unreachable;
@@ -142,6 +147,7 @@ namespace System.Linq.Expressions
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
         /// subclass of BlockExpression which is being used. 
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
             throw ContractUtils.Unreachable;
@@ -601,11 +607,13 @@ namespace System.Linq.Expressions
             return -1;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void Insert(int index, Expression item)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void RemoveAt(int index)
         {
             throw ContractUtils.Unreachable;
@@ -622,6 +630,7 @@ namespace System.Linq.Expressions
 
                 return _block.GetExpression(index);
             }
+            [ExcludeFromCodeCoverage] // Unreachable
             set
             {
                 throw ContractUtils.Unreachable;
@@ -632,11 +641,13 @@ namespace System.Linq.Expressions
 
         #region ICollection<Expression> Members
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void Add(Expression item)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void Clear()
         {
             throw ContractUtils.Unreachable;
@@ -666,6 +677,7 @@ namespace System.Linq.Expressions
             get { return true; }
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public bool Remove(Expression item)
         {
             throw ContractUtils.Unreachable;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -672,9 +672,13 @@ namespace System.Linq.Expressions
             get { return _block.ExpressionCount; }
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public bool IsReadOnly
         {
-            get { return true; }
+            get
+            {
+                throw ContractUtils.Unreachable;
+            }
         }
 
         [ExcludeFromCodeCoverage] // Unreachable

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions.Compiler
@@ -332,6 +333,8 @@ namespace System.Linq.Expressions.Compiler
             : base(expressions)
         {
         }
+
+        [ExcludeFromCodeCoverage] // Unreachable
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
             throw ContractUtils.Unreachable;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions
@@ -44,6 +45,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the start line of this <see cref="DebugInfoExpression" />.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual int StartLine
         {
             get { throw ContractUtils.Unreachable; }
@@ -52,6 +54,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the start column of this <see cref="DebugInfoExpression" />.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual int StartColumn
         {
             get { throw ContractUtils.Unreachable; }
@@ -60,6 +63,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the end line of this <see cref="DebugInfoExpression" />.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual int EndLine
         {
             get { throw ContractUtils.Unreachable; }
@@ -68,6 +72,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the end column of this <see cref="DebugInfoExpression" />.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual int EndColumn
         {
             get { throw ContractUtils.Unreachable; }
@@ -84,6 +89,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the value to indicate if the <see cref="DebugInfoExpression"/> is for clearing a sequence point.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual bool IsClear
         {
             get { throw ContractUtils.Unreachable; }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 
@@ -78,16 +79,19 @@ namespace System.Linq.Expressions
             return Expression.Invoke(expression, arguments);
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual Expression GetArgument(int index)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual int ArgumentCount
         {
             get
@@ -104,6 +108,7 @@ namespace System.Linq.Expressions
             return visitor.VisitInvocation(this);
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual InvocationExpression Rewrite(Expression lambda, Expression[] arguments)
         {
             throw ContractUtils.Unreachable;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 
@@ -61,6 +62,7 @@ namespace System.Linq.Expressions
             get { return ExpressionType.MemberAccess; }
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual MemberInfo GetMember()
         {
             throw ContractUtils.Unreachable;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -89,6 +90,7 @@ namespace System.Linq.Expressions
             return Expression.Call(@object, Method, arguments);
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             throw ContractUtils.Unreachable;
@@ -110,6 +112,7 @@ namespace System.Linq.Expressions
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
         /// subclass of MethodCallExpression which is being used. 
         /// </summary>
+        [ExcludeFromCodeCoverage] // Unreachable
         internal virtual MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
         {
             throw ContractUtils.Unreachable;
@@ -117,11 +120,13 @@ namespace System.Linq.Expressions
 
         #region IArgumentProvider Members
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual Expression GetArgument(int index)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public virtual int ArgumentCount
         {
             get { throw ContractUtils.Unreachable; }


### PR DESCRIPTION
All such members are entirely unreachable, and coverage including them is not
informative.