### PR TITLE
Avoid StringBuilder interop perf

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.GetFullPathNameW.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetFullPathNameW.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {
@@ -13,6 +12,6 @@ internal partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPathName or PathHelper.
         /// </summary>
         [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
-        unsafe internal static extern int GetFullPathNameW(char* path, int numBufferChars, [Out]StringBuilder buffer, IntPtr mustBeZero);
+        unsafe internal static extern uint GetFullPathNameW(char* path, uint numBufferChars, SafeHandle buffer, IntPtr mustBeZero);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathNameW.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetLongPathNameW.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
+using System;
 using System.Runtime.InteropServices;
 
 partial class Interop
@@ -12,6 +12,6 @@ partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPath/PathHelper.
         /// </summary>
         [DllImport(Libraries.CoreFile_L1, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
-        internal static extern int GetLongPathNameW(char[] path, [Out]StringBuilder longPathBuffer, int bufferLength);
+        internal static extern uint GetLongPathNameW(SafeHandle lpszShortPath, SafeHandle lpszLongPath, uint cchBuffer);
     }
 }

--- a/src/Common/src/System/IO/PathInternal.Windows.StringBuffer.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.StringBuffer.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.IO
+{
+    /// <summary>Contains internal path helpers that are shared between many projects.</summary>
+    internal static partial class PathInternal
+    {
+        /// <summary>
+        /// Returns true if the path uses the extended syntax (\\?\)
+        /// </summary>
+        internal static bool IsExtended(StringBuffer path)
+        {
+            Debug.Assert(path != null);
+            return path.StartsWith(ExtendedPathPrefix);
+        }
+
+        /// <summary>
+        /// Returns true if the path uses the extended UNC syntax (\\?\UNC\)
+        /// </summary>
+        internal static bool IsExtendedUnc(StringBuffer path)
+        {
+            Debug.Assert(path != null);
+            return path.StartsWith(UncExtendedPathPrefix);
+        }
+
+        /// <summary>
+        /// Gets the length of the root of the path (drive, share, etc.).
+        /// </summary>
+        internal unsafe static ulong GetRootLength(StringBuffer path)
+        {
+            Debug.Assert(path != null);
+            if (path.Length == 0) return 0;
+            return GetRootLength(path.CharPointer, path.Length);
+        }
+
+        /// <summary>
+        /// Returns true if the path specified is relative to the current drive or working directory.
+        /// Returns false if the path is fixed to a specific drive or UNC path.  This method does no
+        /// validation of the path (URIs will be returned as relative as a result).
+        /// </summary>
+        /// <remarks>
+        /// Handles paths that use the alternate directory separator.  It is a frequent mistake to
+        /// assume that rooted paths (Path.IsPathRooted) are not relative.  This isn't the case.
+        /// "C:a" is drive relative- meaning that it will be resolved against the current directory
+        /// for C: (rooted, but relative). "C:\a" is rooted and not relative (the current directory
+        /// will not be used to modify the path).
+        /// </remarks>
+        internal static bool IsRelative(StringBuffer path)
+        {
+            if (path.Length < 2)
+            {
+                // It isn't fixed, it must be relative.  There is no way to specify a fixed
+                // path with one character (or less).
+                return true;
+            }
+
+            if (IsDirectorySeparator(path[0]))
+            {
+                // There is no valid way to specify a relative path with two initial slashes
+                return !IsDirectorySeparator(path[1]);
+            }
+
+            // The only way to specify a fixed path that doesn't begin with two slashes
+            // is the drive, colon, slash format- i.e. C:\
+            return !((path.Length >= 3)
+                && (path[1] == Path.VolumeSeparatorChar)
+                && IsDirectorySeparator(path[2]));
+        }
+    }
+}

--- a/src/Common/src/System/Runtime/InteropServices/NativeBuffer.cs
+++ b/src/Common/src/System/Runtime/InteropServices/NativeBuffer.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Wrapper for access to the native heap. Dispose to free the memory. Try to use with using statements.
+    /// Does not allocate zero size buffers, and will free the existing native buffer if capacity is dropped to zero.
+    /// 
+    /// NativeBuffer utilizes a cache of heap buffers.
+    /// </summary>
+    /// <remarks>
+    /// Suggested use through P/Invoke: define DllImport arguments that take a byte buffer as SafeHandle.
+    /// 
+    /// Using SafeHandle will ensure that the buffer will not get collected during a P/Invoke.
+    /// (Notably AddRef and ReleaseRef will be called by the interop layer.)
+    /// 
+    /// This class is not threadsafe, changing the capacity or disposing on multiple threads risks duplicate heap
+    /// handles or worse.
+    /// </remarks>
+    internal class NativeBuffer : IDisposable
+    {
+        private readonly static SafeHeapHandleCache s_handleCache = new SafeHeapHandleCache();
+        private readonly static SafeHandle s_emptyHandle = new EmptySafeHandle();
+        private SafeHeapHandle _handle;
+        private ulong _capacity;
+
+        /// <summary>
+        /// Create a buffer with at least the specified initial capacity in bytes.
+        /// </summary>
+        public NativeBuffer(ulong initialMinCapacity = 0)
+        {
+            EnsureByteCapacity(initialMinCapacity);
+        }
+
+        protected unsafe void* VoidPointer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return _handle == null ? null : _handle.DangerousGetHandle().ToPointer();
+            }
+        }
+
+        protected unsafe byte* BytePointer
+        {
+            get
+            {
+                return (byte*)VoidPointer;
+            }
+        }
+
+        /// <summary>
+        /// Get the handle for the buffer.
+        /// </summary>
+        public SafeHandle GetHandle()
+        {
+            // Marshalling code will throw on null for SafeHandle
+            return _handle ?? s_emptyHandle;
+        }
+
+        /// <summary>
+        /// The capacity of the buffer in bytes.
+        /// </summary>
+        public ulong ByteCapacity
+        {
+            get { return _capacity; }
+        }
+
+        /// <summary>
+        /// Ensure capacity in bytes is at least the given minimum.
+        /// </summary>
+        /// <exception cref="OutOfMemoryException">Thrown if unable to allocate memory when setting.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if attempting to set <paramref name="nameof(minCapacity)"/> to a value that is larger than the maximum addressable memory.</exception>
+        public void EnsureByteCapacity(ulong minCapacity)
+        {
+            if (_capacity < minCapacity)
+            {
+                Resize(minCapacity);
+                _capacity = minCapacity;
+            }
+        }
+
+        public unsafe byte this[ulong index]
+        {
+            get
+            {
+                if (index >= _capacity) throw new ArgumentOutOfRangeException();
+                return BytePointer[index];
+            }
+            set
+            {
+                if (index >= _capacity) throw new ArgumentOutOfRangeException();
+                BytePointer[index] = value;
+            }
+        }
+
+        private unsafe void Resize(ulong byteLength)
+        {
+            if (byteLength == 0)
+            {
+                ReleaseHandle();
+                return;
+            }
+
+            if (_handle == null)
+            {
+                _handle = s_handleCache.Acquire(byteLength);
+            }
+            else
+            {
+                _handle.Resize(byteLength);
+            }
+        }
+
+        private void ReleaseHandle()
+        {
+            if (_handle != null)
+            {
+                s_handleCache.Release(_handle);
+                _capacity = 0;
+                _handle = null;
+            }
+        }
+
+        /// <summary>
+        /// Release the backing buffer
+        /// </summary>
+        public virtual void Free()
+        {
+            ReleaseHandle();
+        }
+
+        public void Dispose()
+        {
+            Free();
+        }
+
+        private sealed class EmptySafeHandle : SafeHandle
+        {
+            public EmptySafeHandle() : base(IntPtr.Zero, true) { }
+
+            public override bool IsInvalid
+            {
+                get { return true; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Runtime/InteropServices/SafeHeapHandle.cs
+++ b/src/Common/src/System/Runtime/InteropServices/SafeHeapHandle.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Handle for heap memory that allows tracking of capacity and reallocating.
+    /// </summary>
+    internal sealed class SafeHeapHandle : SafeBuffer
+    {
+        /// <summary>
+        /// Allocate a buffer of the given size if requested.
+        /// </summary>
+        /// <param name="byteLength">Required size in bytes. Must be less than UInt32.MaxValue for 32 bit or UInt64.MaxValue for 64 bit.</param>
+        /// <exception cref="OutOfMemoryException">Thrown if the requested memory size cannot be allocated.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if size is greater than the maximum memory size.</exception>
+        public SafeHeapHandle(ulong byteLength) : base(ownsHandle: true)
+        {
+            Resize(byteLength);
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+
+        /// <summary>
+        /// Resize the buffer to the given size if requested.
+        /// </summary>
+        /// <param name="byteLength">Required size in bytes. Must be less than UInt32.MaxValue for 32 bit or UInt64.MaxValue for 64 bit.</param>
+        /// <exception cref="OutOfMemoryException">Thrown if the requested memory size cannot be allocated.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if size is greater than the maximum memory size.</exception>
+        public void Resize(ulong byteLength)
+        {
+            if (IsClosed) throw new ObjectDisposedException("SafeHeapHandle");
+
+            ulong originalLength = 0;
+            if (handle == IntPtr.Zero)
+            {
+                handle = Marshal.AllocHGlobal((IntPtr)byteLength);
+            }
+            else
+            {
+                originalLength = ByteLength;
+
+                // This may or may not be the same handle, may realloc in place. If the
+                // handle changes Windows will deal with the old handle, trying to free it will
+                // cause an error.
+                handle = Marshal.ReAllocHGlobal(pv: handle, cb: (IntPtr)byteLength);
+            }
+
+            if (handle == IntPtr.Zero)
+            {
+                // Only real plausible answer
+                throw new OutOfMemoryException();
+            }
+
+            if (byteLength > originalLength)
+            {
+                // Add pressure
+                ulong addedBytes = byteLength - originalLength;
+                if (addedBytes > long.MaxValue)
+                {
+                    GC.AddMemoryPressure(long.MaxValue);
+                    GC.AddMemoryPressure((long)(addedBytes - long.MaxValue));
+                }
+                else
+                {
+                    GC.AddMemoryPressure((long)addedBytes);
+                }
+            }
+            else
+            {
+                // Shrank or did nothing, release pressure if needed
+                RemoveMemoryPressure(originalLength - byteLength);
+            }
+
+            Initialize(byteLength);
+        }
+
+        private void RemoveMemoryPressure(ulong removedBytes)
+        {
+            if (removedBytes == 0) return;
+
+            if (removedBytes > long.MaxValue)
+            {
+                GC.RemoveMemoryPressure(long.MaxValue);
+                GC.RemoveMemoryPressure((long)(removedBytes - long.MaxValue));
+            }
+            else
+            {
+                GC.RemoveMemoryPressure((long)removedBytes);
+            }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (handle != IntPtr.Zero)
+            {
+                RemoveMemoryPressure(ByteLength);
+                Marshal.FreeHGlobal(handle);
+            }
+
+            handle = IntPtr.Zero;
+            return true;
+        }
+    }
+}

--- a/src/Common/src/System/Runtime/InteropServices/SafeHeapHandleCache.cs
+++ b/src/Common/src/System/Runtime/InteropServices/SafeHeapHandleCache.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Allows limited thread safe reuse of heap buffers to limit memory pressure.
+    /// 
+    /// This cache does not ensure that multiple copies of handles are not released back into the cache.
+    /// </summary>
+    internal sealed class SafeHeapHandleCache : IDisposable
+    {
+        private readonly ulong _minSize;
+        private readonly ulong _maxSize;
+
+        // internal for testing
+        internal readonly SafeHeapHandle[] _handleCache;
+
+        /// <param name="minSize">Smallest buffer size to allocate in bytes.</param>
+        /// <param name="maxSize">The largest buffer size to cache in bytes.</param>
+        /// <param name="maxHandles">The maximum number of handles to cache.</param>
+        public SafeHeapHandleCache(ulong minSize = 64, ulong maxSize = 1024 * 2, int maxHandles = 0)
+        {
+            _minSize = minSize;
+            _maxSize = maxSize;
+            _handleCache = new SafeHeapHandle[maxHandles > 0 ? maxHandles : Environment.ProcessorCount * 4];
+        }
+
+        /// <summary>
+        /// Get a HeapHandle
+        /// </summary>
+        public SafeHeapHandle Acquire(ulong minSize = 0)
+        {
+            if (minSize < _minSize) minSize = _minSize;
+
+            SafeHeapHandle handle = null;
+
+            for (int i = 0; i < _handleCache.Length; i++)
+            {
+                handle = Interlocked.Exchange(ref _handleCache[i], null);
+                if (handle != null) break;
+            }
+
+            if (handle != null)
+            {
+                // One possible future consideration is to attempt cycling through to
+                // find one that might already have sufficient capacity
+                if (handle.ByteLength < minSize)
+                    handle.Resize(minSize);
+            }
+            else
+            {
+                handle = new SafeHeapHandle(minSize);
+            }
+
+            return handle;
+        }
+
+        /// <summary>
+        /// Give a HeapHandle back for potential reuse
+        /// </summary>
+        public void Release(SafeHeapHandle handle)
+        {
+            if (handle.ByteLength <= _maxSize)
+            {
+                for (int i = 0; i < _handleCache.Length; i++)
+                {
+                    // Push the handles down, walking the last one off the end to keep
+                    // the top of the "stack" fresh
+                    handle = Interlocked.Exchange(ref _handleCache[i], handle);
+                    if (handle == null) return;
+                }
+            }
+
+            handle.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing && _handleCache != null)
+            {
+                foreach (SafeHeapHandle handle in _handleCache)
+                {
+                    if (handle != null) handle.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Runtime/InteropServices/StringBuffer.cs
+++ b/src/Common/src/System/Runtime/InteropServices/StringBuffer.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Native buffer that deals in char size increments. Dispose to free memory. Allows buffers larger
+    /// than a maximum size string to enable working with very large string arrays.  Always makes ordinal
+    /// comparisons.
+    /// 
+    /// A more performant replacement for StringBuilder when performing native interop.
+    /// </summary>
+    /// <remarks>
+    /// Suggested use through P/Invoke: define DllImport arguments that take a character buffer as IntPtr.
+    /// NativeStringBuffer has an implicit conversion to IntPtr.
+    /// </remarks>
+    internal class StringBuffer : NativeBuffer
+    {
+        private ulong _length;
+
+        /// <summary>
+        /// Instantiate the buffer with capacity for at least the specified number of characters. Capacity
+        /// includes the trailing null character.
+        /// </summary>
+        public StringBuffer(ulong initialCapacity = 0)
+            : base(initialCapacity)
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the buffer with a copy of the specified string.
+        /// </summary>
+        public unsafe StringBuffer(string initialContents)
+            : base(0)
+        {
+            // We don't pass the count of bytes to the base constructor, appending will
+            // initialize to the correct size for the specified initial contents.
+            if (initialContents != null)
+            {
+                Append(initialContents);
+            }
+        }
+
+        /// <summary>
+        /// Get/set the character at the given index.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if attempting to index outside of the buffer length.</exception>
+        public new unsafe char this[ulong index]
+        {
+            get
+            {
+                if (index >= _length) throw new ArgumentOutOfRangeException("index");
+                return CharPointer[index];
+            }
+            set
+            {
+                if (index >= _length) throw new ArgumentOutOfRangeException("index");
+                CharPointer[index] = value;
+            }
+        }
+
+        /// <summary>
+        /// Character capacity of the buffer. Includes the count for the trailing null character.
+        /// </summary>
+        public ulong CharCapacity
+        {
+            get
+            {
+                ulong byteCapacity = ByteCapacity;
+                return byteCapacity == 0 ? 0 : byteCapacity / sizeof(char);
+            }
+        }
+
+        /// <summary>
+        /// Ensure capacity in characters is at least the given minimum.
+        /// </summary>
+        /// <exception cref="OutOfMemoryException">Thrown if unable to allocate memory when setting.</exception>
+        public void EnsureCharCapacity(ulong minCapacity)
+        {
+            EnsureByteCapacity(minCapacity * sizeof(char));
+        }
+
+        /// <summary>
+        /// The logical length of the buffer in characters. (Does not include the final null.) Will automatically attempt to increase capacity.
+        /// This is where the usable data ends.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if attempting to set <paramref name="nameof(Length)"/> to a value that is larger than the maximum addressable memory.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown if unable to allocate memory when setting.</exception>
+        public unsafe ulong Length
+        {
+            get { return _length; }
+            set
+            {
+                // Null terminate
+                EnsureCharCapacity(value + 1);
+                CharPointer[value] = '\0';
+
+                _length = value;
+            }
+        }
+
+        /// <summary>
+        /// For use when the native api null terminates but doesn't return a length.
+        /// If no null is found, the length will not be changed.
+        /// </summary>
+        public unsafe void SetLengthToFirstNull()
+        {
+            char* buffer = CharPointer;
+            ulong capacity = CharCapacity;
+            for (ulong i = 0; i < capacity; i++)
+            {
+                if (buffer[i] == '\0')
+                {
+                    _length = i;
+                    break;
+                }
+            }
+        }
+
+        internal unsafe char* CharPointer
+        {
+            get
+            {
+                return (char*)VoidPointer;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the buffer starts with the given string.
+        /// </summary>
+        public bool StartsWith(string value)
+        {
+            if (value == null) throw new ArgumentNullException("value");
+            if (_length < (ulong)value.Length) return false;
+            return SubstringEquals(value, startIndex: 0, count: value.Length);
+        }
+
+        /// <summary>
+        /// Returns true if the specified StringBuffer substring equals the given value.
+        /// </summary>
+        /// <param name="value">The value to compare against the specified substring.</param>
+        /// <param name="startIndex">Start index of the sub string.</param>
+        /// <param name="count">Length of the substring, or -1 to check all remaining.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if <paramref name="startIndex"/> or <paramref name="count"/> are outside the range
+        /// of the buffer's length.
+        /// </exception>
+        public unsafe bool SubstringEquals(string value, ulong startIndex = 0, int count = -1)
+        {
+            if (value == null) return false;
+            if (count < -1) throw new ArgumentOutOfRangeException("count");
+            ulong realCount = count == -1 ? _length - startIndex : (ulong)count;
+            if (startIndex + realCount > _length) throw new ArgumentOutOfRangeException("count");
+
+            int length = value.Length;
+
+            // Check the substring length against the input length
+            if (realCount != (ulong)length) return false;
+
+            fixed (char* valueStart = value)
+            {
+                char* bufferStart = CharPointer + startIndex;
+                for (int i = 0; i < length; i++)
+                {
+                    // Note that indexing in this case generates faster code than trying to copy the pointer and increment it
+                    if (*bufferStart++ != valueStart[i]) return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Append the given string.
+        /// </summary>
+        /// <param name="value">The string to append.</param>
+        /// <param name="startIndex">The index in the input string to start appending from.</param>
+        /// <param name="count">The count of characters to copy from the input string, or -1 for all remaining.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if <paramref name="startIndex"/> or <paramref name="count"/> are outside the range
+        /// of <paramref name="value"/> characters.
+        /// </exception>
+        public void Append(string value, int startIndex = 0, int count = -1)
+        {
+            CopyFrom(
+                bufferIndex: _length,
+                source: value,
+                sourceIndex: startIndex,
+                count: count);
+        }
+
+        /// <summary>
+        /// Append the given buffer.
+        /// </summary>
+        /// <param name="value">The buffer to append.</param>
+        /// <param name="startIndex">The index in the input buffer to start appending from.</param>
+        /// <param name="count">The count of characters to copy from the buffer string.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if <paramref name="startIndex"/> or <paramref name="count"/> are outside the range
+        /// of <paramref name="value"/> characters.
+        /// </exception>
+        public void Append(StringBuffer value, ulong startIndex = 0, ulong count = 0)
+        {
+            if (value == null) throw new ArgumentNullException("value");
+            if (count == 0) return;
+            value.CopyTo(
+                bufferIndex: startIndex,
+                destination: this,
+                destinationIndex: _length,
+                count: count);
+        }
+
+        /// <summary>
+        /// Copy contents to the specified buffer. Destination index must be within current destination length.
+        /// Will grow the destination buffer if needed.
+        /// </summary>
+        public unsafe void CopyTo(ulong bufferIndex, StringBuffer destination, ulong destinationIndex, ulong count)
+        {
+            if (destination == null) throw new ArgumentNullException("destination");
+            if (destinationIndex > destination._length) throw new ArgumentOutOfRangeException("destinationIndex");
+            if (_length < bufferIndex + count) throw new ArgumentOutOfRangeException("count");
+
+            if (count == 0) return;
+            ulong lastIndex = destinationIndex + (ulong)count;
+            if (destination._length < lastIndex) destination.Length = lastIndex;
+
+            Buffer.MemoryCopy(
+                source: CharPointer + bufferIndex,
+                destination: destination.CharPointer + destinationIndex,
+                destinationSizeInBytes: checked((long)(destination.ByteCapacity - (destinationIndex * sizeof(char)))),
+                sourceBytesToCopy: checked((long)count * sizeof(char)));
+        }
+
+        /// <summary>
+        /// Copy contents from the specified string into the buffer at the given index. Start index must be within the current length of
+        /// the buffer, will grow as necessary.
+        /// </summary>
+        public unsafe void CopyFrom(ulong bufferIndex, string source, int sourceIndex = 0, int count = -1)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (bufferIndex > _length) throw new ArgumentOutOfRangeException("bufferIndex");
+            if (sourceIndex < 0 || sourceIndex > source.Length) throw new ArgumentOutOfRangeException("sourceIndex");
+            if (count < 0) count = source.Length - sourceIndex;
+            if (source.Length - count < sourceIndex) throw new ArgumentOutOfRangeException("count");
+
+            if (count == 0) return;
+            ulong lastIndex = bufferIndex + (ulong)count;
+            if (_length < lastIndex) Length = lastIndex;
+
+            fixed (char* content = source)
+            {
+                Buffer.MemoryCopy(
+                    source: content + sourceIndex,
+                    destination: CharPointer + bufferIndex,
+                    destinationSizeInBytes: checked((long)(ByteCapacity - (bufferIndex * sizeof(char)))),
+                    sourceBytesToCopy: (long)count * sizeof(char));
+            }
+        }
+
+        /// <summary>
+        /// Trim the specified values from the end of the buffer. If nothing is specified, nothing is trimmed.
+        /// </summary>
+        public unsafe void TrimEnd(char[] values)
+        {
+            if (values == null || values.Length == 0 || _length == 0) return;
+
+            char* end = CharPointer + _length - 1;
+
+            while (Array.IndexOf(values, *end) >= 0)
+            {
+                Length--;
+                end--;
+            }
+        }
+
+        /// <summary>
+        /// String representation of the entire buffer. If the buffer is larger than the maximum size string (int.MaxValue) this will throw.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if the buffer is too big to fit into a string.</exception>
+        public unsafe override string ToString()
+        {
+            if (_length == 0) return string.Empty;
+            if (_length > int.MaxValue) throw new InvalidOperationException();
+            return new string(CharPointer, startIndex: 0, length: (int)_length);
+        }
+
+        /// <summary>
+        /// Get the given substring in the buffer.
+        /// </summary>
+        /// <param name="count">Count of characters to take, or remaining characters from <paramref name="startIndex"/> if -1.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if <paramref name="startIndex"/> or <paramref name="count"/> are outside the range of the buffer's length
+        /// or count is greater than the maximum string size (int.MaxValue).
+        /// </exception>
+        public unsafe string Substring(ulong startIndex, int count = -1)
+        {
+            if (_length > 0 && startIndex > _length - 1) throw new ArgumentOutOfRangeException("startIndex");
+            if (count < -1) throw new ArgumentOutOfRangeException("count");
+
+            ulong realCount = count == -1 ? _length - startIndex : (ulong)count;
+            if (realCount > int.MaxValue || startIndex + realCount > _length) throw new ArgumentOutOfRangeException("count");
+            if (realCount == 0) return string.Empty;
+
+            // The buffer could be bigger than will fit into a string, but the substring might fit. As the starting
+            // index might be bigger than int we need to index ourselves.
+            return new string(value: CharPointer + startIndex, startIndex: 0, length: (int)realCount);
+        }
+
+        public override void Free()
+        {
+            base.Free();
+            _length = 0;
+        }
+    }
+}

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -42,10 +42,28 @@
       <Link>Common\System\IO\TaskHelpers.cs</Link>
     </Compile>
     <Compile Include="Tests\System\IO\PathInternal.Tests.cs" />
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SafeHeapHandle.cs">
+      <Link>Common\System\Runtime\InteropServices\SafeHeapHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SafeHeapHandleCache.cs">
+      <Link>Common\System\Runtime\InteropServices\SafeHeapHandleCache.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\NativeBuffer.cs">
+      <Link>Common\System\Runtime\InteropServices\NativeBuffer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\StringBuffer.cs">
+      <Link>Common\System\Runtime\InteropServices\StringBuffer.cs</Link>
+    </Compile>
+    <Compile Include="Tests\System\Runtime\InteropServices\NativeBufferTests.cs" />
+    <Compile Include="Tests\System\Runtime\InteropServices\StringBufferTests.cs" />
+    <Compile Include="Tests\System\Runtime\InteropServices\SafeHeapHandleCacheTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-    <Compile Include="..\src\System\IO\PathInternal.Windows.cs">
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.StringBuffer.cs">
+      <Link>Common\System\IO\PathInternal.Windows.StringBuffer.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>

--- a/src/Common/tests/Tests/System/Runtime/InteropServices/NativeBufferTests.cs
+++ b/src/Common/tests/Tests/System/Runtime/InteropServices/NativeBufferTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Tests.System.Runtime.InteropServices
+{
+    public class NativeBufferTests
+    {
+        [Fact]
+        public void EnsureZeroCapacityDoesNotFreeBuffer()
+        {
+            using (var buffer = new NativeBuffer(10))
+            {
+                Assert.NotEqual(buffer.GetHandle().DangerousGetHandle(), IntPtr.Zero);
+                buffer.EnsureByteCapacity(0);
+                Assert.NotEqual(buffer.GetHandle().DangerousGetHandle(), IntPtr.Zero);
+            }
+        }
+
+        [Fact]
+        public void GetOverIndexThrowsArgumentOutOfRange()
+        {
+            using (var buffer = new NativeBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { byte c = buffer[0]; });
+            }
+        }
+
+        [Fact]
+        public void SetOverIndexThrowsArgumentOutOfRange()
+        {
+            using (var buffer = new NativeBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { buffer[0] = 0; });
+            }
+        }
+
+        [Fact]
+        public void CanGetSetBytes()
+        {
+            using (var buffer = new NativeBuffer(1))
+            {
+                buffer[0] = 0xA;
+                Assert.Equal(buffer[0], 0xA);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void NullSafePointerInTest()
+        {
+            using (var buffer = new NativeBuffer(0))
+            {
+                Assert.True(buffer.GetHandle().IsInvalid);
+                Assert.Equal((ulong)0, buffer.ByteCapacity);
+
+                // This will throw if we don't put a stub SafeHandle in for the empty buffer
+                GetCurrentDirectorySafe((uint)buffer.ByteCapacity, buffer.GetHandle());
+            }
+        }
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364934.aspx
+        [DllImport("kernel32.dll", EntryPoint = "GetCurrentDirectoryW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        private static extern uint GetCurrentDirectorySafe(
+            uint nBufferLength,
+            SafeHandle lpBuffer);
+    }
+}

--- a/src/Common/tests/Tests/System/Runtime/InteropServices/SafeHeapHandleCacheTests.cs
+++ b/src/Common/tests/Tests/System/Runtime/InteropServices/SafeHeapHandleCacheTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Tests.System.Runtime.InteropServices
+{
+    public class SafeHeapHandleCacheTests
+    {
+        [Theory,
+            InlineData(5, 5, 5),
+            InlineData(5, 7, 5),
+            InlineData(5, 3, 3),
+            InlineData(0, 1, 1),
+            InlineData(-1, 1, 1),
+            ]
+        public void CachedCountTest(int maxCount, int itemsToCache, int expected)
+        {
+            using (SafeHeapHandleCache cache = new SafeHeapHandleCache(minSize: 5, maxSize: 100, maxHandles: maxCount))
+            {
+                for (int i = 0; i < itemsToCache; i++)
+                {
+                    cache.Release(new SafeHeapHandle(10));
+                }
+
+                int count = cache._handleCache.Count(h => h != null);
+                Assert.Equal(expected, count);
+            }
+        }
+
+        [Fact]
+        public void GrabHandleFromEmptyCache()
+        {
+            using (SafeHeapHandleCache cache = new SafeHeapHandleCache(minSize: 5, maxSize: 100, maxHandles: 2))
+            {
+                var handle = cache.Acquire();
+                Assert.NotNull(handle);
+                Assert.Equal((ulong)5, handle.ByteLength);
+            }
+        }
+
+        [Fact]
+        public void OldestPushedOff()
+        {
+            using (SafeHeapHandleCache cache = new SafeHeapHandleCache(minSize: 5, maxSize: 100, maxHandles: 2))
+            {
+                var first = cache.Acquire();
+                var second = cache.Acquire();
+                var third = cache.Acquire();
+                cache.Release(first);
+                cache.Release(second);
+                cache.Release(third);
+                Assert.True(first.IsClosed);
+                Assert.False(second.IsClosed);
+                Assert.False(third.IsClosed);
+            }
+        }
+
+        [Fact]
+        public void LatestPopped()
+        {
+            using (SafeHeapHandleCache cache = new SafeHeapHandleCache(minSize: 5, maxSize: 100, maxHandles: 2))
+            {
+                var first = cache.Acquire();
+                var second = cache.Acquire();
+                cache.Release(first);
+                cache.Release(second);
+                Assert.Same(second, cache.Acquire());
+                Assert.Same(first, cache.Acquire());
+            }
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
+++ b/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
@@ -1,0 +1,481 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Tests.System.Runtime.InteropServices
+{
+    public class StringBufferTests
+    {
+        private const string TestString = ".NET Core is awesome.";
+
+        [Fact]
+        public void CanIndexChar()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                buffer.Length = 1;
+                buffer[0] = 'Q';
+                Assert.Equal(buffer[0], 'Q');
+            }
+        }
+
+        [Fact]
+        public unsafe void CreateFromString()
+        {
+            string testString = "Test";
+            using (var buffer = new StringBuffer(testString))
+            {
+                Assert.Equal((ulong)testString.Length, buffer.Length);
+                Assert.Equal((ulong)testString.Length + 1, buffer.CharCapacity);
+
+                for (int i = 0; i < testString.Length; i++)
+                {
+                    Assert.Equal(testString[i], buffer[(ulong)i]);
+                }
+
+                // Check the null termination
+                Assert.Equal('\0', buffer.CharPointer[testString.Length]);
+
+                Assert.Equal(testString, buffer.ToString());
+            }
+        }
+
+        [Fact]
+        public void ReduceLength()
+        {
+            using (var buffer = new StringBuffer("Food"))
+            {
+                Assert.Equal((ulong)5, buffer.CharCapacity);
+                buffer.Length = 3;
+                Assert.Equal("Foo", buffer.ToString());
+                // Shouldn't reduce capacity when dropping length
+                Assert.Equal((ulong)5, buffer.CharCapacity);
+            }
+        }
+
+        [Fact]
+        public void GetOverIndexThrowsArgumentOutOfRange()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { char c = buffer[0]; });
+            }
+        }
+
+        [Fact]
+        public void SetOverIndexThrowsArgumentOutOfRange()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { buffer[0] = 'Q'; });
+            }
+        }
+
+        [Theory,
+            InlineData(@"Foo", @"Foo", true),
+            InlineData(@"Foo", @"foo", false),
+            InlineData(@"Foobar", @"Foo", true),
+            InlineData(@"Foobar", @"foo", false),
+            InlineData(@"Fo", @"Foo", false),
+            InlineData(@"Fo", @"foo", false),
+            InlineData(@"", @"", true),
+            InlineData(@"", @"f", false),
+            InlineData(@"f", @"", true),
+            ]
+        public void StartsWith(string source, string value, bool expected)
+        {
+            using (var buffer = new StringBuffer(source))
+            {
+                Assert.Equal(expected, buffer.StartsWith(value));
+            }
+        }
+
+        [Fact]
+        public void StartsWithNullThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentNullException>(() => buffer.StartsWith(null));
+            }
+        }
+
+        [Fact]
+        public void SubstringEqualsNegativeCountThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.SubstringEquals("", startIndex: 0, count: -2));
+            }
+        }
+
+        [Fact]
+        public void SubstringEqualsOverSizeCountThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.SubstringEquals("", startIndex: 0, count: 1));
+            }
+        }
+
+        [Fact]
+        public void SubstringEqualsOverSizeCountWithIndexThrows()
+        {
+            using (var buffer = new StringBuffer("A"))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.SubstringEquals("", startIndex: 1, count: 1));
+            }
+        }
+
+        [Theory,
+            InlineData(@"", null, 0, 0, false),
+            InlineData(@"", @"", 0, 0, true),
+            InlineData(@"", @"", 0, -1, true),
+            InlineData(@"A", @"", 0, -1, false),
+            InlineData(@"", @"A", 0, -1, false),
+            InlineData(@"Foo", @"Foo", 0, -1, true),
+            InlineData(@"Foo", @"foo", 0, -1, false),
+            InlineData(@"Foo", @"Foo", 1, -1, false),
+            InlineData(@"Foo", @"Food", 0, -1, false),
+            InlineData(@"Food", @"Foo", 0, -1, false),
+            InlineData(@"Food", @"Foo", 0, 3, true),
+            InlineData(@"Food", @"ood", 1, 3, true),
+            InlineData(@"Food", @"ooD", 1, 3, false),
+            InlineData(@"Food", @"ood", 1, 2, false),
+            InlineData(@"Food", @"Food", 0, 3, false),
+            ]
+        public void SubstringEquals(string source, string value, int startIndex, int count, bool expected)
+        {
+            using (var buffer = new StringBuffer(source))
+            {
+                Assert.Equal(expected, buffer.SubstringEquals(value, startIndex: (ulong)startIndex, count: count));
+            }
+        }
+
+        [Theory,
+            InlineData(@"", @"", 0, -1, @""),
+            InlineData(@"", @"", 0, 0, @""),
+            InlineData(@"", @"A", 0, -1, @"A"),
+            InlineData(@"", @"A", 0, 0, @""),
+            InlineData(@"", @"Aa", 0, -1, @"Aa"),
+            InlineData(@"", @"Aa", 0, 0, @""),
+            InlineData(@"", "Aa\0", 0, -1, "Aa\0"),
+            InlineData(@"", "Aa\0", 0, 3, "Aa\0"),
+            InlineData(@"", @"AB", 0, -1, @"AB"),
+            InlineData(@"", @"AB", 0, 1, @"A"),
+            InlineData(@"", @"AB", 1, 1, @"B"),
+            InlineData(@"", @"AB", 1, -1, @"B"),
+            InlineData(@"", @"ABC", 1, -1, @"BC"),
+            InlineData(null, @"", 0, -1, @""),
+            InlineData(null, @"", 0, 0, @""),
+            InlineData(null, @"A", 0, -1, @"A"),
+            InlineData(null, @"A", 0, 0, @""),
+            InlineData(null, @"Aa", 0, -1, @"Aa"),
+            InlineData(null, @"Aa", 0, 0, @""),
+            InlineData(null, "Aa\0", 0, -1, "Aa\0"),
+            InlineData(null, "Aa\0", 0, 3, "Aa\0"),
+            InlineData(null, @"AB", 0, -1, @"AB"),
+            InlineData(null, @"AB", 0, 1, @"A"),
+            InlineData(null, @"AB", 1, 1, @"B"),
+            InlineData(null, @"AB", 1, -1, @"B"),
+            InlineData(null, @"ABC", 1, -1, @"BC"),
+            InlineData(@"Q", @"", 0, -1, @"Q"),
+            InlineData(@"Q", @"", 0, 0, @"Q"),
+            InlineData(@"Q", @"A", 0, -1, @"QA"),
+            InlineData(@"Q", @"A", 0, 0, @"Q"),
+            InlineData(@"Q", @"Aa", 0, -1, @"QAa"),
+            InlineData(@"Q", @"Aa", 0, 0, @"Q"),
+            InlineData(@"Q", "Aa\0", 0, -1, "QAa\0"),
+            InlineData(@"Q", "Aa\0", 0, 3, "QAa\0"),
+            InlineData(@"Q", @"AB", 0, -1, @"QAB"),
+            InlineData(@"Q", @"AB", 0, 1, @"QA"),
+            InlineData(@"Q", @"AB", 1, 1, @"QB"),
+            InlineData(@"Q", @"AB", 1, -1, @"QB"),
+            InlineData(@"Q", @"ABC", 1, -1, @"QBC"),
+            ]
+        public void AppendTests(string source, string value, int startIndex, int count, string expected)
+        {
+            // From string
+            using (var buffer = new StringBuffer(source))
+            {
+                buffer.Append(value, startIndex, count);
+                Assert.Equal(expected, buffer.ToString());
+            }
+
+            // From buffer
+            using (var buffer = new StringBuffer(source))
+            using (var valueBuffer = new StringBuffer(value))
+            {
+                if (count == -1)
+                    buffer.Append(valueBuffer, (ulong)startIndex, valueBuffer.Length - (ulong)startIndex);
+                else
+                    buffer.Append(valueBuffer, (ulong)startIndex, (ulong)count);
+                Assert.Equal(expected, buffer.ToString());
+            }
+        }
+
+        [Fact]
+        public void AppendNullStringThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentNullException>(() => buffer.Append((string)null));
+            }
+        }
+
+        [Fact]
+        public void AppendNullStringBufferThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentNullException>(() => buffer.Append((StringBuffer)null));
+            }
+        }
+
+        [Fact]
+        public void AppendNegativeIndexThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Append("a", startIndex: -1));
+            }
+        }
+
+        [Fact]
+        public void AppendOverIndexThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Append("", startIndex: 1));
+            }
+        }
+
+        [Fact]
+        public void AppendOverCountThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Append("", startIndex: 0, count: 1));
+            }
+        }
+
+        [Fact]
+        public void AppendOverCountWithIndexThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Append("A", startIndex: 1, count: 1));
+            }
+        }
+
+        [Fact]
+        public void ToStringIndexOverLengthThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Substring(startIndex: 1));
+            }
+        }
+
+        [Fact]
+        public void ToStringNegativeCountThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Substring(startIndex: 0, count: -2));
+            }
+        }
+
+        [Fact]
+        public void ToStringCountOverLengthThrows()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Substring(startIndex: 0, count: 1));
+            }
+        }
+
+        [Theory,
+            InlineData(@"", 0, -1, @""),
+            InlineData(@"A", 0, -1, @"A"),
+            InlineData(@"AB", 0, -1, @"AB"),
+            InlineData(@"AB", 0, 1, @"A"),
+            InlineData(@"AB", 1, 1, @"B"),
+            InlineData(@"AB", 1, -1, @"B"),
+            InlineData(@"", 0, 0, @""),
+            InlineData(@"A", 0, 0, @""),
+            ]
+        public void ToStringTest(string source, int startIndex, int count, string expected)
+        {
+            using (var buffer = new StringBuffer(source))
+            {
+                Assert.Equal(expected, buffer.Substring(startIndex: (ulong)startIndex, count: count));
+            }
+        }
+
+        [Fact]
+        public unsafe void SetLengthToFirstNullNoNull()
+        {
+            using (var buffer = new StringBuffer("A"))
+            {
+                // Wipe out the last null
+                buffer.CharPointer[buffer.Length] = 'B';
+                buffer.SetLengthToFirstNull();
+                Assert.Equal((ulong)1, buffer.Length);
+            }
+        }
+
+        [Fact]
+        public unsafe void SetLengthToFirstNullEmptyBuffer()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                buffer.SetLengthToFirstNull();
+                Assert.Equal((ulong)0, buffer.Length);
+            }
+        }
+
+        [Theory,
+            InlineData(@"", 0, 0),
+            InlineData(@"Foo", 3, 3),
+            InlineData("\0", 1, 0),
+            InlineData("Foo\0Bar", 7, 3),
+            ]
+        public unsafe void SetLengthToFirstNullTests(string content, ulong startLength, ulong endLength)
+        {
+            using (var buffer = new StringBuffer(content))
+            {
+                // With existing content
+                Assert.Equal(startLength, buffer.Length);
+                buffer.SetLengthToFirstNull();
+                Assert.Equal(endLength, buffer.Length);
+
+                // Clear the buffer & manually copy in
+                buffer.Length = 0;
+                fixed (char* contentPointer = content)
+                {
+                    Buffer.MemoryCopy(contentPointer, buffer.CharPointer, (long)buffer.CharCapacity * 2, content.Length * sizeof(char));
+                }
+
+                Assert.Equal((ulong)0, buffer.Length);
+                buffer.SetLengthToFirstNull();
+                Assert.Equal(endLength, buffer.Length);
+            }
+        }
+
+        [Theory,
+            InlineData("foo", new char[] { }, "foo"),
+            InlineData("foo", null, "foo"),
+            InlineData("foo", new char[] { 'b' }, "foo"),
+            InlineData("", new char[] { }, ""),
+            InlineData("", null, ""),
+            InlineData("", new char[] { 'b' }, ""),
+            InlineData("foo", new char[] { 'o' }, "f"),
+            InlineData("foo", new char[] { 'o', 'f' }, ""),
+            ]
+        public void TrimEnd(string content, char[] trimChars, string expected)
+        {
+            // We want equivalence with built-in string behavior
+            using (var buffer = new StringBuffer(content))
+            {
+                buffer.TrimEnd(trimChars);
+                Assert.Equal(expected, buffer.ToString());
+            }
+        }
+
+        [Theory,
+            InlineData(@"Foo", @"Bar", 0, 0, 3, "Bar"),
+            InlineData(@"Foo", @"Bar", 0, 0, -1, "Bar"),
+            InlineData(@"Foo", @"Bar", 3, 0, 3, "FooBar"),
+            InlineData(@"", @"Bar", 0, 0, 3, "Bar"),
+            InlineData(@"Foo", @"Bar", 1, 0, 3, "FBar"),
+            InlineData(@"Foo", @"Bar", 1, 1, 2, "Far"),
+            ]
+        public void CopyFromString(string content, string source, ulong bufferIndex, int sourceIndex, int count, string expected)
+        {
+            using (var buffer = new StringBuffer(content))
+            {
+                buffer.CopyFrom(bufferIndex, source, sourceIndex, count);
+                Assert.Equal(expected, buffer.ToString());
+            }
+        }
+
+        [Fact]
+        public void CopyFromStringThrowsOnNull()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentNullException>(() => { buffer.CopyFrom(0, null); });
+            }
+        }
+
+        [Fact]
+        public void CopyFromStringThrowsIndexingBeyondBufferLength()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { buffer.CopyFrom(1, ""); });
+            }
+        }
+
+        [Theory,
+            InlineData("", 0, 1),
+            InlineData("", 1, 0),
+            InlineData("", 1, -1),
+            InlineData("", 2, 0),
+            InlineData("Foo", 3, 1),
+            InlineData("Foo", 4, 0),
+            ]
+        public void CopyFromStringThrowsIndexingBeyondStringLength(string value, int index, int count)
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { buffer.CopyFrom(0, value, index, count); });
+            }
+        }
+
+        [Theory,
+            InlineData(@"Foo", @"Bar", 0, 0, 3, "Bar"),
+            InlineData(@"Foo", @"Bar", 3, 0, 3, "FooBar"),
+            InlineData(@"", @"Bar", 0, 0, 3, "Bar"),
+            InlineData(@"Foo", @"Bar", 1, 0, 3, "FBar"),
+            InlineData(@"Foo", @"Bar", 1, 1, 2, "Far"),
+            ]
+        public void CopyToBufferString(string destination, string content, ulong destinationIndex, ulong bufferIndex, ulong count, string expected)
+        {
+            using (var buffer = new StringBuffer(content))
+            using (var destinationBuffer = new StringBuffer(destination))
+            {
+                buffer.CopyTo(bufferIndex, destinationBuffer, destinationIndex, count);
+                Assert.Equal(expected, destinationBuffer.ToString());
+            }
+        }
+
+        [Fact]
+        public void CopyToBufferThrowsOnNull()
+        {
+            using (var buffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentNullException>(() => { buffer.CopyTo(0, null, 0, 0); });
+            }
+        }
+
+        [Theory,
+            InlineData("", 0, 1),
+            InlineData("", 1, 0),
+            InlineData("", 2, 0),
+            InlineData("Foo", 3, 1),
+            InlineData("Foo", 4, 0),
+            ]
+        public void CopyToBufferThrowsIndexingBeyondSourceBufferLength(string source, ulong index, ulong count)
+        {
+            using (var buffer = new StringBuffer(source))
+            using (var targetBuffer = new StringBuffer())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { buffer.CopyTo(index, targetBuffer, 0, count); });
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -44,6 +44,18 @@
     <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
       <Link>Common\System\IO\PathInternal.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SafeHeapHandle.cs">
+      <Link>Common\System\Runtime\InteropServices\SafeHeapHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SafeHeapHandleCache.cs">
+      <Link>Common\System\Runtime\InteropServices\SafeHeapHandleCache.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\NativeBuffer.cs">
+      <Link>Common\System\Runtime\InteropServices\NativeBuffer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\StringBuffer.cs">
+      <Link>Common\System\Runtime\InteropServices\StringBuffer.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="System\Diagnostics\Stopwatch.Windows.cs" />
@@ -91,6 +103,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.StringBuffer.cs">
+      <Link>Common\System\IO\PathInternal.Windows.StringBuffer.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -138,22 +138,6 @@ namespace System.IO
             return path;
         }
 
-        private static string NormalizeStandardPath(string path, bool fullCheck, bool expandShortPaths)
-        {
-            // Technically this doesn't matter, but we used to throw for this case
-            if (String.IsNullOrWhiteSpace(path))
-                throw new ArgumentException(SR.Arg_PathIllegal);
-
-            PathHelper helper = new PathHelper();
-            string returnVal = helper.Normalize(path, fullCheck, expandShortPaths);
-
-            if (String.Equals(returnVal, path, StringComparison.Ordinal))
-            {
-                returnVal = path;
-            }
-            return returnVal;
-        }
-
         private static string NormalizePath(string path, bool fullCheck = true, bool expandShortPaths = true)
         {
             Debug.Assert(path != null, "path can't be null");
@@ -191,7 +175,11 @@ namespace System.IO
             }
             else
             {
-                return NormalizeStandardPath(path, fullCheck, expandShortPaths);
+                // Technically this doesn't matter but we used to throw for this case
+                if (String.IsNullOrWhiteSpace(path))
+                    throw new ArgumentException(SR.Arg_PathIllegal);
+
+                return PathHelper.Normalize(path, fullCheck, expandShortPaths);
             }
         }
 


### PR DESCRIPTION
Creates an internal buffer specifically for interop purposes (NativeBuffer/StringBuffer).
Caching is implicit, disposing will return the buffer to the cache immediately.
Buffers resize implicitly and utilize new (non depreciated) heap APIs (which handle content
copying if needed). Buffers do not zero memory for added perf.
StringBuffer can copy directly with strings and other StringBuffers.

Some StringBuilder perf/functionality issues for interop:
- Does not pin, but could if unchunked (creating 4x allocations for out strings with P/Invoke)
- Does not allow fast copying between StringBuilders
- Does not allow indexing in to skip characters with P/Invoke (char* + offset)
- Cannot compare substrings without allocating or walking char indexing
- Difficult to split null separated string arrays (common in Win32)
- Capacity is actually +1 (doesn't include the null), most Win32 APIs want count + null

Start moving String/StringBuilder/StringBuffer path internal helper methods to use core
char* helper for longer methods. Keep StringBuffer overloads in a separate file to
allow inclusion just with interoping projects.