### PR TITLE
Implement HttpContentAsyncStream.Write in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -741,7 +741,7 @@ namespace System.Net.Http
 
                 // If we get here, there was no previously read data available to copy.
                 // Initiate a new asynchronous read.
-                Task<int> asyncRead = easy._requestContentStream.ReadAsync(
+                Task<int> asyncRead = easy._requestContentStream.ReadAsyncInternal(
                     sts._buffer, 0, Math.Min(sts._buffer.Length, length), easy._cancellationToken);
                 Debug.Assert(asyncRead != null, "Badly implemented stream returned a null task from ReadAsync");
 


### PR DESCRIPTION
WCF ends up trying to use Stream.Write as part of HttpContent.CopyToAsync implementation.  While that should be addressed separately to use WriteAsync, it's possible others are also using Write instead of WriteAsync, and today we throw NotSupportedException from Write.  So as to let this at least work, I'm implementing Write to delegate to WriteAsync. I also noticed we were missing a FlushAsync implementation, so I've added one.

cc: @davidsh, @roncain, @kapilash