### PR TITLE
Fix some IntPtr == null vs IntPtr.Zero checks

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -97,10 +97,7 @@ internal static partial class Interop
 
         internal static string GetX509RootStorePath()
         {
-            IntPtr ptr = GetX509RootStorePath_private();
-            return ptr != null ?
-                Marshal.PtrToStringAnsi(ptr) :
-                null;
+            return Marshal.PtrToStringAnsi(GetX509RootStorePath_private());
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509RootStorePath")]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -128,10 +128,7 @@ internal static partial class Interop
 
         internal static string GetX509VerifyCertErrorString(X509VerifyStatusCode n)
         {
-            IntPtr ptr = X509VerifyCertErrorString(n);
-            return ptr != null ?
-                Marshal.PtrToStringAnsi(ptr) :
-                null;
+            return Marshal.PtrToStringAnsi(X509VerifyCertErrorString(n));
         }
 
         [DllImport(Libraries.CryptoNative)]


### PR DESCRIPTION
I happened to spot one of these while working on one of my outstanding issues; then while trying to find it for a clean PR (remembering it involved Marshal.PtrToString) I saw a second.

cc: @stephentoub @eerhardt 