### PR TITLE
Clean up the remaining shim work for libcrypto.

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -7,7 +7,6 @@ internal static partial class Interop
     {
         internal const string Libc = "libc";                   // C library
         internal const string LibCoreClr = "libcoreclr";       // CoreCLR runtime
-        internal const string LibCrypto = "libcrypto";         // OpenSSL crypto library
         internal const string LibSsl = "libssl";               // OpenSSL library
         internal const string Zlib = "libz";                   // zlib compression library
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -8,16 +8,8 @@ internal static partial class Interop
 {
     // Initialization of libcrypto threading support is done in a static constructor.
     // This enables a project simply to include this file, and any usage of any of
-    // the libcrypto or System.Security.Cryptography.Native functions will trigger 
+    // the System.Security.Cryptography.Native functions will trigger 
     // initialization of the threading support.
-
-    internal static partial class libcrypto
-    {
-        static libcrypto()
-        {
-            CryptoInitializer.Initialize();
-        }
-    }
 
     internal static partial class Crypto
     {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -41,13 +41,6 @@ internal static partial class Interop
                 // these libraries will be unable to operate correctly.
                 throw new InvalidOperationException();
             }
-
-            // Load the SHA-2 hash algorithms, and anything else not in the default
-            // support set.
-            OPENSSL_add_all_algorithms_conf();
-
-            // Ensure that the error message table is loaded.
-            ERR_load_crypto_strings();
         }
 
         internal static void Initialize()
@@ -57,11 +50,5 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative)]
         private static extern int EnsureOpenSslInitialized();
-
-        [DllImport(Libraries.LibCrypto)]
-        private static extern void ERR_load_crypto_strings();
-
-        [DllImport(Libraries.LibCrypto)]
-        private static extern void OPENSSL_add_all_algorithms_conf();
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#include "pal_types.h"
+
 #include <assert.h>
 #include <limits.h>
 #include <pthread.h>
@@ -45,13 +47,13 @@ A time_t representation of the input date. See also man mktime(3).
 static
 time_t
 MakeTimeT(
-    int year,
-    int month,
-    int day,
-    int hour,
-    int minute,
-    int second,
-    int isDst)
+    int32_t year,
+    int32_t month,
+    int32_t day,
+    int32_t hour,
+    int32_t minute,
+    int32_t second,
+    int32_t isDst)
 {
     struct tm currentTm;
     currentTm.tm_year = year - 1900;
@@ -76,11 +78,11 @@ Return values:
 1: Data was copied
 Any negative value: The input buffer size was reported as insufficient. A buffer of size ABS(return) is required.
 */
-int
+int32_t
 GetX509Thumbprint(
     X509* x509,
-    unsigned char* pBuf,
-    int cBuf)
+    uint8_t* pBuf,
+    int32_t cBuf)
 {
     if (!x509)
     {
@@ -250,11 +252,11 @@ Return values:
 1: Data was copied
 Any negative value: The input buffer size was reported as insufficient. A buffer of size ABS(return) is required.
 */
-int
+int32_t
 GetX509PublicKeyParameterBytes(
     X509* x509,
-    unsigned char* pBuf,
-    int cBuf)
+    uint8_t* pBuf,
+    int32_t cBuf)
 {
     if (!x509 || !x509->cert_info || !x509->cert_info->key || !x509->cert_info->key->algor)
     {
@@ -336,11 +338,11 @@ Remarks:
 
  So this function will really work on all of them.
 */
-int
+int32_t
 GetAsn1StringBytes(
     ASN1_STRING* asn1,
-    unsigned char* pBuf,
-    int cBuf)
+    uint8_t* pBuf,
+    int32_t cBuf)
 {
     if (!asn1 || cBuf < 0)
     {
@@ -375,11 +377,11 @@ Return values:
 1: Data was copied
 Any negative value: The input buffer size was reported as insufficient. A buffer of size ABS(return) is required.
 */
-int
+int32_t
 GetX509NameRawBytes(
     X509_NAME* x509Name,
-    unsigned char* pBuf,
-    int cBuf)
+    uint8_t* pBuf,
+    int32_t cBuf)
 {
     if (!x509Name || !x509Name->bytes || cBuf < 0)
     {
@@ -450,7 +452,7 @@ that particular OID.
 ASN1_OBJECT*
 GetX509EkuField(
     EXTENDED_KEY_USAGE* eku,
-    int loc)
+    int32_t loc)
 {
     return sk_ASN1_OBJECT_value(eku, loc);
 }
@@ -469,8 +471,8 @@ memory-backed BIO structure which contains the answer to the GetNameInfo query
 BIO*
 GetX509NameInfo(
     X509* x509,
-    int nameType,
-    int forIssuer)
+    int32_t nameType,
+    int32_t forIssuer)
 {
     static const char szOidUpn[] = "1.3.6.1.4.1.311.20.2.3";
 
@@ -859,11 +861,11 @@ Return values:
 0 if the hostname is not a match
 Any negative number indicates an error in the arguments.
 */
-int
+int32_t
 CheckX509Hostname(
     X509* x509,
     const char* hostname,
-    int cchHostname)
+    int32_t cchHostname)
 {
     if (!x509)
         return -2;
@@ -948,13 +950,13 @@ Return values:
 0 if the hostname is not a match
 Any negative number indicates an error in the arguments.
 */
-int
+int32_t
 CheckX509IpAddress(
     X509* x509,
-    const unsigned char* addressBytes,
-    int addressBytesLen,
+    const uint8_t* addressBytes,
+    int32_t addressBytesLen,
     const char* hostname,
-    int cchHostname)
+    int32_t cchHostname)
 {
     if (!x509)
         return -2;
@@ -1041,7 +1043,7 @@ Return values:
 0 if the field count cannot be determined, or the count of certificates in STACK_OF(X509)
 Note that 0 does not always indicate an error, merely that GetX509StackField should not be called.
 */
-int
+int32_t
 GetX509StackFieldCount(
     STACK_OF(X509)* stack)
 {
@@ -1092,16 +1094,16 @@ Return values:
 0 if ctx is NULL, if ctx has no X509_VERIFY_PARAM, or the date inputs don't produce a valid time_t;
 1 on success.
 */
-int
+int32_t
 SetX509ChainVerifyTime(
     X509_STORE_CTX* ctx,
-    int year,
-    int month,
-    int day,
-    int hour,
-    int minute,
-    int second,
-    int isDst)
+    int32_t year,
+    int32_t month,
+    int32_t day,
+    int32_t hour,
+    int32_t minute,
+    int32_t second,
+    int32_t isDst)
 {
     if (!ctx)
     {
@@ -1183,7 +1185,7 @@ behavior on non-file, non-null BIO objects.
 See also:
 OpenSSL's BIO_tell
 */
-int BioTell(
+int32_t BioTell(
     BIO* bio)
 {
     if (!bio)
@@ -1211,9 +1213,9 @@ otherwise unspecified
 See also:
 OpenSSL's BIO_seek
 */
-int BioSeek(
+int32_t BioSeek(
     BIO* bio,
-    int ofs)
+    int32_t ofs)
 {
     if (!bio)
     {
@@ -1250,7 +1252,7 @@ Return values:
 1 on success
 0 on a NULL stack, or an error within sk_X509_push
 */
-int
+int32_t
 PushX509StackField(
     STACK_OF(X509)* stack,
     X509* x509)
@@ -1274,10 +1276,10 @@ Returns a bool to managed code.
 1 for success
 0 for failure
 */
-int
+int32_t
 GetRandomBytes(
-    unsigned char* buf, 
-    int num)
+    uint8_t* buf,
+    int32_t num)
 {
     int ret = RAND_bytes(buf, num);
 
@@ -1297,7 +1299,7 @@ Return values:
 -1 indicates OpenSSL signalled an error, CryptographicException should be raised.
 -2 indicates an error in the input arguments
 */
-int
+int32_t
 LookupFriendlyNameByOid(
     const char* oidValue,
     const char** friendlyName)
@@ -1414,7 +1416,7 @@ Return values:
 0 on success
 non-zero on failure
 */
-int
+int32_t
 EnsureOpenSslInitialized()
 {
     int ret = 0;
@@ -1475,6 +1477,13 @@ EnsureOpenSslInitialized()
         ret = 4;
         goto done;
     }
+
+    // Load the SHA-2 hash algorithms, and anything else not in the default
+    // support set.
+    OPENSSL_add_all_algorithms_conf();
+
+    // Ensure that the error message table is loaded.
+    ERR_load_crypto_strings();
 
 done:
     if (ret != 0)

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -53,7 +53,7 @@ extern "C" void Asn1ObjectFree(ASN1_OBJECT* a)
     ASN1_OBJECT_free(a);
 }
 
-extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const unsigned char* buf, int32_t len)
+extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -68,7 +68,7 @@ extern "C" void Asn1BitStringFree(ASN1_STRING* a)
     ASN1_BIT_STRING_free(a);
 }
 
-extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const unsigned char* buf, int32_t len)
+extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -83,7 +83,7 @@ extern "C" ASN1_OCTET_STRING* Asn1OctetStringNew()
     return ASN1_OCTET_STRING_new();
 }
 
-extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const unsigned char* data, int32_t len)
+extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
 {
     return ASN1_OCTET_STRING_set(s, data, len);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.h
@@ -52,7 +52,7 @@ extern "C" void Asn1ObjectFree(ASN1_OBJECT* a);
 /*
 Shims the d2i_ASN1_BIT_STRING method and makes it easier to invoke from managed code.
 */
-extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const unsigned char* buf, int32_t len);
+extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const uint8_t* buf, int32_t len);
 
 /*
 Direct shim to ASN1_BIT_STRING_free.
@@ -62,7 +62,7 @@ extern "C" void Asn1BitStringFree(ASN1_STRING* a);
 /*
 Shims the d2i_ASN1_OCTET_STRING method and makes it easier to invoke from managed code.
 */
-extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const unsigned char* buf, int32_t len);
+extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const uint8_t* buf, int32_t len);
 
 /*
 Direct shim to ASN1_OCTET_STRING_new.
@@ -72,7 +72,7 @@ extern "C" ASN1_OCTET_STRING* Asn1OctetStringNew();
 /*
 Direct shim to ASN1_OCTET_STRING_set.
 */
-extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const unsigned char* data, int32_t len);
+extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len);
 
 /*
 Direct shim to ASN1_OCTET_STRING_free.

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1_print.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1_print.cpp
@@ -23,7 +23,7 @@ static_assert(PAL_B_ASN1_SEQUENCE == B_ASN1_SEQUENCE, "");
 
 static_assert(PAL_ASN1_STRFLGS_UTF8_CONVERT == ASN1_STRFLGS_UTF8_CONVERT, "");
 
-extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const unsigned char* buf, int32_t len, Asn1StringTypeFlags type)
+extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type)
 {
     if (!buf || !len)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1_print.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1_print.h
@@ -40,7 +40,7 @@ enum Asn1StringPrintFlags : uint64_t
 /*
 Shims the d2i_ASN1_type_bytes method and makes it easier to invoke from managed code.
 */
-extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const unsigned char* buf, int32_t len, Asn1StringTypeFlags type);
+extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type);
 
 /*
 Direct shim to ASN1_STRING_print_ex.

--- a/src/Native/System.Security.Cryptography.Native/pal_bignum.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_bignum.cpp
@@ -11,7 +11,7 @@ extern "C" void BigNumDestroy(BIGNUM* a)
     }
 }
 
-extern "C" BIGNUM* BigNumFromBinary(const unsigned char* s, int32_t len)
+extern "C" BIGNUM* BigNumFromBinary(const uint8_t* s, int32_t len)
 {
     if (!s || !len)
     {
@@ -21,7 +21,7 @@ extern "C" BIGNUM* BigNumFromBinary(const unsigned char* s, int32_t len)
     return BN_bin2bn(s, len, nullptr);
 }
 
-extern "C" int32_t BigNumToBinary(const BIGNUM* a, unsigned char* to)
+extern "C" int32_t BigNumToBinary(const BIGNUM* a, uint8_t* to)
 {
     if (!a || !to)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_bignum.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_bignum.h
@@ -20,12 +20,12 @@ extern "C" void BigNumDestroy(BIGNUM* a);
 /*
 Shims the BN_bin2bn method.
 */
-extern "C" BIGNUM* BigNumFromBinary(const unsigned char* s, int32_t len);
+extern "C" BIGNUM* BigNumFromBinary(const uint8_t* s, int32_t len);
 
 /*
 Shims the BN_bn2bin method.
 */
-extern "C" int32_t BigNumToBinary(const BIGNUM* a, unsigned char* to);
+extern "C" int32_t BigNumToBinary(const BIGNUM* a, uint8_t* to);
 
 /*
 Returns the number of bytes needed to export a BIGNUM.

--- a/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
@@ -44,7 +44,7 @@ extern "C" int32_t EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt)
     return EVP_DigestUpdate(ctx, d, cnt);
 }
 
-extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, unsigned char* md, uint32_t* s)
+extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
 {
     unsigned int size;
     int32_t ret = EVP_DigestFinal_ex(ctx, md, &size);

--- a/src/Native/System.Security.Cryptography.Native/pal_evp.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp.h
@@ -46,7 +46,7 @@ EvpDigestFinalEx
 
 Direct shim to EVP_DigestFinal_ex.
 */
-extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, unsigned char* md, uint32_t* s);
+extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s);
 
 /*
 Function:

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
@@ -9,7 +9,7 @@
 #define SUCCESS 1
 #define KEEP_CURRENT_DIRECTION -1
 
-extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, unsigned char* key, unsigned char* iv, int32_t enc)
+extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc)
 {
     std::unique_ptr<EVP_CIPHER_CTX> ctx(new (std::nothrow) EVP_CIPHER_CTX);
     if (ctx == nullptr)
@@ -58,7 +58,7 @@ extern "C" int32_t EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)
 }
 
 extern "C" int32_t
-EvpCipherUpdate(EVP_CIPHER_CTX* ctx, unsigned char* out, int32_t* outl, unsigned char* in, int32_t inl)
+EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl)
 {
     int outLength;
     int32_t ret = EVP_CipherUpdate(ctx, out, &outLength, in, inl);
@@ -70,7 +70,7 @@ EvpCipherUpdate(EVP_CIPHER_CTX* ctx, unsigned char* out, int32_t* outl, unsigned
     return ret;
 }
 
-extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, unsigned char* outm, int32_t* outl)
+extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl)
 {
     int outLength;
     int32_t ret = EVP_CipherFinal_ex(ctx, outm, &outLength);

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -14,7 +14,7 @@ Implemented by:
 
 Returns new EVP_CIPHER_CTX on success, nullptr on failure.
 */
-extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, unsigned char* key, unsigned char* iv, int32_t enc);
+extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc);
 
 /*
 Cleans up and deletes an EVP_CIPHER_CTX instance created by EvpCipherCreate.
@@ -52,7 +52,7 @@ EvpCipherUpdate
 Direct shim to EVP_CipherUpdate.
 */
 extern "C" int32_t
-EvpCipherUpdate(EVP_CIPHER_CTX* ctx, unsigned char* out, int32_t* outl, unsigned char* in, int32_t inl);
+EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl);
 
 /*
 Function:
@@ -60,7 +60,7 @@ EvpCipherFinalEx
 
 Direct shim to EVP_CipherFinal_ex.
 */
-extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, unsigned char* outm, int32_t* outl);
+extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl);
 
 /*
 Function:

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
@@ -3,7 +3,7 @@
 
 #include "pal_pkcs12.h"
 
-extern "C" PKCS12* DecodePkcs12(const unsigned char* buf, int32_t len)
+extern "C" PKCS12* DecodePkcs12(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -37,7 +37,7 @@ extern "C" int32_t GetPkcs12DerSize(PKCS12* p12)
     return i2d_PKCS12(p12, nullptr);
 }
 
-extern "C" int32_t EncodePkcs12(PKCS12* p12, unsigned char* buf)
+extern "C" int32_t EncodePkcs12(PKCS12* p12, uint8_t* buf)
 {
     return i2d_PKCS12(p12, &buf);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.h
@@ -8,7 +8,7 @@
 /*
 Shims the d2i_PKCS12 method and makes it easier to invoke from managed code.
 */
-extern "C" PKCS12* DecodePkcs12(const unsigned char* buf, int32_t len);
+extern "C" PKCS12* DecodePkcs12(const uint8_t* buf, int32_t len);
 
 /*
 Shims the d2i_PKCS12_bio method.
@@ -46,7 +46,7 @@ Shims the i2d_PKCS12 method.
 
 Returns the number of bytes written to buf.
 */
-extern "C" int32_t EncodePkcs12(PKCS12* p12, unsigned char* buf);
+extern "C" int32_t EncodePkcs12(PKCS12* p12, uint8_t* buf);
 
 /*
 Shims the PKCS12_parse method.

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
@@ -10,7 +10,7 @@ extern "C" PKCS7* PemReadBioPkcs7(BIO* bp)
     return PEM_read_bio_PKCS7(bp, nullptr, nullptr, nullptr);
 }
 
-extern "C" PKCS7* DecodePkcs7(const unsigned char* buf, int32_t len)
+extern "C" PKCS7* DecodePkcs7(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.h
@@ -17,7 +17,7 @@ extern "C" PKCS7* PemReadBioPkcs7(BIO* bp);
 /*
 Shims the d2i_PKCS7 method and makes it easier to invoke from managed code.
 */
-extern "C" PKCS7* DecodePkcs7(const unsigned char* buf, int32_t len);
+extern "C" PKCS7* DecodePkcs7(const uint8_t* buf, int32_t len);
 
 /*
 Reads a PKCS7 instance in DER format from a BIO.

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -55,7 +55,7 @@ extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509)
     return X509_PUBKEY_get(X509_get_X509_PUBKEY(x509));
 }
 
-extern "C" X509_CRL* DecodeX509Crl(const unsigned char* buf, int32_t len)
+extern "C" X509_CRL* DecodeX509Crl(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -65,7 +65,7 @@ extern "C" X509_CRL* DecodeX509Crl(const unsigned char* buf, int32_t len)
     return d2i_X509_CRL(nullptr, &buf, len);
 }
 
-extern "C" X509* DecodeX509(const unsigned char* buf, int32_t len)
+extern "C" X509* DecodeX509(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -71,12 +71,12 @@ extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509);
 /*
 Shims the d2i_X509_CRL method and makes it easier to invoke from managed code.
 */
-extern "C" X509_CRL* DecodeX509Crl(const unsigned char* buf, int32_t len);
+extern "C" X509_CRL* DecodeX509Crl(const uint8_t* buf, int32_t len);
 
 /*
 Shims the d2i_X509 method and makes it easier to invoke from managed code.
 */
-extern "C" X509* DecodeX509(const unsigned char* buf, int32_t len);
+extern "C" X509* DecodeX509(const uint8_t* buf, int32_t len);
 
 /*
 Returns the number of bytes it will take to convert

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -13,7 +13,7 @@ extern "C" X509_NAME* GetX509NameStackField(X509NameStack* sk, int32_t loc)
     return sk_X509_NAME_value(sk, loc);
 }
 
-extern "C" X509_NAME* DecodeX509Name(const unsigned char* buf, int32_t len)
+extern "C" X509_NAME* DecodeX509Name(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
@@ -21,7 +21,7 @@ extern "C" X509_NAME* GetX509NameStackField(X509NameStack* sk, int32_t loc);
 /*
 Shims the d2i_X509_NAME method and makes it easier to invoke from managed code.
 */
-extern "C" X509_NAME* DecodeX509Name(const unsigned char* buf, int32_t len);
+extern "C" X509_NAME* DecodeX509Name(const uint8_t* buf, int32_t len);
 
 /*
 Cleans up and deletes an X509_NAME instance.

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
@@ -23,7 +23,7 @@ extern "C" int32_t X509V3ExtPrint(BIO* out, X509_EXTENSION* ext)
     return X509V3_EXT_print(out, ext, X509V3_EXT_DEFAULT, /*indent*/ 0);
 }
 
-extern "C" int32_t DecodeX509BasicConstraints2Extension(const unsigned char* encoded,
+extern "C" int32_t DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
                                                         int32_t encodedLength,
                                                         int32_t* certificateAuthority,
                                                         int32_t* hasPathLengthConstraint,
@@ -66,7 +66,7 @@ extern "C" int32_t DecodeX509BasicConstraints2Extension(const unsigned char* enc
     return result;
 }
 
-extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const unsigned char* buf, int32_t len)
+extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.h
@@ -41,7 +41,7 @@ Decodes the X509 BASIC_CONSTRAINTS information and fills the out variables:
 Returns 1 if the BASIC_CONSTRAINTS information was successfully decoded,
 otherwise 0.
 */
-extern "C" int32_t DecodeX509BasicConstraints2Extension(const unsigned char* encoded,
+extern "C" int32_t DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
                                                         int32_t encodedLength,
                                                         int32_t* certificateAuthority,
                                                         int32_t* hasPathLengthConstraint,
@@ -50,7 +50,7 @@ extern "C" int32_t DecodeX509BasicConstraints2Extension(const unsigned char* enc
 /*
 Shims the d2i_EXTENDED_KEY_USAGE method and makes it easier to invoke from managed code.
 */
-extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const unsigned char* buf, int32_t len);
+extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len);
 
 /*
 Cleans up and deletes an EXTENDED_KEY_USAGE instance.

--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 using Test.Cryptography;
 using Xunit;
@@ -59,9 +60,9 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
         [Fact]
         public static void CtorHandle224()
         {
-            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp224r1);
+            IntPtr ecKey = Interop.Crypto.EcKeyCreateByCurveName(NID_secp224r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EcKeyGenerateKey(ecKey);
+            int success = Interop.Crypto.EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
@@ -71,15 +72,15 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
                 e.Exercise();
             }
 
-            EcKeyDestroy(ecKey);
+            Interop.Crypto.EcKeyDestroy(ecKey);
         }
 
         [Fact]
         public static void CtorHandle384()
         {
-            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp384r1);
+            IntPtr ecKey = Interop.Crypto.EcKeyCreateByCurveName(NID_secp384r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EcKeyGenerateKey(ecKey);
+            int success = Interop.Crypto.EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
@@ -89,15 +90,15 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
                 e.Exercise();
             }
 
-            EcKeyDestroy(ecKey);
+            Interop.Crypto.EcKeyDestroy(ecKey);
         }
 
         [Fact]
         public static void CtorHandle521()
         {
-            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp521r1);
+            IntPtr ecKey = Interop.Crypto.EcKeyCreateByCurveName(NID_secp521r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EcKeyGenerateKey(ecKey);
+            int success = Interop.Crypto.EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
@@ -107,21 +108,21 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
                 e.Exercise();
             }
 
-            EcKeyDestroy(ecKey);
+            Interop.Crypto.EcKeyDestroy(ecKey);
         }
 
         [Fact]
         public static void CtorHandleDuplicate()
         {
-            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp521r1);
+            IntPtr ecKey = Interop.Crypto.EcKeyCreateByCurveName(NID_secp521r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EcKeyGenerateKey(ecKey);
+            int success = Interop.Crypto.EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
             {
                 // Make sure ECDsaOpenSsl did his own ref-count bump.
-                EcKeyDestroy(ecKey);
+                Interop.Crypto.EcKeyDestroy(ecKey);
 
                 int keySize = e.KeySize;
                 Assert.Equal(521, keySize);
@@ -251,17 +252,20 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
         private const int NID_secp224r1 = 713;
         private const int NID_secp384r1 = 715;
         private const int NID_secp521r1 = 716;
-
-        private const string CryptoNative = "System.Security.Cryptography.Native";
-
-        [DllImport(CryptoNative)]
-        private static extern IntPtr EcKeyCreateByCurveName(int nid);
-
-        [DllImport(CryptoNative)]
-        private static extern int EcKeyGenerateKey(IntPtr ecKey);
-
-        [DllImport(CryptoNative)]
-        private static extern void EcKeyDestroy(IntPtr r);
     }
 }
- 
+
+internal static partial class Interop
+{
+    internal static class Crypto
+    {
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern IntPtr EcKeyCreateByCurveName(int nid);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int EcKeyGenerateKey(IntPtr ecKey);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void EcKeyDestroy(IntPtr r);
+    }
+}

--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -59,9 +59,9 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
         [Fact]
         public static void CtorHandle224()
         {
-            IntPtr ecKey = EC_KEY_new_by_curve_name(NID_secp224r1);
+            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp224r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EC_KEY_generate_key(ecKey);
+            int success = EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
@@ -71,15 +71,15 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
                 e.Exercise();
             }
 
-            EC_KEY_free(ecKey);
+            EcKeyDestroy(ecKey);
         }
 
         [Fact]
         public static void CtorHandle384()
         {
-            IntPtr ecKey = EC_KEY_new_by_curve_name(NID_secp384r1);
+            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp384r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EC_KEY_generate_key(ecKey);
+            int success = EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
@@ -89,15 +89,15 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
                 e.Exercise();
             }
 
-            EC_KEY_free(ecKey);
+            EcKeyDestroy(ecKey);
         }
 
         [Fact]
         public static void CtorHandle521()
         {
-            IntPtr ecKey = EC_KEY_new_by_curve_name(NID_secp521r1);
+            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp521r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EC_KEY_generate_key(ecKey);
+            int success = EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
@@ -107,21 +107,21 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
                 e.Exercise();
             }
 
-            EC_KEY_free(ecKey);
+            EcKeyDestroy(ecKey);
         }
 
         [Fact]
         public static void CtorHandleDuplicate()
         {
-            IntPtr ecKey = EC_KEY_new_by_curve_name(NID_secp521r1);
+            IntPtr ecKey = EcKeyCreateByCurveName(NID_secp521r1);
             Assert.NotEqual(IntPtr.Zero, ecKey);
-            int success = EC_KEY_generate_key(ecKey);
+            int success = EcKeyGenerateKey(ecKey);
             Assert.NotEqual(0, success);
 
             using (ECDsaOpenSsl e = new ECDsaOpenSsl(ecKey))
             {
                 // Make sure ECDsaOpenSsl did his own ref-count bump.
-                EC_KEY_free(ecKey);
+                EcKeyDestroy(ecKey);
 
                 int keySize = e.KeySize;
                 Assert.Equal(521, keySize);
@@ -252,14 +252,16 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
         private const int NID_secp384r1 = 715;
         private const int NID_secp521r1 = 716;
 
-        [DllImport("libcrypto")]
-        private static extern IntPtr EC_KEY_new_by_curve_name(int nid);
+        private const string CryptoNative = "System.Security.Cryptography.Native";
 
-        [DllImport("libcrypto")]
-        private static extern int EC_KEY_generate_key(IntPtr ecKey);
+        [DllImport(CryptoNative)]
+        private static extern IntPtr EcKeyCreateByCurveName(int nid);
 
-        [DllImport("libcrypto")]
-        private static extern void EC_KEY_free(IntPtr r);
+        [DllImport(CryptoNative)]
+        private static extern int EcKeyGenerateKey(IntPtr ecKey);
+
+        [DllImport(CryptoNative)]
+        private static extern void EcKeyDestroy(IntPtr r);
     }
 }
  

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -19,6 +19,9 @@
   <ItemGroup>
     <Compile Include="EcDsaOpenSslTests.cs" />
     <Compile Include="RSAOpenSslProvider.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
- Removed LibCrypto from the Interop.Libraries list
- Converted "unsigned char" usages to "uint8_t"
- Converted any remaining "int" usages to "int32_t"
- Moved two OpenSSL initialization calls ino EnsureOpenSslInitialized PAL method.
- Moved a few OpenSSL.Tests to use the PAL shims instead of directly calling libcrypto.

@bartonjs, @nguerrera, @sokket 