### PR TITLE
Make Unix X509Certificate2(PFX) prefer a cert with a private key.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -281,6 +281,11 @@ namespace Internal.Cryptography.Pal
                     {
                         first = certPal;
                     }
+                    else if (certPal.HasPrivateKey && !first.HasPrivateKey)
+                    {
+                        first.Dispose();
+                        first = certPal;
+                    }
                     else
                     {
                         certPal.Dispose();

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -476,7 +476,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3099, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_Decimal()
         {
             // Decimal string is an allowed input format.
@@ -486,7 +485,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3099, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_DecimalLeadingZeros()
         {
             // Checking that leading zeros are ignored.
@@ -507,7 +505,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3099, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_Hex()
         {
             // Hex string is also an allowed input format.
@@ -517,7 +514,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3099, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_HexIgnoreCase()
         {
             // Hex string is also an allowed input format and case-blind
@@ -527,7 +523,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3099, PlatformID.AnyUnix)]
         public static void TestBySerialNumber_HexLeadingZeros()
         {
             // Checking that leading zeros are ignored.

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -24,6 +24,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void EnsurePrivateKeyPreferred()
+        {
+            using (var cert = new X509Certificate2(TestData.ChainPfxBytes, TestData.ChainPfxPassword))
+            {
+                // While checking cert.HasPrivateKey first is most matching of the test description, asserting
+                // on the certificate's simple name will provide a more diagnosable failure.
+                Assert.Equal("test.local", cert.GetNameInfo(X509NameType.SimpleName, false));
+                Assert.True(cert.HasPrivateKey, "cert.HasPrivateKey");
+            }
+        }
+
+        [Fact]
         public static void TestRawData()
         {
             byte[] expectedRawData = (


### PR DESCRIPTION
The Unix implementation returned back essentially the value of X509Certificate2Collection(PFX)[0].  The Windows version was more nuanced, returning the first value with a private key, or the first value if nothing had a private key.  The Unix version now matches that behavior.

Fixes #3099.