### PR TITLE
Append unknown scope IDs if necessary.

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -82,7 +82,6 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<FormatException>(() => { IPAddress.Parse("Fe08::/64"); });
         }
 
-        [ActiveIssue(3213, PlatformID.OSX)]
         [Fact]
         public void ParseIPv6_ScopeId_Success()
         {


### PR DESCRIPTION
Certain platforms (e.g. OS X) will not append unknown scope IDs to
IPv6 addresses when converting them from `sockaddr_in6` values to
strings. Append the scope manually in this case.

Fixes #3213.