### PR TITLE
Support for crc32 generation using clrcompression.dll

### DIFF
--- a/src/System.IO.Compression/src/Interop/Interop.zlib.cs
+++ b/src/System.IO.Compression/src/Interop/Interop.zlib.cs
@@ -21,6 +21,9 @@ internal static partial class Interop
         private extern unsafe static int deflateEnd(byte* strm);
 
         [DllImport(Libraries.Zlib)]
+        internal extern unsafe static uint crc32(uint crc, byte* buffer, int len);
+
+        [DllImport(Libraries.Zlib)]
         private extern unsafe static int inflateInit2_(byte* stream, int windowBits, byte* version, int stream_size);
 
         [DllImport(Libraries.Zlib)]
@@ -49,6 +52,11 @@ internal static partial class Interop
             }
         }
 
+        internal static unsafe uint crc32(uint crc, byte[] buffer, int offset, int len)
+        {
+            fixed (byte* buf = &buffer[offset])
+                return crc32(crc, buf, len);
+        }
 
         internal static unsafe ZLibNative.ErrorCode Deflate(ref ZLibNative.ZStream stream, ZLibNative.FlushCode flush)
         {


### PR DESCRIPTION
This pull requests moves crc32 generation from managed code to the native code found in Zlib whenever clrcompression.dll is available. Using this, I see a 1-2% performance improvement when tested on GZipStream compression using an Intel® 5th Generation Core i5 Processor based system.

Note that this PR will fail any tests until crc32() has been exported in clrcompression.dll. The version included with the DNX runtimes has this function exported, but the .dll included in functionality tests, does not have the function exported.

This also opens up opportunity for future optimizations, namely issue #3986, which includes an optimized native crc32 function.