### PR TITLE
native: Adds check for header

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -210,6 +210,7 @@ case $OSName in
 
     FreeBSD)
         __HostOS=FreeBSD
+        __TestNugetRuntimeId=osx.10.10-x64
         ;;
 
     *)

--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -19,6 +19,7 @@
 #cmakedefine01 HAVE_SCHED_SETAFFINITY
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
+#cmakedefine01 HAVE_ALLOCA_H
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -5,6 +5,7 @@
 #include "pal_networking.h"
 #include "pal_utilities.h"
 
+#include <stdlib.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -12,10 +13,13 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-#include <alloca.h>
 #include <errno.h>
 #include <assert.h>
 #include <vector>
+
+#if HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
 
 #if !defined(IPV6_ADD_MEMBERSHIP) && defined(IPV6_JOIN_GROUP)
 #define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
@@ -124,12 +128,16 @@ static int32_t ConvertGetAddrInfoAndGetNameInfoErrorsToPal(int32_t error)
             return PAL_EAI_AGAIN;
         case EAI_BADFLAGS:
             return PAL_EAI_BADFLAGS;
+#ifdef EAI_FAIL
         case EAI_FAIL:
             return PAL_EAI_FAIL;
+#endif
         case EAI_FAMILY:
             return PAL_EAI_FAMILY;
         case EAI_NONAME:
+#ifdef EAI_NODATA
         case EAI_NODATA:
+#endif
             return PAL_EAI_NONAME;
     }
 

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -1,13 +1,18 @@
-include(CheckFunctionExists)
-include(CheckStructHasMember)
 include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
+include(CheckFunctionExists)
+include(CheckIncludeFiles)
 include(CheckPrototypeDefinition)
+include(CheckStructHasMember)
 include(CheckSymbolExists)
 
 #CMake does not include /usr/local/include into the include search path
 #thus add it manually. This is required on FreeBSD.
 include_directories(SYSTEM /usr/local/include)
+
+check_include_files(
+    alloca.h
+    HAVE_ALLOCA_H)
 
 check_function_exists(
     stat64


### PR DESCRIPTION
`<alloca.h>` is not available on FreeBSD, instead `stdlib.h` has
`alloca()` defined.
Also added check for `EAI_NODATA` and `EAI_FAIL`, as those are
considered obsolete in FreeBSD.