### PR TITLE
Correct the spelling of OpenSslEncode

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
             // So to ensure we're getting a set of bytes compatible with BigInteger (though with the
             // wrong endianness here), DER encode it, then use the DER reader to skip past the tag
             // and length.
-            byte[] derEncoded = OpenSslEnocde(
+            byte[] derEncoded = OpenSslEncode(
                 handle => GetAsn1IntegerDerSize(handle),
                 (handle, buf) => EncodeAsn1Integer(handle, buf),
                 asn1Integer);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Encode.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Encode.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 
         internal delegate int EncodeFunc<in THandle>(THandle handle, byte[] buf);
 
-        internal static byte[] OpenSslEnocde<THandle>(GetEncodedSizeFunc<THandle> getSize, EncodeFunc<THandle> encode, THandle handle)
+        internal static byte[] OpenSslEncode<THandle>(GetEncodedSizeFunc<THandle> getSize, EncodeFunc<THandle> encode, THandle handle)
             where THandle : SafeHandle
         {
             int size = getSize(handle);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
@@ -122,7 +122,7 @@ namespace Internal.Cryptography.Pal
                         throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 
-                    return Interop.Crypto.OpenSslEnocde(
+                    return Interop.Crypto.OpenSslEncode(
                         Interop.Crypto.GetPkcs12DerSize,
                         Interop.Crypto.EncodePkcs12,
                         pkcs12);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
@@ -266,7 +266,7 @@ namespace Internal.Cryptography.Pal
 
                         using (HashAlgorithm hash = SHA1.Create())
                         {
-                            byte[] publicKeyInfoBytes = Interop.Crypto.OpenSslEnocde(
+                            byte[] publicKeyInfoBytes = Interop.Crypto.OpenSslEncode(
                                 Interop.Crypto.GetX509SubjectPublicKeyInfoDerSize,
                                 Interop.Crypto.EncodeX509SubjectPublicKeyInfo,
                                 certPal.SafeHandle);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -138,7 +138,7 @@ namespace Internal.Cryptography.Pal
         {
             get
             {
-                return Interop.Crypto.OpenSslEnocde(
+                return Interop.Crypto.OpenSslEncode(
                     Interop.Crypto.GetX509DerSize,
                     Interop.Crypto.EncodeX509,
                     _cert);


### PR DESCRIPTION
`OpenSslEnocde` => `OpenSslEncode` :smile:

cc: @stephentoub @eerhardt 