### PR TITLE
Compute the fallback value for FindBySubjectKeyIdentifier when needed.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -137,6 +137,12 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative)]
         internal static extern SafeX509CrlHandle PemReadBioX509Crl(SafeBioHandle bio);
 
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int GetX509SubjectPublicKeyInfoDerSize(SafeX509Handle x509);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int EncodeX509SubjectPublicKeyInfo(SafeX509Handle x509, byte[] buf);
+
         internal enum X509VerifyStatusCode : int
         {
             X509_V_OK = 0,

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -3,6 +3,7 @@
 
 #include "pal_x509.h"
 
+#include <assert.h>
 #include <openssl/pem.h>
 #include <openssl/x509v3.h>
 
@@ -251,4 +252,26 @@ extern "C" int32_t PemWriteBioX509Crl(BIO* bio, X509_CRL* crl)
 extern "C" X509_CRL* PemReadBioX509Crl(BIO* bio)
 {
     return PEM_read_bio_X509_CRL(bio, nullptr, nullptr, nullptr);
+}
+
+extern "C" int32_t GetX509SubjectPublicKeyInfoDerSize(X509* x509)
+{
+    if (!x509)
+    {
+        return 0;
+    }
+
+    // X509_get_X509_PUBKEY returns an interior pointer, so should not be freed
+    return i2d_X509_PUBKEY(X509_get_X509_PUBKEY(x509), nullptr);
+}
+
+extern "C" int32_t EncodeX509SubjectPublicKeyInfo(X509* x509, uint8_t* buf)
+{
+    if (!x509)
+    {
+        return 0;
+    }
+
+    // X509_get_X509_PUBKEY returns an interior pointer, so should not be freed
+    return i2d_X509_PUBKEY(X509_get_X509_PUBKEY(x509), &buf);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -262,3 +262,16 @@ Shims the PEM_read_bio_X509_CRL method.
 The new X509_CRL instance.
 */
 extern "C" X509_CRL* PemReadBioX509Crl(BIO* bio);
+
+/*
+Returns the number of bytes it will take to convert the SubjectPublicKeyInfo
+portion of the X509 to DER format.
+*/
+extern "C" int32_t GetX509SubjectPublicKeyInfoDerSize(X509* x);
+
+/*
+Shims the i2d_X509_PUBKEY method, providing X509_get_X509_PUBKEY(x) as the input.
+
+Returns the number of bytes written to buf.
+*/
+extern "C" int32_t EncodeX509SubjectPublicKeyInfo(X509* x, uint8_t* buf);

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -588,8 +588,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3099, PlatformID.AnyUnix)]
-        public static void TestBySubjectKeyIdentifier_MatchA()
+        public static void TestBySubjectKeyIdentifier_UsingFallback()
         {
             RunSingleMatchTest_PfxCer(
                 X509FindType.FindBySubjectKeyIdentifier,
@@ -611,7 +610,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("597 1A6 5A3 34D DA9 807 80F F84 1EB E87 F97 232 41F 2")]
         // Non-symmetric whitespace is allowed
         [InlineData("    5971A65   A334DDA980780FF84  1EBE87F97           23241F   2")]
-        public static void TestBySubjectKeyIdentifier_MatchB(string subjectKeyIdentifier)
+        public static void TestBySubjectKeyIdentifier_ExtensionPresent(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
         }
@@ -625,7 +624,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 p9 72 32 41 F2")]
         // Compat: A non-hex character as the low nybble makes the whole byte FF.
         [InlineData("59 71 A6 5A 33 4D DA 98 07 80 0p 84 1E BE 87 F9 72 32 41 F2")]
-        public static void TestBySubjectKeyIdentifier_MatchB_Compat(string subjectKeyIdentifier)
+        public static void TestBySubjectKeyIdentifier_Compat(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
         }


### PR DESCRIPTION
The Windows CryptoAPI method that FindBySubjectKeyIdentifier defers to has documented fallback logic that, happily, a test was testing.

Updated the names of the tests to better identify what they're accomplishing, and implemented the fallback logic described.

Fixes #3935.