### PR TITLE
Make X500DistinguishedName.Decode be the same on Unix and Windows.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -61,6 +61,22 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative)]
         internal static extern void Asn1StringFree(IntPtr o);
 
+        internal static string GetOidValue(SafeSharedAsn1ObjectHandle asn1Object)
+        {
+            Debug.Assert(asn1Object != null);
+
+            bool added = false;
+            asn1Object.DangerousAddRef(ref added);
+            try
+            {
+                return GetOidValue(asn1Object.DangerousGetHandle());
+            }
+            finally
+            {
+                asn1Object.DangerousRelease();
+            }
+        }
+
         internal static string GetOidValue(IntPtr asn1ObjectPtr)
         {
             // OBJ_obj2txt returns the number of bytes that should have been in the answer, but it does not accept
@@ -104,6 +120,17 @@ internal static partial class Interop
             }
 
             return buf.ToString();
+        }
+    }
+}
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafeSharedAsn1ObjectHandle : SafeInteriorHandle
+    {
+        private SafeSharedAsn1ObjectHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -41,10 +41,7 @@ internal static partial class Interop
         internal static extern void X509NameDestroy(IntPtr a);
 
         [DllImport(Libraries.CryptoNative)]
-        internal static extern int X509NamePrintForFind(SafeBioHandle @out, SafeX509NameHandle nm);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern int X509NamePrintEx(SafeBioHandle @out, SafeX509NameHandle nm, X500DistinguishedNameFlags flags);
+        internal static extern int GetX509NameEntryCount(SafeX509NameHandle x509Name);
 
         internal static X500DistinguishedName LoadX500Name(SafeSharedX509NameHandle namePtr)
         {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509NameEntry.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509NameEntry.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameEntry")]
+        private static extern SafeSharedX509NameEntryHandle GetX509NameEntry_private(SafeX509NameHandle x509Name, int loc);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameEntryOid")]
+        private static extern SafeSharedAsn1ObjectHandle GetX509NameEntryOid_private(SafeSharedX509NameEntryHandle nameEntry);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameEntryData")]
+        private static extern SafeSharedAsn1StringHandle GetX509NameEntryData_private(SafeSharedX509NameEntryHandle nameEntry);
+
+        internal static SafeSharedX509NameEntryHandle GetX509NameEntry(SafeX509NameHandle x509Name, int loc)
+        {
+            CheckValidOpenSslHandle(x509Name);
+
+            SafeSharedX509NameEntryHandle handle = GetX509NameEntry_private(x509Name, loc);
+
+            if (!handle.IsInvalid)
+            {
+                handle.SetParent(x509Name);
+            }
+
+            return handle;
+        }
+
+        internal static SafeSharedAsn1ObjectHandle GetX509NameEntryOid(SafeSharedX509NameEntryHandle nameEntry)
+        {
+            CheckValidOpenSslHandle(nameEntry);
+
+            SafeSharedAsn1ObjectHandle handle = GetX509NameEntryOid_private(nameEntry);
+
+            if (!handle.IsInvalid)
+            {
+                handle.SetParent(nameEntry);
+            }
+
+            return handle;
+        }
+
+        internal static SafeSharedAsn1StringHandle GetX509NameEntryData(SafeSharedX509NameEntryHandle nameEntry)
+        {
+            CheckValidOpenSslHandle(nameEntry);
+
+            SafeSharedAsn1StringHandle handle = GetX509NameEntryData_private(nameEntry);
+
+            if (!handle.IsInvalid)
+            {
+                handle.SetParent(nameEntry);
+            }
+
+            return handle;
+        }
+    }
+}
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafeSharedX509NameEntryHandle : SafeInteriorHandle
+    {
+        private SafeSharedX509NameEntryHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+    }
+}

--- a/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
@@ -90,4 +90,12 @@ namespace Microsoft.Win32.SafeHandles
             get { return handle == IntPtr.Zero; }
         }
     }
+
+    internal sealed class SafeSharedAsn1StringHandle : SafeInteriorHandle
+    {
+        private SafeSharedAsn1StringHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+    }
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -31,71 +31,6 @@ extern "C" void X509NameDestroy(X509_NAME* a)
     }
 }
 
-static int32_t X509NamePrint(BIO* out, X509_NAME* nm, unsigned long flags)
-{
-    return X509_NAME_print_ex(out, nm, /*indent*/ 0, flags);
-}
-
-extern "C" int32_t X509NamePrintForFind(BIO* out, X509_NAME* nm)
-{
-    const unsigned long findFormat = XN_FLAG_FN_NONE | XN_FLAG_SEP_CPLUS_SPC;
-
-    return X509NamePrint(out, nm, findFormat);
-}
-
-/*
-Converts from X500DistinguishedNameFlags to the correct flags used in X509_NAME_print_ex.
-*/
-static unsigned long ConvertFormatFlags(X500DistinguishedNameFlags inFlags)
-{
-    unsigned long outFlags = 0;
-
-    if ((inFlags & X500DistinguishedNameFlags::Reversed) != 0)
-    {
-        outFlags |= XN_FLAG_DN_REV;
-    }
-
-    if ((inFlags & X500DistinguishedNameFlags::UseSemicolons) != 0)
-    {
-        outFlags |= XN_FLAG_SEP_SPLUS_SPC;
-    }
-    else if ((inFlags & X500DistinguishedNameFlags::UseNewLines) != 0)
-    {
-        outFlags |= XN_FLAG_SEP_MULTILINE;
-    }
-    else
-    {
-        outFlags |= XN_FLAG_SEP_CPLUS_SPC;
-    }
-
-    if ((inFlags & X500DistinguishedNameFlags::DoNotUseQuotes) != 0)
-    {
-        // TODO: Handle this.
-    }
-
-    if ((inFlags & X500DistinguishedNameFlags::ForceUTF8Encoding) != 0)
-    {
-        // TODO: Handle this.
-    }
-
-    if ((inFlags & X500DistinguishedNameFlags::UseUTF8Encoding) != 0)
-    {
-        // TODO: Handle this.
-    }
-    else if ((inFlags & X500DistinguishedNameFlags::UseT61Encoding) != 0)
-    {
-        // TODO: Handle this.
-    }
-
-    return outFlags;
-}
-
-extern "C" int32_t X509NamePrintEx(BIO* out, X509_NAME* nm, X500DistinguishedNameFlags flags)
-{
-    unsigned long format = ConvertFormatFlags(flags);
-    return X509NamePrint(out, nm, format);
-}
-
 extern "C" STACK_OF(X509_NAME)* NewX509NameStack()
 {
     return sk_X509_NAME_new_null();
@@ -119,4 +54,24 @@ extern "C" void RecursiveFreeX509NameStack(STACK_OF(X509_NAME)* stack)
 extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name)
 {
     return X509_NAME_dup(x509Name);
+}
+
+extern "C" int32_t GetX509NameEntryCount(X509_NAME* x509Name)
+{
+    return X509_NAME_entry_count(x509Name);
+}
+
+extern "C" X509_NAME_ENTRY* GetX509NameEntry(X509_NAME* x509Name, int32_t loc)
+{
+    return X509_NAME_get_entry(x509Name, loc);
+}
+
+extern "C" ASN1_OBJECT* GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry)
+{
+    return X509_NAME_ENTRY_get_object(nameEntry);
+}
+
+extern "C" ASN1_STRING* GetX509NameEntryData(X509_NAME_ENTRY* nameEntry)
+{
+    return X509_NAME_ENTRY_get_data(nameEntry);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
@@ -6,25 +6,6 @@
 #include <openssl/x509.h>
 
 /*
-These values should be kept in sync with System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags
-*/
-enum X500DistinguishedNameFlags : int32_t
-{
-    None = 0x0000,
-    Reversed = 0x0001,
-
-    UseSemicolons = 0x0010,
-    DoNotUsePlusSign = 0x0020,
-    DoNotUseQuotes = 0x0040,
-    UseCommas = 0x0080,
-    UseNewLines = 0x0100,
-
-    UseUTF8Encoding = 0x1000,
-    UseT61Encoding = 0x2000,
-    ForceUTF8Encoding = 0x4000,
-};
-
-/*
 Function:
 GetX509NameStackFieldCount
 
@@ -33,9 +14,6 @@ Direct shim to sk_X509_NAME_num
 extern "C" int32_t GetX509NameStackFieldCount(X509NameStack* sk);
 
 /*
-Function:
-GetX509NameStackField
-
 Direct shim to sk_X509_NAME_value
 */
 extern "C" X509_NAME* GetX509NameStackField(X509NameStack* sk, int32_t loc);
@@ -55,21 +33,6 @@ The given X509_NAME pointer is invalid after this call.
 Always succeeds.
 */
 extern "C" void X509NameDestroy(X509_NAME* a);
-
-/*
-Prints the X509_NAME into the BIO using a format that is acceptable
-for use in "Find*" functions.
-
-Returns the number of bytes written to the BIO.
-*/
-extern "C" int32_t X509NamePrintForFind(BIO* out, X509_NAME* nm);
-
-/*
-Prints the X509_NAME into the BIO using the specified format.
-
-Returns the number of bytes written to the BIO.
-*/
-extern "C" int32_t X509NamePrintEx(BIO* out, X509_NAME* nm, X500DistinguishedNameFlags flags);
 
 /*
 Function:
@@ -106,3 +69,22 @@ Direct shim to X509_NAME_dup
 */
 extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name);
 
+/*
+Direct shim to X509_NAME_entry_count
+*/
+extern "C" int32_t GetX509NameEntryCount(X509_NAME* x509Name);
+
+/*
+Direct shim to X509_NAME_get_entry
+*/
+extern "C" X509_NAME_ENTRY* GetX509NameEntry(X509_NAME* x509Name, int32_t loc);
+
+/*
+Direct shim to X509_NAME_ENTRY_get_object
+*/
+extern "C" ASN1_OBJECT* GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry);
+
+/*
+Direct shim to X509_NAME_ENTRY_get_data
+*/
+extern "C" ASN1_STRING* GetX509NameEntryData(X509_NAME_ENTRY* nameEntry);

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -85,6 +85,9 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -64,6 +64,9 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
@@ -46,10 +46,7 @@ namespace Internal.Cryptography.Pal
             FindCore(
                 cert =>
                 {
-                    string formedSubject = OpenSslX509Encoder.X500DistinguishedNameDecode(
-                        cert.SubjectName.RawData,
-                        X500DistinguishedNameFlags.None,
-                        useFindFormat: true);
+                    string formedSubject = X500NameEncoder.X500DistinguishedNameDecode(cert.SubjectName.RawData, false, X500DistinguishedNameFlags.None);
 
                     return formedSubject.IndexOf(subjectName, StringComparison.OrdinalIgnoreCase) >= 0;
                 });
@@ -65,10 +62,7 @@ namespace Internal.Cryptography.Pal
             FindCore(
                 cert =>
                 {
-                    string formedIssuer = OpenSslX509Encoder.X500DistinguishedNameDecode(
-                        cert.IssuerName.RawData,
-                        X500DistinguishedNameFlags.None,
-                        useFindFormat: true);
+                    string formedIssuer = X500NameEncoder.X500DistinguishedNameDecode(cert.IssuerName.RawData, false, X500DistinguishedNameFlags.None);
 
                     return formedIssuer.IndexOf(issuerName, StringComparison.OrdinalIgnoreCase) >= 0;
                 });

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
-
 using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
@@ -29,44 +27,7 @@ namespace Internal.Cryptography.Pal
 
         public string X500DistinguishedNameDecode(byte[] encodedDistinguishedName, X500DistinguishedNameFlags flags)
         {
-            return X500DistinguishedNameDecode(encodedDistinguishedName, flags, false);
-        }
-
-        internal static string X500DistinguishedNameDecode(byte[] encodedDistinguishedName, X500DistinguishedNameFlags flags, bool useFindFormat)
-        {
-            using (SafeX509NameHandle x509Name = Interop.Crypto.DecodeX509Name(encodedDistinguishedName, encodedDistinguishedName.Length))
-            {
-                Interop.Crypto.CheckValidOpenSslHandle(x509Name);
-
-                using (SafeBioHandle bioHandle = Interop.Crypto.CreateMemoryBio())
-                {
-                    Interop.Crypto.CheckValidOpenSslHandle(bioHandle);
-
-                    int written;
-
-                    if (useFindFormat)
-                    {
-                        written = Interop.Crypto.X509NamePrintForFind(bioHandle, x509Name);
-                    }
-                    else
-                    {
-                        written = Interop.Crypto.X509NamePrintEx(bioHandle, x509Name, flags);
-                    }
-
-                    // X509_NAME_print_ex returns how many bytes were written into the buffer.
-                    // BIO_gets wants to ensure that the response is NULL-terminated.
-                    // So add one to leave space for the NULL.
-                    StringBuilder builder = new StringBuilder(written + 1);
-                    int read = Interop.Crypto.BioGets(bioHandle, builder, builder.Capacity);
-
-                    if (read < 0)
-                    {
-                        throw Interop.Crypto.CreateOpenSslCryptographicException();
-                    }
-
-                    return builder.ToString();
-                }
-            }
+            return X500NameEncoder.X500DistinguishedNameDecode(encodedDistinguishedName, true, flags);
         }
 
         public byte[] X500DistinguishedNameEncode(string distinguishedName, X500DistinguishedNameFlags flag)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Internal.Cryptography.Pal
+{
+    internal static class X500NameEncoder
+    {
+        private static readonly char[] s_quoteNeedingChars =
+        {
+            ',',
+            '+',
+            '=',
+            '\"',
+            '\n',
+            // \r is NOT in this list, because it isn't in Windows.
+            '<',
+            '>',
+            '#',
+            ';',
+        };
+
+        internal static string X500DistinguishedNameDecode(
+            byte[] encodedName,
+            bool printOid,
+            X500DistinguishedNameFlags flags)
+        {
+            bool reverse = (flags & X500DistinguishedNameFlags.Reversed) == X500DistinguishedNameFlags.Reversed;
+            bool quoteIfNeeded = (flags & X500DistinguishedNameFlags.DoNotUseQuotes) != X500DistinguishedNameFlags.DoNotUseQuotes;
+            string dnSeparator;
+
+            if ((flags & X500DistinguishedNameFlags.UseSemicolons) == X500DistinguishedNameFlags.UseSemicolons)
+            {
+                dnSeparator = "; ";
+            }
+            else if ((flags & X500DistinguishedNameFlags.UseNewLines) == X500DistinguishedNameFlags.UseNewLines)
+            {
+                dnSeparator = Environment.NewLine;
+            }
+            else
+            {
+                // This is matching Windows (native) behavior, UseCommas does not need to be asserted,
+                // it is just what happens if neither UseSemicolons nor UseNewLines is specified.
+                dnSeparator = ", ";
+            }
+
+            using (SafeX509NameHandle x509Name = Interop.Crypto.DecodeX509Name(encodedName, encodedName.Length))
+            {
+                if (x509Name.IsInvalid)
+                {
+                    return "";
+                }
+
+                // We need to allocate a StringBuilder to hold the data as we're building it, and there's the usual
+                // arbitrary process of choosing a number that's "big enough" to minimize reallocations without wasting
+                // too much space in the average case.
+                //
+                // So, let's look at an example of what our output might be.
+                //
+                // GitHub.com's SSL cert has a "pretty long" subject (partially due to the unknown OIDs):
+                //   businessCategory=Private Organization
+                //   1.3.6.1.4.1.311.60.2.1.3=US
+                //   1.3.6.1.4.1.311.60.2.1.2=Delaware
+                //   serialNumber=5157550
+                //   street=548 4th Street
+                //   postalCode=94107
+                //   C=US
+                //   ST=California
+                //   L=San Francisco
+                //   O=GitHub, Inc.
+                //   CN=github.com
+                //
+                // Which comes out to 228 characters using OpenSSL's default pretty-print
+                // (openssl x509 -in github.cer -text -noout)
+                // Throw in some "maybe-I-need-to-quote-this" quotes, and a couple of extra/extra-long O/OU values
+                // and round that up to the next programmer number, and you get that 512 should avoid reallocations
+                // in all but the most dire of cases.
+                StringBuilder decodedName = new StringBuilder(512);
+                int entryCount = Interop.Crypto.GetX509NameEntryCount(x509Name);
+                bool printSpacing = false;
+
+                for (int i = 0; i < entryCount; i++)
+                {
+                    int loc = reverse ? entryCount - i - 1 : i;
+
+                    using (SafeSharedX509NameEntryHandle nameEntry = Interop.Crypto.GetX509NameEntry(x509Name, loc))
+                    {
+                        Interop.Crypto.CheckValidOpenSslHandle(nameEntry);
+
+                        string thisOidValue;
+
+                        using (SafeSharedAsn1ObjectHandle oidHandle = Interop.Crypto.GetX509NameEntryOid(nameEntry))
+                        {
+                            thisOidValue = Interop.Crypto.GetOidValue(oidHandle);
+                        }
+
+                        if (printSpacing)
+                        {
+                            decodedName.Append(dnSeparator);
+                        }
+                        else
+                        {
+                            printSpacing = true;
+                        }
+
+                        if (printOid)
+                        {
+                            AppendOid(decodedName, thisOidValue);
+                        }
+
+                        string rdnValue;
+
+                        using (SafeSharedAsn1StringHandle valueHandle = Interop.Crypto.GetX509NameEntryData(nameEntry))
+                        {
+                            rdnValue = Interop.Crypto.Asn1StringToManagedString(valueHandle);
+                        }
+
+                        bool quote = quoteIfNeeded && NeedsQuoting(rdnValue);
+
+                        if (quote)
+                        {
+                            decodedName.Append('"');
+
+                            // If the RDN itself had a quote within it, that quote needs to be escaped
+                            // with another quote.
+                            rdnValue = rdnValue.Replace("\"", "\"\"");
+                        }
+
+                        decodedName.Append(rdnValue);
+
+                        if (quote)
+                        {
+                            decodedName.Append('"');
+                        }
+                    }
+                }
+
+                return decodedName.ToString();
+            }
+        }
+        
+        private static bool NeedsQuoting(string rdnValue)
+        {
+            if (string.IsNullOrEmpty(rdnValue))
+            {
+                return false;
+            }
+
+            if (IsQuotableWhitespace(rdnValue[0]) ||
+                IsQuotableWhitespace(rdnValue[rdnValue.Length - 1]))
+            {
+                return true;
+            }
+
+            int index = rdnValue.IndexOfAny(s_quoteNeedingChars);
+
+            return index != -1;
+        }
+
+        private static bool IsQuotableWhitespace(char c)
+        {
+            // There's a whole lot of Unicode whitespace that isn't covered here; but this
+            // matches what Windows deems quote-worthy.
+            //
+            // 0x20: Space
+            // 0x09: Character Tabulation (tab)
+            // 0x0A: Line Feed
+            // 0x0B: Line Tabulation (vertical tab)
+            // 0x0C: Form Feed
+            // 0x0D: Carriage Return
+            return (c == ' ' || (c >= 0x09 && c <= 0x0D));
+        }
+
+        private static void AppendOid(StringBuilder decodedName, string oidValue)
+        {
+            Oid oid = new Oid(oidValue);
+
+            if (StringComparer.Ordinal.Equals(oid.FriendlyName, oidValue) ||
+                string.IsNullOrEmpty(oid.FriendlyName))
+            {
+                decodedName.Append("OID.");
+                decodedName.Append(oid.Value);
+            }
+            else
+            {
+                decodedName.Append(oid.FriendlyName);
+            }
+
+            decodedName.Append('=');
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Internal\Cryptography\Pal.Unix\OpenSslX509StoreProvider.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\PkcsFormatReader.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\StorePal.cs" />
+    <Compile Include="Internal\Cryptography\Pal.Unix\X500NameEncoder.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Pal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Persistence.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
@@ -217,6 +218,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509NameEntry.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509NameEntry.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcrypto\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\libcrypto\Interop.Rsa.cs</Link>

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -9,11 +9,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class CertTests
     {
         [Fact]
-        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void X509CertTest()
         {
-            string certSubject = TestData.NormalizeX500String(
-                @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com");
+            string certSubject = @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
 
             using (X509Certificate cert = new X509Certificate(Path.Combine("TestData", "microsoft.cer")))
             {
@@ -49,11 +47,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1985, PlatformID.AnyUnix)]
+        [ActiveIssue(3893, PlatformID.AnyUnix)]
         public static void X509Cert2Test()
         {
-            string certName = TestData.NormalizeX500String(
-                @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US");
+            string certName = @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US";
 
             DateTime notBefore = new DateTime(1999, 7, 12, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
             DateTime notAfter = new DateTime(2009, 7, 9, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -237,7 +237,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Corporation,     OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US    ")]
         [InlineData("    CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
-        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void TestDistinguishedSubjectName_NoMatch(string distinguishedSubjectName)
         {
             RunZeroMatchTest(X509FindType.FindBySubjectDistinguishedName, distinguishedSubjectName);
@@ -247,7 +246,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=microsoft corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("cn=microsoft corporation, ou=mopr, o=microsoft corporation, l=redmond, s=washington, c=us")]
-        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void TestDistinguishedSubjectName_Match(string distinguishedSubjectName)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectDistinguishedName, distinguishedSubjectName);
@@ -281,7 +279,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Code Signing PCA,     O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US    ")]
         [InlineData("    CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
-        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void TestDistinguishedIssuerName_NoMatch(string issuerDistinguishedName)
         {
             RunZeroMatchTest(X509FindType.FindByIssuerDistinguishedName, issuerDistinguishedName);
@@ -291,7 +288,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=microsoft Code signing pca, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("cn=microsoft code signing pca, o=microsoft corporation, l=redmond, s=washington, c=us")]
-        [ActiveIssue(1985, PlatformID.AnyUnix)]
         public static void TestDistinguishedIssuerName_Match(string issuerDistinguishedName)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindByIssuerDistinguishedName, issuerDistinguishedName);

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 string issuer = c.Issuer;
 
                 Assert.Equal(
-                    TestData.NormalizeX500String("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
+                    "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     issuer);
             }
         }
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 string subject = c.Subject;
 
                 Assert.Equal(
-                    TestData.NormalizeX500String("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
+                    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     subject);
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    TestData.NormalizeX500String("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
+                    "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     c.Issuer);
             }
         }
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    TestData.NormalizeX500String("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
+                    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     c.Subject);
             }
         }
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    TestData.NormalizeX500String("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
+                    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     c.SubjectName.Name);
             }
         }
@@ -231,7 +231,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.Equal(
-                    TestData.NormalizeX500String("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"),
+                    "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     c.IssuerName.Name);
 
             }

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="PropsTests.cs" />
     <Compile Include="PublicKeyTests.cs" />
     <Compile Include="TestData.cs" />
+    <Compile Include="X500DistinguishedNameTests.cs" />
     <Compile Include="X509StoreTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
@@ -1132,20 +1132,5 @@ WQndXd9du7pKZJi5yiJbbjaLlJE7/CTeayvZomsZK5VzBLiVMekC/8kbVLI3uyKL
             public byte[] QY;
             public byte[] D;
         }
-    
-        internal static string NormalizeX500String(string expected)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return expected;
-            }
-
-            // Windows calls OID(2.5.4.8) "S", which matches ITU X.520.
-            // OpenSSL calls it "ST", because RFC1327 calls "S" surname.
-            // 
-            // This provides a test mitigation for issue 1985, allowing the
-            // thrust of the test to proceed with this one known problem.
-            return expected.Replace(" S=", " ST=");
-        }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -1,0 +1,392 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    public static class X500DistinguishedNameTests
+    {
+        [Fact]
+        public static void PrintInvalidEncoding()
+        {
+            // One byte has been removed from the payload here.  Since DER is length-prepended
+            // this will run out of data too soon, and report as invalid.
+            byte[] encoded = "3017311530130603550403130C436F6D6D6F6E204E616D65".HexToByteArray();
+
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal("", dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
+        [Fact]
+        [ActiveIssue(3892, PlatformID.AnyUnix)]
+        public static void PrintMultiComponentRdn()
+        {
+            byte[] encoded = (
+                "30223120300C060355040313054A616D65733010060355040A13094D6963726F" +
+                "736F6674").HexToByteArray();
+
+            const string expected = "CN=James + O=Microsoft";
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.None));
+
+            // It should not change ordering when reversed, since the two are one unit.
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.Reversed));
+        }
+
+        [Fact]
+        public static void PrintUnknownOidRdn()
+        {
+            byte[] encoded = (
+                "30183116301406052901020203130B496E76616C6964204F6964").HexToByteArray();
+
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal("OID.1.1.1.2.2.3=Invalid Oid", dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
+        [Theory]
+        [MemberData("WhitespaceBeforeCases")]
+        public static void QuoteWhitespaceBefore(string expected, string hexEncoded)
+        {
+            byte[] encoded = hexEncoded.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
+        [Theory]
+        [MemberData("WhitespaceBeforeCases")]
+        public static void NoQuoteWhitespaceBefore(string expectedQuoted, string hexEncoded)
+        {
+            string expected = expectedQuoted.Replace("\"", "");
+            byte[] encoded = hexEncoded.HexToByteArray();
+
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.DoNotUseQuotes));
+        }
+
+        [Theory]
+        [MemberData("WhitespaceAfterCases")]
+        public static void QuoteWhitespaceAfter(string expected, string hexEncoded)
+        {
+            byte[] encoded = hexEncoded.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
+        [Theory]
+        [MemberData("WhitespaceAfterCases")]
+        public static void NoQuoteWhitespaceAfter(string expectedQuoted, string hexEncoded)
+        {
+            string expected = expectedQuoted.Replace("\"", "");
+            byte[] encoded = hexEncoded.HexToByteArray();
+
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.DoNotUseQuotes));
+        }
+
+        [Theory]
+        [MemberData("QuotedContentsCases")]
+        public static void QuoteByContents(string expected, string hexEncoded)
+        {
+            byte[] encoded = hexEncoded.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
+        [Theory]
+        [MemberData("QuotedContentsCases")]
+        public static void NoQuoteByContents(string expectedQuoted, string hexEncoded)
+        {
+            string expected = expectedQuoted.Replace("\"", "");
+            byte[] encoded = hexEncoded.HexToByteArray();
+
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+            Assert.Equal(expected, dn.Decode(X500DistinguishedNameFlags.DoNotUseQuotes));
+        }
+
+        [Theory]
+        [MemberData("InternallyQuotedRDNs")]
+        public static void QuotedWithQuotes(string quoted, string notQuoted, string hexEncoded)
+        {
+            byte[] encoded = hexEncoded.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+
+            Assert.Equal(quoted, dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
+        [Theory]
+        [MemberData("InternallyQuotedRDNs")]
+        public static void NotQuotedWithQuotes(string quoted, string notQuoted, string hexEncoded)
+        {
+            byte[] encoded = hexEncoded.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+
+            Assert.Equal(notQuoted, dn.Decode(X500DistinguishedNameFlags.DoNotUseQuotes));
+        }
+
+        [Fact]
+        public static void PrintComplexReversed()
+        {
+            byte[] encoded = MicrosoftDotComSubject.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+
+            const string expected =
+                "CN=www.microsoft.com, OU=MSCOM, O=Microsoft Corporation, STREET=1 Microsoft Way, " +
+                "L=Redmond, S=Washington, PostalCode=98052, C=US, SERIALNUMBER=600413485, ";
+
+            // Windows 8.1 would continue the string with some unknown OIDs, but OpenSSL 1.0.1 can decode
+            // at least businessCategory (2.5.4.15), and other Windows versions may do so in the future.
+            //    "OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Washington, " +
+            //    "OID.1.3.6.1.4.1.311.60.2.1.3=US";
+
+            Assert.StartsWith(expected, dn.Decode(X500DistinguishedNameFlags.Reversed), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public static void PrintComplexForwards()
+        {
+            byte[] encoded = MicrosoftDotComSubject.HexToByteArray();
+            X500DistinguishedName dn = new X500DistinguishedName(encoded);
+
+            const string expected =
+                ", SERIALNUMBER=600413485, C=US, PostalCode=98052, S=Washington, L=Redmond, " +
+                "STREET=1 Microsoft Way, O=Microsoft Corporation, OU=MSCOM, CN=www.microsoft.com";
+
+            Assert.EndsWith(expected, dn.Decode(X500DistinguishedNameFlags.None), StringComparison.Ordinal);
+        }
+
+        public static readonly object[][] WhitespaceBeforeCases =
+        {
+            // Regular space.
+            new object[]
+            {
+                "CN=\" Common Name\"",
+                "3017311530130603550403130C20436F6D6D6F6E204E616D65"
+            },
+
+            // Tab
+            new object[]
+            {
+                "CN=\"\tCommon Name\"",
+                "30233121301F06035504031E1800090043006F006D006D006F006E0020004E00" +
+                "61006D0065"
+            },
+
+            // Newline
+            new object[]
+            {
+                "CN=\"\nCommon Name\"",
+                "30233121301F06035504031E18000A0043006F006D006D006F006E0020004E00" +
+                "61006D0065"
+
+            },
+
+            // xUnit doesn't like \v in Assert.Equals, reports it as an invalid character.
+            //new object[]
+            //{
+            //    "CN=\"\vCommon Name\"",
+            //    "30233121301F06035504031E18000B0043006F006D006D006F006E0020004E00" +
+            //    "61006D0065"
+            //},
+
+            // xUnit doesn't like FormFeed in Assert.Equals, reports it as an invalid character.
+            //new object[]
+            //{
+            //    "CN=\"\u000cCommon Name\"",
+            //    "30233121301F06035504031E18000C0043006F006D006D006F006E0020004E00" +
+            //    "61006D0065"
+            //},
+
+            // Carriage return
+            new object[]
+            {
+                "CN=\"\rCommon Name\"",
+                "30233121301F06035504031E18000D0043006F006D006D006F006E0020004E00" +
+                "61006D0065"
+            },
+
+            // em quad.  This is char.IsWhitespace, but is not quoted.
+            new object[]
+            {
+                "CN=\u2002Common Name",
+                "30233121301F06035504031E1820020043006F006D006D006F006E0020004E00" +
+                "61006D0065"
+            },
+        };
+
+        public static readonly object[][] WhitespaceAfterCases =
+        {
+            // Regular space.
+            new object[]
+            {
+                "CN=\"Common Name \"",
+                "3017311530130603550403130C436F6D6D6F6E204E616D6520"
+            },
+
+            // Newline
+            new object[]
+            {
+                "CN=\"Common Name\t\"",
+                "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+                "6D00650009"
+            },
+
+            // Newline
+            new object[]
+            {
+                "CN=\"Common Name\n\"",
+                "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+                "6D0065000A"
+            },
+
+            // xUnit doesn't like \v in Assert.Equals, reports it as an invalid character.
+            //new object[]
+            //{
+            //    "CN=\"Common Name\v\"",
+            //    "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+            //    "6D0065000B"
+            //},
+
+            // xUnit doesn't like FormFeed in Assert.Equals, reports it as an invalid character.
+            //new object[]
+            //{
+            //    "CN=\"Common Name\u000c\"",
+            //    "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+            //    "6D0065000C"
+            //},
+
+             // Carriage return
+            new object[]
+            {
+                "CN=\"Common Name\r\"",
+                "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+                "6D0065000D"
+            },
+
+            // em quad.  This is char.IsWhitespace, but is not quoted.
+            new object[]
+            {
+                "CN=Common Name\u2002",
+                "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+                "6D00652002"
+            },
+        };
+
+        public static readonly object[][] QuotedContentsCases =
+        {
+            // Comma (RDN separator)
+            new object[]
+            {
+                "CN=\"Common,Name\"",
+                "3016311430120603550403130B436F6D6D6F6E2C4E616D65"
+            },
+
+            // Plus (RDN component separator)
+            new object[]
+            {
+                "CN=\"Common+Name\"",
+                "3016311430120603550403130B436F6D6D6F6E2B4E616D65"
+            },
+
+            // Equal (Key/Value separator)
+            new object[]
+            {
+                "CN=\"Common=Name\"",
+                "3016311430120603550403130B436F6D6D6F6E3D4E616D65"
+            },
+
+            // Note: Double Quote has been removed from this set, it's a dedicated test suite.
+
+            // Newline
+            new object[]
+            {
+                "CN=\"Common\nName\"",
+                "3021311F301D06035504031E160043006F006D006D006F006E000A004E006100" +
+                "6D0065"
+            },
+
+            // Carriage return is NOT quoted.
+            new object[]
+            {
+                "CN=Common\rName",
+                "3021311F301D06035504031E160043006F006D006D006F006E000D004E006100" +
+                "6D0065"
+            },
+
+            // Less-than
+            new object[]
+            {
+                "CN=\"Common<Name\"",
+                "3021311F301D06035504031E160043006F006D006D006F006E003C004E006100" +
+                "6D0065"
+            },
+
+            // Greater-than
+            new object[]
+            {
+                "CN=\"Common>Name\"",
+                "3021311F301D06035504031E160043006F006D006D006F006E003E004E006100" +
+                "6D0065"
+            },
+
+            // Octothorpe (Number Sign, Pound, Hash, whatever)
+            new object[]
+            {
+                "CN=\"Common#Name\"",
+                "3021311F301D06035504031E160043006F006D006D006F006E0023004E006100" +
+                "6D0065"
+            },
+
+            // Semi-colon
+            new object[]
+            {
+                "CN=\"Common;Name\"",
+                "3021311F301D06035504031E160043006F006D006D006F006E003B004E006100" +
+                "6D0065"
+            },
+        };
+
+        public static readonly object[][] InternallyQuotedRDNs =
+        {
+            // Interior Double Quote
+            new object[]
+            {
+                "CN=\"Common\"\"Name\"", // Quoted
+                "CN=Common\"Name", // Not-Quoted
+                "3021311F301D06035504031E160043006F006D006D006F006E0022004E006100" +
+                "6D0065"
+            },
+
+            // Starts with a double quote
+            new object[]
+            {
+                "CN=\"\"\"Common Name\"", // Quoted
+                "CN=\"Common Name", // Not-Quoted
+                "30233121301F06035504031E1800220043006F006D006D006F006E0020004E00" +
+                "61006D0065"
+            },
+
+            // Ends with a double quote
+            new object[]
+            {
+                "CN=\"Common Name\"\"\"", // Quoted
+                "CN=Common Name\"", // Not-Quoted
+                "30233121301F06035504031E180043006F006D006D006F006E0020004E006100" +
+                "6D00650022"
+            },
+        };
+
+        private const string MicrosoftDotComSubject =
+            "3082010F31133011060B2B0601040182373C02010313025553311B3019060B2B" +
+            "0601040182373C0201020C0A57617368696E67746F6E311D301B060355040F13" +
+            "1450726976617465204F7267616E697A6174696F6E3112301006035504051309" +
+            "363030343133343835310B3009060355040613025553310E300C06035504110C" +
+            "0539383035323113301106035504080C0A57617368696E67746F6E3110300E06" +
+            "035504070C075265646D6F6E643118301606035504090C0F31204D6963726F73" +
+            "6F667420576179311E301C060355040A0C154D6963726F736F667420436F7270" +
+            "6F726174696F6E310E300C060355040B0C054D53434F4D311A30180603550403" +
+            "0C117777772E6D6963726F736F66742E636F6D";
+    }
+}


### PR DESCRIPTION
The Windows and Unix implementations differed in a few cases:
* Key 2.5.4.8: Windows: "S", Unix: "ST"
* Key 1.2.840.113549.1.9.1: Windows "E", Unix "emailAddress"
* Value quoting: Windows wrapped the value in quotes for several special characters (such as comma).  Unix did not.

Now they're substantially closer to agreeing.  There's at least one known difference, and that is a single RDN with multiple components gets treated as separate RDNs on Unix, but is a special case on Windows.

Fixes #1985.