### PR TITLE
Add Sort(Comparison<T>) methods to ImmutableArray and Builder

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -636,6 +636,25 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
+            /// Sorts the elements in the entire array using
+            /// the specified <see cref="Comparison{T}"/>.
+            /// </summary>
+            /// <param name="comparison">
+            /// The <see cref="Comparison{T}"/> to use when comparing elements.
+            /// </param>
+            /// <exception cref="ArgumentNullException"><paramref name="comparison"/> is null.</exception>
+            [Pure]
+            public void Sort(Comparison<T> comparison)
+            {
+                Requires.NotNull(comparison, "comparison");
+
+                if (Count > 1)
+                {
+                    Array.Sort(_elements, comparison);
+                }
+            }
+
+            /// <summary>
             /// Sorts the array.
             /// </summary>
             /// <param name="comparer">The comparer to use in sorting. If <c>null</c>, the default comparer is used.</param>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -922,6 +922,24 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
+        /// Sorts the elements in the entire <see cref="ImmutableArray{T}"/> using
+        /// the specified <see cref="Comparison{T}"/>.
+        /// </summary>
+        /// <param name="comparison">
+        /// The <see cref="Comparison{T}"/> to use when comparing elements.
+        /// </param>
+        /// <returns>The sorted list.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="comparison"/> is null.</exception>
+        [Pure]
+        public ImmutableArray<T> Sort(Comparison<T> comparison)
+        {
+            Requires.NotNull(comparison, "comparison");
+
+            var self = this;
+            return self.Sort(Comparer<T>.Create(comparison));
+        }
+
+        /// <summary>
         /// Returns a sorted instance of this array.
         /// </summary>
         /// <param name="comparer">The comparer to use in sorting. If <c>null</c>, the default comparer is used.</param>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -285,12 +285,27 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void Sort_Comparison()
+        {
+            var builder = new ImmutableArray<int>.Builder();
+            builder.AddRange(2, 4, 1, 3);
+            builder.Sort((x, y) => y.CompareTo(x));
+            Assert.Equal(new[] { 4, 3, 2, 1 }, builder);
+        }
+
+        [Fact]
+        public void Sort_NullComparison_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => ImmutableArray.CreateBuilder<int>().Sort((Comparison<int>)null));
+        }
+
+        [Fact]
         public void SortNullComparer()
         {
             var template = ImmutableArray.Create(2, 4, 1, 3);
 
             var builder = template.ToBuilder();
-            builder.Sort(null);
+            builder.Sort((IComparer<int>)null);
             Assert.Equal(new[] { 1, 2, 3, 4 }, builder);
 
             builder = template.ToBuilder();

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1161,10 +1161,24 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void Sort_Comparison()
+        {
+            var array = ImmutableArray.Create(2, 4, 1, 3);
+            Assert.Equal(new[] { 4, 3, 2, 1 }, array.Sort((x, y) => y.CompareTo(x)));
+            Assert.Equal(new[] { 2, 4, 1, 3 }, array); // original array unaffected.
+        }
+
+        [Fact]
+        public void Sort_NullComparison_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => ImmutableArray.Create<int>().Sort((Comparison<int>)null));
+        }
+
+        [Fact]
         public void SortNullComparer()
         {
             var array = ImmutableArray.Create(2, 4, 1, 3);
-            Assert.Equal(new[] { 1, 2, 3, 4 }, array.Sort(null));
+            Assert.Equal(new[] { 1, 2, 3, 4 }, array.Sort((IComparer<int>)null));
             Assert.Equal(new[] { 2, 1, 4, 3 }, array.Sort(1, 2, null));
             Assert.Equal(new[] { 2, 4, 1, 3 }, array); // original array unaffected.
         }


### PR DESCRIPTION
ImmutableList and Builder has these Sort overloads, as does Array itself. This makes this same functionality easily accessible from ImmutableArray.

Fix #2167 