### PR TITLE
Enable X509 TestECDsaPublicKey_ValidatesSignature

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -144,7 +144,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3769, PlatformID.AnyUnix)]
         public static void TestECDsaPublicKey_ValidatesSignature()
         {
             // This signature was produced as the output of ECDsaCng.SignData with the same key


### PR DESCRIPTION
The test was effectively fixed with issue 3769, but due to the X509 tests having a nuget package dependency on the library with the bug the test couldn't be re-enabled at the same time.

Fixes #3816.