### PR TITLE
Change how/when Console writes escape strings on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern bool IsATty(int fd);
+    }
+}

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -813,3 +813,8 @@ extern "C" int32_t GetWindowSize(WinSize* windowSize)
     return -1;
 #endif
 }
+
+extern "C" int32_t IsATty(int fd)
+{
+	return isatty(fd);
+}

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -623,8 +623,16 @@ extern "C" void Sync();
 extern "C" int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize);
 
 /**
-* Gets the windows size of the terminal
-*
-* Returns 0 on success; otherwise, returns errorNo.
-*/
+ * Gets the windows size of the terminal
+ *
+ * Returns 0 on success; otherwise, returns errorNo.
+ */
 extern "C" int32_t GetWindowSize(WinSize* windowsSize);
+
+/**
+ * Gets whether the specified file descriptor is for a terminal.
+ *
+ * Returns 1 if the file descriptor is referring to a terminal;
+ * otherwise returns 0 and sets errno.
+ */
+extern "C" int32_t IsATty(int filedes);

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -143,6 +143,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
       <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IsATty.cs">
+      <Link>Common\Interop\Unix\Interop.IsATty.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.LSeek.cs">
       <Link>Common\Interop\Unix\Interop.LSeek.cs</Link>
     </Compile>


### PR DESCRIPTION
ForegroundColor, BackgroundColor, ResetColo, and CursorVisible all need to write out ANSI escape strings to perform their work, and we only want to do such writing if we expect the target will be able to correctly understand the inputs.

Previously, we were doing this by checking whether the file descriptor wrapped by the current output stream was a character device.  However, this behavior differs from the Windows implementation, which doesn't factor Console.SetOut into its decisions.  The heuristic is also susceptible to non-terminal character devices being the target of redirection, e.g. /dev/null.

This change updates the Unix implementation to be more consistent with Windows, simply checking whether stdout has been redirected rather than factoring in SetOut.  It also now uses isatty to determine whether to write out to the terminal.