### PR TITLE
Modified Collections perf tests to use ints

### DIFF
--- a/src/System.Collections/tests/Performance/Perf.Dictionary.cs
+++ b/src/System.Collections/tests/Performance/Perf.Dictionary.cs
@@ -10,26 +10,9 @@ namespace System.Collections.Tests
     public class Perf_Dictionary
     {
         /// <summary>
-        /// Creates a Dictionary of string-string with the specified number of pairs
-        /// </summary>
-        public static Dictionary<string, string> CreateDictionary(int size)
-        {
-            PerfUtils utils = new PerfUtils(837322);
-            Dictionary<string, string> dict = new Dictionary<string, string>();
-            while (dict.Count < size)
-            {
-                string key = utils.CreateString(50);
-                while (dict.ContainsKey(key))
-                    key = utils.CreateString(50);
-                dict.Add(key, utils.CreateString(50));
-            }
-            return dict;
-        }
-
-        /// <summary>
         /// Creates a Dictionary of int-int with the specified number of pairs
         /// </summary>
-        public static Dictionary<int, int> CreateDictionaryIntInt(int size)
+        public static Dictionary<int, int> CreateDictionary(int size)
         {
             Random rand = new Random(837322);
             Dictionary<int, int> dict = new Dictionary<int, int>();
@@ -48,7 +31,7 @@ namespace System.Collections.Tests
         [InlineData(100000)]
         public void Add(int size)
         {
-            Dictionary<int, int> dict = CreateDictionaryIntInt(size);
+            Dictionary<int, int> dict = CreateDictionary(size);
             foreach (var iteration in Benchmark.Iterations)
             {
                 Dictionary<int, int> copyDict = new Dictionary<int, int>(dict);
@@ -98,12 +81,12 @@ namespace System.Collections.Tests
         [InlineData(100000)]
         public void GetItem(int size)
         {
-            Dictionary<string, string> dict = CreateDictionary(size);
+            Dictionary<int, int> dict = CreateDictionary(size);
 
             // Setup
-            string retrieved;
+            int retrieved;
             for (int i = 1; i <= 9; i++)
-                dict.Add("key" + i, "value");
+                dict.Add(i, 0);
 
             // Actual perf testing
             foreach (var iteration in Benchmark.Iterations)
@@ -111,9 +94,9 @@ namespace System.Collections.Tests
                 using (iteration.StartMeasurement())
                     for (int i = 0; i <= 10000; i++)
                     {
-                        retrieved = dict["key1"]; retrieved = dict["key2"]; retrieved = dict["key3"];
-                        retrieved = dict["key4"]; retrieved = dict["key5"]; retrieved = dict["key6"];
-                        retrieved = dict["key7"]; retrieved = dict["key8"]; retrieved = dict["key9"];
+                        retrieved = dict[1]; retrieved = dict[2]; retrieved = dict[3];
+                        retrieved = dict[4]; retrieved = dict[5]; retrieved = dict[6];
+                        retrieved = dict[7]; retrieved = dict[8]; retrieved = dict[9];
                     }
             }
         }
@@ -124,10 +107,10 @@ namespace System.Collections.Tests
         [InlineData(100000)]
         public void SetItem(int size)
         {
-            Dictionary<string, string> dict = CreateDictionary(size);
+            Dictionary<int, int> dict = CreateDictionary(size);
             // Setup
             for (int i = 1; i <= 9; i++)
-                dict.Add("key" + i, "value");
+                dict.Add(i, 0);
 
             // Actual perf testing
             foreach (var iteration in Benchmark.Iterations)
@@ -135,9 +118,9 @@ namespace System.Collections.Tests
                 using (iteration.StartMeasurement())
                     for (int i = 0; i <= 10000; i++)
                     {
-                        dict["key1"] = "string"; dict["key2"] = "string"; dict["key3"] = "string";
-                        dict["key4"] = "string"; dict["key5"] = "string"; dict["key6"] = "string";
-                        dict["key7"] = "string"; dict["key8"] = "string"; dict["key9"] = "string";
+                        dict[1] = 0; dict[2] = 0; dict[3] = 0;
+                        dict[4] = 0; dict[5] = 0; dict[6] = 0;
+                        dict[7] = 0; dict[8] = 0; dict[9] = 0;
                     }
             }
         }
@@ -148,8 +131,8 @@ namespace System.Collections.Tests
         [InlineData(100000)]
         public void GetKeys(int size)
         {
-            Dictionary<string, string> dict = CreateDictionary(size);
-            IEnumerable<string> result;
+            Dictionary<int, int> dict = CreateDictionary(size);
+            IEnumerable<int> result;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i <= 20000; i++)
@@ -166,12 +149,12 @@ namespace System.Collections.Tests
         [InlineData(100000)]
         public void TryGetValue(int size)
         {
-            Dictionary<string, string> dict = CreateDictionary(size);
+            Dictionary<int, int> dict = CreateDictionary(size);
             // Setup - utils needs a specific seed to prevent key collision with TestData
-            string retrieved;
-            PerfUtils utils = new PerfUtils(56334);
-            string key = utils.CreateString(50);
-            dict.Add(key, "value");
+            int retrieved;
+            Random rand = new Random(837322);
+            int key = rand.Next(0, 400000);
+            dict.Add(key, 12);
 
             // Actual perf testing
             foreach (var iteration in Benchmark.Iterations)
@@ -191,12 +174,12 @@ namespace System.Collections.Tests
         [InlineData(100000)]
         public void ContainsKey(int size)
         {
-            Dictionary<string, string> dict = CreateDictionary(size);
+            Dictionary<int, int> dict = CreateDictionary(size);
 
             // Setup - utils needs a specific seed to prevent key collision with TestData
-            PerfUtils utils = new PerfUtils(152891);
-            string key = utils.CreateString(50);
-            dict.Add(key, "value");
+            Random rand = new Random(837322);
+            int key = rand.Next(0, 400000);
+            dict.Add(key, 12);
 
             // Actual perf testing
             foreach (var iteration in Benchmark.Iterations)

--- a/src/System.Collections/tests/Performance/Perf.List.cs
+++ b/src/System.Collections/tests/Performance/Perf.List.cs
@@ -14,10 +14,10 @@ namespace System.Collections.Tests
         /// </summary>
         public static List<object> CreateList(int size)
         {
-            PerfUtils utils = new PerfUtils(24565653);
+            Random rand = new Random(24565653);
             List<object> list = new List<object>();
             for (int i = 0; i < size; i++)
-                list.Add(utils.CreateString(100));
+                list.Add(rand.Next());
             return list;
         }
 
@@ -35,8 +35,8 @@ namespace System.Collections.Tests
                 {
                     for (int i = 0; i < 10000; i++)
                     {
-                        copyList.Add("TestString1"); copyList.Add("TestString2"); copyList.Add("TestString3"); copyList.Add("TestString4");
-                        copyList.Add("TestString5"); copyList.Add("TestString6"); copyList.Add("TestString7"); copyList.Add("TestString8");
+                        copyList.Add(123555); copyList.Add(123555); copyList.Add(123555); copyList.Add(123555);
+                        copyList.Add(123555); copyList.Add(123555); copyList.Add(123555); copyList.Add(123555);
                     }
                 }
             }


### PR DESCRIPTION
The perf results for the Collections tests were being affected by the performance of the String Equals/GetHashCode methods. I've modified the tests to use ints so that the overhead of string comparison is taken out of the measurement.

@stephentoub 