### PR TITLE
Correct parameter name when creating block with erroneous element

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -898,6 +898,11 @@ namespace System.Linq.Expressions
                 {
                     var lastExpression = expressionList[expressionCount - 1];
 
+                    if (lastExpression == null)
+                    {
+                        throw Error.ArgumentNull("expressions");
+                    }
+
                     if (lastExpression.Type == type)
                     {
                         return GetOptimizedBlockExpression(expressionList);
@@ -972,15 +977,15 @@ namespace System.Linq.Expressions
 
         private static BlockExpression GetOptimizedBlockExpression(IReadOnlyList<Expression> expressions)
         {
+            RequiresCanRead(expressions, "expressions");
             switch (expressions.Count)
             {
-                case 2: return Block(expressions[0], expressions[1]);
-                case 3: return Block(expressions[0], expressions[1], expressions[2]);
-                case 4: return Block(expressions[0], expressions[1], expressions[2], expressions[3]);
-                case 5: return Block(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
+                case 2: return new Block2(expressions[0], expressions[1]);
+                case 3: return new Block3(expressions[0], expressions[1], expressions[2]);
+                case 4: return new Block4(expressions[0], expressions[1], expressions[2], expressions[3]);
+                case 5: return new Block5(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
                 default:
                     ContractUtils.RequiresNotEmptyList(expressions, "expressions");
-                    RequiresCanRead(expressions, "expressions");
                     return new BlockN(expressions as ReadOnlyCollection<Expression> ?? (IList<Expression>)expressions.ToArray());
             }
         }

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -205,7 +205,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData("BlockSizes")]
-        [ActiveIssue(3909)]
         public void NullExpressionInExpressionList(int size)
         {
             List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
@@ -224,25 +223,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData("BlockSizes")]
-        public void NullExpressionInExpressionListTemp(int size)
-        {
-            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
-            for (int i = 0; i != expressionList.Count; ++i)
-            {
-                Expression[] expressions = expressionList.ToArray();
-                expressions[i] = null;
-                Assert.Throws<ArgumentNullException>(() => Expression.Block(expressions));
-                Assert.Throws<ArgumentNullException>(() => Expression.Block(expressions.Skip(0)));
-                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), expressions));
-                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), expressions.Skip(0)));
-                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), null, expressions));
-                Assert.ThrowsAny<Exception>(() => Expression.Block(typeof(int), null, expressions.Skip(0)));
-            }
-        }
-
-        [Theory]
-        [MemberData("BlockSizes")]
-        [ActiveIssue(3909)]
         public void UnreadableExpressionInExpressionList(int size)
         {
             List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
@@ -256,24 +236,6 @@ namespace System.Linq.Expressions.Tests
                 Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), expressions.Skip(0)));
                 Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), null, expressions));
                 Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
-            }
-        }
-
-        [Theory]
-        [MemberData("BlockSizes")]
-        public void UnreadableExpressionInExpressionListTemp(int size)
-        {
-            List<Expression> expressionList = Enumerable.Range(0, size).Select(i => (Expression)Expression.Constant(1)).ToList();
-            for (int i = 0; i != expressionList.Count; ++i)
-            {
-                Expression[] expressions = expressionList.ToArray();
-                expressions[i] = UnreadableExpression;
-                Assert.Throws<ArgumentException>(() => Expression.Block(expressions));
-                Assert.Throws<ArgumentException>(() => Expression.Block(expressions.Skip(0)));
-                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), expressions));
-                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), expressions.Skip(0)));
-                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), null, expressions));
-                Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), null, expressions.Skip(0)));
             }
         }
 


### PR DESCRIPTION
Fixes #3909