### PR TITLE
Add a padding byte for "negative" cert serial numbers on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int GetAsn1IntegerDerSize(SafeSharedAsn1IntegerHandle i);
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int EncodeAsn1Integer(SafeSharedAsn1IntegerHandle i, byte[] buf);
+
+        internal static byte[] GetAsn1IntegerBytes(SafeSharedAsn1IntegerHandle asn1Integer)
+        {
+            CheckValidOpenSslHandle(asn1Integer);
+
+            // OpenSSL stores negative numbers in their two's complement (positive) form, but
+            // sets an internal negative bit.
+            //
+            // If the number was positive, but could sign-test as negative, DER puts in a leading
+            // 0x00 byte, which reading OpenSSL's data directly won't have.
+            //
+            // So to ensure we're getting a set of bytes compatible with BigInteger (though with the
+            // wrong endianness here), DER encode it, then use the DER reader to skip past the tag
+            // and length.
+            byte[] derEncoded = OpenSslEnocde(
+                handle => GetAsn1IntegerDerSize(handle),
+                (handle, buf) => EncodeAsn1Integer(handle, buf),
+                asn1Integer);
+
+            DerSequenceReader reader = DerSequenceReader.CreateForPayload(derEncoded);
+            return reader.ReadIntegerBytes();
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -38,8 +38,17 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative)]
         internal static extern SafeX509Handle PemReadX509FromBio(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern IntPtr X509GetSerialNumber(SafeX509Handle x);
+        [DllImport(Libraries.CryptoNative, EntryPoint = "X509GetSerialNumber")]
+        private static extern SafeSharedAsn1IntegerHandle X509GetSerialNumber_private(SafeX509Handle x);
+
+        internal static SafeSharedAsn1IntegerHandle X509GetSerialNumber(SafeX509Handle x)
+        {
+            CheckValidOpenSslHandle(x);
+
+            return SafeInteriorHandle.OpenInteriorHandle(
+                handle => X509GetSerialNumber_private(handle),
+                x);
+        }
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern IntPtr X509GetIssuerName(SafeX509Handle x);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -55,14 +55,10 @@ internal static partial class Interop
         {
             CheckValidOpenSslHandle(sk);
 
-            SafeSharedX509NameHandle handle = GetX509NameStackField_private(sk, loc);
-
-            if (!handle.IsInvalid)
-            {
-                handle.SetParent(sk);
-            }
-
-            return handle;
+            return SafeInteriorHandle.OpenInteriorHandle(
+                (handle, i) => GetX509NameStackField_private(handle, i),
+                sk,
+                loc);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509NameEntry.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509NameEntry.cs
@@ -22,42 +22,28 @@ internal static partial class Interop
         {
             CheckValidOpenSslHandle(x509Name);
 
-            SafeSharedX509NameEntryHandle handle = GetX509NameEntry_private(x509Name, loc);
-
-            if (!handle.IsInvalid)
-            {
-                handle.SetParent(x509Name);
-            }
-
-            return handle;
+            return SafeInteriorHandle.OpenInteriorHandle(
+                (nameHandle, i) => GetX509NameEntry_private(nameHandle, i),
+                x509Name,
+                loc);
         }
 
         internal static SafeSharedAsn1ObjectHandle GetX509NameEntryOid(SafeSharedX509NameEntryHandle nameEntry)
         {
             CheckValidOpenSslHandle(nameEntry);
 
-            SafeSharedAsn1ObjectHandle handle = GetX509NameEntryOid_private(nameEntry);
-
-            if (!handle.IsInvalid)
-            {
-                handle.SetParent(nameEntry);
-            }
-
-            return handle;
+            return SafeInteriorHandle.OpenInteriorHandle(
+                handle => GetX509NameEntryOid_private(handle),
+                nameEntry);
         }
 
         internal static SafeSharedAsn1StringHandle GetX509NameEntryData(SafeSharedX509NameEntryHandle nameEntry)
         {
             CheckValidOpenSslHandle(nameEntry);
 
-            SafeSharedAsn1StringHandle handle = GetX509NameEntryData_private(nameEntry);
-
-            if (!handle.IsInvalid)
-            {
-                handle.SetParent(nameEntry);
-            }
-
-            return handle;
+            return SafeInteriorHandle.OpenInteriorHandle(
+                handle => GetX509NameEntryData_private(handle),
+                nameEntry);
         }
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
@@ -98,4 +98,12 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
     }
+
+    internal sealed class SafeSharedAsn1IntegerHandle : SafeInteriorHandle
+    {
+        private SafeSharedAsn1IntegerHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+    }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeInteriorHandle.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeInteriorHandle.cs
@@ -48,5 +48,38 @@ namespace Microsoft.Win32.SafeHandles
 
             _parent = parent;
         }
+
+        internal static TInteriorHandle OpenInteriorHandle<TInteriorHandle, TExteriorHandle>(
+            Func<TExteriorHandle, TInteriorHandle> accessor,
+            TExteriorHandle exteriorHandle)
+            where TInteriorHandle : SafeInteriorHandle
+            where TExteriorHandle : SafeHandle
+        {
+            TInteriorHandle interiorHandle = accessor(exteriorHandle);
+
+            if (!interiorHandle.IsInvalid)
+            {
+                interiorHandle.SetParent(exteriorHandle);
+            }
+
+            return interiorHandle;
+        }
+
+        internal static TInteriorHandle OpenInteriorHandle<TExteriorHandle, TArg1, TInteriorHandle>(
+            Func<TExteriorHandle, TArg1, TInteriorHandle> accessor,
+            TExteriorHandle exteriorHandle,
+            TArg1 arg1)
+            where TInteriorHandle : SafeInteriorHandle
+            where TExteriorHandle : SafeHandle
+        {
+            TInteriorHandle interiorHandle = accessor(exteriorHandle, arg1);
+
+            if (!interiorHandle.IsInvalid)
+            {
+                interiorHandle.SetParent(exteriorHandle);
+            }
+
+            return interiorHandle;
+        }
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -97,3 +97,13 @@ extern "C" void Asn1StringFree(ASN1_STRING* a)
 {
     ASN1_STRING_free(a);
 }
+
+extern "C" int32_t GetAsn1IntegerDerSize(ASN1_INTEGER* i)
+{
+    return i2d_ASN1_INTEGER(i, nullptr);
+}
+
+extern "C" int32_t EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf)
+{
+    return i2d_ASN1_INTEGER(i, &buf);
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.h
@@ -83,3 +83,16 @@ extern "C" void Asn1OctetStringFree(ASN1_STRING* a);
 Direct shim to ASN1_STRING_free.
 */
 extern "C" void Asn1StringFree(ASN1_STRING* a);
+
+/*
+Returns the number of bytes it will take to convert
+the ASN1_INTEGER to a DER format.
+*/
+extern "C" int32_t GetAsn1IntegerDerSize(ASN1_INTEGER* i);
+
+/*
+Shims the i2d_ASN1_INTEGER method.
+
+Returns the number of bytes written to buf.
+*/
+extern "C" int32_t EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -99,8 +99,8 @@ namespace Internal.Cryptography.Pal
         {
             get
             {
-                IntPtr serialNumberPtr = Interop.Crypto.X509GetSerialNumber(_cert);
-                byte[] serial = Interop.Crypto.GetAsn1StringBytes(serialNumberPtr);
+                SafeSharedAsn1IntegerHandle serialNumber = Interop.Crypto.X509GetSerialNumber(_cert);
+                byte[] serial = Interop.Crypto.GetAsn1IntegerBytes(serialNumber);
 
                 // Windows returns this in BigInteger Little-Endian,
                 // OpenSSL returns this in BigInteger Big-Endian.

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -183,6 +183,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Print.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Print.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using Test.Cryptography;
 using Xunit;
 
@@ -31,7 +32,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void TestSerial()
+        public static void TestSerialBytes()
         {
             byte[] expectedSerialBytes = "b00000000100dd9f3bd08b0aaf11b000000033".HexToByteArray();
             string expectedSerialString = "33000000B011AF0A8BD03B9FDD0001000000B0";
@@ -42,6 +43,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(expectedSerialBytes, serial);
 
                 Assert.Equal(expectedSerialString, c.SerialNumber);
+            }
+        }
+
+        [Theory]
+        // Nice, normal serial number.
+        [InlineData("microsoft.cer", "2A98A8770374E7B34195EBE04D9B17F6")]
+        // Positive serial number which requires a padding byte to be interpreted positive.
+        [InlineData("test.cer", "00D01E4090000046520000000100000004")]
+        // Negative serial number.
+        //   RFC 2459: INTEGER
+        //   RFC 3280: INTEGER, MUST be positive.
+        //   RFC 5280: INTEGER, MUST be positive, MUST be 20 bytes or less.
+        //       Readers SHOULD handle negative values.
+        //       (Presumably readers also "should" handle long values created under the previous rules)
+        [InlineData("My.cer", "D5B5BC1C458A558845BFF51CB4DFF31C")]
+        public static void TestSerialString(string fileName, string expectedSerial)
+        {
+            using (var c = new X509Certificate2(Path.Combine("TestData", fileName)))
+            {
+                Assert.Equal(expectedSerial, c.SerialNumber);
             }
         }
 


### PR DESCRIPTION
Ensured that there's an explicit test for when this is required, and when it isn't.

Fixes #3893.

cc @stephentoub @AtsushiKan 