### PR TITLE
Fix an AV in *nix sockets.

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -23,7 +23,9 @@ namespace System.Net.Sockets
         {
             get
             {
-                return _innerSocket.AsyncContext;
+                return _innerSocket == null ?
+                    SocketAsyncContext.ClosedAsyncContext :
+                    _innerSocket.AsyncContext;
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -366,20 +366,20 @@ namespace System.Net.Sockets
             }
         }
 
-        private static SocketAsyncContext _closedAsyncContext;
+        private static SocketAsyncContext s_closedAsyncContext;
         public static SocketAsyncContext ClosedAsyncContext
         {
             get
             {
-                if (Volatile.Read(ref _closedAsyncContext) == null)
+                if (Volatile.Read(ref s_closedAsyncContext) == null)
                 {
                     var ctx = new SocketAsyncContext(-1, null);
                     ctx.Close();
 
-                    Volatile.Write(ref _closedAsyncContext, ctx);
+                    Volatile.Write(ref s_closedAsyncContext, ctx);
                 }
 
-                return _closedAsyncContext;
+                return s_closedAsyncContext;
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -366,6 +366,23 @@ namespace System.Net.Sockets
             }
         }
 
+        private static SocketAsyncContext _closedAsyncContext;
+        public static SocketAsyncContext ClosedAsyncContext
+        {
+            get
+            {
+                if (Volatile.Read(ref _closedAsyncContext) == null)
+                {
+                    var ctx = new SocketAsyncContext(-1, null);
+                    ctx.Close();
+
+                    Volatile.Write(ref _closedAsyncContext, ctx);
+                }
+
+                return _closedAsyncContext;
+            }
+        }
+
         private int _fileDescriptor;
         private GCHandle _handle;
         private OperationQueue<TransferOperation> _receiveQueue;


### PR DESCRIPTION
If the inner handle of a SafeCloseSocket is null, return an already-closed
AsyncContext for SafeCloseSocket.AsyncContext.

Fixes #3948.