### PR TITLE
Make ExcludeFromCodeCoverage attribution conditional on DEBUG

### DIFF
--- a/src/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
+++ b/src/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
@@ -3,6 +3,7 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
+    [Conditional("DEBUG")] // don't bloat release assemblies
     [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
     internal sealed class ExcludeFromCodeCoverageAttribute : Attribute
     {


### PR DESCRIPTION
Some of our assemblies (e.g. System.Collections.Immutable) use ExcludeFromCodeCoverage to exclude from code coverage various members.  Since we only do code coverage runs against debug builds, there's no need to bloat such assemblies with ExcludeFromCodeCoverage on these members in release builds.

cc: @AArnott