### PR TITLE
Do not throw from ImmutableArray<T>.RemoveRange when index==length

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -757,7 +757,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> RemoveRange(int index, int length)
         {
             var self = this;
-            Requires.Range(index >= 0 && index < self.Length, "index");
+            Requires.Range(index >= 0 && index <= self.Length, "index");
             Requires.Range(length >= 0 && index + length <= self.Length, "length");
 
             if (length == 0)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -344,7 +344,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> RemoveRange(int index, int count)
         {
-            Requires.Range(index >= 0 && (index < this.Count || (index == this.Count && count == 0)), "index");
+            Requires.Range(index >= 0 && index <= this.Count, "index");
             Requires.Range(count >= 0 && index + count <= this.Count, "count");
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -863,11 +863,12 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void RemoveRange()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => s_empty.RemoveRange(0, 0));
+            Assert.Equal(s_empty, s_empty.RemoveRange(0, 0));
             Assert.Throws<NullReferenceException>(() => s_emptyDefault.RemoveRange(0, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_emptyDefault.RemoveRange(-1, 0));
             Assert.Throws<NullReferenceException>(() => s_emptyDefault.RemoveRange(0, -1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => s_oneElement.RemoveRange(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => s_oneElement.RemoveRange(2, 0));
+            Assert.Equal(s_oneElement, s_oneElement.RemoveRange(1, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_empty.RemoveRange(-1, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_oneElement.RemoveRange(0, 2));
             Assert.Throws<ArgumentOutOfRangeException>(() => s_oneElement.RemoveRange(0, -1));

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -605,14 +605,15 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void RemoveRangeArrayTest()
         {
+            Assert.True(ImmutableList<int>.Empty.RemoveRange(0, 0).IsEmpty);
+
             var list = ImmutableList.Create(1, 2, 3);
             Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(-1, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(0, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(4, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(0, 4));
             Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(2, 2));
-            list.RemoveRange(3, 0);
-            Assert.Equal(3, list.Count);
+            Assert.Equal(list, list.RemoveRange(3, 0));
         }
 
         [Fact]


### PR DESCRIPTION
ImmutableArray<T>.RemoveRange(int, int) would throw when the first argument equals the length of the array, whereas ImmutableList<T>.RemoveRange(int, int) allows the first argument to equal the length of the list. This makes them consistent by slightly widening the allowed input to ImmutableArray.

ImmutableList is changed slightly to simplify the logic (but keep the meaning equivalent). The test is enhanced and a bug in the test fixed.

Fix #2028