### PR TITLE
Enable System.Console.ReadKey

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal unsafe static extern int ReadStdinUnbuffered(byte* buffer, int bufferSize);
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.ReadConsoleInput.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.ReadConsoleInput.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal const short KEY_EVENT = 1;
+
+    // Windows's KEY_EVENT_RECORD
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct KeyEventRecord
+    {
+        internal bool keyDown;
+        internal short repeatCount;
+        internal short virtualKeyCode;
+        internal short virtualScanCode;
+        internal char uChar; // Union between WCHAR and ASCII char
+        internal int controlKeyState;
+    }
+
+    // Really, this is a union of KeyEventRecords and other types.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct InputRecord
+    {
+        internal short eventType;
+        internal KeyEventRecord keyEvent;
+        // This struct is a union!  Word alighment should take care of padding!
+    }
+
+
+    internal partial class mincore
+    {
+        
+        [DllImport(Libraries.Console_L1, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "ReadConsoleInputW")]
+        internal static extern bool ReadConsoleInput(IntPtr hConsoleInput, out InputRecord buffer, int numInputRecords_UseOne, out int numEventsRead);
+
+    }
+}

--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -19,6 +19,11 @@
 #cmakedefine01 HAVE_SCHED_SETAFFINITY
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
+#cmakedefine01 HAVE_TCGETATTR
+#cmakedefine01 HAVE_TCSETATTR
+#cmakedefine01 HAVE_ECHO
+#cmakedefine01 HAVE_ICANON
+#cmakedefine01 HAVE_TCSANOW
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -5,6 +5,7 @@
 
 #include "pal_types.h"
 #include <dirent.h>
+#include <termios.h>
 
 /**
  * File status returned by Stat or FStat.
@@ -23,7 +24,7 @@ struct FileStatus
 };
 
 /*
- * Window Size of the terminal
+* Window Size of the terminal
 */
 struct WinSize
 {
@@ -636,3 +637,8 @@ extern "C" int32_t GetWindowSize(WinSize* windowsSize);
  * otherwise returns 0 and sets errno.
  */
 extern "C" int32_t IsATty(int filedes);
+
+/**
+ * Reads stdin in non-echo and non-canonical mode.
+*/
+extern "C" int32_t ReadStdinUnbuffered(void* buffer, int32_t bufferSize);

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -50,6 +50,29 @@ check_symbol_exists(
     "sys/ioctl.h"
     HAVE_TIOCGWINSZ)
 
+check_function_exists(
+    tcgetattr
+    HAVE_TCGETATTR)
+
+check_function_exists(
+    tcsetattr
+    HAVE_TCSETATTR)
+
+check_symbol_exists(
+    ECHO
+    "termios.h"
+    HAVE_ECHO)
+
+check_symbol_exists(
+    ICANON
+    "termios.h"
+    HAVE_ICANON)
+
+check_symbol_exists(
+    TCSANOW
+    "termios.h"
+    HAVE_TCSANOW)
+
 check_struct_has_member(
     "struct stat"
     st_birthtime

--- a/src/System.Console/ref/System.Console.cs
+++ b/src/System.Console/ref/System.Console.cs
@@ -23,6 +23,8 @@ namespace System
         public static System.IO.Stream OpenStandardInput() { return default(System.IO.Stream); }
         public static System.IO.Stream OpenStandardOutput() { return default(System.IO.Stream); }
         public static int Read() { return default(int); }
+        public static ConsoleKeyInfo ReadKey() { return default(ConsoleKeyInfo); }
+        public static ConsoleKeyInfo ReadKey(bool intercept) { return default(ConsoleKeyInfo); }
         public static string ReadLine() { return default(string); }
         public static void ResetColor() { }
         public static void SetError(System.IO.TextWriter newError) { }
@@ -94,6 +96,173 @@ namespace System
         Red = 12,
         White = 15,
         Yellow = 14,
+    }
+    public partial struct ConsoleKeyInfo
+    {
+        public ConsoleKeyInfo(char keyChar, ConsoleKey key, bool shift, bool alt, bool control) { }
+        public char KeyChar { get { return default(char); } }
+        public ConsoleKey Key { get { return default(ConsoleKey); } }
+        public ConsoleModifiers Modifiers { get { return default(ConsoleModifiers); ; } }
+    }
+    public enum ConsoleKey
+    {
+        Backspace = 0x8,
+        Tab = 0x9,
+        Clear = 0xC,
+        Enter = 0xD,
+        Pause = 0x13,
+        Escape = 0x1B,
+        Spacebar = 0x20,
+        PageUp = 0x21,
+        PageDown = 0x22,
+        End = 0x23,
+        Home = 0x24,
+        LeftArrow = 0x25,
+        UpArrow = 0x26,
+        RightArrow = 0x27,
+        DownArrow = 0x28,
+        Select = 0x29,
+        Print = 0x2A,
+        Execute = 0x2B,
+        PrintScreen = 0x2C,
+        Insert = 0x2D,
+        Delete = 0x2E,
+        Help = 0x2F,
+        D0 = 0x30,  // 0 through 9
+        D1 = 0x31,
+        D2 = 0x32,
+        D3 = 0x33,
+        D4 = 0x34,
+        D5 = 0x35,
+        D6 = 0x36,
+        D7 = 0x37,
+        D8 = 0x38,
+        D9 = 0x39,
+        A = 0x41,
+        B = 0x42,
+        C = 0x43,
+        D = 0x44,
+        E = 0x45,
+        F = 0x46,
+        G = 0x47,
+        H = 0x48,
+        I = 0x49,
+        J = 0x4A,
+        K = 0x4B,
+        L = 0x4C,
+        M = 0x4D,
+        N = 0x4E,
+        O = 0x4F,
+        P = 0x50,
+        Q = 0x51,
+        R = 0x52,
+        S = 0x53,
+        T = 0x54,
+        U = 0x55,
+        V = 0x56,
+        W = 0x57,
+        X = 0x58,
+        Y = 0x59,
+        Z = 0x5A,
+#if TODO
+        LeftWindows = 0x5B,  // Microsoft Natural keyboard
+        RightWindows = 0x5C,  // Microsoft Natural keyboard
+        Applications = 0x5D,  // Microsoft Natural keyboard
+#endif
+        Sleep = 0x5F,
+        NumPad0 = 0x60,
+        NumPad1 = 0x61,
+        NumPad2 = 0x62,
+        NumPad3 = 0x63,
+        NumPad4 = 0x64,
+        NumPad5 = 0x65,
+        NumPad6 = 0x66,
+        NumPad7 = 0x67,
+        NumPad8 = 0x68,
+        NumPad9 = 0x69,
+        Multiply = 0x6A,
+        Add = 0x6B,
+        Separator = 0x6C,
+        Subtract = 0x6D,
+        Decimal = 0x6E,
+        Divide = 0x6F,
+        F1 = 0x70,
+        F2 = 0x71,
+        F3 = 0x72,
+        F4 = 0x73,
+        F5 = 0x74,
+        F6 = 0x75,
+        F7 = 0x76,
+        F8 = 0x77,
+        F9 = 0x78,
+        F10 = 0x79,
+        F11 = 0x7A,
+        F12 = 0x7B,
+        F13 = 0x7C,
+        F14 = 0x7D,
+        F15 = 0x7E,
+        F16 = 0x7F,
+        F17 = 0x80,
+        F18 = 0x81,
+        F19 = 0x82,
+        F20 = 0x83,
+        F21 = 0x84,
+        F22 = 0x85,
+        F23 = 0x86,
+        F24 = 0x87,
+#if TODO
+        BrowserBack = 0xA6,  // Windows 2000/XP
+        BrowserForward = 0xA7,  // Windows 2000/XP
+        BrowserRefresh = 0xA8,  // Windows 2000/XP
+        BrowserStop = 0xA9,  // Windows 2000/XP
+        BrowserSearch = 0xAA,  // Windows 2000/XP
+        BrowserFavorites = 0xAB,  // Windows 2000/XP
+        BrowserHome = 0xAC,  // Windows 2000/XP
+        VolumeMute = 0xAD,  // Windows 2000/XP
+        VolumeDown = 0xAE,  // Windows 2000/XP
+        VolumeUp = 0xAF,  // Windows 2000/XP
+        MediaNext = 0xB0,  // Windows 2000/XP
+        MediaPrevious = 0xB1,  // Windows 2000/XP
+        MediaStop = 0xB2,  // Windows 2000/XP
+        MediaPlay = 0xB3,  // Windows 2000/XP
+        LaunchMail = 0xB4,  // Windows 2000/XP
+        LaunchMediaSelect = 0xB5,  // Windows 2000/XP
+        LaunchApp1 = 0xB6,  // Windows 2000/XP
+        LaunchApp2 = 0xB7,  // Windows 2000/XP
+#endif
+        Oem1 = 0xBA,
+        OemPlus = 0xBB,
+        OemComma = 0xBC,
+        OemMinus = 0xBD,
+        OemPeriod = 0xBE,
+        Oem2 = 0xBF,
+        Oem3 = 0xC0,
+        Oem4 = 0xDB,
+        Oem5 = 0xDC,
+        Oem6 = 0xDD,
+        Oem7 = 0xDE,
+        Oem8 = 0xDF,
+#if TODO
+        Oem102 = 0xE2,  // Win2K/XP: Either angle or backslash on RT 102-key keyboard
+        Process = 0xE5,  // Windows: IME Process Key
+        Packet = 0xE7,  // Win2K/XP: Used to pass Unicode chars as if keystrokes
+        Attention = 0xF6,
+        CrSel = 0xF7,
+        ExSel = 0xF8,
+        EraseEndOfFile = 0xF9,
+        Play = 0xFA,
+        Zoom = 0xFB,
+        NoName = 0xFC,  // Reserved
+        Pa1 = 0xFD,
+        OemClear = 0xFE,
+#endif
+    }
+    [Flags]
+    public enum ConsoleModifiers
+    {
+        Alt = 1,
+        Shift = 2,
+        Control = 4
     }
     public enum ConsoleSpecialKey
     {

--- a/src/System.Console/src/Resources/Strings.resx
+++ b/src/System.Console/src/Resources/Strings.resx
@@ -204,10 +204,16 @@
   <data name="InvalidOperation_PrintF" xml:space="preserve">
     <value>The printf operation failed.</value>
   </data>
+  <data name="InvalidOperation_ConsoleReadKeyOnFile" xml:space="preserve">
+    <value>Cannot read keys when either application does not have a console or when console input has been redirected from a file. Try Console.Read.</value>
+  </data>
   <data name="PlatformNotSupported_GettingColor" xml:space="preserve">
     <value>This platform does not support getting the current color.</value>
   </data>
   <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
     <value>The home directory of the current user could not be determined.</value>
+  </data>
+  <data name="ArgumentOutOfRange_ConsoleKey" xml:space="preserve">
+    <value>Console key values must be between 0 and 255.</value>
   </data>
 </root>

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -27,6 +27,9 @@
     <Compile Include="System\ConsoleCancelEventArgs.cs" />
     <Compile Include="System\ConsoleColor.cs" />
     <Compile Include="System\ConsoleSpecialKey.cs" />
+    <Compile Include="System\ConsoleKey.cs" />
+    <Compile Include="System\ConsoleKeyInfo.cs" />
+    <Compile Include="System\ConsoleModifiers.cs" />
     <Compile Include="System\IO\ConsoleStream.cs" />
     <Compile Include="System\IO\SyncTextReader.cs" />
     <Compile Include="System\IO\SyncTextWriter.cs" />
@@ -83,6 +86,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.ReadConsole.cs">
       <Link>Common\Interop\Windows\Interop.ReadConsole.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.ReadConsoleInput.cs">
+      <Link>Common\Interop\Windows\Interop.ReadConsoleInput.cs</Link>
+    </Compile>
 	<Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetConsoleCtrlHandler.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleCtrlHandler.cs</Link>
     </Compile>
@@ -110,6 +116,8 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\ConsolePal.Unix.cs" />
+	<Compile Include="System\IO\StdInStreamReader.cs" />
+    <Compile Include="System\IO\SyncTextReader.Unix.cs" />
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>
     </Compile>
@@ -178,6 +186,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetWindowWidth.cs">
       <Link>Common\Interop\Unix\Interop.GetWindowWidth.cs"</Link>
+    </Compile>
+	<Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ReadStdinUnbuffered.cs">
+      <Link>Common\Interop\Unix\Interop.ReadStdinUnbuffered.cs"</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -39,17 +39,19 @@ namespace System
             {
                 return Volatile.Read(ref _in) ?? EnsureInitialized(ref _in, () =>
                 {
-                    Stream inputStream = OpenStandardInput();
-                    return SyncTextReader.GetSynchronizedTextReader(inputStream == Stream.Null ?
-                        StreamReader.Null :
-                        new StreamReader(
-                            stream: inputStream,
-                            encoding: ConsolePal.InputEncoding,
-                            detectEncodingFromByteOrderMarks: false,
-                            bufferSize: DefaultConsoleBufferSize,
-                            leaveOpen: true));
+                    return ConsolePal.In;
                 });
             }
+        }
+
+        public static ConsoleKeyInfo ReadKey()
+        {
+            return ConsolePal.ReadKey(false);
+        }
+
+        public static ConsoleKeyInfo ReadKey(bool intercept)
+        {
+            return ConsolePal.ReadKey(intercept);
         }
 
         public static TextWriter Out

--- a/src/System.Console/src/System/ConsoleKey.cs
+++ b/src/System.Console/src/System/ConsoleKey.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System
+{
+
+    public enum ConsoleKey
+    {
+        Backspace = 0x8,
+        Tab = 0x9,
+        Clear = 0xC,
+        Enter = 0xD,
+        Pause = 0x13,
+        Escape = 0x1B,
+        Spacebar = 0x20,
+        PageUp = 0x21,
+        PageDown = 0x22,
+        End = 0x23,
+        Home = 0x24,
+        LeftArrow = 0x25,
+        UpArrow = 0x26,
+        RightArrow = 0x27,
+        DownArrow = 0x28,
+        Select = 0x29,
+        Print = 0x2A,
+        Execute = 0x2B,
+        PrintScreen = 0x2C,
+        Insert = 0x2D,
+        Delete = 0x2E,
+        Help = 0x2F,
+        D0 = 0x30,  // 0 through 9
+        D1 = 0x31,
+        D2 = 0x32,
+        D3 = 0x33,
+        D4 = 0x34,
+        D5 = 0x35,
+        D6 = 0x36,
+        D7 = 0x37,
+        D8 = 0x38,
+        D9 = 0x39,
+        A = 0x41,
+        B = 0x42,
+        C = 0x43,
+        D = 0x44,
+        E = 0x45,
+        F = 0x46,
+        G = 0x47,
+        H = 0x48,
+        I = 0x49,
+        J = 0x4A,
+        K = 0x4B,
+        L = 0x4C,
+        M = 0x4D,
+        N = 0x4E,
+        O = 0x4F,
+        P = 0x50,
+        Q = 0x51,
+        R = 0x52,
+        S = 0x53,
+        T = 0x54,
+        U = 0x55,
+        V = 0x56,
+        W = 0x57,
+        X = 0x58,
+        Y = 0x59,
+        Z = 0x5A,
+#if TODO
+        LeftWindows = 0x5B,  // Microsoft Natural keyboard
+        RightWindows = 0x5C,  // Microsoft Natural keyboard
+        Applications = 0x5D,  // Microsoft Natural keyboard
+#endif
+        Sleep = 0x5F,  // Computer Sleep Key
+        NumPad0 = 0x60,
+        NumPad1 = 0x61,
+        NumPad2 = 0x62,
+        NumPad3 = 0x63,
+        NumPad4 = 0x64,
+        NumPad5 = 0x65,
+        NumPad6 = 0x66,
+        NumPad7 = 0x67,
+        NumPad8 = 0x68,
+        NumPad9 = 0x69,
+        Multiply = 0x6A,
+        Add = 0x6B,
+        Separator = 0x6C,
+        Subtract = 0x6D,
+        Decimal = 0x6E,
+        Divide = 0x6F,
+        F1 = 0x70,
+        F2 = 0x71,
+        F3 = 0x72,
+        F4 = 0x73,
+        F5 = 0x74,
+        F6 = 0x75,
+        F7 = 0x76,
+        F8 = 0x77,
+        F9 = 0x78,
+        F10 = 0x79,
+        F11 = 0x7A,
+        F12 = 0x7B,
+        F13 = 0x7C,
+        F14 = 0x7D,
+        F15 = 0x7E,
+        F16 = 0x7F,
+        F17 = 0x80,
+        F18 = 0x81,
+        F19 = 0x82,
+        F20 = 0x83,
+        F21 = 0x84,
+        F22 = 0x85,
+        F23 = 0x86,
+        F24 = 0x87,
+#if TODO
+        BrowserBack = 0xA6,  // Windows 2000/XP
+        BrowserForward = 0xA7,  // Windows 2000/XP
+        BrowserRefresh = 0xA8,  // Windows 2000/XP
+        BrowserStop = 0xA9,  // Windows 2000/XP
+        BrowserSearch = 0xAA,  // Windows 2000/XP
+        BrowserFavorites = 0xAB,  // Windows 2000/XP
+        BrowserHome = 0xAC,  // Windows 2000/XP
+        VolumeMute = 0xAD,  // Windows 2000/XP
+        VolumeDown = 0xAE,  // Windows 2000/XP
+        VolumeUp = 0xAF,  // Windows 2000/XP
+        MediaNext = 0xB0,  // Windows 2000/XP
+        MediaPrevious = 0xB1,  // Windows 2000/XP
+        MediaStop = 0xB2,  // Windows 2000/XP
+        MediaPlay = 0xB3,  // Windows 2000/XP
+        LaunchMail = 0xB4,  // Windows 2000/XP
+        LaunchMediaSelect = 0xB5,  // Windows 2000/XP
+        LaunchApp1 = 0xB6,  // Windows 2000/XP
+        LaunchApp2 = 0xB7,  // Windows 2000/XP
+#endif
+        Oem1 = 0xBA,  // Misc characters, varies by keyboard. For US standard, ;:
+        OemPlus = 0xBB,  // Misc characters, varies by keyboard. For US standard, +
+        OemComma = 0xBC,  // Misc characters, varies by keyboard. For US standard, ,
+        OemMinus = 0xBD,  // Misc characters, varies by keyboard. For US standard, -
+        OemPeriod = 0xBE,  // Misc characters, varies by keyboard. For US standard, .
+        Oem2 = 0xBF,  // Misc characters, varies by keyboard. For US standard, /?
+        Oem3 = 0xC0,  // Misc characters, varies by keyboard. For US standard, `~
+        Oem4 = 0xDB,  // Misc characters, varies by keyboard. For US standard, [{
+        Oem5 = 0xDC,  // Misc characters, varies by keyboard. For US standard, \|
+        Oem6 = 0xDD,  // Misc characters, varies by keyboard. For US standard, ]}
+        Oem7 = 0xDE,  // Misc characters, varies by keyboard. For US standard,
+        Oem8 = 0xDF,  // Used for miscellaneous characters; it can vary by keyboard
+#if TODO
+        Oem102 = 0xE2,  // Win2K/XP: Either angle or backslash on RT 102-key keyboard
+        Process = 0xE5,  // Windows: IME Process Key
+        Packet = 0xE7,  // Win2K/XP: Used to pass Unicode chars as if keystrokes
+        Attention = 0xF6,
+        CrSel = 0xF7,
+        ExSel = 0xF8,
+        EraseEndOfFile = 0xF9,
+        Play = 0xFA,
+        Zoom = 0xFB,
+        NoName = 0xFC,  // Reserved
+        Pa1 = 0xFD,
+        OemClear = 0xFE,
+#endif
+    }
+}
+
+

--- a/src/System.Console/src/System/ConsoleKeyInfo.cs
+++ b/src/System.Console/src/System/ConsoleKeyInfo.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ 
+namespace System
+{
+    public partial struct ConsoleKeyInfo
+    {
+        private char _keyChar;
+        private ConsoleKey _key;
+        private ConsoleModifiers _mods;
+
+        public ConsoleKeyInfo(char keyChar, ConsoleKey key, bool shift, bool alt, bool control)
+        {
+            // Limit ConsoleKey values to 0 to 255, but don't check whether the
+            // key is a valid value in our ConsoleKey enum.  There are a few 
+            // values in that enum that we didn't define, and reserved keys 
+            // that might start showing up on keyboards in a few years.
+            if (((int)key) < 0 || ((int)key) > 255)
+            {
+                throw new ArgumentOutOfRangeException("key", SR.ArgumentOutOfRange_ConsoleKey);
+            }
+
+            _keyChar = keyChar;
+            _key = key;
+            _mods = 0;
+            if (shift)
+                _mods |= ConsoleModifiers.Shift;
+            if (alt)
+                _mods |= ConsoleModifiers.Alt;
+            if (control)
+                _mods |= ConsoleModifiers.Control;
+        }
+
+        public char KeyChar
+        {
+            get { return _keyChar; }
+        }
+
+        public ConsoleKey Key
+        {
+            get { return _key; }
+        }
+
+        public ConsoleModifiers Modifiers
+        {
+            get { return _mods; }
+        }
+
+        public override bool Equals(Object value)
+        {
+            if (value is ConsoleKeyInfo)
+                return Equals((ConsoleKeyInfo)value);
+            else
+                return false;
+        }
+
+        public bool Equals(ConsoleKeyInfo obj)
+        {
+            return obj._keyChar == _keyChar && obj._key == _key && obj._mods == _mods;
+        }
+
+        public static bool operator ==(ConsoleKeyInfo a, ConsoleKeyInfo b)
+        {
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(ConsoleKeyInfo a, ConsoleKeyInfo b)
+        {
+            return !(a == b);
+        }
+
+        public override int GetHashCode()
+        {
+            return (int)_keyChar | (int)_mods;
+        }
+    }
+}
+
+
+

--- a/src/System.Console/src/System/ConsoleModifiers.cs
+++ b/src/System.Console/src/System/ConsoleModifiers.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System
+{
+    [Flags]
+    public enum ConsoleModifiers
+    {
+        Alt = 1,
+        Shift = 2,
+        Control = 4
+    }
+}

--- a/src/System.Console/src/System/IO/StdInStreamReader.cs
+++ b/src/System.Console/src/System/IO/StdInStreamReader.cs
@@ -1,0 +1,350 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace System.IO
+{
+    /* This class is used by for reading from the stdin.
+     * It is designed to read stdin in raw mode for interpreting
+     * key press events and maintain its own buffer for the same.
+     * which is then used for all the Read operations
+     */
+    internal class StdInStreamReader : StreamReader
+    {
+        char[] unprocessedBufferToBeRead; // Buffer that might have already been read from stdin but not yet processed.
+        const int bytesToBeRead = 255; // No. of bytes to be read from the stream at a time.
+        int startIndex; // First unprocessed index in the buffer;
+        int endIndex; // Last unprocessed index in the buffer;
+
+        internal StdInStreamReader(Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize, bool leaveOpen) : base(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen)
+        {
+            unprocessedBufferToBeRead = new char[encoding.GetMaxCharCount(bufferSize)];
+            startIndex = endIndex = -1; // There is no unprocessed index yet.
+        }
+
+        /// <summary> Checks whether the unprocessed buffer is empty. </summary>
+        bool IsExtraBufferEmpty()
+        {
+            if (startIndex == -1 && endIndex == -1) return true;
+
+            if (startIndex > endIndex) // Everything has been processed;
+            {
+                startIndex = -1;
+                endIndex = -1;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary> Reads the buffer in the raw mode. </summary>
+        unsafe void ReadExtraBuffer()
+        {
+            Debug.Assert(IsExtraBufferEmpty());
+
+            byte[] buffer = new byte[bytesToBeRead];
+            fixed (byte* bufPtr = buffer)
+            {
+                int result;
+                Interop.CheckIo(result = Interop.Sys.ReadStdinUnbuffered((byte*)bufPtr, bytesToBeRead));
+                Debug.Assert(result <= bytesToBeRead);
+
+                // Now we need to convert the byte buffer to char buffer.
+                int charCount = CurrentEncoding.GetMaxCharCount(result);
+                Debug.Assert(charCount < unprocessedBufferToBeRead.Length);
+
+                CurrentEncoding.GetChars(buffer, 0, buffer.Length, unprocessedBufferToBeRead, ++startIndex);
+                endIndex += charCount;
+
+            }
+        }
+
+        public override string ReadLine()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            //Check if there is anything left in the unprocessedBufferToBeRead.
+            while (!IsExtraBufferEmpty())
+            {
+                ConsoleKeyInfo keyInfo = ReadKeyInternal();
+
+                if (keyInfo.Key == ConsoleKey.Enter)
+                    return sb.ToString();
+
+                else if (keyInfo.Key == ConsoleKey.Backspace && sb.Length > 0)
+                    sb.Length--;
+
+                if (keyInfo.KeyChar != '\0') // We ignore all non-printable keys
+                    sb.Append(keyInfo.KeyChar);
+            }
+
+            return sb.Append(base.ReadLine()).ToString();
+        }
+
+
+        public override int Read()
+        {
+            int x;
+
+            // Convert byte to char.
+            if (IsExtraBufferEmpty())
+            {
+                x = base.Read();
+            }
+            else
+            {
+                x = (int)unprocessedBufferToBeRead[startIndex++];
+            }
+
+            return x;
+        }
+
+        internal ConsoleKey GetKeyFromCharValue(ref char x, out bool isShift, out bool isCtrl)
+        {
+            isShift = false;
+            isCtrl = false;
+
+            switch (x)
+            {
+                case '\b':
+                    x = '\0'; // Non-printable character.
+                    return ConsoleKey.Backspace;
+
+                case '\t':
+                    x = '\0'; // Non-printable character.
+                    return ConsoleKey.Tab;
+
+                case (char)(int)(0x0A):
+                    x = '\0'; // Non-printable character.
+                    return ConsoleKey.Enter;
+
+                case (char)(int)(0x1B):
+                    x = '\0'; // Non-printable character.
+                    return ConsoleKey.Escape;
+
+                case (char)(int)(0x2A): return ConsoleKey.Multiply;
+
+                case (char)(int)(0x2B): return ConsoleKey.Add;
+
+                case (char)(int)(0x2D): return ConsoleKey.Subtract;
+
+                case (char)(int)(0x2F): return ConsoleKey.Divide;
+
+                case (char)(int)(0x2E): return ConsoleKey.Decimal;
+
+                case (char)(int)(0x7F):
+                    x = '\0'; // Non-printable character.
+                    return ConsoleKey.Delete;
+
+                case (char)(int)(0x20): return ConsoleKey.Spacebar;
+
+                case (char)(int)(0x21):
+                    isShift = true;
+                    return ConsoleKey.D1;
+                    
+                case (char)(int)(0x40):
+                    isShift = true;
+                    return ConsoleKey.D2;
+
+                case (char)(int)(0x23):
+                    isShift = true;
+                    return ConsoleKey.D3;
+
+                case (char)(int)(0x24):
+                    isShift = true;
+                    return ConsoleKey.D4;
+
+                case (char)(int)(0x25):
+                    isShift = true;
+                    return ConsoleKey.D5;
+
+                case (char)(int)(0x5E):
+                    isShift = true;
+                    return ConsoleKey.D6;
+
+                case (char)(int)(0x26):
+                    isShift = true;
+                    return ConsoleKey.D7;
+
+                case (char)(int)(0x28):
+                    isShift = true;
+                    return ConsoleKey.D9;
+
+                case (char)(int)(0x29):
+                    isShift = true;
+                    return ConsoleKey.D0;
+
+                case (char)(int)(0x60): return ConsoleKey.Oem3;
+
+                case (char)(int)(0x7E):
+                    isShift = true;
+                    return ConsoleKey.Oem3;
+
+                case (char)(int)(0x5B): return ConsoleKey.Oem4;
+
+                case (char)(int)(0x7B): 
+                    isShift = true;
+                    return ConsoleKey.Oem4;
+
+                case (char)(int)(0x5D): return ConsoleKey.Oem6;
+
+                case (char)(int)(0x7D):
+                    isShift = true;
+                    return ConsoleKey.Oem6;
+
+                case (char)(int)(0x3B): return ConsoleKey.Oem1;
+
+                case (char)(int)(0x3A):
+                    isShift = true;
+                    return ConsoleKey.Oem1;
+
+                case (char)(int)(0x27): return ConsoleKey.Oem7;
+
+                case (char)(int)(0x22):
+                    isShift = true;
+                    return ConsoleKey.Oem7;
+
+                case (char)(int)(0x2C): return ConsoleKey.OemComma;
+
+                case (char)(int)(0x3C):
+                    isShift = true;
+                    return ConsoleKey.OemComma;
+
+                case (char)(int)(0x3D): return ConsoleKey.OemPlus;
+
+                case (char)(int)(0x5F): return ConsoleKey.OemMinus;
+
+                case (char)(int)(0x3E): return ConsoleKey.OemPeriod;
+
+                case (char)(int)(0x3F):
+                    isShift = true;
+                    return ConsoleKey.Oem2;
+
+                case (char)(int)(0x5C): return ConsoleKey.Oem5;
+
+                case (char)(int)(0x7C):
+                    isShift = true;
+                    return ConsoleKey.Oem5;
+
+                default:
+                    // 1. Ctrl A to Ctrl Z.
+                    if (x >= 1 && x <= 26)
+                    {
+                        isCtrl = true;
+                        return ConsoleKey.A + x - 1;
+                    }
+
+                    // 2. Numbers from 0 to 9.
+                    if (x >= '0' && x <= '9')
+                    {
+                        return ConsoleKey.D0 + x - '0';
+                    }
+
+                    //3. A to Z
+                    if (x >= 'A' && x <= 'Z')
+                    {
+                        isShift = true;
+                        return ConsoleKey.A + (x - 'A');
+                    }
+
+                    // 4. a to z.
+                    if (x >= 'a' && x <= 'z')
+                    {
+                        return ConsoleKey.A + (x - 'a');
+                    }
+
+                    break;
+            }
+
+            return default(ConsoleKey);
+        }
+
+        internal bool TryMapBufferToConsoleKey(out ConsoleKey key, out char ch, out bool isShift, out bool isAlt, out bool isCtrl)
+        {
+            Debug.Assert(!IsExtraBufferEmpty());
+
+            isAlt = isCtrl = isShift = false;
+            int keyLength;
+
+            // 1. Try to get the special key match from the TermInfo static information.
+            if (ConsolePal.TryGetSpecialConsoleKey(unprocessedBufferToBeRead, startIndex, endIndex, out key, out keyLength))
+            {
+                startIndex += keyLength;
+                ch = '\0'; //Special keys are non-printable.
+                return true;
+            }
+
+            // 1. Check if we can match Esc + combination and guess if alt was pressed.
+            if (isAlt == false && unprocessedBufferToBeRead[startIndex] == (char)(int)(0x1B) /*Alt is send as an escape character*/ && endIndex - startIndex + 1 >= 2 /*We have at least two characters to read.*/)
+            {
+                isAlt = true; // Since the alt is pressed.
+                startIndex++;
+                if (TryMapBufferToConsoleKey(out key, out ch, out isShift, out isAlt, out isCtrl))
+                {
+                    isAlt = true;
+                    return true;
+                }
+                else
+                {
+                    // We could not find a matching key here so, Alt+ combination assumption is in-correct.
+                    // The current key needs to be marked as Esc key.
+                    // Also, we do not increment startIndex as we already did it.
+                    key = ConsoleKey.Escape;
+                    ch = (char)(int)(0x1B);
+                    isAlt = false;
+                    return true;
+                }
+            }
+
+            // Try reading the first char in the buffer and interpret it as a key.
+            ch = unprocessedBufferToBeRead[startIndex++];
+            key = GetKeyFromCharValue(ref ch, out isShift, out isCtrl);
+            return key != (ConsoleKey)0;
+
+        }
+
+        internal ConsoleKeyInfo ReadKeyInternal()
+        {
+            ConsoleKey key;
+            char ch;
+            bool isAlt, isCtrl, isShift;
+
+            if (IsExtraBufferEmpty())
+            {
+                ReadExtraBuffer();
+            }
+
+            if(TryMapBufferToConsoleKey(out key, out ch, out isShift, out isAlt, out isCtrl))
+            {
+                return new ConsoleKeyInfo(ch, key, isShift, isAlt, isCtrl);
+            }
+
+            return default(ConsoleKeyInfo);
+        }
+
+
+        /// <summary> Try to intercept the key pressed. </summary>
+        public ConsoleKeyInfo ReadKey()
+        {
+            ConsoleKeyInfo keyInfo = default(ConsoleKeyInfo);
+            do
+            {
+                /* Unlike Windows Unix has no concept of virtual key codes.
+                 * Hence, in case we do not recognize a key, we can't really get the ConsoleKey
+                 * key code associated with it.
+                 * As a result, we try to recognize the key, and if that does not work,
+                 * we simply ignore and try to get the next batch of bytes and match them.
+                 */
+                keyInfo = ReadKeyInternal();
+            } while (keyInfo == default(ConsoleKeyInfo));
+
+            return keyInfo;
+        }
+    }
+}

--- a/src/System.Console/src/System/IO/SyncTextReader.Unix.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.Unix.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /* SyncTextReader intentionally locks on itself rather than a private lock object.
+     * This is done to synchronize different console readers(Issue#2855).
+     */
+    internal sealed partial class SyncTextReader : TextReader
+    {
+        public ConsoleKeyInfo ReadKey()
+        {
+            lock (this)
+            {
+                Debug.Assert(_in is StdInStreamReader);
+
+                return ((StdInStreamReader)_in).ReadKey();
+            }
+        }
+    }
+}

--- a/src/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.cs
@@ -11,7 +11,7 @@ namespace System.IO
     /* SyncTextReader intentionally locks on itself rather than a private lock object.
      * This is done to synchronize different console readers(Issue#2855).
      */
-    internal sealed class SyncTextReader : TextReader
+    internal sealed partial class SyncTextReader : TextReader
     {
         internal readonly TextReader _in;
 

--- a/src/System.Console/src/project.json
+++ b/src/System.Console/src/project.json
@@ -5,6 +5,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Tools": "4.0.0",
     "System.Globalization": "4.0.10",
+    "System.Linq": "4.0.0",
     "System.IO": "4.0.10",
     "System.IO.FileSystem.Primitives": "4.0.0",
     "System.Reflection": "4.0.10",

--- a/src/System.Console/src/project.lock.json
+++ b/src/System.Console/src/project.lock.json
@@ -89,6 +89,22 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
       "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
@@ -474,6 +490,39 @@
         "System.IO.FileSystem.Primitives.4.0.0.nupkg",
         "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
         "System.IO.FileSystem.Primitives.nuspec"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.4.0.0.nupkg",
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
@@ -870,6 +919,7 @@
       "System.Diagnostics.Debug >= 4.0.10",
       "System.Diagnostics.Tools >= 4.0.0",
       "System.Globalization >= 4.0.10",
+      "System.Linq >= 4.0.0",
       "System.IO >= 4.0.10",
       "System.IO.FileSystem.Primitives >= 4.0.0",
       "System.Reflection >= 4.0.10",


### PR DESCRIPTION
This change tries to enable #1153.

On Windows the implementation is pretty straight-forward. We have APIs to capture the standard input and APIs that tell us the kind of key and modifier is pressed. 

On Unix, there is no concept of virtual key codes and so, the implementation is mostly best case effort. 
The current implementation works as follows.
1. Capture stdin in the raw mode and reads as much of buffer as possible (max = 255 bytes).
2. Try to match the buffer with any of the special keys which it maintains in the db from the static string capabilities from TermInfo.
3. If not, it simply tries to use the ASCII key chart and map it to an equivalent ConsoleKey.

It also tries to second guess the modifier keys as follows
1. Alt - This is captured as esc key, so, we try to check if at the time of processing we can a combination of ESC + known key and if so, we assume alt was pressed.
2. Ctrl - Other than the known keys like \b \t and \n, the rest of the ASCII key charts from 1 to 26 are considered typed with Ctrl + the alphabet.
3. Shift - Any capital A to Z are assumed to be pressed with Shift key.

Not all keys are captured by this logic. For example, on my keyboard, NumLock + No. key results in a byte sequence, that can't be mapped to the no. itself. So, Unix implementation can never return ConsoleKey.NumPadX, Similarly combinations of Alt+FunctionKeys can't be interpreted correctly and are interpreted as Esc + the individual keys. Since not all key presses can be mapped to the correct ConsoleKey, the implementation tries to ignore 1 byte in case it can't be mapped to anything and continue to interpret the next byte. This is done because (ConsoleKey)0 is invalid. So, even if we can get the int representation of the byte being processed, we can't really create a valid ConsoleKeyInfo from it.