### PR TITLE
Fix VS intellisense experience on corefx projects.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -30,7 +30,7 @@
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
-    <SourceDir>$(ProjectDir)src/</SourceDir>
+    <SourceDir>$(ProjectDir)src\</SourceDir>
 
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>


### PR DESCRIPTION
The forward slash inside Common source files disconnects them
from their containing projects, breaking the Intellisense
experience. See Issue #3534