### PR TITLE
Fix a typo in pal_networking.cpp.

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -613,7 +613,7 @@ extern "C" void FreeHostEntry(HostEntry* entry)
 
             case HOST_ENTRY_HANDLE_HOSTENT:
             {
-#if !defined(HAS_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR)
+#if !HAVE_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR
                 free(entry->AddressListHandle);
 #endif
                 break;   

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -25,7 +25,6 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(hostEntry.Aliases);
         }
 
-        [ActiveIssue(3218, PlatformID.OSX)]
         [Fact]
         public void GetHostByName_HostName()
         {


### PR DESCRIPTION
This change also re-enables a disabled NameResolution PAL test.

Fixes #2318.