### PR TITLE
native: Disable unreachable rule for clang v3.4

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -20,6 +20,10 @@ add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/Common)
 add_compile_options(-I${CMAKE_CURRENT_BINARY_DIR}/Common)
 add_compile_options(-Wno-c99-extensions)
 
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
+    add_compile_options(-Wno-unreachable-code)
+endif ()
+
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
     add_definitions(-DBIT64=1)
 elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)


### PR DESCRIPTION
The latest EPEL provisioned version of Clang on CentOS 7 is v3.4.2.
On compiling native binaries, I was getting the following error:

```bash
/home/root/corefx/src/Native/System.Native/pal_process.cpp:439:25: error: will never be executed
      [-Werror,-Wunreachable-code]
        for (size_t i = sizeof(native); i < sizeof(pal); i++)
                        ^~~~~~~~~~~~~~
1 error generated.
make[2]: *** [System.Native/CMakeFiles/System.Native.dir/pal_process.cpp.o] Error 1
make[1]: *** [System.Native/CMakeFiles/System.Native.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

The fix was to disable the rule for Clang version less thant 3.5.

This was the only stopper.