### PR TITLE
Add runtime directive for DbDataReader.GetFieldValue<T>

### DIFF
--- a/src/System.Data.Common/src/Resources/System.Data.Common.rd.xml
+++ b/src/System.Data.Common/src/Resources/System.Data.Common.rd.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- TODO there are probably more more directives necessary -->
+    <Type Name="System.Data.Common.DbDataReader">
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Byte" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Int16" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.UInt16" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Int32" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.UInt32" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Int64" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.UInt64" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.String" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Single" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Double" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Decimal" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.TimeSpan" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.DateTime" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.DateTimeOffset" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Guid" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Boolean" Dynamic="Required"/>
+      <MethodInstantiation Name="GetFieldValue" Arguments="System.Char" Dynamic="Required"/>
+    </Type>
+  </Library>
+</Directives>

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -43,5 +43,8 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Enables using this generic method on UWP apps where in some situations the netnative compiler leaves out the metadata.