### PR TITLE
1st shims for the LibSsl library.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     // Initialization of libssl threading support is done in a static constructor.
     // This enables a project simply to include this file, and any usage of any of
-    // the libssl functions will trigger initialization of the threading support.
+    // the libssl or Crypto functions will trigger initialization of the threading support.
 
     internal static partial class libssl
     {
@@ -18,11 +18,18 @@ internal static partial class Interop
         }
     }
 
+    internal static partial class Crypto
+    {
+        static partial void InitializeSsl()
+        {
+            SslInitializer.Initialize();
+        }
+    }
+
     internal static class SslInitializer
     {
         static SslInitializer()
         {
-
             CryptoInitializer.Initialize();
 
             //Call ssl specific initializer

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -24,7 +24,10 @@ internal static partial class Interop
         static Crypto()
         {
             CryptoInitializer.Initialize();
+            InitializeSsl();
         }
+
+        static partial void InitializeSsl();
     } 
 
     internal static class CryptoInitializer

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern IntPtr SslV2_3Method();
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern IntPtr SslV3Method();
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern IntPtr TlsV1Method();
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern IntPtr TlsV1_1Method();
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern IntPtr TlsV1_2Method();
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern libssl.SafeSslContextHandle SslCtxCreate(IntPtr method);
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static unsafe extern int SslWrite(libssl.SafeSslHandle ssl, byte* buf, int num);
+
+        [DllImport(Interop.Libraries.CryptoNative)]
+        internal static extern int SslRead(libssl.SafeSslHandle ssl, byte[] buf, int num);
+
+        // NOTE: this is just an (unsafe) overload to the BioWrite method from Interop.Bio.cs.
+        [DllImport(Libraries.CryptoNative)]
+        internal static unsafe extern int BioWrite(SafeBioHandle b, byte* data, int len);
+    }
+}

--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -25,7 +25,7 @@ internal static partial class Interop
 
             IntPtr method = GetSslMethod(isServer, options);
 
-            using (libssl.SafeSslContextHandle innerContext = new libssl.SafeSslContextHandle(method))
+            using (libssl.SafeSslContextHandle innerContext = Crypto.SslCtxCreate(method))
             {
                 if (innerContext.IsInvalid)
                 {
@@ -47,8 +47,8 @@ internal static partial class Interop
                 {
                     Debug.Assert(isServer, "isServer flag should be true");
                     libssl.SSL_CTX_set_verify(innerContext,
-                        (int) libssl.ClientCertOption.SSL_VERIFY_PEER |
-                        (int) libssl.ClientCertOption.SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                        (int)libssl.ClientCertOption.SSL_VERIFY_PEER |
+                        (int)libssl.ClientCertOption.SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                         s_verifyClientCertificate);
 
                     //update the client CA list 
@@ -67,13 +67,13 @@ internal static partial class Interop
             return context;
         }
 
-        internal static bool DoSslHandshake(SafeSslHandle context, IntPtr recvPtr, int recvCount, out IntPtr sendPtr, out int sendCount)
+        internal static bool DoSslHandshake(SafeSslHandle context, byte[] recvBuf, int recvOffset, int recvCount, out byte[] sendBuf, out int sendCount)
         {
-            sendPtr = IntPtr.Zero;
+            sendBuf = null;
             sendCount = 0;
-            if ((IntPtr.Zero != recvPtr) && (recvCount > 0))
+            if ((recvBuf != null) && (recvCount > 0))
             {
-                BioWrite(context.InputBio, recvPtr, recvCount);
+                BioWrite(context.InputBio, recvBuf, recvOffset, recvCount);
             }
 
             libssl.SslErrorCode error;
@@ -93,32 +93,39 @@ internal static partial class Interop
 
             if (sendCount > 0)
             {
-                sendPtr = Marshal.AllocHGlobal(sendCount);
+                sendBuf = new byte[sendCount];
 
                 try
                 {
-                    sendCount = BioRead(context.OutputBio, sendPtr, sendCount);
+                    sendCount = BioRead(context.OutputBio, sendBuf, sendCount);
                 }
                 finally
                 {
                     if (sendCount <= 0)
                     {
-                        Marshal.FreeHGlobal(sendPtr);
-                        sendPtr = IntPtr.Zero;
+                        sendBuf = null;
                         sendCount = 0;
                     }
                 }
             }
-        
+
             return ((libssl.SSL_state(context) == (int)libssl.SslState.SSL_ST_OK));
 
         }
 
-        internal static int Encrypt(SafeSslHandle context, IntPtr buffer, int offset, int count, int bufferCapacity, out libssl.SslErrorCode errorCode)
+        internal static int Encrypt(SafeSslHandle context, byte[] buffer, int offset, int count, int bufferCapacity, out libssl.SslErrorCode errorCode)
         {
             errorCode = libssl.SslErrorCode.SSL_ERROR_NONE;
 
-            int retVal = libssl.SSL_write(context, new IntPtr(buffer.ToInt64() + offset), count);
+            int retVal;
+            unsafe
+            {
+                fixed (byte* fixedBuffer = buffer)
+                {
+                    retVal = Crypto.SslWrite(context, fixedBuffer + offset, count);
+                }
+            }
+
             if (retVal != count)
             {
                 errorCode = GetSslError(context, retVal);
@@ -148,15 +155,15 @@ internal static partial class Interop
             return retVal;
         }
 
-        internal static int Decrypt(SafeSslHandle context, IntPtr outBufferPtr, int count, out libssl.SslErrorCode errorCode)
+        internal static int Decrypt(SafeSslHandle context, byte[] outBuffer, int count, out libssl.SslErrorCode errorCode)
         {
             errorCode = libssl.SslErrorCode.SSL_ERROR_NONE;
 
-            int retVal = BioWrite(context.InputBio, outBufferPtr, count);
+            int retVal = BioWrite(context.InputBio, outBuffer, 0, count);
 
             if (retVal == count)
             {
-                retVal = libssl.SSL_read(context, outBufferPtr, retVal);
+                retVal = Crypto.SslRead(context, outBuffer, retVal);
 
                 if (retVal > 0)
                 {
@@ -172,7 +179,7 @@ internal static partial class Interop
                 switch (errorCode)
                 {
                     // indicate end-of-file
-                    case libssl.SslErrorCode.SSL_ERROR_ZERO_RETURN:                      
+                    case libssl.SslErrorCode.SSL_ERROR_ZERO_RETURN:
                         break;
 
                     case libssl.SslErrorCode.SSL_ERROR_WANT_READ:
@@ -310,7 +317,7 @@ internal static partial class Interop
                 //Enumerate Certificates from LocalMachine and CurrentUser root store 
                 AddX509Names(nameStack, StoreLocation.LocalMachine, issuerNameHashSet);
                 AddX509Names(nameStack, StoreLocation.CurrentUser, issuerNameHashSet);
-                
+
                 libssl.SSL_CTX_set_client_CA_list(context, nameStack);
 
                 // The handle ownership has been transferred into the CTX.
@@ -364,9 +371,9 @@ internal static partial class Interop
         }
 
         //TODO (Issue #3362) should we check Bio should retry?
-        private static int BioRead(SafeBioHandle bio, IntPtr buffer, int count)
+        private static int BioRead(SafeBioHandle bio, byte[] buffer, int count)
         {
-            int bytes = libssl.BIO_read(bio, buffer, count);
+            int bytes = Crypto.BioRead(bio, buffer, count);
             if (bytes != count)
             {
                 throw CreateSslException(SR.net_ssl_read_bio_failed_error);
@@ -375,14 +382,17 @@ internal static partial class Interop
         }
 
         //TODO (Issue #3362) should we check Bio should retry?
-        private static int BioWrite(SafeBioHandle bio, IntPtr buffer, int count)
+        private static unsafe int BioWrite(SafeBioHandle bio, byte[] buffer, int offset, int count)
         {
-            int bytes = libssl.BIO_write(bio, buffer, count);
-            if (bytes != count)
+            fixed (byte* bufPtr = buffer)
             {
-                throw CreateSslException(SR.net_ssl_write_bio_failed_error);
+                int bytes = Crypto.BioWrite(bio, bufPtr + offset, count);
+                if (bytes != count)
+                {
+                    throw CreateSslException(SR.net_ssl_write_bio_failed_error);
+                }
+                return bytes;
             }
-            return bytes;
         }
 
         private static libssl.SslErrorCode GetSslError(SafeSslHandle context, int result)
@@ -451,7 +461,7 @@ internal static partial class Interop
         {
             return CreateSslException(message, libssl.SSL_get_error(context, error));
         }
-    
+
         #endregion
 
         #region Internal class

--- a/src/Common/src/Interop/Unix/libssl/Interop.SafeSslHandle.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.SafeSslHandle.cs
@@ -12,10 +12,9 @@ internal static partial class Interop
     {
         internal sealed class SafeSslContextHandle : SafeHandle
         {
-            public SafeSslContextHandle(IntPtr method)
+            private SafeSslContextHandle()
                 : base(IntPtr.Zero, true)
             {
-                handle = SSL_CTX_new(method);
             }
 
             public override bool IsInvalid
@@ -26,6 +25,7 @@ internal static partial class Interop
             protected override bool ReleaseHandle()
             {
                 SSL_CTX_free(handle);
+                SetHandle(IntPtr.Zero);
                 return true;
             }
         }

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl.cs
@@ -11,24 +11,6 @@ internal static partial class Interop
     internal static partial class libssl
     {
         [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr SSLv23_method();
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr SSLv3_method();
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr TLSv1_method();
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr TLSv1_1_method();
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr TLSv1_2_method();
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern IntPtr SSL_CTX_new(IntPtr meth);
-
-        [DllImport(Interop.Libraries.LibSsl)]
         internal static extern long SSL_CTX_ctrl(SafeSslContextHandle ctx, int cmd, long larg, IntPtr parg);
 
         [DllImport(Interop.Libraries.LibSsl)]
@@ -56,12 +38,6 @@ internal static partial class Interop
         internal static extern void SSL_set_accept_state(SafeSslHandle ssl);
 
         [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern int SSL_write(SafeSslHandle ssl, IntPtr buf, int num);
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern int SSL_read(SafeSslHandle ssl, IntPtr buf, int num);
-
-        [DllImport(Interop.Libraries.LibSsl)]
         internal static extern int SSL_renegotiate_pending(SafeSslHandle ssl);
 
         [DllImport(Interop.Libraries.LibSsl)]
@@ -75,12 +51,6 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern int SSL_state(SafeSslHandle ssl);
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern int BIO_read(SafeBioHandle bio, IntPtr buf, int num);
-
-        [DllImport(Interop.Libraries.LibSsl)]
-        internal static extern int BIO_write(SafeBioHandle bio, IntPtr buf, int num);
 
         [DllImport(Interop.Libraries.LibSsl)]
         internal static extern SafeX509Handle SSL_get_peer_certificate(SafeSslHandle ssl);

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
@@ -59,11 +59,11 @@ internal static partial class Interop
 
         internal static class SslMethods
         {
-            internal static readonly IntPtr TLSv1_method = libssl.TLSv1_method();
-            internal static readonly IntPtr TLSv1_1_method = libssl.TLSv1_1_method();
-            internal static readonly IntPtr TLSv1_2_method = libssl.TLSv1_2_method();
-            internal static readonly IntPtr SSLv3_method = libssl.SSLv3_method();
-            internal static readonly IntPtr SSLv23_method = libssl.SSLv23_method();
+            internal static readonly IntPtr TLSv1_method = Crypto.TlsV1Method();
+            internal static readonly IntPtr TLSv1_1_method = Crypto.TlsV1_1Method();
+            internal static readonly IntPtr TLSv1_2_method = Crypto.TlsV1_2Method();
+            internal static readonly IntPtr SSLv3_method = Crypto.SslV3Method();
+            internal static readonly IntPtr SSLv23_method = Crypto.SslV2_3Method();
 
 #if DEBUG
             static SslMethods()

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
@@ -69,8 +69,9 @@ internal static partial class Interop
             static SslMethods()
             {
                 Debug.Assert(TLSv1_method != IntPtr.Zero, "TLSv1_method is null");
-                Debug.Assert(TLSv1_1_method != IntPtr.Zero, "TLSv1_1_method is null");
-                Debug.Assert(TLSv1_2_method != IntPtr.Zero, "TLSv1_2_method is null");
+                // TLSv1_1_method and TLSv1_2_method do not exist on earlier versions of OpenSSL
+                // Debug.Assert(TLSv1_1_method != IntPtr.Zero, "TLSv1_1_method is null");
+                // Debug.Assert(TLSv1_2_method != IntPtr.Zero, "TLSv1_2_method is null");
                 Debug.Assert(SSLv3_method != IntPtr.Zero, "SSLv3_method is null");
                 Debug.Assert(SSLv23_method != IntPtr.Zero, "SSLv23 method is null");
             }

--- a/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
+++ b/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.InteropServices;
-
 namespace System.Net
 {
     internal class StreamSizes
@@ -10,10 +8,8 @@ namespace System.Net
         public int header;
         public int trailer;
         public int maximumMessage;
-        public int buffersCount = 0;
-        public int blockSize = 0;
 
-        internal unsafe StreamSizes(int headerSize, int trailerSize, int maxMessageSize)
+        internal StreamSizes(int headerSize, int trailerSize, int maxMessageSize)
         {
             header = headerSize;
             trailer = trailerSize;

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -17,6 +17,12 @@ if(CRYPTO STREQUAL CRYPTO-NOTFOUND)
     return()
 endif()
 
+find_library(SSL NAMES ssl)  
+if(SSL STREQUAL SSL-NOTFOUND)  
+    message(SEND_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!")  
+    return()  
+endif()  
+
 set(NATIVECRYPTO_SOURCES
     openssl.c
     pal_asn1.cpp
@@ -35,6 +41,7 @@ set(NATIVECRYPTO_SOURCES
     pal_pkcs12.cpp
     pal_pkcs7.cpp
     pal_rsa.cpp
+    pal_ssl.cpp
     pal_x509.cpp
     pal_x509_name.cpp
     pal_x509ext.cpp
@@ -50,6 +57,7 @@ set_target_properties(System.Security.Cryptography.Native PROPERTIES PREFIX "")
 
 target_link_libraries(System.Security.Cryptography.Native
   ${CRYPTO}
+  ${SSL}
 )
 
 install (TARGETS System.Security.Cryptography.Native DESTINATION .)

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -11,17 +11,20 @@ add_compile_options(-Wno-cast-align)
 
 add_definitions(-DPIC=1)
 
-find_library(CRYPTO NAMES crypto)
-if(CRYPTO STREQUAL CRYPTO-NOTFOUND)
-    message(SEND_ERROR "!!! Cannot find libcrypto and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!")
-    return()
+find_package(OpenSSL REQUIRED)
+
+# Check which versions of TLS the OpenSSL/ssl library supports
+include(CheckLibraryExists)
+
+CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_1_method" "" OPENSSL_TLSV11)
+if (OPENSSL_TLSV11)
+    add_definitions(-DHAVE_TLS_V1_1=1)
 endif()
 
-find_library(SSL NAMES ssl)  
-if(SSL STREQUAL SSL-NOTFOUND)  
-    message(SEND_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!")  
-    return()  
-endif()  
+CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_2_method" "" OPENSSL_TLSV12)
+if (OPENSSL_TLSV12)
+    add_definitions(-DHAVE_TLS_V1_2=1)
+endif()
 
 set(NATIVECRYPTO_SOURCES
     openssl.c
@@ -56,8 +59,8 @@ add_library(System.Security.Cryptography.Native
 set_target_properties(System.Security.Cryptography.Native PROPERTIES PREFIX "")
 
 target_link_libraries(System.Security.Cryptography.Native
-  ${CRYPTO}
-  ${SSL}
+  ${OPENSSL_CRYPTO_LIBRARY}
+  ${OPENSSL_SSL_LIBRARY}
 )
 
 install (TARGETS System.Security.Cryptography.Native DESTINATION .)

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -20,15 +20,23 @@ extern "C" const SSL_METHOD* TlsV1Method()
 
 extern "C" const SSL_METHOD* TlsV1_1Method()
 {
+#ifdef HAVE_TLS_V1_1
     return TLSv1_1_method();
+#else
+    return nullptr;
+#endif
 }
 
 extern "C" const SSL_METHOD* TlsV1_2Method()
 {
+#ifdef HAVE_TLS_V1_2
     return TLSv1_2_method();
+#else
+    return nullptr;
+#endif
 }
 
-extern "C" SSL_CTX* SslCtxCreate(const SSL_METHOD* method)
+extern "C" SSL_CTX* SslCtxCreate(SSL_METHOD* method)
 {
     return SSL_CTX_new(method);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_ssl.h"
+
+extern "C" const SSL_METHOD* SslV2_3Method()
+{
+    return SSLv23_method();
+}
+
+extern "C" const SSL_METHOD* SslV3Method()
+{
+    return SSLv3_method();
+}
+
+extern "C" const SSL_METHOD* TlsV1Method()
+{
+    return TLSv1_method();
+}
+
+extern "C" const SSL_METHOD* TlsV1_1Method()
+{
+    return TLSv1_1_method();
+}
+
+extern "C" const SSL_METHOD* TlsV1_2Method()
+{
+    return TLSv1_2_method();
+}
+
+extern "C" SSL_CTX* SslCtxCreate(const SSL_METHOD* method)
+{
+    return SSL_CTX_new(method);
+}
+
+extern "C" int32_t SslWrite(SSL* ssl, const void* buf, int32_t num)
+{
+    return SSL_write(ssl, buf, num);
+}
+
+extern "C" int32_t SslRead(SSL* ssl, void* buf, int32_t num)
+{
+    return SSL_read(ssl, buf, num);
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_types.h"
+
+#include <openssl/ssl.h>
+
+/*
+Shims the SSLv23_method method.
+
+Returns the requested SSL_METHOD.
+*/
+extern "C" const SSL_METHOD* SslV2_3Method();
+
+/*
+Shims the SSLv3_method method.
+
+Returns the requested SSL_METHOD.
+*/
+extern "C" const SSL_METHOD* SslV3Method();
+
+/*
+Shims the TLSv1_method method.
+
+Returns the requested SSL_METHOD.
+*/
+extern "C" const SSL_METHOD* TlsV1Method();
+
+/*
+Shims the TLSv1_1_method method.
+
+Returns the requested SSL_METHOD.
+*/
+extern "C" const SSL_METHOD* TlsV1_1Method();
+
+/*
+Shims the TLSv1_2_method method.
+
+Returns the requested SSL_METHOD.
+*/
+extern "C" const SSL_METHOD* TlsV1_2Method();
+
+/*
+Shims the SSL_CTX_new method.
+
+Returns the new SSL_CTX instance.
+*/
+extern "C" SSL_CTX* SslCtxCreate(const SSL_METHOD* method);
+
+/*
+Shims the SSL_write method.
+
+Returns the positive number of bytes written when successful, 0 or a negative number
+when an error is encountered.
+*/
+extern "C" int32_t SslWrite(SSL* ssl, const void* buf, int32_t num);
+
+/*
+Shims the SSL_read method.
+
+Returns the positive number of bytes read when successful, 0 or a negative number
+when an error is encountered.
+*/
+extern "C" int32_t SslRead(SSL* ssl, void* buf, int32_t num);

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -45,7 +45,7 @@ Shims the SSL_CTX_new method.
 
 Returns the new SSL_CTX instance.
 */
-extern "C" SSL_CTX* SslCtxCreate(const SSL_METHOD* method);
+extern "C" SSL_CTX* SslCtxCreate(SSL_METHOD* method);
 
 /*
 Shims the SSL_write method.

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -343,7 +343,7 @@
     <value>Encrypt failed with OpenSSL error - {0}.</value>
   </data>
   <data name="net_get_ssl_method_failed" xml:space="preserve">
-    <value>Failed to get SSL method, OpenSSL error - {0}.</value>
+    <value>Failed to get SSL method '{0}'. Ensure the OpenSSL method exists on the current system.</value>
   </data>
   <data name="net_ssl_check_private_key_failed" xml:space="preserve">
     <value>SSL certificate private key check failed with OpenSSL error - {0}.</value>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -128,70 +128,70 @@
     
     <!-- Interop -->
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
-      <Link>Interop\Windows\Interop.Libraries.cs</Link>
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates.cs">
-      <Link>Interop\Windows\Crypt32\Interop.certificates.cs</Link>
+      <Link>Common\Interop\Windows\Crypt32\Interop.certificates.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
-      <Link>Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
+      <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.CloseHandle.cs">
-      <Link>Interop\Windows\mincore\Interop.CloseHandle.cs</Link>
+      <Link>Common\Interop\Windows\mincore\Interop.CloseHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SchProtocols.cs">
-      <Link>Interop\Windows\SChannel\Interop.SchProtocols.cs</Link>
+      <Link>Common\Interop\Windows\SChannel\Interop.SchProtocols.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecurityStatus.cs">
-      <Link>Interop\Windows\SChannel\Interop.SecurityStatus.cs</Link>
+      <Link>Common\Interop\Windows\SChannel\Interop.SecurityStatus.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SslConnectionInfo.cs">
-      <Link>Interop\Windows\SChannel\SslConnectionInfo.cs</Link>
+      <Link>Common\Interop\Windows\SChannel\SslConnectionInfo.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.cs">
-      <Link>Interop\Windows\SChannel\UnmanagedCertificateContext.cs</Link>
+      <Link>Common\Interop\Windows\SChannel\UnmanagedCertificateContext.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\Bindings.cs">
-      <Link>Interop\Windows\secur32\Bindings.cs</Link>
+      <Link>Common\Interop\Windows\secur32\Bindings.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\GlobalSSPI.cs">
-      <Link>Interop\Windows\secur32\GlobalSSPI.cs</Link>
+      <Link>Common\Interop\Windows\secur32\GlobalSSPI.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\Interop.SSPI.cs">
-      <Link>Interop\Windows\secur32\Interop.SSPI.cs</Link>
+      <Link>Common\Interop\Windows\secur32\Interop.SSPI.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\NegotiationInfo.cs">
-      <Link>Interop\Windows\secur32\NegotiationInfo.cs</Link>
+      <Link>Common\Interop\Windows\secur32\NegotiationInfo.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\NegotiationInfoClass.cs">
-      <Link>Interop\Windows\secur32\NegotiationInfoClass.cs</Link>
+      <Link>Common\Interop\Windows\secur32\NegotiationInfoClass.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecSizes.cs">
-      <Link>Interop\Windows\secur32\SecSizes.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SecSizes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecurityPackageInfo.cs">
-      <Link>Interop\Windows\secur32\SecurityPackageInfo.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SecurityPackageInfo.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecurityPackageInfoClass.cs">
-      <Link>Interop\Windows\secur32\SecurityPackageInfoClass.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SecurityPackageInfoClass.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecuritySafeHandles.cs">
-      <Link>Interop\Windows\secur32\SecuritySafeHandles.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SecuritySafeHandles.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPIAuthType.cs">
-      <Link>Interop\Windows\secur32\SSPIAuthType.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SSPIAuthType.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPIInterface.cs">
-      <Link>Interop\Windows\secur32\SSPIInterface.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SSPIInterface.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPISecureChannelType.cs">
-      <Link>Interop\Windows\secur32\SSPISecureChannelType.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SSPISecureChannelType.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SSPIWrapper.cs">
-      <Link>Interop\Windows\secur32\SSPIWrapper.cs</Link>
+      <Link>Common\Interop\Windows\secur32\SSPIWrapper.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\StreamSizes.cs">
-      <Link>Interop\Windows\secur32\StreamSizes.cs</Link>
+      <Link>Common\Interop\Windows\secur32\StreamSizes.cs</Link>
     </Compile>
   </ItemGroup>
   
@@ -201,28 +201,28 @@
 
     <!-- Interop -->
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
-      <Link>Interop\Unix\Interop.Libraries.cs</Link>
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.libssl.cs">
-      <Link>Interop\Unix\libssl\Interop.libssl.cs</Link>
+      <Link>Common\Interop\Unix\libssl\Interop.libssl.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.libssl_types.cs">
-      <Link>Interop\Unix\libssl\Interop.libssl_types.cs</Link>
+      <Link>Common\Interop\Unix\libssl\Interop.libssl_types.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.SafeSslHandle.cs">
-      <Link>Interop\Unix\libssl\Interop.SafeSslHandle.cs</Link>
+      <Link>Common\Interop\Unix\libssl\Interop.SafeSslHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\SecuritySafeHandles.cs">
-      <Link>Interop\Unix\libssl\SecuritySafeHandles.cs</Link>
+      <Link>Common\Interop\Unix\libssl\SecuritySafeHandles.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\StreamSizes.cs">
-      <Link>Interop\Unix\libssl\StreamSizes.cs</Link>
+      <Link>Common\Interop\Unix\libssl\StreamSizes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\SslConnectionInfo.cs">
-      <Link>Interop\Unix\libssl\SslConnectionInfo.cs</Link>
+      <Link>Common\Interop\Unix\libssl\SslConnectionInfo.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.OpenSsl.cs">
-      <Link>Interop\Unix\libssl\Interop.OpenSsl.cs</Link>
+      <Link>Common\Interop\Unix\libssl\Interop.OpenSsl.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
@@ -238,6 +238,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>


### PR DESCRIPTION
I added shims the first 8 libssl functions and did a little clean up.
- Put all Interop files under "Common\Interop" in System.Net.Security.
- Removed some unused fields from StreamSizes.
- Changed some unnecessary IntPtr usages to byte[] or byte*, where appropriate.

@bartonjs @stephentoub @vijaykota @rajansingh10 @shrutigarg
(optionally, @nguerrera, @sokket if you want to take a look)