### PR TITLE
Use DerSequenceReader instead of marshalling for the SubjectKeyIdentifier.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -187,12 +187,8 @@ namespace Internal.Cryptography.Pal
 
         internal static byte[] DecodeX509SubjectKeyIdentifierExtension(byte[] encoded)
         {
-            using (SafeAsn1OctetStringHandle octetString = Interop.Crypto.DecodeAsn1OctetString(encoded, encoded.Length))
-            {
-                Interop.Crypto.CheckValidOpenSslHandle(octetString);
-
-                return Interop.Crypto.GetAsn1StringBytes(octetString.DangerousGetHandle());
-            }
+            DerSequenceReader reader = DerSequenceReader.CreateForPayload(encoded);
+            return reader.ReadOctetString();
         }
 
         public byte[] ComputeCapiSha1OfPublicKey(PublicKey key)


### PR DESCRIPTION
Across several sets of 1,000,000 calls this change reduces the total time by about 26%, mostly because it doesn't send data to native to read it right back. (DER Octet String decoding is just "skip the tag and length").

Data acquisition:
```C#
[Fact]
public static void SubjectKeyIdentifierPerf()
{
    byte[] skid = "04145971a65a334dda980780ff841ebe87f9723241f2".HexToByteArray();
    AsnEncodedData skidAsn1 = new AsnEncodedData(skid);
    Stopwatch stopwatch = Stopwatch.StartNew();
            
    for (int i = 0; i < 1000000; i++)
    {
        X509SubjectKeyIdentifierExtension skidExtension = new X509SubjectKeyIdentifierExtension(skidAsn1, false);
        Assert.Equal("5971A65A334DDA980780FF841EBE87F9723241F2", skidExtension.SubjectKeyIdentifier);
    }

    stopwatch.Stop();
    Assert.Equal(0, stopwatch.ElapsedMilliseconds);
}
```
During execution the `-method` argument was passed to xunit to ensure no other tests were interfering with results.

Before (ms): 5948, 5689, 4725, 6103, 5164
Before (ms, average): 5525

After (ms): 4253, 4192, 4207, 3900, 3857
After (ms, average): 4081

`4081 / 5525` = `0.73864...`, so about a 26% reduction in time.
