### PR TITLE
Throw PNSE instead of NIE on machine X509Store not-supported functionality

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -136,9 +136,7 @@ namespace Internal.Cryptography.Pal
 
             if (openFlags.HasFlag(OpenFlags.ReadWrite))
             {
-                // TODO (#2206): Support CurrentUser persisted stores
-                // (they'd not be very useful without the ability to add/remove content)
-                throw new NotImplementedException();
+                throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresReadOnly);
             }
 
             // The static store approach here is making an optimization based on not
@@ -165,8 +163,7 @@ namespace Internal.Cryptography.Pal
                 return CloneStore(s_machineIntermediateStore);
             }
 
-            // TODO (#2207): Support the rest of the stores, or throw PlatformNotSupportedException.
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresRootOnly);
         }
 
         private static IStorePal SingleCertToStorePal(ICertificatePal singleCert)

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -168,6 +168,12 @@
   <data name="Cryptography_InvalidStoreHandle" xml:space="preserve">
     <value>The store handle is invalid.</value>
   </data>
+  <data name="Cryptography_Unix_X509_MachineStoresReadOnly" xml:space="preserve">
+    <value>Unix LocalMachine X509Stores are read-only for all users.</value>
+  </data>
+  <data name="Cryptography_Unix_X509_MachineStoresRootOnly" xml:space="preserve">
+    <value>Unix LocalMachine X509Store is limited to the Root and CertificateAuthority stores.</value>
+  </data>
   <data name="Cryptography_X509_ExportFailed" xml:space="preserve">
     <value>The certificate export operation failed.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -135,5 +135,46 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.ThrowsAny<CryptographicException>(() => store.Remove(cert));
             }
         }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void OpenMachineMyStore_Supported()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine))
+            {
+                store.Open(OpenFlags.ReadOnly);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void OpenMachineMyStore_NotSupported()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => store.Open(OpenFlags.ReadOnly));
+            }
+        }
+
+        [Theory]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [InlineData(OpenFlags.ReadOnly, false)]
+        [InlineData(OpenFlags.MaxAllowed, false)]
+        [InlineData(OpenFlags.ReadWrite, true)]
+        public static void OpenMachineRootStore_Permissions(OpenFlags permissions, bool shouldThrow)
+        {
+            using (X509Store store = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
+            {
+                if (shouldThrow)
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => store.Open(permissions));
+                }
+                else
+                {
+                    // Assert.DoesNotThrow
+                    store.Open(permissions);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Supporting LocalMachine stores is complicated, and tracked by #3690.  Since that isn't something likely to be fixed by 1.0-rtm, replace the placeholder NotImplementedExceptions with PlatformNotSupportedExceptions.

Fixes #2207. (#2206 was fixed a long time ago, that comment was stale)