### PR TITLE
Correctly space expression variable name in catch block expression ToString

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -758,9 +758,10 @@ namespace System.Linq.Expressions
         protected override CatchBlock VisitCatchBlock(CatchBlock node)
         {
             Out("catch (" + node.Test.Name);
-            if (node.Variable != null)
+            if (node.Variable != null && !string.IsNullOrEmpty(node.Variable.Name))
             {
-                Out(node.Variable.Name ?? "");
+                Out(' ');
+                Out(node.Variable.Name);
             }
             Out(") { ... }");
             return node;

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -501,7 +501,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
-        [ActiveIssue(3957)]
         public void NamedExceptionCatchToString()
         {
             CatchBlock cb = Expression.Catch(Expression.Variable(typeof(TestException), "ex"), Expression.Empty());


### PR DESCRIPTION
Fixes #3957

Temporarily based upon branch of #3959. Will separate out when possible.