### PR TITLE
Fix assert and leak of WinHttpRequestState object

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -191,8 +191,6 @@ namespace System.Net.Http
                         _state.RequestHandle.Dispose();
                         _state.RequestHandle = null;
                     }
-                    
-                    _state.Dispose();
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -33,7 +33,27 @@ namespace System.Net.Http
             return s_TraceEnabled;
         }
 
-        public static void TraceCallbackStatus(string message, IntPtr handle, bool invokeCallback, uint status)
+        public static void Trace(string message)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(message);
+        }
+
+        public static void Trace(string format, object arg0, object arg1, object arg2)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(format, arg0, arg1, arg2);
+        }
+
+        public static void TraceCallbackStatus(string message, IntPtr handle, IntPtr context, uint status)
         {
             if (!IsTraceEnabled())
             {
@@ -41,10 +61,10 @@ namespace System.Net.Http
             }
 
             Debug.WriteLine(
-                "{0}: handle=0x{1:X}, {2}, {3}",
+                "{0}: handle=0x{1:X}, context=0x{2:X}, {3}",
                 message,
                 handle,
-                invokeCallback ? "processing" : "skipping",
+                context,
                 GetStringFromInternetStatus(status));
         }
 


### PR DESCRIPTION
Discovered during testing with DEBUG version of CoreCLR running internal ToF tests. The design of the WinHttpRequestState is such that it stays alive due to a GCHandle.Alloc(this) in its constructor. This keeps the object alive during any of the native WinHTTP callbacks. However, the object was being prematurely disposed during the Dispose() of the WinHttpResponseStream. Instead, it should have been explicitly disposed during the final HANDLE_CLOSING callback from WinHTTP when the request handle was disposed. The early disposing of the WinHttpRequestState object was doing a GCHandle.Free() of the state object. This later caused an Assert() in the DEBUG version of the CoreCLR when doing GCHandle.FromIntPtr() indicating that the handle was already deallocated.