### PR TITLE
Add block expression tests.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -118,12 +118,6 @@ namespace System.Linq.Expressions
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
-        internal virtual ParameterExpression GetVariable(int index)
-        {
-            throw ContractUtils.Unreachable;
-        }
-
         internal virtual int VariableCount
         {
             get
@@ -424,11 +418,6 @@ namespace System.Linq.Expressions
             {
                 return _variables.Count;
             }
-        }
-
-        internal override ParameterExpression GetVariable(int index)
-        {
-            return _variables[index];
         }
 
         internal override ReadOnlyCollection<ParameterExpression> GetOrMakeVariables()

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -1,0 +1,491 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Test
+{
+    public class NoParameterBlockTests : SharedBlockTests
+    {
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void SingleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void DoubleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                Expression.Empty(),
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Fact]
+        public void DoubleElementBlockNullArgument()
+        {
+            Assert.Throws<ArgumentNullException>("arg0", () => Expression.Block(default(Expression), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg1", () => Expression.Block(Expression.Constant(1), default(Expression)));
+        }
+
+        [Fact]
+        public void DoubleElementBlockUnreadable()
+        {
+            Assert.Throws<ArgumentException>("arg0", () => Expression.Block(UnreadableExpression, Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg1", () => Expression.Block(Expression.Constant(1), UnreadableExpression));
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void TripleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                Expression.Empty(),
+                Expression.Empty(),
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Fact]
+        public void TripleElementBlockNullArgument()
+        {
+            Assert.Throws<ArgumentNullException>("arg0", () => Expression.Block(default(Expression), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg1", () => Expression.Block(Expression.Constant(1), default(Expression), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg2", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), default(Expression)));
+        }
+
+        [Fact]
+        public void TripleElementBlockUnreadable()
+        {
+            Assert.Throws<ArgumentException>("arg0", () => Expression.Block(UnreadableExpression, Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg1", () => Expression.Block(Expression.Constant(1), UnreadableExpression, Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg2", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), UnreadableExpression));
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void QuadrupleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                Expression.Empty(),
+                Expression.Empty(),
+                Expression.Empty(),
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Fact]
+        public void QuadrupleElementBlockNullArgument()
+        {
+            Assert.Throws<ArgumentNullException>("arg0", () => Expression.Block(default(Expression), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg1", () => Expression.Block(Expression.Constant(1), default(Expression), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg2", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), default(Expression), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg3", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), default(Expression)));
+        }
+
+        [Fact]
+        public void QuadrupleElementBlockUnreadable()
+        {
+            Assert.Throws<ArgumentException>("arg0", () => Expression.Block(UnreadableExpression, Expression.Constant(1), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg1", () => Expression.Block(Expression.Constant(1), UnreadableExpression, Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg2", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), UnreadableExpression, Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg3", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), UnreadableExpression));
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void QuintupleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                Expression.Empty(),
+                Expression.Empty(),
+                Expression.Empty(),
+                Expression.Empty(),
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Fact]
+        public void QuintupleElementBlockNullArgument()
+        {
+            Assert.Throws<ArgumentNullException>("arg0", () => Expression.Block(default(Expression), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg1", () => Expression.Block(Expression.Constant(1), default(Expression), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg2", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), default(Expression), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg3", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), default(Expression), Expression.Constant(1)));
+            Assert.Throws<ArgumentNullException>("arg4", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), default(Expression)));
+        }
+
+        [Fact]
+        public void QuintupleElementBlockUnreadable()
+        {
+            Assert.Throws<ArgumentException>("arg0", () => Expression.Block(UnreadableExpression, Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg1", () => Expression.Block(Expression.Constant(1), UnreadableExpression, Expression.Constant(1), Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg2", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), UnreadableExpression, Expression.Constant(1), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg3", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), UnreadableExpression, Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("arg4", () => Expression.Block(Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), Expression.Constant(1), UnreadableExpression));
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void SextupleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                Expression.Empty(),
+                Expression.Empty(),
+                Expression.Empty(),
+                Expression.Empty(),
+                Expression.Empty(),
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Fact]
+        public void NullExpicitType()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Block(default(Type), default(IEnumerable<ParameterExpression>), Expression.Constant(0)));
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Block(default(Type), null, Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void NullExpressionList()
+        {
+            Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(default(Expression[])));
+            Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(default(IEnumerable<Expression>)));
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        [ActiveIssue(3909)]
+        [ActiveIssue(3908)]
+        public void NullExpressionInExpressionList(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i != expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = null;
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(expressions));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(expressions.Skip(0)));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), expressions));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), expressions.Skip(0)));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), null, expressions));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void NullExpressionInExpressionListTemp(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i != expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = null;
+                Assert.Throws<ArgumentNullException>(() => Expression.Block(expressions));
+                Assert.Throws<ArgumentNullException>(() => Expression.Block(expressions.Skip(0)));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), expressions));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), expressions.Skip(0)));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), null, expressions));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), null, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        [ActiveIssue(3909)]
+        public void UnreadableExpressionInExpressionList(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i != expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = UnreadableExpression;
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(expressions));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(expressions.Skip(0)));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), expressions));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), expressions.Skip(0)));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), null, expressions));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void UnreadableExpressionInExpressionListTemp(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i != expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = UnreadableExpression;
+                Assert.Throws<ArgumentException>(() => Expression.Block(expressions));
+                Assert.Throws<ArgumentException>(() => Expression.Block(expressions.Skip(0)));
+                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), expressions));
+                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), expressions.Skip(0)));
+                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), null, expressions));
+                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), null, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("ObjectAssignableConstantValuesAndSizes")]
+        public void BlockExplicitType(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            BlockExpression block = Expression.Block(typeof(object), PadBlock(blockSize - 1, constant));
+
+            Assert.Equal(typeof(object), block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void BlockInvalidExplicitType(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), expressions));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), expressions.ToArray()));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        [ActiveIssue(3881)]
+        public void InvalidExpressionIndex(object value, int blockSize)
+        {
+            BlockExpression block = Expression.Block(PadBlock(blockSize - 1, Expression.Constant(value, value.GetType())));
+            Assert.Throws<ArgumentOutOfRangeException>(() => block.Expressions[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => block.Expressions[blockSize]);
+        }
+
+        // Remove below if issue blocking above is fixed.
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void InvalidExpressionIndexVaryingExceptin(object value, int blockSize)
+        {
+            BlockExpression block = Expression.Block(PadBlock(blockSize - 1, Expression.Constant(value, value.GetType())));
+            Assert.ThrowsAny<Exception>(() => block.Expressions[-1]);
+            Assert.ThrowsAny<Exception>(() => block.Expressions[blockSize]);
+        }
+
+        // See https://github.com/dotnet/corefx/issues/3043
+        [Fact]
+        public void EmptyBlockNotAllowed()
+        {
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block());
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void)));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        [ActiveIssue(3882)]
+        public void EmptyBlockWithParametersNotAllowed()
+        {
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1)));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1), Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1)));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1), Enumerable.Empty<Expression>()));
+        }
+
+        // If https://github.com/dotnet/corefx/issues/3043 is ever actioned, this case would still be prohibited.
+
+        [Fact]
+        public void EmptyBlockWithNonVoidTypeNotAllowed()
+        {
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int)));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        [ActiveIssue(3882)]
+        public void EmptyBlockWithParametersAndNonVoidTypeNotAllowed()
+        {
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1)));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1), Enumerable.Empty<Expression>()));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void ResultPropertyFromParams(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions.ToArray());
+
+            Assert.Same(constant, block.Result);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void ResultPropertyFromEnumerable(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.Same(constant, block.Result);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void VariableCountZeroOnNonVariableAcceptingForms(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.Empty(block.Variables);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        [ActiveIssue(3883)]
+        public void RewriteToSameWithSameValues(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant).ToArray();
+
+            BlockExpression block = Expression.Block(expressions);
+            Assert.Same(block, block.Update(null, expressions));
+            Assert.Same(block, block.Update(Enumerable.Empty<ParameterExpression>(), expressions));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void CanFindItems(object value, int blockSize)
+        {
+            ConstantExpression[] values = new ConstantExpression[blockSize];
+            for (int i = 0; i != values.Length; ++i)
+                values[i] = Expression.Constant(value);
+
+            BlockExpression block = Expression.Block(values);
+
+            IList<Expression> expressions = block.Expressions;
+
+            for (int i = 0; i != values.Length; ++i)
+                Assert.Equal(i, expressions.IndexOf(values[i]));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void IdentifyNonAbsentItemAsAbsent(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.Equal(-1, block.Expressions.IndexOf(Expression.Default(typeof(long))));
+            Assert.False(block.Expressions.Contains(null));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void ExpressionsEnumerable(object value, int blockSize)
+        {
+            ConstantExpression[] values = new ConstantExpression[blockSize];
+            for (int i = 0; i != values.Length; ++i)
+                values[i] = Expression.Constant(value);
+
+            BlockExpression block = Expression.Block(values);
+
+            Assert.True(values.SequenceEqual(block.Expressions));
+            int index = 0;
+            foreach (Expression exp in ((IEnumerable)block.Expressions))
+                Assert.Same(exp, values[index++]);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void UpdateWithExpressionsReturnsSame(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.Same(block, block.Update(block.Variables, block.Expressions));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void Visit(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.NotSame(block, new TestVistor().Visit(block));
+        }
+
+        [Theory]
+        [MemberData("ObjectAssignableConstantValuesAndSizes")]
+        public void VisitTyped(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(typeof(object), expressions);
+
+            Assert.NotSame(block, new TestVistor().Visit(block));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -1,0 +1,366 @@
+﻿// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Test
+{
+    public class ParameterBlockTests : SharedBlockTests
+    {
+        private static IEnumerable<ParameterExpression> SingleParameter
+        {
+            get { return Enumerable.Repeat(Expression.Variable(typeof(int)), 1); }
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void SingleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                SingleParameter,
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ConstantValueData")]
+        public void DoubleElementBlock(object value)
+        {
+            Type type = value.GetType();
+            ConstantExpression constant = Expression.Constant(value, type);
+            BlockExpression block = Expression.Block(
+                SingleParameter,
+                Expression.Empty(),
+                constant
+               );
+
+            Assert.Equal(type, block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Fact]
+        public void NullExpicitType()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Block(null, SingleParameter, Expression.Constant(0)));
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Block(null, SingleParameter, Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void NullExpressionList()
+        {
+            Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(SingleParameter, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(SingleParameter, default(IEnumerable<Expression>)));
+            Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), SingleParameter, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), SingleParameter, default(IEnumerable<Expression>)));
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        [ActiveIssue(3908)]
+        public void NullExpressionInExpressionList(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i < expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = null;
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(SingleParameter, expressions));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(SingleParameter, expressions.Skip(0)));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), SingleParameter, expressions));
+                Assert.Throws<ArgumentNullException>("expressions", () => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void NullExpressionInExpressionListTemp(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i != expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = null;
+                Assert.ThrowsAny<Exception>(() => Expression.Block(SingleParameter, expressions));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(SingleParameter, expressions.Skip(0)));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), SingleParameter, expressions));
+                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void UnreadableExpressionInExpressionList(int size)
+        {
+            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
+            for (int i = 0; i != expressionList.Count; ++i)
+            {
+                Expression[] expressions = expressionList.ToArray();
+                expressions[i] = UnreadableExpression;
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(SingleParameter, expressions));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(SingleParameter, expressions.Skip(0)));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), SingleParameter, expressions));
+                Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
+            }
+        }
+
+        [Theory]
+        [MemberData("ObjectAssignableConstantValuesAndSizes")]
+        public void BlockExplicitType(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            BlockExpression block = Expression.Block(typeof(object), SingleParameter, PadBlock(blockSize - 1, constant));
+
+            Assert.Equal(typeof(object), block.Type);
+
+            Expression equal = Expression.Equal(constant, block);
+            Assert.True(Expression.Lambda<Func<bool>>(equal).Compile()());
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void BlockInvalidExplicitType(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), SingleParameter, expressions));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), SingleParameter, expressions.ToArray()));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void BlockFromEmptyParametersSameAsFromParams(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression fromParamsBlock = Expression.Block(SingleParameter, expressions.ToArray());
+            BlockExpression fromEnumBlock = Expression.Block(SingleParameter, expressions);
+
+            Assert.Equal(fromParamsBlock.GetType(), fromEnumBlock.GetType());
+
+            Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(constant, fromParamsBlock)).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(Expression.Equal(constant, fromEnumBlock)).Compile()());
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        [ActiveIssue(3881)]
+        public void InvalidExpressionIndex(object value, int blockSize)
+        {
+            BlockExpression block = Expression.Block(SingleParameter, PadBlock(blockSize - 1, Expression.Constant(value, value.GetType())));
+            Assert.Throws<ArgumentOutOfRangeException>(() => block.Expressions[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => block.Expressions[blockSize]);
+        }
+
+        // Remove below if issue blocking above is fixed.
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void InvalidExpressionIndexVaryingExceptin(object value, int blockSize)
+        {
+            BlockExpression block = Expression.Block(SingleParameter, PadBlock(blockSize - 1, Expression.Constant(value, value.GetType())));
+            Assert.ThrowsAny<Exception>(() => block.Expressions[-1]);
+            Assert.ThrowsAny<Exception>(() => block.Expressions[blockSize]);
+        }
+
+        // See https://github.com/dotnet/corefx/issues/3043
+        [Fact]
+        [ActiveIssue(3882)]
+        public void EmptyBlockWithParametersNotAllowed()
+        {
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(SingleParameter));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(SingleParameter, Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), SingleParameter));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), SingleParameter, Enumerable.Empty<Expression>()));
+        }
+
+        // If https://github.com/dotnet/corefx/issues/3043 is ever actioned, this case would still be prohibited.
+
+        [Fact]
+        [ActiveIssue(3882)]
+        public void EmptyBlockWithParametersAndNonVoidTypeNotAllowed()
+        {
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), SingleParameter));
+            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void ResultPropertyFromParams(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(SingleParameter, expressions.ToArray());
+
+            Assert.Same(constant, block.Result);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void ResultPropertyFromEnumerable(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(SingleParameter, expressions);
+
+            Assert.Same(constant, block.Result);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void VariableCountCorrect(object value, int blockSize)
+        {
+            IEnumerable<ParameterExpression> vars = Enumerable.Range(0, blockSize).Select(i => Expression.Variable(value.GetType()));
+            BlockExpression block = Expression.Block(vars, Expression.Constant(value, value.GetType()));
+
+            Assert.Equal(blockSize, block.Variables.Count);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        [ActiveIssue(3883)]
+        public void RewriteToSameWithSameValues(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant).ToArray();
+
+            BlockExpression block = Expression.Block(SingleParameter, expressions);
+            Assert.Same(block, block.Update(block.Variables.ToArray(), expressions));
+            Assert.Same(block, block.Update(block.Variables.ToArray(), expressions));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void CanFindItems(object value, int blockSize)
+        {
+            ConstantExpression[] values = new ConstantExpression[blockSize];
+            for (int i = 0; i != values.Length; ++i)
+                values[i] = Expression.Constant(value);
+
+            BlockExpression block = Expression.Block(SingleParameter, values);
+
+            IList<Expression> expressions = block.Expressions;
+
+            for (int i = 0; i != values.Length; ++i)
+                Assert.Equal(i, expressions.IndexOf(values[i]));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void IdentifyNonAbsentItemAsAbsent(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(SingleParameter, expressions);
+
+            Assert.Equal(-1, block.Expressions.IndexOf(Expression.Default(typeof(long))));
+            Assert.False(block.Expressions.Contains(null));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void ExpressionsEnumerable(object value, int blockSize)
+        {
+            ConstantExpression[] values = new ConstantExpression[blockSize];
+            for (int i = 0; i != values.Length; ++i)
+                values[i] = Expression.Constant(value);
+
+            BlockExpression block = Expression.Block(SingleParameter, values);
+
+            Assert.True(values.SequenceEqual(block.Expressions));
+            int index = 0;
+            foreach (Expression exp in ((IEnumerable)block.Expressions))
+                Assert.Same(exp, values[index++]);
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void UpdateWithExpressionsReturnsSame(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(SingleParameter, expressions);
+
+            Assert.Same(block, block.Update(block.Variables, block.Expressions));
+        }
+
+        [Theory]
+        [MemberData("ConstantValuesAndSizes")]
+        public void Visit(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(SingleParameter, expressions);
+
+            Assert.NotSame(block, new TestVistor().Visit(block));
+        }
+
+        [Theory]
+        [MemberData("ObjectAssignableConstantValuesAndSizes")]
+        public void VisitTyped(object value, int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(value, value.GetType());
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(typeof(object), SingleParameter, expressions);
+
+            Assert.NotSame(block, new TestVistor().Visit(block));
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void NullVariables(int blockSize)
+        {
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
+            IEnumerable<ParameterExpression> vars = Enumerable.Repeat(default(ParameterExpression), 1);
+
+            Assert.Throws<ArgumentNullException>(() => Expression.Block(vars, expressions));
+            Assert.Throws<ArgumentNullException>(() => Expression.Block(vars, expressions.ToArray()));
+            Assert.Throws<ArgumentNullException>(() => Expression.Block(typeof(object), vars, expressions));
+            Assert.Throws<ArgumentNullException>(() => Expression.Block(typeof(object), vars, expressions.ToArray()));
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void ByRefVariables(int blockSize)
+        {
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
+            IEnumerable<ParameterExpression> vars = Enumerable.Repeat(Expression.Parameter(typeof(int).MakeByRefType()), 1);
+
+            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions));
+            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions.ToArray()));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions.ToArray()));
+        }
+
+        [Theory]
+        [MemberData("BlockSizes")]
+        public void RepeatedVariables(int blockSize)
+        {
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
+            ParameterExpression variable = Expression.Variable(typeof(int));
+            IEnumerable<ParameterExpression> vars = Enumerable.Repeat(variable, 2);
+
+            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions));
+            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions.ToArray()));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions.ToArray()));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Jon Hanna. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Test
+{
+    public abstract class SharedBlockTests
+    {
+        private static IEnumerable<object> ObjectAssignableConstantValues()
+        {
+            yield return new object();
+            yield return "Hello";
+            yield return new Uri("http://example.net/");
+        }
+        private static IEnumerable<object> ConstantValues()
+        {
+            yield return 42;
+            yield return 42L;
+            yield return DateTime.MinValue;
+            foreach (object obj in ObjectAssignableConstantValues())
+                yield return obj;
+        }
+
+        public static IEnumerable<object[]> ConstantValueData()
+        {
+            return ConstantValues().Select(i => new object[] { i });
+        }
+
+        public static IEnumerable<object[]> ConstantValuesAndSizes()
+        {
+            return
+                from size in Enumerable.Range(1, 6)
+                from value in ConstantValues()
+                select new object[] { value, size };
+        }
+
+        public static IEnumerable<object[]> ObjectAssignableConstantValuesAndSizes()
+        {
+            return
+                from size in Enumerable.Range(1, 6)
+                from value in ObjectAssignableConstantValues()
+                select new object[] { value, size };
+        }
+
+        public static IEnumerable<object[]> BlockSizes()
+        {
+            return Enumerable.Range(1, 6).Select(i => new object[] { i });
+        }
+
+        protected static IEnumerable<Expression> PadBlock(int padCount, Expression tailExpression)
+        {
+            while (padCount-- != 0) yield return Expression.Empty();
+            yield return tailExpression;
+        }
+
+        protected class TestVistor : ExpressionVisitor
+        {
+            protected override Expression VisitDefault(DefaultExpression node)
+            {
+                return Expression.Default(node.Type);
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                return Expression.Constant(node.Value, node.Type);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                return Expression.Parameter(node.Type.IsByRef ? node.Type.MakeByRefType() : node.Type, node.Name);
+            }
+        }
+
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        protected static Expression UnreadableExpression
+        {
+            get
+            {
+                return Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -79,6 +79,9 @@
     <Compile Include="BinaryOperators\ReferenceComparison\ReferenceNotEqual.cs" />
     <Compile Include="Block\BlockFactoryTests.cs" />
     <Compile Include="Block\BlockTests.cs" />
+    <Compile Include="Block\NoParameterBlockTests.cs" />
+    <Compile Include="Block\ParameterBlockTests.cs" />
+    <Compile Include="Block\SharedBlockTests.cs" />
     <Compile Include="Call\CallFactoryTests.cs" />
     <Compile Include="Cast\AsNullable.cs" />
     <Compile Include="Cast\AsTests.cs" />


### PR DESCRIPTION
Includes removal of dead code in BlockExpression.cs; `GetVariable(int)` is
never hit.