### PR TITLE
native: Check if in_pktinfo exists

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -32,6 +32,7 @@
 #cmakedefine01 HAVE_ECHO
 #cmakedefine01 HAVE_ICANON
 #cmakedefine01 HAVE_TCSANOW
+#cmakedefine01 HAVE_IN_PKTINFO
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -27,6 +27,17 @@
 #include <unistd.h>
 #include <vector>
 
+#if !HAVE_IN_PKTINFO
+// On platforms, such as FreeBSD, where in_pktinfo
+// is not available, fallback to custom definition
+// with required members.
+struct in_pktinfo
+{
+    in_addr ipi_addr;
+};
+#define IP_PKTINFO IP_RECVDSTADDR
+#endif
+
 #if !defined(IPV6_ADD_MEMBERSHIP) && defined(IPV6_JOIN_GROUP)
 #define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
 #endif
@@ -1055,7 +1066,15 @@ static int32_t GetIPv4PacketInformation(cmsghdr* controlMessage, IPPacketInforma
 
     auto* pktinfo = reinterpret_cast<in_pktinfo*>(CMSG_DATA(controlMessage));
     ConvertInAddrToByteArray(&packetInfo->Address.Address[0], NUM_BYTES_IN_IPV4_ADDRESS, pktinfo->ipi_addr);
+#if HAVE_IN_PKTINFO
     packetInfo->InterfaceIndex = static_cast<int32_t>(pktinfo->ipi_ifindex);
+#else
+    // TODO: Figure out how to get interface index with in_addr.
+    // One option is http://www.unix.com/man-page/freebsd/3/if_nametoindex
+    // which requires interface name to be known.
+    // Meanwhile:
+    packetInfo->InterfaceIndex = 0;
+#endif
 
     return 1;
 }

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -5,10 +5,30 @@ include(CheckIncludeFiles)
 include(CheckPrototypeDefinition)
 include(CheckStructHasMember)
 include(CheckSymbolExists)
+include(CheckTypeSize)
 
 #CMake does not include /usr/local/include into the include search path
 #thus add it manually. This is required on FreeBSD.
 include_directories(SYSTEM /usr/local/include)
+
+# in_pktinfo: Find whether this struct exists
+check_include_files(
+    linux/in.h
+    HAVE_LINUX_IN_H)
+
+if (HAVE_LINUX_IN_H)
+    set (SOCKET_INCLUDES ${SOCKET_INCLUDES} linux/in.h)
+else ()
+    set (SOCKET_INCLUDES ${SOCKET_INCLUDES} netinet/in.h)
+endif ()
+
+set(CMAKE_EXTRA_INCLUDE_FILES ${SOCKET_INCLUDES})
+check_type_size(
+    "struct in_pktinfo"
+    HAVE_IN_PKTINFO
+    BUILTIN_TYPES_ONLY)
+set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
+# /in_pktinfo
 
 check_include_files(
     alloca.h


### PR DESCRIPTION
If it does not exist, `typedef in_addr in_pktinfo`.

Same question as I asked [under the outdated commit](https://github.com/jasonwilliams200OK/corefx/commit/f49a9069e9db9447095fb39fb86bb948b48a12e2#commitcomment-13833233):

> @nguerrera, @pgavlin, @sokket,
>
With this change (`typedef`'ing `int_add` as `in_pktinfo`), native builds on FreeBSD.
This makes me wonder, given `int_add` is more POSIX-y than `in_pktinfo` (which encapsulates an `int_add` typed member), should we just use `int_addr` and dump `in_pkginfo`, if we only *really* need `in_pktinfo` at one instance to get the interface index? We can then probably get interface index by making some(?) syscall.

Note that even BSDs aren't same. I configured NetBSD 7.0 amd64 VM today and found that `in_pktinfo` is defined in `netinet/in.h` header (but not on FreeBSD). On Ubuntu 14 (LTS), `in_pkinfo` is forward declared in `netinet/in.h`, but the actual definition lives in `linux/in.h` and so forth..
Nevertheless, this feature detection approach is working out quite well (much better than OS detection).

---

Disclaimer / Credits:
I have taken some inspirations from OpenVPN for this work: https://github.com/OpenVPN/openvpn/search?utf8=✓&q=HAVE_IN_PKTINFO. They are using autoconfig; I translated ac constructs to corresponding cmake ones.