### PR TITLE
Interpreter/compiler cross-check tests

### DIFF
--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Array.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Array.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> ArrayIndex()
+        {
+            var arr1 = Expression.Constant(new[] { 2, 3, 5 });
+
+            for (var i = -1; i <= 3; i++)
+            {
+                yield return Expression.ArrayIndex(arr1, Expression.Constant(i));
+            }
+
+            var arr2 = Expression.Constant(new[,] { { 2, 3, 5 }, { 7, 11, 13 } });
+
+            for (var i = -1; i <= 2; i++)
+            {
+                for (var j = -1; i <= 3; i++)
+                {
+                    yield return Expression.ArrayIndex(arr2, Expression.Constant(i), Expression.Constant(j));
+                }
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ArrayIndex_WithLog()
+        {
+            var arr1 = Expression.Constant(new[] { 2, 3, 5 });
+            var arr2 = Expression.Constant(new[,] { { 2, 3, 5 }, { 7, 11, 13 } });
+
+            yield return WithLog(ExpressionType.ArrayIndex, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int));
+                var toStringTemplate = (Expression<Func<int, string>>)(x => x.ToString());
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.ArrayIndex(arr1, ReturnWithLog(log, 1))
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+
+            yield return WithLog(ExpressionType.ArrayIndex, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int));
+                var toStringTemplate = (Expression<Func<int, string>>)(x => x.ToString());
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.ArrayIndex(arr2, ReturnWithLog(log, 1), ReturnWithLog(log, 2))
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+        }
+
+        private static IEnumerable<Expression> ArrayAccess()
+        {
+            var arr1 = Expression.Constant(new[] { 2, 3, 5 });
+
+            for (var i = -1; i <= 3; i++)
+            {
+                yield return Expression.ArrayAccess(arr1, Expression.Constant(i));
+            }
+
+            var arr2 = Expression.Constant(new[,] { { 2, 3, 5 }, { 7, 11, 13 } });
+
+            for (var i = -1; i <= 2; i++)
+            {
+                for (var j = -1; i <= 3; i++)
+                {
+                    yield return Expression.ArrayAccess(arr2, Expression.Constant(i), Expression.Constant(j));
+                }
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ArrayAccess_WithLog()
+        {
+            var arr1 = Expression.Constant(new[] { 2, 3, 5 });
+            var arr2 = Expression.Constant(new[,] { { 2, 3, 5 }, { 7, 11, 13 } });
+
+            yield return WithLog(ExpressionType.Index, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int));
+                var toStringTemplate = (Expression<Func<int, string>>)(x => x.ToString());
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.ArrayAccess(arr1, ReturnWithLog(log, 1))
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+
+            yield return WithLog(ExpressionType.Index, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int));
+                var toStringTemplate = (Expression<Func<int, string>>)(x => x.ToString());
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.ArrayAccess(arr2, ReturnWithLog(log, 1), ReturnWithLog(log, 2))
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+        }
+
+        private static IEnumerable<Expression> ArrayLength()
+        {
+            yield return Expression.ArrayLength(Expression.Constant(new object[0]));
+            yield return Expression.ArrayLength(Expression.Constant(new int[1]));
+            yield return Expression.ArrayLength(Expression.Constant(new string[42]));
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> NewArrayInit()
+        {
+            var expr = (Expression<Func<int>>)(() => new[] { 2, 3, 5, 7 }.Sum());
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.NewArrayInit, expr.Body);
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> NewArrayInit_WithLog()
+        {
+            yield return WithLog(ExpressionType.NewArrayInit, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int[]));
+                var newArrTemplate = (Expression<Func<int[]>>)(() => new[] { 2, 3, 5, 7 });
+                var toStringTemplate = (Expression<Func<int[], string>>)(xs => string.Join(", ", xs));
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.Invoke(
+                                ReturnAllConstants(log, newArrTemplate)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+        }
+
+        private static IEnumerable<Expression> NewArrayBounds()
+        {
+            foreach (var e in new[]
+            {
+                Expression.NewArrayBounds(typeof(int), Expression.Constant(-1)),
+                Expression.NewArrayBounds(typeof(int), Expression.Constant(0)),
+                Expression.NewArrayBounds(typeof(int), Expression.Constant(1), Expression.Constant(-1)),
+                Expression.NewArrayBounds(typeof(int), Expression.Constant(1), Expression.Constant(0)),
+            })
+            {
+                yield return e;
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> NewArrayBounds_WithLog()
+        {
+            yield return WithLog(ExpressionType.NewArrayBounds, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int[]));
+                var toStringTemplate = (Expression<Func<int[], string>>)(xs => string.Join(", ", xs));
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.NewArrayBounds(
+                                typeof(int),
+                                ReturnWithLog(log, 1)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+
+            yield return WithLog(ExpressionType.NewArrayBounds, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(int[,]));
+                var toStringTemplate = (Expression<Func<int[,], string>>)(xs => string.Join(", ", xs));
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.NewArrayBounds(
+                                typeof(int),
+                                ReturnWithLog(log, 1),
+                                ReturnWithLog(log, 2)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Assign.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Assign.cs
@@ -1,0 +1,835 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssign()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Add(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssign_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssignChecked()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Add(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssignChecked_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssign()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Subtract(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssign_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssignChecked()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Subtract(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssignChecked_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssign()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Multiply(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssign_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssignChecked()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Multiply(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssignChecked_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> DivideAssign()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Divide(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> DivideAssign_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ModuloAssign()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Modulo(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ModuloAssign_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> LeftShiftAssign()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[typeof(int)])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.LeftShift(Expression.Default(typeof(S1)), Expression.Default(typeof(int))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(int)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> LeftShiftAssign_Nullable()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[typeof(int)])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> RightShiftAssign()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[typeof(int)])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.RightShift(Expression.Default(typeof(S1)), Expression.Default(typeof(int))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(int)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> RightShiftAssign_Nullable()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[typeof(int)])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AndAssign()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.And(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AndAssign_Nullable()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> OrAssign()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.Or(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> OrAssign_Nullable()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ExclusiveOrAssign()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = Expression.ExclusiveOr(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+					}
+
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs, null, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ExclusiveOrAssign_Nullable()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PowerAssign()
+        {
+			foreach (var t in s_binaryPowerTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
+						}
+					}
+				}
+			}
+
+			var x = Expression.Parameter(typeof(S1));
+			var c = Expression.Lambda(Expression.Negate(x), x);
+			var m = typeof(S1).GetTypeInfo().GetDeclaredMethod("Pow");
+
+			foreach (var l in s_exprs[typeof(S1)])
+			{
+				foreach (var r in s_exprs[typeof(S1)])
+				{
+					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs, m, c)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PowerAssign_Nullable()
+        {
+			foreach (var t in s_binaryPowerTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs)))
+						{
+							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
+						}
+					}
+				}
+			}
+
+			// TODO: conversion
+        }
+
+		private static IEnumerable<Expression> GetAssignments(Expression initialValue, Expression value, Func<Expression, Expression, Expression> createAssignment)
+        {
+            // Parameter
+            {
+                var p = Expression.Parameter(initialValue.Type);
+                var a = Expression.Assign(p, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, createAssignment(p, value));
+            }
+            
+            // Member
+            {
+                var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(initialValue.Type));
+                var a = Expression.Assign(p, Expression.New(p.Type));
+                var v = Expression.Property(p, "Value");
+                var b = Expression.Assign(v, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, b, createAssignment(v, value));
+            }
+
+            // Array
+            {
+                var p = Expression.Parameter(initialValue.Type.MakeArrayType());
+                var a = Expression.Assign(p, Expression.NewArrayBounds(initialValue.Type, Expression.Constant(1)));
+                var e = Expression.ArrayAccess(p, Expression.Constant(0));
+                var b = Expression.Assign(e, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, b, createAssignment(e, value));
+            }
+
+			// Vector
+            {
+                var p = Expression.Parameter(typeof(Vector<>).MakeGenericType(initialValue.Type));
+                var a = Expression.Assign(p, Expression.New(p.Type));
+                var e = Expression.MakeIndex(p, p.Type.GetTypeInfo().GetDeclaredProperty("Item"), new[] { Expression.Constant(0) });
+                var b = Expression.Assign(e, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, b, createAssignment(e, value));
+            }
+        }
+
+		// TODO: conversion lambda
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Generated.cs
@@ -1,0 +1,637 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+		private static readonly Type[] s_binaryArithTypes = new[] { typeof(S1), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long), typeof(float), typeof(double) };
+		private static readonly Type[] s_binaryShiftTypes = new[] { typeof(S1), typeof(byte), typeof(sbyte), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long) };
+		private static readonly Type[] s_binaryLogicTypes = new[] { typeof(S1), typeof(bool), typeof(byte), typeof(sbyte), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long) };
+		private static readonly Type[] s_binaryComprTypes = new[] { typeof(S1), typeof(byte), typeof(sbyte), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long), typeof(float), typeof(double) };
+		private static readonly Type[] s_binaryEqualTypes = new[] { typeof(S1), typeof(string), typeof(byte), typeof(sbyte), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long), typeof(float), typeof(double) };
+		private static readonly Type[] s_binaryShCirTypes = new[] { typeof(S2), typeof(bool) };
+		private static readonly Type[] s_binaryPowerTypes = new[] { typeof(double) };
+
+        private static IEnumerable<Expression> Add()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Add(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Add_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Add(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> AddChecked()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.AddChecked(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> AddChecked_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.AddChecked(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Subtract()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Subtract(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Subtract_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Subtract(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> SubtractChecked()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.SubtractChecked(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> SubtractChecked_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.SubtractChecked(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Multiply()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Multiply(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Multiply_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Multiply(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> MultiplyChecked()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.MultiplyChecked(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> MultiplyChecked_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.MultiplyChecked(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Divide()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Divide(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Divide_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Divide(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Modulo()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Modulo(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Modulo_Nullable()
+        {
+			foreach (var t in s_binaryArithTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Modulo(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> LeftShift()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[typeof(int)])
+					{
+						yield return Expression.LeftShift(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> LeftShift_Nullable()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[typeof(int)])
+					{
+						yield return Expression.LeftShift(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> RightShift()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[typeof(int)])
+					{
+						yield return Expression.RightShift(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> RightShift_Nullable()
+        {
+			foreach (var t in s_binaryShiftTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[typeof(int)])
+					{
+						yield return Expression.RightShift(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> And()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.And(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> And_Nullable()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.And(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Or()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Or(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Or_Nullable()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Or(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> ExclusiveOr()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.ExclusiveOr(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> ExclusiveOr_Nullable()
+        {
+			foreach (var t in s_binaryLogicTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.ExclusiveOr(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> LessThan()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.LessThan(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> LessThan_Nullable()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.LessThan(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> LessThanOrEqual()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.LessThanOrEqual(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> LessThanOrEqual_Nullable()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.LessThanOrEqual(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> GreaterThan()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.GreaterThan(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> GreaterThan_Nullable()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.GreaterThan(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> GreaterThanOrEqual()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.GreaterThanOrEqual(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> GreaterThanOrEqual_Nullable()
+        {
+			foreach (var t in s_binaryComprTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.GreaterThanOrEqual(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Equal()
+        {
+			foreach (var t in s_binaryEqualTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Equal(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Equal_Nullable()
+        {
+			foreach (var t in s_binaryEqualTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Equal(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> NotEqual()
+        {
+			foreach (var t in s_binaryEqualTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.NotEqual(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> NotEqual_Nullable()
+        {
+			foreach (var t in s_binaryEqualTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.NotEqual(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> AndAlso()
+        {
+			foreach (var t in s_binaryShCirTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.AndAlso(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> AndAlso_Nullable()
+        {
+			foreach (var t in s_binaryShCirTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.AndAlso(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> OrElse()
+        {
+			foreach (var t in s_binaryShCirTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.OrElse(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> OrElse_Nullable()
+        {
+			foreach (var t in s_binaryShCirTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.OrElse(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Power()
+        {
+			foreach (var t in s_binaryPowerTypes)
+			{
+				foreach (var l in s_exprs[t])
+				{
+					foreach (var r in s_exprs[t])
+					{
+						yield return Expression.Power(l, r);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Power_Nullable()
+        {
+			foreach (var t in s_binaryPowerTypes)
+			{
+				foreach (var l in s_nullableExprs[t])
+				{
+					foreach (var r in s_nullableExprs[t])
+					{
+						yield return Expression.Power(l, r);
+					}
+				}
+			}
+        }
+
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Assign()
+        {
+            foreach (var a in GetAssignments(Expression.Constant(42), Expression.Constant(43), (e, v) => Expression.Assign(e, v)))
+            {
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Assign, a);
+            }
+
+            foreach (var a in GetAssignments(Expression.Constant(42), Expression.Constant(43), (e, v) => Expression.Block(Expression.Assign(e, v), e)))
+            {
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Assign, a);
+            }
+        }
+
+        private static IEnumerable<Expression> Coalesce()
+        {
+            var ex = Expression.Constant(new Exception("Oops!"));
+            var er = Expression.Constant(new Exception("!spoO"));
+
+            yield return Expression.Coalesce(Expression.Constant("bar", typeof(string)), Expression.Constant("foo", typeof(string)));
+            yield return Expression.Coalesce(Expression.Constant(null, typeof(string)), Expression.Constant("foo", typeof(string)));
+            yield return Expression.Coalesce(Expression.Constant("bar", typeof(string)), Expression.Throw(ex, typeof(string)));
+            yield return Expression.Coalesce(Expression.Constant(null, typeof(string)), Expression.Throw(ex, typeof(string)));
+            yield return Expression.Coalesce(Expression.Throw(ex, typeof(string)), Expression.Constant("foo", typeof(string)));
+            yield return Expression.Coalesce(Expression.Throw(ex, typeof(string)), Expression.Throw(er, typeof(string)));
+
+            yield return Expression.Coalesce(Expression.Constant(42, typeof(int?)), Expression.Constant(43, typeof(int?)));
+            yield return Expression.Coalesce(Expression.Constant(null, typeof(int?)), Expression.Constant(43, typeof(int?)));
+            yield return Expression.Coalesce(Expression.Constant(42, typeof(int?)), Expression.Throw(ex, typeof(int?)));
+            yield return Expression.Coalesce(Expression.Constant(null, typeof(int?)), Expression.Throw(ex, typeof(int?)));
+            yield return Expression.Coalesce(Expression.Throw(ex, typeof(int?)), Expression.Constant(43, typeof(int?)));
+            yield return Expression.Coalesce(Expression.Throw(ex, typeof(int?)), Expression.Throw(er, typeof(int?)));
+
+            // TODO: with conversion
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Block.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Block.cs
@@ -1,0 +1,392 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> Block()
+        {
+            yield return Expression.Block(Expression.Constant(1));
+            yield return Expression.Block(Expression.Constant("bar"), Expression.Constant(2));
+            yield return Expression.Block(Expression.Constant("bar"), Expression.Constant(false), Expression.Constant(3));
+
+            yield return Expression.Block(typeof(int), Expression.Constant(1));
+            yield return Expression.Block(typeof(int), Expression.Constant("bar"), Expression.Constant(2));
+            yield return Expression.Block(typeof(int), Expression.Constant("bar"), Expression.Constant(false), Expression.Constant(3));
+
+            yield return Expression.Block(typeof(object), Expression.Constant("bar"));
+            yield return Expression.Block(typeof(object), Expression.Constant(2), Expression.Constant("bar"));
+            yield return Expression.Block(typeof(object), Expression.Constant(false), Expression.Constant(3), Expression.Constant("bar"));
+
+            yield return Expression.Block(typeof(int), new[] { Expression.Parameter(typeof(int)) }, Expression.Constant(1));
+            yield return Expression.Block(typeof(int), new[] { Expression.Parameter(typeof(int)) }, Expression.Constant("bar"), Expression.Constant(2));
+            yield return Expression.Block(typeof(int), new[] { Expression.Parameter(typeof(int)) }, Expression.Constant("bar"), Expression.Constant(false), Expression.Constant(3));
+
+            yield return Expression.Block(typeof(object), new[] { Expression.Parameter(typeof(int)) }, Expression.Constant("bar"));
+            yield return Expression.Block(typeof(object), new[] { Expression.Parameter(typeof(int)) }, Expression.Constant(2), Expression.Constant("bar"));
+            yield return Expression.Block(typeof(object), new[] { Expression.Parameter(typeof(int)) }, Expression.Constant(false), Expression.Constant(3), Expression.Constant("bar"));
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Block_WithLog()
+        {
+            yield return WithLog(ExpressionType.Block, (log, summary) =>
+            {
+                return Expression.Block(
+                    log(Expression.Constant("A")),
+                    log(Expression.Constant("B")),
+                    log(Expression.Constant("C")),
+                    summary
+                );
+            });
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Block_Primes()
+        {
+            var to = Expression.Parameter(typeof(int), "to");
+            var res = Expression.Variable(typeof(List<int>), "res");
+            var n = Expression.Variable(typeof(int), "n");
+            var found = Expression.Variable(typeof(bool), "found");
+            var d = Expression.Variable(typeof(int), "d");
+            var breakOuter = Expression.Label();
+            var breakInner = Expression.Label();
+            var getPrimes =
+                // Func<int, List<int>> getPrimes =
+                Expression.Lambda<Func<int, List<int>>>(
+                    // {
+                    Expression.Block(
+                        // List<int> res;
+                        new[] { res },
+                        // res = new List<int>();
+                        Expression.Assign(
+                            res,
+                            Expression.New(typeof(List<int>))
+                        ),
+                        // {
+                        Expression.Block(
+                            // int n;
+                            new[] { n },
+                            // n = 2;
+                            Expression.Assign(
+                                n,
+                                Expression.Constant(2)
+                            ),
+                            // while (true)
+                            Expression.Loop(
+                                // {
+                                Expression.Block(
+                                    // if
+                                    Expression.IfThen(
+                                        // (!
+                                        Expression.Not(
+                                            // (n <= to)
+                                            Expression.LessThanOrEqual(
+                                                n,
+                                                to
+                                            )
+                                        // )
+                                        ),
+                                        // break;
+                                        Expression.Break(breakOuter)
+                                    ),
+                                    // {
+                                    Expression.Block(
+                                        // bool found;
+                                        new[] { found },
+                                        // found = false;
+                                        Expression.Assign(
+                                            found,
+                                            Expression.Constant(false)
+                                        ),
+                                        // {
+                                        Expression.Block(
+                                            // int d;
+                                            new[] { d },
+                                            // d = 2;
+                                            Expression.Assign(
+                                                d,
+                                                Expression.Constant(2)
+                                            ),
+                                            // while (true)
+                                            Expression.Loop(
+                                                // {
+                                                Expression.Block(
+                                                    // if
+                                                    Expression.IfThen(
+                                                        // (!
+                                                        Expression.Not(
+                                                            // d <= Math.Sqrt(n)
+                                                            Expression.LessThanOrEqual(
+                                                                d,
+                                                                Expression.Convert(
+                                                                    Expression.Call(
+                                                                        null,
+                                                                        typeof(Math).GetTypeInfo().GetDeclaredMethod("Sqrt"),
+                                                                        Expression.Convert(
+                                                                            n,
+                                                                            typeof(double)
+                                                                        )
+                                                                    ),
+                                                                    typeof(int)
+                                                                )
+                                                            )
+                                                        // )
+                                                        ),
+                                                        // break;
+                                                        Expression.Break(breakInner)
+                                                    ),
+                                                    // {
+                                                    Expression.Block(
+                                                        // if (n % d == 0)
+                                                        Expression.IfThen(
+                                                            Expression.Equal(
+                                                                Expression.Modulo(
+                                                                    n,
+                                                                    d
+                                                                ),
+                                                                Expression.Constant(0)
+                                                            ),
+                                                            // {
+                                                            Expression.Block(
+                                                                // found = true;
+                                                                Expression.Assign(
+                                                                    found,
+                                                                    Expression.Constant(true)
+                                                                ),
+                                                                // break;
+                                                                Expression.Break(breakInner)
+                                                            // }
+                                                            )
+                                                        )
+                                                    // }
+                                                    ),
+                                                    // d++;
+                                                    Expression.PostIncrementAssign(d)
+                                                // }
+                                                ),
+                                                breakInner
+                                            )
+                                        ),
+                                        // if
+                                        Expression.IfThen(
+                                            // (!found)
+                                            Expression.Not(found),
+                                            //    res.Add(n);
+                                            Expression.Call(
+                                                res,
+                                                typeof(List<int>).GetTypeInfo().GetDeclaredMethod("Add"),
+                                                n
+                                            )
+                                        )
+                                    ),
+                                    // n++;
+                                    Expression.PostIncrementAssign(n)
+                                // }
+                                ),
+                                breakOuter
+                            )
+                        ),
+                        res
+                    ),
+                    to
+                // }
+                );
+
+            var joinTemplate = (Expression<Func<List<int>, string>>)(xs => string.Join(", ", xs));
+
+            var expr = Expression.Invoke(joinTemplate, Expression.Invoke(getPrimes, Expression.Constant(100)));
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Block, expr);
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Block_Primes_WithLog()
+        {
+            var joinTemplate = (Expression<Func<List<int>, string>>)(xs => string.Join(", ", xs));
+            var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+            var to = Expression.Parameter(typeof(int), "to");
+            var res = Expression.Variable(typeof(List<int>), "res");
+            var n = Expression.Variable(typeof(int), "n");
+            var found = Expression.Variable(typeof(bool), "found");
+            var d = Expression.Variable(typeof(int), "d");
+            var breakOuter = Expression.Label();
+            var breakInner = Expression.Label();
+            var expr =
+                WithLog((log, summary) =>
+                {
+                    var body =
+                        // {
+                        Expression.Block(
+                            // List<int> res;
+                            new[] { res, to },
+                            // to = 100;
+                            Expression.Assign(
+                                to,
+                                Expression.Constant(100)
+                            ),
+                            // res = new List<int>();
+                            Expression.Assign(
+                                res,
+                                Expression.New(typeof(List<int>))
+                            ),
+                            // {
+                            Expression.Block(
+                                // int n;
+                                new[] { n },
+                                // n = 2;
+                                Expression.Assign(
+                                    n,
+                                    Expression.Constant(2)
+                                ),
+                                // while (true)
+                                Expression.Loop(
+                                    // {
+                                    Expression.Block(
+                                        // if
+                                        Expression.IfThen(
+                                            // (!
+                                            Expression.Not(
+                                                // (n <= to)
+                                                Expression.LessThanOrEqual(
+                                                    n,
+                                                    to
+                                                )
+                                            // )
+                                            ),
+                                            // break;
+                                            Expression.Break(breakOuter)
+                                        ),
+                                        // {
+                                        Expression.Block(
+                                            // bool found;
+                                            new[] { found },
+                                            // found = false;
+                                            Expression.Assign(
+                                                found,
+                                                Expression.Constant(false)
+                                            ),
+                                            // {
+                                            Expression.Block(
+                                                // int d;
+                                                new[] { d },
+                                                // d = 2;
+                                                Expression.Assign(
+                                                    d,
+                                                    Expression.Constant(2)
+                                                ),
+                                                // while (true)
+                                                Expression.Loop(
+                                                    // {
+                                                    Expression.Block(
+                                                        // if
+                                                        Expression.IfThen(
+                                                            // (!
+                                                            Expression.Not(
+                                                                // d <= Math.Sqrt(n)
+                                                                Expression.LessThanOrEqual(
+                                                                    d,
+                                                                    Expression.Convert(
+                                                                        Expression.Call(
+                                                                            null,
+                                                                            typeof(Math).GetTypeInfo().GetDeclaredMethod("Sqrt"),
+                                                                            Expression.Convert(
+                                                                                n,
+                                                                                typeof(double)
+                                                                            )
+                                                                        ),
+                                                                        typeof(int)
+                                                                    )
+                                                                )
+                                                            // )
+                                                            ),
+                                                            // break;
+                                                            Expression.Break(breakInner)
+                                                        ),
+                                                        // {
+                                                        Expression.Block(
+                                                            // if (n % d == 0)
+                                                            Expression.IfThen(
+                                                                Expression.Equal(
+                                                                    Expression.Modulo(
+                                                                        n,
+                                                                        d
+                                                                    ),
+                                                                    Expression.Constant(0)
+                                                                ),
+                                                                // {
+                                                                Expression.Block(
+                                                                    // found = true;
+                                                                    Expression.Assign(
+                                                                        found,
+                                                                        Expression.Constant(true)
+                                                                    ),
+                                                                    // break;
+                                                                    Expression.Break(breakInner)
+                                                                // }
+                                                                )
+                                                            )
+                                                        // }
+                                                        ),
+                                                        // d++;
+                                                        Expression.PostIncrementAssign(d)
+                                                    // }
+                                                    ),
+                                                    breakInner
+                                                )
+                                            ),
+                                            // if
+                                            Expression.IfThen(
+                                                // (!found)
+                                                Expression.Not(found),
+                                                //    res.Add(n);
+                                                Expression.Call(
+                                                    res,
+                                                    typeof(List<int>).GetTypeInfo().GetDeclaredMethod("Add"),
+                                                    n
+                                                )
+                                            )
+                                        ),
+                                        // n++;
+                                        Expression.PostIncrementAssign(n)
+                                    // }
+                                    ),
+                                    breakOuter
+                                )
+                            ),
+                            Expression.Invoke(
+                                concatTemplate,
+                                Expression.Invoke(joinTemplate, res),
+                                summary
+                            )
+                        );
+
+                        return new InstrumentWithLog(log).Visit(body);
+                    });
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Block, expr);
+        }
+
+        class InstrumentWithLog : ExpressionVisitor
+        {
+            private readonly Func<Expression, Expression> _log;
+            private int _n;
+
+            public InstrumentWithLog(Func<Expression, Expression> log)
+            {
+                _log = log;
+            }
+
+            protected override Expression VisitBlock(BlockExpression node)
+            {
+                var exprs = node.Expressions.SelectMany(e => new Expression[] { _log(Expression.Constant("S" + _n++)), Visit(e) }).ToList();
+                return node.Update(node.Variables, exprs);
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.Generated.cs
@@ -1,0 +1,515 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+		private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Call()
+        {
+			var concat = ((MethodCallExpression)((Expression<Func<object, object, string>>)((o1, o2) => string.Concat(o1, o2))).Body).Method;
+
+			var res0 = Expression.Parameter(typeof(int));
+			var res1 = Expression.Parameter(typeof(string));
+			var res2 = Expression.Parameter(typeof(bool));
+			var res3 = Expression.Parameter(typeof(E));
+			var res4 = Expression.Parameter(typeof(int?));
+
+			var objc = Expression.Parameter(typeof(CallC));
+			var objs = Expression.Parameter(typeof(CallS));
+
+			var newObjc = ((NewExpression)((Expression<Func<CallC>>)(() => new CallC(default(Action<string>)))).Body).Constructor;
+			var newObjs = ((NewExpression)((Expression<Func<CallS>>)(() => new CallS(default(Action<string>)))).Body).Constructor;
+
+			// Static
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S0"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S1"), ReturnWithLog(add, (E)E.Red)), summary));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S2"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S3"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S4"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res1 }, Expression.Assign(res1, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S5"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res1, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S6"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S7"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S8"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res1 }, Expression.Assign(res1, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S9"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res1, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S10"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S11"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S12"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S13"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S14"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(typeof(CallC).GetTypeInfo().GetDeclaredMethod("S15"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S0")), summary));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S1"), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S2"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S3"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res1 }, Expression.Assign(res1, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S4"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res1, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S5"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S6"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S7"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S8"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S9"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar")), summary));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S10"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res1 }, Expression.Assign(res1, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S11"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res1, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S12"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S13"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), summary)));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S14"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red)), summary));
+			yield return WithLog(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(typeof(CallS).GetTypeInfo().GetDeclaredMethod("S15"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), summary)));
+
+			// Instance
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I0"))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I1"), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I2"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I3"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I4"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res0 }, Expression.Assign(res0, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I5"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I6"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I7"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I8"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I9"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I10"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I11"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I12"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I13"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I14"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjc, add), typeof(CallC).GetTypeInfo().GetDeclaredMethod("I15"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I0"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I1"), ReturnWithLog(add, (int)42)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I2"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I3"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res1 }, Expression.Assign(res1, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I4"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res1, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I5"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I6"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I7"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I8"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I9"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I10"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I11"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I12"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res4 }, Expression.Assign(res4, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I13"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res3 }, Expression.Assign(res3, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I14"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { res2 }, Expression.Assign(res2, Expression.Call(Expression.New(newObjs, add), typeof(CallS).GetTypeInfo().GetDeclaredMethod("I15"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+
+			// Instance variable non-null
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res0 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res0, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I0"))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I1"), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I2"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I3"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I4"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res0 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res0, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I5"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I6"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I7"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res3 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res3, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I8"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I9"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I10"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I11"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I12"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I13"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I14"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res3 }, Expression.Assign(objc, Expression.New(newObjc, add)), Expression.Assign(res3, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I15"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I0"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I1"), ReturnWithLog(add, (int)42)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I2"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I3"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res1 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res1, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I4"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res1, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I5"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I6"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I7"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I8"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I9"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res4 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res4, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I10"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res2 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res2, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I11"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res2 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res2, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I12"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res4 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res4, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I13"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res3 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res3, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I14"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objs, res2 }, Expression.Assign(objs, Expression.New(newObjs, add)), Expression.Assign(res2, Expression.Call(objs, typeof(CallS).GetTypeInfo().GetDeclaredMethod("I15"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+
+			// Instance variable null
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res0 }, Expression.Assign(res0, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I0"))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I1"), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I2"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I3"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I4"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res0 }, Expression.Assign(res0, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I5"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42))), Expression.Call(concat, Expression.Convert(res0, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I6"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I7"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res3 }, Expression.Assign(res3, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I8"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I9"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I10"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I11"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res4 }, Expression.Assign(res4, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I12"), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res4, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res2 }, Expression.Assign(res2, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I13"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true))), Expression.Call(concat, Expression.Convert(res2, typeof(object)), Expression.Invoke(summary))));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc }, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I14"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (bool)true)), Expression.Invoke(summary)));
+			yield return WithLogExpr(ExpressionType.Call, (add, summary) => Expression.Block(new[] { objc, res3 }, Expression.Assign(res3, Expression.Call(objc, typeof(CallC).GetTypeInfo().GetDeclaredMethod("I15"), ReturnWithLog(add, (int)42), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (int)42), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (bool)true), ReturnWithLog(add, (string)"bar"), ReturnWithLog(add, (int?)42), ReturnWithLog(add, (E)E.Red), ReturnWithLog(add, (string)"bar"))), Expression.Call(concat, Expression.Convert(res3, typeof(object)), Expression.Invoke(summary))));
+        }
+
+		class CallC
+		{
+			private readonly Action<string> _addToLog;
+
+			public CallC(Action<string> addToLog)
+			{
+				_addToLog = addToLog;
+				_addToLog(".ctor");
+			}
+
+			public static int? S0()
+			{
+				return 42;
+			}
+
+			public static void S1(E p0)
+			{
+			}
+
+			public static bool S2(int? p0, bool p1)
+			{
+				return true;
+			}
+
+			public static E S3(bool p0, string p1, string p2)
+			{
+				return E.Red;
+			}
+
+			public static int S4(string p0, E p1, int? p2, int p3)
+			{
+				return 42;
+			}
+
+			public static string S5(bool p0, bool p1, bool p2, string p3, int p4)
+			{
+				return "bar";
+			}
+
+			public static bool S6(string p0, int p1, E p2, int p3, int? p4, int? p5)
+			{
+				return true;
+			}
+
+			public static int? S7(string p0, int p1, string p2, E p3, E p4, E p5, int p6)
+			{
+				return 42;
+			}
+
+			public static bool S8(E p0, E p1, int? p2, int? p3, int? p4, E p5, E p6, E p7)
+			{
+				return true;
+			}
+
+			public static string S9(int p0, int? p1, bool p2, int? p3, string p4, E p5, bool p6, E p7, bool p8)
+			{
+				return "bar";
+			}
+
+			public static bool S10(string p0, bool p1, int p2, E p3, bool p4, E p5, int p6, int p7, int p8, string p9)
+			{
+				return true;
+			}
+
+			public static bool S11(int? p0, int p1, int p2, string p3, int? p4, E p5, bool p6, bool p7, string p8, E p9, E p10)
+			{
+				return true;
+			}
+
+			public static int S12(string p0, int? p1, int? p2, string p3, bool p4, int? p5, string p6, int? p7, int p8, string p9, bool p10, E p11)
+			{
+				return 42;
+			}
+
+			public static E S13(bool p0, int p1, string p2, string p3, int? p4, E p5, bool p6, bool p7, int? p8, int p9, int? p10, bool p11, bool p12)
+			{
+				return E.Red;
+			}
+
+			public static bool S14(int p0, int? p1, string p2, int p3, bool p4, E p5, int p6, E p7, int? p8, bool p9, string p10, bool p11, int p12, int? p13)
+			{
+				return true;
+			}
+
+			public static int S15(bool p0, E p1, E p2, string p3, int p4, string p5, E p6, int p7, int p8, bool p9, int p10, int p11, int p12, string p13, E p14)
+			{
+				return 42;
+			}
+
+			public int I0()
+			{
+				_addToLog("I0(" + string.Join(", ", new object[] {  }) + ")");
+				return 42;
+			}
+
+			public int? I1(int? p0)
+			{
+				_addToLog("I1(" + string.Join(", ", new object[] { p0 }) + ")");
+				return 42;
+			}
+
+			public bool I2(string p0, bool p1)
+			{
+				_addToLog("I2(" + string.Join(", ", new object[] { p0, p1 }) + ")");
+				return true;
+			}
+
+			public int? I3(bool p0, int? p1, E p2)
+			{
+				_addToLog("I3(" + string.Join(", ", new object[] { p0, p1, p2 }) + ")");
+				return 42;
+			}
+
+			public bool I4(int p0, bool p1, int? p2, bool p3)
+			{
+				_addToLog("I4(" + string.Join(", ", new object[] { p0, p1, p2, p3 }) + ")");
+				return true;
+			}
+
+			public int I5(string p0, int p1, int p2, E p3, int p4)
+			{
+				_addToLog("I5(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4 }) + ")");
+				return 42;
+			}
+
+			public int? I6(int? p0, int? p1, E p2, int? p3, E p4, bool p5)
+			{
+				_addToLog("I6(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5 }) + ")");
+				return 42;
+			}
+
+			public void I7(int? p0, int? p1, int p2, string p3, E p4, int p5, bool p6)
+			{
+				_addToLog("I7(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6 }) + ")");
+			}
+
+			public E I8(bool p0, string p1, bool p2, E p3, int? p4, int? p5, int p6, int? p7)
+			{
+				_addToLog("I8(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7 }) + ")");
+				return E.Red;
+			}
+
+			public bool I9(string p0, int? p1, int? p2, int p3, bool p4, int? p5, int p6, string p7, E p8)
+			{
+				_addToLog("I9(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8 }) + ")");
+				return true;
+			}
+
+			public void I10(int p0, int p1, int? p2, string p3, int? p4, int? p5, E p6, int p7, E p8, E p9)
+			{
+				_addToLog("I10(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9 }) + ")");
+			}
+
+			public void I11(int? p0, int? p1, int p2, bool p3, int? p4, int? p5, E p6, int p7, int p8, string p9, int? p10)
+			{
+				_addToLog("I11(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10 }) + ")");
+			}
+
+			public int? I12(string p0, E p1, E p2, bool p3, E p4, bool p5, int p6, int? p7, int? p8, int? p9, E p10, string p11)
+			{
+				_addToLog("I12(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11 }) + ")");
+				return 42;
+			}
+
+			public bool I13(bool p0, int p1, bool p2, E p3, string p4, int? p5, bool p6, int p7, E p8, string p9, int p10, int? p11, bool p12)
+			{
+				_addToLog("I13(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12 }) + ")");
+				return true;
+			}
+
+			public void I14(int p0, bool p1, string p2, E p3, int p4, string p5, int p6, E p7, E p8, string p9, bool p10, int? p11, E p12, bool p13)
+			{
+				_addToLog("I14(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13 }) + ")");
+			}
+
+			public E I15(int p0, int? p1, string p2, E p3, int? p4, bool p5, E p6, int p7, string p8, int? p9, bool p10, string p11, int? p12, E p13, string p14)
+			{
+				_addToLog("I15(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14 }) + ")");
+				return E.Red;
+			}
+
+		}
+
+		struct CallS
+		{
+			private readonly Action<string> _addToLog;
+
+			public CallS(Action<string> addToLog)
+			{
+				_addToLog = addToLog;
+				_addToLog(".ctor");
+			}
+
+			public static void S0()
+			{
+			}
+
+			public static bool S1(int? p0)
+			{
+				return true;
+			}
+
+			public static int? S2(int p0, int? p1)
+			{
+				return 42;
+			}
+
+			public static int S3(int p0, int? p1, int p2)
+			{
+				return 42;
+			}
+
+			public static string S4(int? p0, int p1, int? p2, int? p3)
+			{
+				return "bar";
+			}
+
+			public static int S5(bool p0, E p1, int p2, bool p3, bool p4)
+			{
+				return 42;
+			}
+
+			public static int? S6(int p0, string p1, string p2, bool p3, int? p4, int p5)
+			{
+				return 42;
+			}
+
+			public static E S7(bool p0, bool p1, int p2, string p3, int p4, bool p5, bool p6)
+			{
+				return E.Red;
+			}
+
+			public static bool S8(bool p0, E p1, bool p2, E p3, E p4, int? p5, string p6, int p7)
+			{
+				return true;
+			}
+
+			public static void S9(bool p0, string p1, string p2, string p3, bool p4, bool p5, int p6, int? p7, string p8)
+			{
+			}
+
+			public static E S10(E p0, bool p1, int p2, E p3, int p4, bool p5, string p6, string p7, bool p8, int p9)
+			{
+				return E.Red;
+			}
+
+			public static string S11(int p0, string p1, bool p2, E p3, int p4, int? p5, bool p6, E p7, int? p8, string p9, E p10)
+			{
+				return "bar";
+			}
+
+			public static int S12(int? p0, int p1, bool p2, int? p3, bool p4, int p5, int? p6, int p7, bool p8, int? p9, bool p10, E p11)
+			{
+				return 42;
+			}
+
+			public static bool S13(string p0, int p1, bool p2, string p3, string p4, bool p5, E p6, int p7, int? p8, string p9, int? p10, E p11, bool p12)
+			{
+				return true;
+			}
+
+			public static void S14(E p0, bool p1, int p2, string p3, E p4, int? p5, string p6, string p7, bool p8, bool p9, E p10, int? p11, int p12, E p13)
+			{
+			}
+
+			public static E S15(int p0, string p1, int? p2, int? p3, E p4, E p5, E p6, int? p7, bool p8, bool p9, E p10, int p11, string p12, int p13, int? p14)
+			{
+				return E.Red;
+			}
+
+			public E I0()
+			{
+				_addToLog("I0(" + string.Join(", ", new object[] {  }) + ")");
+				return E.Red;
+			}
+
+			public void I1(int p0)
+			{
+				_addToLog("I1(" + string.Join(", ", new object[] { p0 }) + ")");
+			}
+
+			public E I2(int p0, bool p1)
+			{
+				_addToLog("I2(" + string.Join(", ", new object[] { p0, p1 }) + ")");
+				return E.Red;
+			}
+
+			public E I3(string p0, bool p1, int? p2)
+			{
+				_addToLog("I3(" + string.Join(", ", new object[] { p0, p1, p2 }) + ")");
+				return E.Red;
+			}
+
+			public string I4(int? p0, string p1, string p2, string p3)
+			{
+				_addToLog("I4(" + string.Join(", ", new object[] { p0, p1, p2, p3 }) + ")");
+				return "bar";
+			}
+
+			public void I5(int p0, int? p1, string p2, E p3, bool p4)
+			{
+				_addToLog("I5(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4 }) + ")");
+			}
+
+			public E I6(int p0, E p1, int? p2, string p3, string p4, int? p5)
+			{
+				_addToLog("I6(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5 }) + ")");
+				return E.Red;
+			}
+
+			public void I7(E p0, int? p1, string p2, int p3, string p4, E p5, E p6)
+			{
+				_addToLog("I7(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6 }) + ")");
+			}
+
+			public E I8(E p0, bool p1, string p2, bool p3, E p4, E p5, E p6, string p7)
+			{
+				_addToLog("I8(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7 }) + ")");
+				return E.Red;
+			}
+
+			public E I9(bool p0, E p1, int? p2, E p3, string p4, bool p5, E p6, int? p7, int? p8)
+			{
+				_addToLog("I9(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8 }) + ")");
+				return E.Red;
+			}
+
+			public int? I10(bool p0, string p1, int? p2, int? p3, string p4, E p5, E p6, int? p7, int p8, string p9)
+			{
+				_addToLog("I10(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9 }) + ")");
+				return 42;
+			}
+
+			public bool I11(int p0, E p1, bool p2, string p3, bool p4, bool p5, int? p6, string p7, E p8, string p9, string p10)
+			{
+				_addToLog("I11(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10 }) + ")");
+				return true;
+			}
+
+			public bool I12(string p0, int? p1, bool p2, int p3, int? p4, bool p5, bool p6, E p7, int p8, bool p9, int p10, string p11)
+			{
+				_addToLog("I12(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11 }) + ")");
+				return true;
+			}
+
+			public int? I13(E p0, bool p1, int p2, E p3, int? p4, E p5, E p6, int? p7, int? p8, string p9, int p10, string p11, string p12)
+			{
+				_addToLog("I13(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12 }) + ")");
+				return 42;
+			}
+
+			public E I14(int p0, E p1, E p2, int p3, bool p4, string p5, int? p6, bool p7, int p8, E p9, E p10, E p11, string p12, bool p13)
+			{
+				_addToLog("I14(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13 }) + ")");
+				return E.Red;
+			}
+
+			public bool I15(E p0, bool p1, E p2, string p3, int? p4, E p5, int? p6, E p7, bool p8, int? p9, bool p10, bool p11, bool p12, bool p13, bool p14)
+			{
+				_addToLog("I15(" + string.Join(", ", new object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14 }) + ")");
+				return true;
+			}
+
+		}
+	}
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        public static IEnumerable<KeyValuePair<ExpressionType, Expression>> Call_Misc()
+        {
+            var concat = ((MethodCallExpression)((Expression<Func<object, string, string>>)((o, s) => string.Concat(o, s))).Body).Method;
+            var add = ((MethodCallExpression)((Expression<Func<int, int, int>>)((a, b) => C.Add(a, b))).Body).Method;
+
+            var ex = new Exception("Oops!");
+            var err = Expression.Throw(Expression.Constant(ex), typeof(int));
+
+            var argss = new Expression[][]
+            {
+                new Expression[] { Expression.Constant(1), Expression.Constant(2) },
+                new Expression[] { Expression.Constant(1), err },
+                new Expression[] { err, Expression.Constant(2) },
+                new Expression[] { err, err },
+            };
+
+            foreach (var args in argss)
+            {
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Call, Expression.Call(add, args));
+            }
+
+            foreach (var args in argss)
+            {
+                var v = Expression.Parameter(typeof(int));
+
+                yield return WithLogExpr(ExpressionType.Call, (log, summary) =>
+                    Expression.Block(
+                        new[] { v },
+                        Expression.Assign(v, Expression.Call(add, args.Select((arg, i) => Expression.Block(Expression.Invoke(log, Expression.Constant("Arg" + i)), arg)))),
+                        Expression.Call(
+                            concat,
+                            Expression.Convert(v, typeof(object)),
+                            Expression.Invoke(summary)
+                        )
+                    )
+                );
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Call_ByRef()
+        {
+            var res = Expression.Parameter(typeof(int));
+            var mtd = typeof(C).GetTypeInfo().GetDeclaredMethod("Foo");
+            var toStringTemplate = (Expression<Func<int, string>>)(x => x.ToString());
+            var concatIntStringTemplate = (Expression<Func<int, string, string>>)((x, s) => x + s);
+            var concatIntStringStringTemplate = (Expression<Func<int, string, string, string>>)((x, s1, s2) => x + s1 + s2);
+
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Call,
+                    Expression.Block(
+                        new[] { res, p },
+                        Expression.Assign(p, Expression.Constant(42)),
+                        Expression.Assign(
+                            res,
+                            Expression.Call(
+                                mtd,
+                                Expression.Constant("bar"),
+                                p,
+                                Expression.Constant(true)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatIntStringTemplate,
+                            p,
+                            Expression.Invoke(toStringTemplate, res)
+                        )
+                    )
+                );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(HolderWithLog<int>));
+                var value = Expression.Property(p, "Value");
+
+                yield return
+                    WithLogExpr(ExpressionType.Call, (add, summarize) =>
+                        Expression.Block(
+                            new[] { res, p },
+                            Expression.Assign(
+                                p,
+                                Expression.New(typeof(HolderWithLog<int>).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(Action<string>) }), add)
+                            ),
+                            Expression.Assign(
+                                res,
+                                Expression.Call(
+                                    mtd,
+                                    ReturnWithLog(add, "bar"),
+                                    value,
+                                    ReturnWithLog(add, true)
+                                )
+                            ),
+                            Expression.Invoke(
+                                concatIntStringStringTemplate,
+                                value,
+                                Expression.Invoke(toStringTemplate, res),
+                                Expression.Invoke(summarize)
+                            )
+                        )
+                    );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(int[]));
+                var value = Expression.ArrayAccess(p, Expression.Constant(0));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Call,
+                    Expression.Block(
+                        new[] { res, p },
+                        Expression.Assign(
+                            p,
+                            Expression.NewArrayBounds(typeof(int), Expression.Constant(1))
+                        ),
+                        Expression.Assign(
+                            res,
+                            Expression.Call(
+                                mtd,
+                                Expression.Constant("bar"),
+                                value,
+                                Expression.Constant(true)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatIntStringTemplate,
+                            value,
+                            Expression.Invoke(toStringTemplate, res)
+                        )
+                    )
+                );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(VectorWithLog<int>));
+                var value = Expression.MakeIndex(p, p.Type.GetTypeInfo().GetDeclaredProperty("Item"), new[] { Expression.Constant(0) });
+
+                yield return
+                    WithLogExpr(ExpressionType.Call, (add, summarize) =>
+                        Expression.Block(
+                            new[] { res, p },
+                            Expression.Assign(
+                                p,
+                                Expression.New(typeof(VectorWithLog<int>).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(Action<string>) }), add)
+                            ),
+                            Expression.Assign(
+                                res,
+                                Expression.Call(
+                                    mtd,
+                                    ReturnWithLog(add, "bar"),
+                                    ReturnAllConstants(add, value),
+                                    ReturnWithLog(add, true)
+                                )
+                            ),
+                            Expression.Invoke(
+                                concatIntStringStringTemplate,
+                                value,
+                                Expression.Invoke(toStringTemplate, res),
+                                Expression.Invoke(summarize)
+                            )
+                        )
+                    );
+            }
+        }
+
+        // TODO: more writebacks and by-ref tests
+        // TODO: tests for special methods that can't just be call'd or callvirt'd
+
+        class C
+        {
+            public static int Add(int a, int b)
+            {
+                return a + b;
+            }
+
+            public static int Foo(string x, ref int y, bool z)
+            {
+                y = y + 1;
+                return y * 2;
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Conditional.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Conditional.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> Conditional()
+        {
+            var tests = new[] { Expression.Constant(true), Expression.Constant(false) };
+
+            foreach (var test in tests)
+            {
+                foreach (var values in s_exprs.Values)
+                {
+                    foreach (var ifTrue in values)
+                    {
+                        foreach (var ifFalse in values)
+                        {
+                            yield return Expression.Condition(test, ifTrue, ifFalse);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> IfThen_WithLog()
+        {
+            var tests = new[] { Expression.Constant(true), Expression.Constant(false) };
+
+            foreach (var test in tests)
+            {
+                yield return WithLog(ExpressionType.Conditional, (log, summary) =>
+                {
+                    return
+                        Expression.Block(
+                            Expression.IfThen(test, log(Expression.Constant("T"))),
+                            summary
+                        );
+                });
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> IfThenElse_WithLog()
+        {
+            var tests = new[] { Expression.Constant(true), Expression.Constant(false) };
+
+            foreach (var test in tests)
+            {
+                yield return WithLog(ExpressionType.Conditional, (log, summary) =>
+                {
+                    return
+                        Expression.Block(
+                            Expression.IfThenElse(test, log(Expression.Constant("T")), log(Expression.Constant("F"))),
+                            summary
+                        );
+                });
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Conditional_WithLog()
+        {
+            var tests = new[] { Expression.Constant(true), Expression.Constant(false) };
+
+            foreach (var test in tests)
+            {
+                yield return WithLog(ExpressionType.Conditional, (log, summary) =>
+                {
+                    var valueParam = Expression.Parameter(typeof(int));
+                    var toStringTemplate = (Expression<Func<int, string>>)(x => x.ToString());
+                    var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                    return
+                        Expression.Block(
+                            new[] { valueParam },
+                            Expression.Assign(
+                                valueParam,
+                                Expression.Condition(
+                                    ReturnWithLog(log, test),
+                                    ReturnWithLog(log, 1),
+                                    ReturnWithLog(log, 2)
+                                )
+                            ),
+                            Expression.Invoke(
+                                concatTemplate,
+                                Expression.Invoke(toStringTemplate, valueParam),
+                                summary
+                            )
+                        );
+                    });
+                }
+            }
+        }
+    }

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Constant.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Constant.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> Constant()
+        {
+            yield return Expression.Constant(null, typeof(object));
+            yield return Expression.Constant(null, typeof(string));
+            yield return Expression.Constant(null, typeof(IDisposable));
+            yield return Expression.Constant(null, typeof(int?));
+
+            yield return Expression.Constant(42, typeof(object));
+            yield return Expression.Constant(42, typeof(ValueType));
+            yield return Expression.Constant(42, typeof(int));
+            yield return Expression.Constant(42, typeof(int?));
+
+            yield return Expression.Constant("", typeof(string));
+            yield return Expression.Constant("bar", typeof(string));
+            yield return Expression.Constant("foo", typeof(IComparable));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.DebugInfo.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.DebugInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> DebugInfo()
+        {
+            var doc = Expression.SymbolDocument("foo.cs");
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DebugInfo,
+                Expression.Block(
+                    Expression.DebugInfo(doc, 1, 2, 3, 4),
+                    Expression.Constant(41),
+                    Expression.DebugInfo(doc, 2, 3, 4, 5),
+                    Expression.Constant(42)
+                )
+            );
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Default.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Default.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> Default()
+        {
+            foreach (var t in new[] { typeof(object), typeof(int), typeof(string), typeof(int?), typeof(TimeSpan), typeof(TimeSpan?) })
+            {
+                yield return Expression.Default(t);
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Extension.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Extension.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> Extension()
+        {
+            yield return new Ext();
+        }
+
+        class Ext : Expression
+        {
+            public override Type Type
+            {
+                get
+                {
+                    return typeof(int);
+                }
+            }
+
+            public override ExpressionType NodeType
+            {
+                get
+                {
+                    return ExpressionType.Extension;
+                }
+            }
+
+            public override bool CanReduce
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override Expression Reduce()
+            {
+                return Expression.Constant(42);
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Goto.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Goto.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Goto()
+        {
+            var l1 = Expression.Label();
+            var l2 = Expression.Label();
+            var l3 = Expression.Label();
+            var b = Expression.Parameter(typeof(bool));
+
+            yield return WithLog(ExpressionType.Goto, (add, summary) =>
+                Expression.Block(
+                    add(Expression.Constant("B1")),
+                    Expression.Label(l1),
+                    add(Expression.Constant("B2")),
+                    Expression.Label(l2),
+                    add(Expression.Constant("B3")),
+                    summary
+                )
+            );
+
+            yield return WithLog(ExpressionType.Goto, (add, summary) =>
+                Expression.Block(
+                    add(Expression.Constant("B1")),
+                    Expression.Goto(l2),
+                    add(Expression.Constant("B2")),
+                    Expression.Label(l2),
+                    add(Expression.Constant("B3")),
+                    summary
+                )
+            );
+
+            yield return WithLog(ExpressionType.Goto, (add, summary) =>
+                Expression.Block(
+                    new[] { b },
+                    Expression.Assign(b, Expression.Constant(false)),
+                    add(Expression.Constant("B1")),
+                    Expression.Label(l1),
+                    add(Expression.Constant("B2")),
+                    Expression.IfThenElse(
+                        b,
+                        Expression.Goto(l3),
+                        Expression.Assign(b, Expression.Constant(true))
+                    ),
+                    Expression.Goto(l1),
+                    Expression.Label(l3),
+                    add(Expression.Constant("B3")),
+                    summary
+                )
+            );
+
+            // TODO: goto with values
+            // TODO: branches across blocks and exception handlers
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Invoke.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Invoke.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Invoke()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var i = Expression.Parameter(typeof(Action));
+            var d = Expression.Parameter(typeof(Action));
+
+            var cs = new[] { i, i, i, d, i, d, d, i };
+
+            for (var j = 1; j < cs.Length; j++)
+            {
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Invoke,
+                    Expression.Block(
+                        new[] { p, i, d },
+                        Expression.Assign(i, Expression.Lambda<Action>(Expression.PostIncrementAssign(p))),
+                        Expression.Assign(d, Expression.Lambda<Action>(Expression.PostDecrementAssign(p))),
+                        Expression.Block(cs.Take(j).Select(e => Expression.Invoke(e))),
+                        p
+                    )
+                );
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Invoke_ByRef()
+        {
+            var q = Expression.Parameter(typeof(int).MakeByRefType());
+            var f = Expression.Lambda<IntByRef>(Expression.Assign(q, Expression.Constant(43)), q);
+
+            var concatIntStringTemplate = (Expression<Func<int, string, string>>)((x, s) => x + s);
+
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Invoke,
+                    Expression.Block(
+                        new[] { p },
+                        Expression.Assign(p, Expression.Constant(42)),
+                        Expression.Invoke(f, p),
+                        p
+                    )
+                );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(HolderWithLog<int>));
+                var value = Expression.Property(p, "Value");
+
+                yield return
+                    WithLogExpr(ExpressionType.Invoke, (add, summarize) =>
+                        Expression.Block(
+                            new[] { p },
+                            Expression.Assign(
+                                p,
+                                Expression.New(typeof(HolderWithLog<int>).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(Action<string>) }), add)
+                            ),
+                            Expression.Invoke(f, value),
+                            Expression.Invoke(
+                                concatIntStringTemplate,
+                                value,
+                                Expression.Invoke(summarize)
+                            )
+                        )
+                    );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(int[]));
+                var value = Expression.ArrayAccess(p, Expression.Constant(0));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Invoke,
+                    Expression.Block(
+                        new[] { p },
+                        Expression.Assign(
+                            p,
+                            Expression.NewArrayBounds(typeof(int), Expression.Constant(1))
+                        ),
+                        Expression.Invoke(f, value),
+                        value
+                    )
+                );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(VectorWithLog<int>));
+                var value = Expression.MakeIndex(p, p.Type.GetTypeInfo().GetDeclaredProperty("Item"), new[] { Expression.Constant(0) });
+
+                yield return
+                    WithLogExpr(ExpressionType.Invoke, (add, summarize) =>
+                        Expression.Block(
+                            new[] { p },
+                            Expression.Assign(
+                                p,
+                                Expression.New(typeof(VectorWithLog<int>).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(Action<string>) }), add)
+                            ),
+                            Expression.Invoke(f, value),
+                            Expression.Invoke(
+                                concatIntStringTemplate,
+                                value,
+                                Expression.Invoke(summarize)
+                            )
+                        )
+                    );
+            }
+        }
+
+        delegate void IntByRef(ref int x);
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Lambda.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Lambda.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Lambda()
+        {
+            for (var i = 0; i <= 16; i++)
+            {
+                var p = Enumerable.Range(0, i).Select(_ => Expression.Parameter(typeof(int))).ToArray();
+                var c = p.Aggregate((Expression)Expression.Constant(0), (s, e) => Expression.Add(s, e));
+                var f = Expression.Lambda(c, p);
+                var a = Enumerable.Range(42, i).Select(j => Expression.Constant(j)).ToArray();
+                var r = Expression.Invoke(f, a);
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Lambda, r);
+            }
+
+            for (var i = 0; i <= 16; i++)
+            {
+                var p = Enumerable.Range(0, i).Select(_ => Expression.Parameter(typeof(int))).ToArray();
+                var c = p.Aggregate((Expression)Expression.Constant(0), (s, e) => Expression.Add(s, e));
+                var f = p.Aggregate(c, (s, q) => Expression.Lambda(s, q));
+                var a = Enumerable.Range(42, i).Select(j => Expression.Constant(j)).ToArray();
+                var r = a.Aggregate(f, (g, b) => Expression.Invoke(g, b));
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Lambda, r);
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.ListInit.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.ListInit.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ListInit()
+        {
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int> { 2 }.Sum()))).Body);
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int> { 2, 3 }.Sum()))).Body);
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int> { 2, 3, 5 }.Sum()))).Body);
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int>(1) { 2 }.Sum()))).Body);
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int>(1) { 2, 3 }.Sum()))).Body);
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int>(1) { 2, 3, 5 }.Sum()))).Body);
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new List<int>(-1) { 2 }.Sum()))).Body);
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new Dictionary<string, int> { { "foo", 42 }, { "bar", 43 } }.Sum(kv => kv.Value)))).Body);
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ListInit, (((Expression<Func<int>>)(() => new Dictionary<string, int> { { null, 42 } }.Sum(kv => kv.Value)))).Body);
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ListInit_WithLog()
+        {
+            yield return WithLogExpr(ExpressionType.ListInit, (add, summarize) =>
+            {
+                var newTemplate = ((Expression<Func<Action<string>, LIWithLog>>)(addToLog => new LIWithLog(addToLog) { 2, 3, 5 }));
+                var valueParam = Expression.Parameter(typeof(LIWithLog));
+                var toStringTemplate = ((Expression<Func<LIWithLog, string>>)(mi => mi.ToString()));
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.Invoke(
+                                ReturnAllConstants(add, newTemplate),
+                                add
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            Expression.Invoke(summarize)
+                        )
+                    );
+            });
+        }
+
+        class LIWithLog : IEnumerable<int>
+        {
+            private readonly Action<string> _addToLog;
+            private readonly List<int> _values;
+
+            public LIWithLog(Action<string> addToLog)
+            {
+                _addToLog = addToLog;
+                _values = new List<int>();
+
+                _addToLog(".ctor");
+            }
+
+            public void Add(int x)
+            {
+                _addToLog("Add(" + x + ")");
+                _values.Add(x);
+            }
+
+            public IEnumerator<int> GetEnumerator()
+            {
+                _addToLog("GetEnumerator");
+                return _values.GetEnumerator();
+            }
+
+            public override string ToString()
+            {
+                return "{ " + string.Join(", ", _values) + " }";
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Logging.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Logging.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    public static partial class ExpressionCatalog
+    {
+        private static KeyValuePair<ExpressionType, Expression> WithLogExpr(ExpressionType nodeType, Func<Expression<Action<string>>, Expression<Func<string>>, Expression> f)
+        {
+            return new KeyValuePair<ExpressionType, Expression>(nodeType, WithLogExpr(f));
+        }
+
+        private static KeyValuePair<ExpressionType, Expression> WithLog(ExpressionType nodeType, Func<Func<Expression, Expression>, Expression, Expression> f)
+        {
+            return new KeyValuePair<ExpressionType, Expression>(nodeType, WithLog(f));
+        }
+
+        private static Expression WithLogExpr(Func<Expression<Action<string>>, Expression<Func<string>>, Expression> f)
+        {
+            var newLogTemplate = (Expression<Func<List<string>>>)(() => new List<string>());
+            var addToLogTemplate = (Expression<Action<List<string>, string>>)((log, value) => log.Add(value));
+            var summarizeTemplate = (Expression<Func<List<string>, string>>)(log => string.Join(", ", log));
+
+            var logParam = addToLogTemplate.Parameters[0];
+            var newLog = Expression.Assign(logParam, newLogTemplate.Body);
+
+            var valParam = addToLogTemplate.Parameters[1];
+            var addToLog = Expression.Lambda<Action<string>>(addToLogTemplate.Body, valParam);
+            var summarize = Expression.Lambda<Func<string>>(Expression.Invoke(summarizeTemplate, logParam));
+
+            var res = Expression.Block(
+                new[] { logParam },
+                newLog,
+                f(addToLog, summarize)
+            );
+
+            return res;
+        }
+
+        private static Expression WithLog(Func<Func<Expression, Expression>, Expression, Expression> f)
+        {
+            var newLogTemplate = (Expression<Func<List<string>>>)(() => new List<string>());
+            var addToLogTemplate = (Expression<Action<List<string>, string>>)((log, value) => log.Add(value));
+            var summarizeTemplate = (Expression<Func<List<string>, string>>)(log => string.Join(", ", log));
+
+            var logParam = addToLogTemplate.Parameters[0];
+            var newLog = Expression.Assign(logParam, newLogTemplate.Body);
+
+            var valParam = addToLogTemplate.Parameters[1];
+            var addMethod = ((MethodCallExpression)addToLogTemplate.Body).Method;
+            var addToLog = (Func<Expression, Expression>)(e => Expression.Call(logParam, addMethod, e));
+            var summarize = Expression.Invoke(summarizeTemplate, logParam);
+
+            var res = Expression.Block(
+                new[] { logParam },
+                newLog,
+                f(addToLog, summarize)
+            );
+
+            return res;
+        }
+
+        private static Expression ReturnWithLog<T>(Expression<Action<string>> addToLog, T value)
+        {
+            return ReturnWithLog(addToLog, Expression.Constant(value, typeof(T)));
+        }
+
+        private static Expression ReturnWithLog<T>(Func<Expression, Expression> addToLog, T value)
+        {
+            return ReturnWithLog(addToLog, Expression.Constant(value, typeof(T)));
+        }
+
+        private static Expression ReturnWithLog(Expression<Action<string>> addToLog, ConstantExpression valueExpr)
+        {
+            var toStringTemplate = (Expression<Func<object, string>>)(x => "Return(" + x.ToString() + ")");
+
+            return
+                Expression.Block(
+                    Expression.Invoke(
+                        addToLog,
+                        Expression.Invoke(toStringTemplate, Expression.Convert(valueExpr, typeof(object)))
+                    ),
+                    valueExpr
+                );
+        }
+
+        private static Expression ReturnWithLog(Func<Expression, Expression> addToLog, ConstantExpression valueExpr)
+        {
+            var toStringTemplate = (Expression<Func<object, string>>)(x => "Return(" + x.ToString() + ")");
+
+            return
+                Expression.Block(
+                    addToLog(
+                        Expression.Invoke(toStringTemplate, Expression.Convert(valueExpr, typeof(object)))
+                    ),
+                    valueExpr
+                );
+        }
+
+        private static Expression ReturnAllConstants(Expression<Action<string>> addToLog, Expression expression)
+        {
+            return new ReturnVisitorExpr(addToLog, ReturnWithLog).Visit(expression);
+        }
+
+        private static Expression ReturnAllConstants(Func<Expression, Expression> addToLog, Expression expression)
+        {
+            return new ReturnVisitor(addToLog, ReturnWithLog).Visit(expression);
+        }
+
+        class ReturnVisitorExpr : ExpressionVisitor
+        {
+            private readonly Func<ConstantExpression, Expression> _returnWithLog;
+
+            public ReturnVisitorExpr(Expression<Action<string>> addToLog, Func<Expression<Action<string>>, ConstantExpression, Expression> returnWithLog)
+            {
+                _returnWithLog = add => returnWithLog(addToLog, add);
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                return _returnWithLog(node);
+            }
+        }
+
+        class ReturnVisitor : ExpressionVisitor
+        {
+            private readonly Func<ConstantExpression, Expression> _returnWithLog;
+
+            public ReturnVisitor(Func<Expression, Expression> addToLog, Func<Func<Expression, Expression>, ConstantExpression, Expression> returnWithLog)
+            {
+                _returnWithLog = add => returnWithLog(addToLog, add);
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                return _returnWithLog(node);
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Loop.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Loop.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Loop()
+        {
+            var intToString = ((MethodCallExpression)((Expression<Func<int, string>>)(x => x.ToString())).Body).Method;
+
+            var b = Expression.Label();
+            var c = Expression.Label();
+            var i = Expression.Parameter(typeof(int));
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Loop,
+                Expression.Block(
+                    new[] { i },
+                    Expression.Loop(
+                        Expression.Block(
+                            Expression.IfThen(
+                                Expression.GreaterThanOrEqual(i, Expression.Constant(10)),
+                                Expression.Break(b)
+                            ),
+                            Expression.PostIncrementAssign(i)
+                        ),
+                        b, c
+                    ),
+                    Expression.Multiply(i, Expression.Constant(2))
+                )
+            );
+
+            yield return WithLog(ExpressionType.Loop, (add, summary) =>
+                Expression.Block(
+                    new[] { i },
+                    Expression.Assign(i, Expression.Constant(0)),
+                    add(Expression.Constant("LB")),
+                    Expression.Loop(
+                        Expression.Block(
+                            add(Expression.Constant("LIB")),
+                            Expression.IfThen(
+                                Expression.GreaterThanOrEqual(i, Expression.Constant(10)),
+                                Expression.Break(b)
+                            ),
+                            add(Expression.Call(i, intToString)),
+                            Expression.PostIncrementAssign(i),
+                            add(Expression.Constant("LIE"))
+                        ),
+                        b, c
+                    ),
+                    add(Expression.Constant("LE")),
+                    summary
+                )
+            );
+
+            yield return WithLog(ExpressionType.Loop, (add, summary) =>
+                Expression.Block(
+                    new[] { i },
+                    Expression.Assign(i, Expression.Constant(0)),
+                    add(Expression.Constant("LB")),
+                    Expression.Loop(
+                        Expression.Block(
+                            add(Expression.Constant("LIB")),
+                            Expression.IfThen(
+                                Expression.GreaterThanOrEqual(i, Expression.Constant(10)),
+                                Expression.Break(b)
+                            ),
+                            Expression.IfThen(
+                                Expression.Equal(Expression.Modulo(i, Expression.Constant(2)), Expression.Constant(0)),
+                                Expression.Block(
+                                    Expression.PostIncrementAssign(i),
+                                    Expression.Continue(c)
+                                )
+                            ),
+                            add(Expression.Call(i, intToString)),
+                            Expression.PostIncrementAssign(i),
+                            add(Expression.Constant("LIE"))
+                        ),
+                        b, c
+                    ),
+                    add(Expression.Constant("LE")),
+                    summary
+                )
+            );
+
+            // TODO: typed labels
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberAccess.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberAccess.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> MemberAccess()
+        {
+            var instance = Expression.Constant(new Members());
+
+            foreach (var member in typeof(Members).GetMembers().Where(m => m is FieldInfo || m is PropertyInfo))
+            {
+                var isStatic = false;
+                if (member is FieldInfo)
+                {
+                    var field = (FieldInfo)member;
+                    isStatic = field.IsStatic || field.IsLiteral;
+                }
+                else
+                {
+                    var property = (PropertyInfo)member;
+                    isStatic = property.GetGetMethod().IsStatic;
+                }
+
+                if (isStatic)
+                {
+                    yield return Expression.MakeMemberAccess(null, member);
+                }
+                else
+                {
+                    yield return Expression.MakeMemberAccess(instance, member);
+                    yield return Expression.MakeMemberAccess(Expression.Default(typeof(Members)), member);
+                }
+            }
+        }
+    }
+
+    class Members
+    {
+        public static readonly int A = 42;
+
+        public const int B = 43;
+
+        public static int C
+        {
+            get { return 44; }
+        }
+
+        public static readonly string D = "bar";
+
+        public const string E = "foo";
+
+        public static string F
+        {
+            get { return "qux"; }
+        }
+
+        public int G = 45;
+
+        public int H
+        {
+            get { return 46; }
+        }
+
+        public string I = "baz";
+
+        public string J
+        {
+            get { return "foz"; }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberInit.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberInit.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> MemberInit()
+        {
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { X = 1 })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { X = 1, Y = "bar" })).Body;
+
+            yield return ((Expression<Func<MI1>>)(() => new MI1(true) { })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1(true) { X = 1 })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1(true) { X = 1, Y = "bar" })).Body;
+
+            yield return ((Expression<Func<MI1>>)(() => new MI1(false) { })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1(false) { X = 1 })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1(false) { X = 1, Y = "bar" })).Body;
+
+            var g1 = new Func<string>(() =>
+            {
+                throw new InvalidOperationException("Oops I did it again.");
+            });
+
+            var g2 = new Func<int>(() =>
+            {
+                throw new InvalidOperationException("Oops you did it again.");
+            });
+
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { X = 0, Y = g1() })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { X = 1, Y = g1() })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { Y = g1(), X = 0 })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { Y = g1(), X = 1 })).Body;
+
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { Y = null, X = g2() })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { Y = "bar", X = g2() })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { X = g2(), Y = null })).Body;
+            yield return ((Expression<Func<MI1>>)(() => new MI1 { X = g2(), Y = "bar" })).Body;
+
+            yield return ((Expression<Func<MI2>>)(() => new MI2 { MI1 = { X = 42, Y = "qux" }, Bars = { 2, 3, 5 } })).Body;
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MemberInit_WithLog()
+        {
+            yield return WithLogExpr(ExpressionType.MemberInit, (add, summarize) =>
+            {
+                var newTemplate = ((Expression<Func<Action<string>, MIWithLog1>>)(addToLog => new MIWithLog1(addToLog) { Bar = 42, Foo = "qux", Quxs = { 2, 3, 5 }, Baz = { Bar = 43, Foo = "baz" } }));
+                var valueParam = Expression.Parameter(typeof(MIWithLog1));
+                var toStringTemplate = ((Expression<Func<MIWithLog1, string>>)(mi => mi.ToString()));
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.Invoke(
+                                ReturnAllConstants(add, newTemplate),
+                                add
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            Expression.Invoke(summarize)
+                        )
+                    );
+            });
+        }
+
+        public class MI1 : IEquatable<MI1>
+        {
+            private int _x;
+            private string _y;
+
+            public MI1()
+            {
+            }
+
+            public MI1(bool b)
+            {
+                if (!b)
+                    throw new ArgumentException("Can't be false.", "b");
+            }
+
+            public int X
+            {
+                get { return _x; }
+                set
+                {
+                    if (_x == 0)
+                        throw new ArgumentException("Can't be zero.", "value");
+
+                    _x = value;
+                }
+            }
+            public string Y
+            {
+                get { return _y; }
+                set
+                {
+                    if (_y == null)
+                        throw new ArgumentNullException("value", "Can't be null.");
+
+                    _y = value;
+                }
+            }
+
+            public bool Equals(MI1 other)
+            {
+                if (other == null)
+                {
+                    return false;
+                }
+
+                return X == other.X && Y == other.Y;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as MI1);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0;
+            }
+        }
+
+        public class MI2 : IEquatable<MI2>
+        {
+            private readonly MI1 _mi1 = new MI1();
+            private readonly List<int> _bars = new List<int>();
+
+            public MI1 MI1
+            {
+                get
+                {
+                    return _mi1;
+                }
+            }
+
+            public List<int> Bars
+            {
+                get
+                {
+                    return _bars;
+                }
+            }
+
+            public bool Equals(MI2 other)
+            {
+                if (other == null)
+                {
+                    return false;
+                }
+
+                return other.MI1.Equals(MI1) && other.Bars.SequenceEqual(Bars);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as MI2);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0;
+            }
+        }
+
+        class MIWithLog1
+        {
+            private readonly Action<string> _addToLog;
+            private readonly LIWithLog _quxs;
+            private readonly MIWithLog2 _child;
+            private int _bar;
+            private string _foo;
+
+            public MIWithLog1(Action<string> addToLog)
+            {
+                _addToLog = addToLog;
+                _quxs = new LIWithLog(addToLog);
+                _child = new MIWithLog2(addToLog);
+
+                _addToLog(".ctor");
+            }
+
+            public int Bar
+            {
+                get
+                {
+                    _addToLog("get_Bar");
+                    return _bar;
+                }
+
+                set
+                {
+                    _addToLog("set_Bar(" + value + ")");
+                    _bar = value;
+                }
+            }
+
+            public string Foo
+            {
+                get
+                {
+                    _addToLog("get_Foo");
+                    return _foo;
+                }
+
+                set
+                {
+                    _addToLog("set_Foo(" + value + ")");
+                    _foo = value;
+                }
+            }
+
+            public LIWithLog Quxs
+            {
+                get
+                {
+                    _addToLog("get_Quxs");
+                    return _quxs;
+                }
+            }
+
+            public MIWithLog2 Baz
+            {
+                get
+                {
+                    _addToLog("get_Baz");
+                    return _child;
+                }
+            }
+
+            public override string ToString()
+            {
+                return "{ Bar = " + Bar + ", Foo = " + Foo + ", Baz = " + Baz.ToString() + ", Quxs = " + Quxs.ToString() + " }";
+            }
+        }
+
+        class MIWithLog2
+        {
+            private readonly Action<string> _addToLog;
+            private int _bar;
+            private string _foo;
+
+            public MIWithLog2(Action<string> addToLog)
+            {
+                _addToLog = addToLog;
+
+                _addToLog(".ctor");
+            }
+
+            public int Bar
+            {
+                get
+                {
+                    _addToLog("get_Bar");
+                    return _bar;
+                }
+
+                set
+                {
+                    _addToLog("set_Bar(" + value + ")");
+                    _bar = value;
+                }
+            }
+
+            public string Foo
+            {
+                get
+                {
+                    _addToLog("get_Foo");
+                    return _foo;
+                }
+
+                set
+                {
+                    _addToLog("set_Foo(" + value + ")");
+                    _foo = value;
+                }
+            }
+
+            public override string ToString()
+            {
+                return "{ Bar = " + Bar + ", Foo = " + Foo + " }";
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.New.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.New.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> New()
+        {
+            yield return Expression.New(typeof(TimeSpan));
+            yield return Expression.New(typeof(TimeSpan).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(long) }), Expression.Constant(1234567890L));
+            yield return Expression.New(typeof(TimeSpan).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(int), typeof(int), typeof(int) }), Expression.Constant(12), Expression.Constant(34), Expression.Constant(56));
+
+            yield return Expression.New(typeof(string).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(char), typeof(int) }), Expression.Constant('*'), Expression.Constant(-1));
+            yield return Expression.New(typeof(string).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(char), typeof(int) }), Expression.Constant('*'), Expression.Constant(2));
+
+            yield return ((Expression<Func<object>>)(() => new { })).Body;
+            yield return ((Expression<Func<object>>)(() => new { a = 1 })).Body;
+            yield return ((Expression<Func<object>>)(() => new { a = 1, b = "foo" })).Body;
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> New_ByRef()
+        {
+            var res = Expression.Parameter(typeof(N));
+            var ctor = typeof(N).GetTypeInfo().DeclaredConstructors.Single();
+            var toStringTemplate = (Expression<Func<N, string>>)(x => x.ToString());
+            var concatIntStringTemplate = (Expression<Func<int, string, string>>)((x, s) => x + s);
+            var concatIntStringStringTemplate = (Expression<Func<int, string, string, string>>)((x, s1, s2) => x + s1 + s2);
+
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.New,
+                    Expression.Block(
+                        new[] { res, p },
+                        Expression.Assign(p, Expression.Constant(42)),
+                        Expression.Assign(
+                            res,
+                            Expression.New(
+                                ctor,
+                                Expression.Constant("bar"),
+                                p,
+                                Expression.Constant(true)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatIntStringTemplate,
+                            p,
+                            Expression.Invoke(toStringTemplate, res)
+                        )
+                    )
+                );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(HolderWithLog<int>));
+                var value = Expression.Property(p, "Value");
+
+                yield return
+                    WithLogExpr(ExpressionType.New, (add, summarize) =>
+                        Expression.Block(
+                            new[] { res, p },
+                            Expression.Assign(
+                                p,
+                                Expression.New(typeof(HolderWithLog<int>).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(Action<string>) }), add)
+                            ),
+                            Expression.Assign(
+                                res,
+                                Expression.New(
+                                    ctor,
+                                    ReturnWithLog(add, "bar"),
+                                    value,
+                                    ReturnWithLog(add, true)
+                                )
+                            ),
+                            Expression.Invoke(
+                                concatIntStringStringTemplate,
+                                value,
+                                Expression.Invoke(toStringTemplate, res),
+                                Expression.Invoke(summarize)
+                            )
+                        )
+                    );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(int[]));
+                var value = Expression.ArrayAccess(p, Expression.Constant(0));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.New,
+                    Expression.Block(
+                        new[] { res, p },
+                        Expression.Assign(
+                            p,
+                            Expression.NewArrayBounds(typeof(int), Expression.Constant(1))
+                        ),
+                        Expression.Assign(
+                            res,
+                            Expression.New(
+                                ctor,
+                                Expression.Constant("bar"),
+                                value,
+                                Expression.Constant(true)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatIntStringTemplate,
+                            value,
+                            Expression.Invoke(toStringTemplate, res)
+                        )
+                    )
+                );
+            }
+
+            {
+                var p = Expression.Parameter(typeof(VectorWithLog<int>));
+                var value = Expression.MakeIndex(p, p.Type.GetTypeInfo().GetDeclaredProperty("Item"), new[] { Expression.Constant(0) });
+
+                yield return
+                    WithLogExpr(ExpressionType.New, (add, summarize) =>
+                        Expression.Block(
+                            new[] { res, p },
+                            Expression.Assign(
+                                p,
+                                Expression.New(typeof(VectorWithLog<int>).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(Action<string>) }), add)
+                            ),
+                            Expression.Assign(
+                                res,
+                                Expression.New(
+                                    ctor,
+                                    ReturnWithLog(add, "bar"),
+                                    ReturnAllConstants(add, value),
+                                    ReturnWithLog(add, true)
+                                )
+                            ),
+                            Expression.Invoke(
+                                concatIntStringStringTemplate,
+                                value,
+                                Expression.Invoke(toStringTemplate, res),
+                                Expression.Invoke(summarize)
+                            )
+                        )
+                    );
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> New_WithLog()
+        {
+            yield return WithLog(ExpressionType.New, (log, summary) =>
+            {
+                var valueParam = Expression.Parameter(typeof(TimeSpan));
+                var toStringTemplate = (Expression<Func<TimeSpan, string>>)(x => x.ToString());
+                var concatTemplate = (Expression<Func<string, string, string>>)((s1, s2) => s1 + s2);
+
+                return
+                    Expression.Block(
+                        new[] { valueParam },
+                        Expression.Assign(
+                            valueParam,
+                            Expression.New(
+                                typeof(TimeSpan).GetTypeInfo().GetDeclaredConstructor(new[] { typeof(int), typeof(int), typeof(int) }),
+                                ReturnWithLog(log, 1),
+                                ReturnWithLog(log, 2),
+                                ReturnWithLog(log, 3)
+                            )
+                        ),
+                        Expression.Invoke(
+                            concatTemplate,
+                            Expression.Invoke(toStringTemplate, valueParam),
+                            summary
+                        )
+                    );
+            });
+        }
+
+        class N
+        {
+            private readonly bool _b;
+            private readonly string _s;
+            private readonly int _x;
+
+            public N(string s, ref int x, bool b)
+            {
+                _s = s;
+                _x = x;
+                _b = b;
+
+                x++;
+            }
+
+            public override string ToString()
+            {
+                return "{ s = " + _s + ", x = " + _x + ", b = " + _b + " }";
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Parameter.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Parameter.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Parameter()
+        {
+            // Shadowing with lambdas
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Parameter,
+                    Expression.Invoke(
+                        Expression.Invoke(
+                            Expression.Lambda(
+                                Expression.Lambda(p, p),
+                                p
+                            ),
+                            Expression.Constant(1)
+                        ),
+                        Expression.Constant(2)
+                    )
+                );
+            }
+
+            // Shadowing with lambdas and blocks
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Parameter,
+                    Expression.Block(
+                        new[] { p },
+                        Expression.Assign(
+                            p,
+                            Expression.Constant(1)
+                        ),
+                        Expression.Invoke(
+                            Expression.Lambda(p, p),
+                            Expression.Constant(2)
+                        )
+                    )
+                );
+            }
+
+            // Shadowing with blocks
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Parameter,
+                    Expression.Block(
+                        new[] { p },
+                        Expression.Assign(
+                            p,
+                            Expression.Constant(1)
+                        ),
+                        Expression.Block(
+                            new[] { p },
+                            Expression.Assign(
+                                p,
+                                Expression.Constant(2)
+                            )
+                        ),
+                        p
+                    )
+                );
+            }
+
+            // Closures with lambdas
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Parameter,
+                    Expression.Invoke(
+                        Expression.Invoke(
+                            Expression.Lambda(
+                                Expression.Lambda(p),
+                                p
+                            ),
+                            Expression.Constant(1)
+                        )
+                    )
+                );
+            }
+
+            // Closures with lambdas and blocks
+            {
+                var p = Expression.Parameter(typeof(int));
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Parameter,
+                    Expression.Block(
+                        new[] { p },
+                        Expression.Assign(
+                            p,
+                            Expression.Constant(1)
+                        ),
+                        Expression.Invoke(
+                            Expression.Lambda(p)
+                        )
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.RuntimeVariables.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.RuntimeVariables.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> RuntimeVariables()
+        {
+            var p0 = Expression.Parameter(typeof(int));
+            var p1 = Expression.Parameter(typeof(int));
+            var p2 = Expression.Parameter(typeof(int));
+            var rv = Expression.Parameter(typeof(IRuntimeVariables));
+
+            var getInfo = ((MethodCallExpression)((Expression<Func<IRuntimeVariables, string>>)(rvp => GetInfo(rvp))).Body).Method;
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RuntimeVariables,
+                Expression.Block(
+                    new[] { p0, p1, p2, rv },
+                    Expression.Assign(p0, Expression.Constant(1)),
+                    Expression.Assign(p1, Expression.Constant(2)),
+                    Expression.Assign(p2, Expression.Constant(3)),
+                    Expression.Assign(rv, Expression.RuntimeVariables(p0, p2)),
+                    Expression.Call(getInfo, rv)
+                )
+            );
+        }
+
+        private static string GetInfo(IRuntimeVariables vars)
+        {
+            return "{ Count = " + vars.Count + ", Values = { " + string.Join(", ", Enumerable.Range(0, vars.Count).Select(i => vars[i])) + " } }";
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Switch.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Switch.cs
@@ -1,0 +1,289 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Switch()
+        {
+            for (var i = -1; i <= 4; i++)
+            {
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(i),
+                        Expression.Constant("other"),
+                        Expression.SwitchCase(Expression.Constant("one"), Expression.Constant(1)),
+                        Expression.SwitchCase(Expression.Constant("two"), Expression.Constant(2)),
+                        Expression.SwitchCase(Expression.Constant("thr"), Expression.Constant(3))
+                    )
+                );
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(i),
+                        Expression.Constant("?"),
+                        Expression.SwitchCase(Expression.Constant("odd"), Expression.Constant(1), Expression.Constant(3)),
+                        Expression.SwitchCase(Expression.Constant("even"), Expression.Constant(2), Expression.Constant(4))
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(i)),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant("other")),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C1")), Expression.Constant("one")), Expression.Constant(1)),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C2")), Expression.Constant("two")), Expression.Constant(2)),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C3")), Expression.Constant("thr")), Expression.Constant(3))
+                        ),
+                        summary
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(i)),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant("?")),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C1")), Expression.Constant("odd")), Expression.Constant(1), Expression.Constant(3)),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C2")), Expression.Constant("even")), Expression.Constant(2), Expression.Constant(4))
+                        ),
+                        summary
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(i)),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant("other")),
+                            Expression.SwitchCase(Expression.Constant("one"), Expression.Block(add(Expression.Constant("V1")), Expression.Constant(1))),
+                            Expression.SwitchCase(Expression.Constant("two"), Expression.Block(add(Expression.Constant("V2")), Expression.Constant(2))),
+                            Expression.SwitchCase(Expression.Constant("thr"), Expression.Block(add(Expression.Constant("V3")), Expression.Constant(3)))
+                        ),
+                        summary
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(i)),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant("?")),
+                            Expression.SwitchCase(Expression.Constant("odd"), Expression.Block(add(Expression.Constant("V1")), Expression.Constant(1)), Expression.Block(add(Expression.Constant("V3")), Expression.Constant(3))),
+                            Expression.SwitchCase(Expression.Constant("even"), Expression.Block(add(Expression.Constant("V2")), Expression.Constant(2)), Expression.Block(add(Expression.Constant("V4")), Expression.Constant(4)))
+                        ),
+                        summary
+                    )
+                );
+            }
+
+            foreach (var s in new[] { default(string), "one", "two", "thr", "zer", "fiv", "for" })
+            {
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(s, typeof(string)),
+                        Expression.Constant(null, typeof(int?)),
+                        Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Constant("one")),
+                        Expression.SwitchCase(Expression.Constant(2, typeof(int?)), Expression.Constant("two")),
+                        Expression.SwitchCase(Expression.Constant(3, typeof(int?)), Expression.Constant("thr"))
+                    )
+                );
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(s, typeof(string)),
+                        Expression.Constant(int.MaxValue, typeof(int?)),
+                        Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Constant("one")),
+                        Expression.SwitchCase(Expression.Constant(2, typeof(int?)), Expression.Constant("two")),
+                        Expression.SwitchCase(Expression.Constant(3, typeof(int?)), Expression.Constant("thr"))
+                    )
+                );
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(s, typeof(string)),
+                        Expression.Constant(-1, typeof(int?)),
+                        Expression.SwitchCase(Expression.Constant(null, typeof(int?)), Expression.Constant(null, typeof(string))),
+                        Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Constant("one")),
+                        Expression.SwitchCase(Expression.Constant(2, typeof(int?)), Expression.Constant("two")),
+                        Expression.SwitchCase(Expression.Constant(3, typeof(int?)), Expression.Constant("thr"))
+                    )
+                );
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(s, typeof(string)),
+                        Expression.Constant(-1, typeof(int?)),
+                        Expression.SwitchCase(Expression.Constant(int.MaxValue, typeof(int?)), Expression.Constant(null, typeof(string))),
+                        Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Constant("one")),
+                        Expression.SwitchCase(Expression.Constant(2, typeof(int?)), Expression.Constant("two")),
+                        Expression.SwitchCase(Expression.Constant(3, typeof(int?)), Expression.Constant("thr"))
+                    )
+                );
+
+                yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Switch,
+                    Expression.Switch(
+                        Expression.Constant(s, typeof(string)),
+                        Expression.Constant(null, typeof(int?)),
+                        Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Constant("one"), Expression.Constant("thr")),
+                        Expression.SwitchCase(Expression.Constant(0, typeof(int?)), Expression.Constant("two"), Expression.Constant("for"))
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(s, typeof(string))),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant(null, typeof(int?))),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C1")), Expression.Constant(1, typeof(int?))), Expression.Constant("one")),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C2")), Expression.Constant(2, typeof(int?))), Expression.Constant("two")),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C3")), Expression.Constant(3, typeof(int?))), Expression.Constant("thr"))
+                        ),
+                        summary
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(s, typeof(string))),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant(null, typeof(int?))),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C1")), Expression.Constant(1, typeof(int?))), Expression.Constant("one"), Expression.Constant("thr")),
+                            Expression.SwitchCase(Expression.Block(add(Expression.Constant("C2")), Expression.Constant(0, typeof(int?))), Expression.Constant("two"), Expression.Constant("for"))
+                        ),
+                        summary
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(s, typeof(string))),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant(null, typeof(int?))),
+                            Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Block(add(Expression.Constant("V1")), Expression.Constant("one"))),
+                            Expression.SwitchCase(Expression.Constant(2, typeof(int?)), Expression.Block(add(Expression.Constant("V2")), Expression.Constant("two"))),
+                            Expression.SwitchCase(Expression.Constant(3, typeof(int?)), Expression.Block(add(Expression.Constant("V3")), Expression.Constant("thr")))
+                        ),
+                        summary
+                    )
+                );
+
+                yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                    Expression.Block(
+                        Expression.Switch(
+                            Expression.Block(add(Expression.Constant("T")), Expression.Constant(s, typeof(string))),
+                            Expression.Block(add(Expression.Constant("D")), Expression.Constant(null, typeof(int?))),
+                            Expression.SwitchCase(Expression.Constant(1, typeof(int?)), Expression.Block(add(Expression.Constant("V1")), Expression.Constant("one")), Expression.Block(add(Expression.Constant("V3")), Expression.Constant("thr"))),
+                            Expression.SwitchCase(Expression.Constant(0, typeof(int?)), Expression.Block(add(Expression.Constant("V2")), Expression.Constant("two")), Expression.Block(add(Expression.Constant("V4")), Expression.Constant("for")))
+                        ),
+                        summary
+                    )
+                );
+            }
+
+            var xs = Enumerable.Range(0, 10).ToArray();
+            var ss = xs.Select(x => x.ToString()).ToArray();
+
+            foreach (var t in new[] { typeof(byte), typeof(sbyte), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong) })
+            {
+                var vals = xs.Select(x => System.Convert.ChangeType(x, t)).ToArray();
+                var cass = vals.Skip(1).Take(vals.Length - 2).ToArray();
+
+                foreach (var v in vals)
+                {
+                    yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                        Expression.Block(
+                            Expression.Switch(
+                                Expression.Block(add(Expression.Constant("T")), Expression.Constant(v, t)),
+                                Expression.Block(add(Expression.Constant("D")), Expression.Constant("", typeof(string))),
+                                cass.Select((c, i) => Expression.SwitchCase(Expression.Block(add(Expression.Constant("C" + i)), Expression.Constant(ss[i], typeof(string))), Expression.Constant(c, t))).ToArray()
+                            ),
+                            summary
+                        )
+                    );
+
+                    yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                        Expression.Block(
+                            Expression.Switch(
+                                Expression.Block(add(Expression.Constant("T")), Expression.Constant(v, t)),
+                                Expression.Block(add(Expression.Constant("D")), Expression.Constant("", typeof(string))),
+                                cass.Select((c, i) => Expression.SwitchCase(Expression.Constant(ss[i], typeof(string)), Expression.Block(add(Expression.Constant("V" + i)), Expression.Constant(c, t)))).ToArray()
+                            ),
+                            summary
+                        )
+                    );
+                }
+            }
+
+            foreach (var t in new[] { typeof(byte), typeof(sbyte), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong) })
+            {
+                var n = typeof(Nullable<>).MakeGenericType(t);
+
+                var vals = xs.Select(x => System.Convert.ChangeType(x, t)).Concat(new object[] { null }).ToArray();
+                var cass = vals.Skip(1).Take(vals.Length - 3).ToArray();
+
+                foreach (var v in vals)
+                {
+                    yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                        Expression.Block(
+                            Expression.Switch(
+                                Expression.Block(add(Expression.Constant("T")), Expression.Constant(v, n)),
+                                Expression.Block(add(Expression.Constant("D")), Expression.Constant("", typeof(string))),
+                                cass.Select((c, i) => Expression.SwitchCase(Expression.Block(add(Expression.Constant("C" + i)), Expression.Constant(ss[i], typeof(string))), Expression.Constant(c, n))).ToArray()
+                            ),
+                            summary
+                        )
+                    );
+
+                    yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                        Expression.Block(
+                            Expression.Switch(
+                                Expression.Block(add(Expression.Constant("T")), Expression.Constant(v, n)),
+                                Expression.Block(add(Expression.Constant("D")), Expression.Constant("", typeof(string))),
+                                cass.Select((c, i) => Expression.SwitchCase(Expression.Block(add(Expression.Constant("C" + i)), Expression.Constant(ss[i], typeof(string))), Expression.Constant(c, n))).Concat(new[] {
+                                    Expression.SwitchCase(Expression.Block(add(Expression.Constant("CN")), Expression.Constant("null", typeof(string))), Expression.Constant(null, n))
+                                }).ToArray()
+                            ),
+                            summary
+                        )
+                    );
+
+                    yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                        Expression.Block(
+                            Expression.Switch(
+                                Expression.Block(add(Expression.Constant("T")), Expression.Constant(v, n)),
+                                Expression.Block(add(Expression.Constant("D")), Expression.Constant("", typeof(string))),
+                                cass.Select((c, i) => Expression.SwitchCase(Expression.Constant(ss[i], typeof(string)), Expression.Block(add(Expression.Constant("V" + i)), Expression.Constant(c, n)))).ToArray()
+                            ),
+                            summary
+                        )
+                    );
+
+                    yield return WithLog(ExpressionType.Switch, (add, summary) =>
+                        Expression.Block(
+                            Expression.Switch(
+                                Expression.Block(add(Expression.Constant("T")), Expression.Constant(v, n)),
+                                Expression.Block(add(Expression.Constant("D")), Expression.Constant("", typeof(string))),
+                                cass.Select((c, i) => Expression.SwitchCase(Expression.Constant(ss[i], typeof(string)), Expression.Block(add(Expression.Constant("V" + i)), Expression.Constant(c, n)))).Concat(new[] {
+                                    Expression.SwitchCase(Expression.Constant("null", typeof(string)), Expression.Block(add(Expression.Constant("VN")), Expression.Constant(null, n)))
+                                }).ToArray()
+                            ),
+                            summary
+                        )
+                    );
+                }
+            }
+
+            // TODO: comparison method
+            // TODO: result type
+            // TODO: lifted case
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.TypeBinary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.TypeBinary.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> TypeIs()
+        {
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(int?));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(int));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(IComparable));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(IEquatable<int>));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(bool));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(ValueType));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int)), typeof(object));
+
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(int?));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(int));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(IComparable));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(IEquatable<int>));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(bool));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(ValueType));
+            yield return Expression.TypeIs(Expression.Constant(1, typeof(int?)), typeof(object));
+
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(int?));
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(int));
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(IComparable));
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(IEquatable<int>));
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(bool));
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(ValueType));
+            yield return Expression.TypeIs(Expression.Constant(null, typeof(int?)), typeof(object));
+
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(string));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(int));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(object));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(IComparable));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(IEquatable<string>));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(IEnumerable<char>));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(IEnumerable));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(IEquatable<int>));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(string)), typeof(IComparer<bool>));
+
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(string));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(int));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(object));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IComparable));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEquatable<string>));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEnumerable<char>));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEnumerable));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEquatable<int>));
+            yield return Expression.TypeIs(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IComparer<bool>));
+        }
+
+        private static IEnumerable<Expression> TypeEqual()
+        {
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(int?));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(int));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(IComparable));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(IEquatable<int>));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(bool));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(ValueType));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int)), typeof(object));
+
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(int?));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(int));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(IComparable));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(IEquatable<int>));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(bool));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(ValueType));
+            yield return Expression.TypeEqual(Expression.Constant(1, typeof(int?)), typeof(object));
+
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(int?));
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(int));
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(IComparable));
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(IEquatable<int>));
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(bool));
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(ValueType));
+            yield return Expression.TypeEqual(Expression.Constant(null, typeof(int?)), typeof(object));
+
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(string));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(int));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(object));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(IComparable));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(IEquatable<string>));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(IEnumerable<char>));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(IEnumerable));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(IEquatable<int>));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(string)), typeof(IComparer<bool>));
+
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(string));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(int));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(object));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IComparable));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEquatable<string>));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEnumerable<char>));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEnumerable));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IEquatable<int>));
+            yield return Expression.TypeEqual(Expression.Constant("bar", typeof(IEnumerable<char>)), typeof(IComparer<bool>));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Types.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Types.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Tests.Expressions
+{
+    public struct S1
+    {
+        private int _x;
+
+        public S1(int x)
+        {
+            _x = x;
+        }
+
+        public static S1 operator +(S1 l, S1 r)
+        {
+            return new S1(l._x + r._x);
+        }
+
+        public static S1 operator -(S1 l, S1 r)
+        {
+            return new S1(l._x - r._x);
+        }
+
+        public static S1 operator *(S1 l, S1 r)
+        {
+            return new S1(l._x * r._x);
+        }
+
+        public static S1 operator /(S1 l, S1 r)
+        {
+            return new S1(l._x / r._x);
+        }
+
+        public static S1 operator %(S1 l, S1 r)
+        {
+            return new S1(l._x % r._x);
+        }
+
+        public static S1 operator &(S1 l, S1 r)
+        {
+            return new S1(l._x & r._x);
+        }
+
+        public static S1 operator |(S1 l, S1 r)
+        {
+            return new S1(l._x | r._x);
+        }
+
+        public static S1 operator ^(S1 l, S1 r)
+        {
+            return new S1(l._x ^ r._x);
+        }
+
+        public static S1 operator <<(S1 l, int r)
+        {
+            return new S1(l._x << r);
+        }
+
+        public static S1 operator >>(S1 l, int r)
+        {
+            return new S1(l._x >> r);
+        }
+
+        public static bool operator <(S1 l, S1 r)
+        {
+            return l._x < r._x;
+        }
+
+        public static bool operator <=(S1 l, S1 r)
+        {
+            return l._x <= r._x;
+        }
+
+        public static bool operator >(S1 l, S1 r)
+        {
+            return l._x > r._x;
+        }
+
+        public static bool operator >=(S1 l, S1 r)
+        {
+            return l._x >= r._x;
+        }
+
+        public static bool operator ==(S1 l, S1 r)
+        {
+            return l._x == r._x;
+        }
+
+        public static bool operator !=(S1 l, S1 r)
+        {
+            return l._x != r._x;
+        }
+
+        public static S1 operator +(S1 o)
+        {
+            return o;
+        }
+
+        public static S1 operator -(S1 o)
+        {
+            return new S1(-o._x);
+        }
+
+        public static S1 operator ~(S1 o)
+        {
+            return new S1(~o._x);
+        }
+
+        public static S1 operator ++(S1 o)
+        {
+            return new S1(o._x++);
+        }
+
+        public static S1 operator --(S1 o)
+        {
+            return new S1(o._x--);
+        }
+
+        public static explicit operator S1(int x)
+        {
+            return new S1(x);
+        }
+
+        public static S1 Pow(S1 l, S1 r)
+        {
+            return new S1((int)Math.Pow(l._x, r._x));
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is S1))
+            {
+                return false;
+            }
+
+            return ((S1)obj)._x == _x;
+        }
+
+        public override int GetHashCode()
+        {
+            return _x.GetHashCode();
+        }
+    }
+
+    public struct S2
+    {
+        private bool _b;
+
+        public S2(bool b)
+        {
+            _b = b;
+        }
+
+        public static S2 operator !(S2 o)
+        {
+            return new S2(!o._b);
+        }
+
+        public static bool operator true(S2 o)
+        {
+            return o._b;
+        }
+
+        public static bool operator false(S2 o)
+        {
+            return !o._b;
+        }
+
+        public static S2 operator &(S2 l, S2 r)
+        {
+            return new S2(l._b & r._b);
+        }
+
+        public static S2 operator |(S2 l, S2 r)
+        {
+            return new S2(l._b | r._b);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is S2))
+            {
+                return false;
+            }
+
+            return ((S2)obj)._b == _b;
+        }
+
+        public override int GetHashCode()
+        {
+            return _b.GetHashCode();
+        }
+    }
+
+    public enum E
+    {
+        Red,
+        Green,
+        Blue
+    }
+
+    public class Holder<T>
+    {
+        public T Value { get; set; }
+    }
+
+    public class HolderWithLog<T>
+    {
+        private readonly Action<string> _addToLog;
+        private T _value;
+
+        public HolderWithLog(Action<string> addToLog)
+        {
+            _addToLog = addToLog;
+        }
+
+        public T Value
+        {
+            get
+            {
+                _addToLog("get_Value");
+                return _value;
+            }
+
+            set
+            {
+                _addToLog("set_Value(" + _value + ")");
+                _value = value;
+            }
+        }
+    }
+
+    public class Vector<T>
+    {
+        private T _value;
+
+        public T this[int x]
+        {
+            get
+            {
+                return _value;
+            }
+
+            set
+            {
+                _value = value;
+            }
+        }
+    }
+
+    public class VectorWithLog<T>
+    {
+        private readonly Action<string> _addToLog;
+        private T _value;
+
+        public VectorWithLog(Action<string> addToLog)
+        {
+            _addToLog = addToLog;
+        }
+
+        public T this[int x]
+        {
+            get
+            {
+                _addToLog("get_Item(" + x + ")");
+                return _value;
+            }
+
+            set
+            {
+                _addToLog("set_Item(" + x + ", " + _value + ")");
+                _value = value;
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Assign.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Assign.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreIncrementAssign()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PreIncrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreIncrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreIncrementAssign_Nullable()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PreIncrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreIncrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostIncrementAssign()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PostIncrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostIncrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostIncrementAssign_Nullable()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PostIncrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostIncrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreDecrementAssign()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PreDecrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreDecrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreDecrementAssign_Nullable()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PreDecrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreDecrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostDecrementAssign()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PostDecrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostDecrementAssign, e);
+					}
+				}
+			}
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostDecrementAssign_Nullable()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					foreach (var e in GetAssignments(o, (op) => Expression.PostDecrementAssign(op)))
+					{
+						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostDecrementAssign, e);
+					}
+				}
+			}
+        }
+
+		private static IEnumerable<Expression> GetAssignments(Expression initialValue, Func<Expression, Expression> createAssignment)
+        {
+            // Parameter
+            {
+                var p = Expression.Parameter(initialValue.Type);
+                var a = Expression.Assign(p, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, createAssignment(p));
+            }
+            
+            // Member
+            {
+                var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(initialValue.Type));
+                var a = Expression.Assign(p, Expression.New(p.Type));
+                var v = Expression.Property(p, "Value");
+                var b = Expression.Assign(v, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, b, createAssignment(v));
+            }
+
+            // Array
+            {
+                var p = Expression.Parameter(initialValue.Type.MakeArrayType());
+                var a = Expression.Assign(p, Expression.NewArrayBounds(initialValue.Type, Expression.Constant(1)));
+                var e = Expression.ArrayAccess(p, Expression.Constant(0));
+                var b = Expression.Assign(e, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, b, createAssignment(e));
+            }
+
+			// Vector
+            {
+                var p = Expression.Parameter(typeof(Vector<>).MakeGenericType(initialValue.Type));
+                var a = Expression.Assign(p, Expression.New(p.Type));
+                var e = Expression.MakeIndex(p, p.Type.GetTypeInfo().GetDeclaredProperty("Item"), new[] { Expression.Constant(0) });
+                var b = Expression.Assign(e, initialValue);
+
+                yield return Expression.Block(new[] { p }, a, b, createAssignment(e));
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Generated.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+		private static readonly Type[] s_unaryArithTypesUnaryPlus = new[] { typeof(S1), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long), typeof(float), typeof(double) };
+		private static readonly Type[] s_unaryArithTypesOnesComplement = new[] { typeof(S1), typeof(ushort), typeof(short), typeof(uint), typeof(int), typeof(ulong), typeof(long) };
+		private static readonly Type[] s_unaryArithTypesNegate = new[] { typeof(S1), typeof(short), typeof(int), typeof(long), typeof(float), typeof(double) };
+		private static readonly Type[] s_unaryLogicTypes = new[] { typeof(S2), typeof(bool) };
+		private static readonly Type[] s_unaryIncrDecrTypes = new[] { typeof(S1), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double) };
+
+        private static IEnumerable<Expression> UnaryPlus()
+        {
+			foreach (var t in s_unaryArithTypesUnaryPlus)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.UnaryPlus(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> UnaryPlus_Nullable()
+        {
+			foreach (var t in s_unaryArithTypesUnaryPlus)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.UnaryPlus(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Negate()
+        {
+			foreach (var t in s_unaryArithTypesNegate)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.Negate(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Negate_Nullable()
+        {
+			foreach (var t in s_unaryArithTypesNegate)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.Negate(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> NegateChecked()
+        {
+			foreach (var t in s_unaryArithTypesNegate)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.NegateChecked(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> NegateChecked_Nullable()
+        {
+			foreach (var t in s_unaryArithTypesNegate)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.NegateChecked(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> OnesComplement()
+        {
+			foreach (var t in s_unaryArithTypesOnesComplement)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.OnesComplement(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> OnesComplement_Nullable()
+        {
+			foreach (var t in s_unaryArithTypesOnesComplement)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.OnesComplement(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> IsTrue()
+        {
+			foreach (var t in s_unaryLogicTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.IsTrue(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> IsTrue_Nullable()
+        {
+			foreach (var t in s_unaryLogicTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.IsTrue(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> IsFalse()
+        {
+			foreach (var t in s_unaryLogicTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.IsFalse(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> IsFalse_Nullable()
+        {
+			foreach (var t in s_unaryLogicTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.IsFalse(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Not()
+        {
+			foreach (var t in s_unaryLogicTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.Not(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Not_Nullable()
+        {
+			foreach (var t in s_unaryLogicTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.Not(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Increment()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.Increment(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Increment_Nullable()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.Increment(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Decrement()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_exprs[t])
+				{
+					yield return Expression.Decrement(o);
+				}
+			}
+        }
+
+        private static IEnumerable<Expression> Decrement_Nullable()
+        {
+			foreach (var t in s_unaryIncrDecrTypes)
+			{
+				foreach (var o in s_nullableExprs[t])
+				{
+					yield return Expression.Decrement(o);
+				}
+			}
+        }
+
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.cs
@@ -1,0 +1,311 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    partial class ExpressionCatalog
+    {
+        private static IEnumerable<Expression> Unbox()
+        {
+            yield return Expression.Unbox(Expression.Constant(42, typeof(object)), typeof(int));
+            yield return Expression.Unbox(Expression.Constant(42, typeof(IEquatable<int>)), typeof(int));
+
+            yield return Expression.Unbox(Expression.Constant(null, typeof(object)), typeof(int));
+            yield return Expression.Unbox(Expression.Constant(null, typeof(IEquatable<int>)), typeof(int));
+
+            yield return Expression.Unbox(Expression.Constant(42, typeof(object)), typeof(int?));
+            yield return Expression.Unbox(Expression.Constant(42, typeof(IEquatable<int>)), typeof(int?));
+
+            yield return Expression.Unbox(Expression.Constant(null, typeof(object)), typeof(int?));
+            yield return Expression.Unbox(Expression.Constant(null, typeof(IEquatable<int>)), typeof(int?));
+        }
+
+        private static IEnumerable<Expression> Convert()
+        {
+            var factories = new Func<Expression, Type, Expression>[]
+            {
+                (e, t) => Expression.Convert(e, t),
+                (e, t) => Expression.ConvertChecked(e, t),
+            };
+
+            var convertValueTypes = new[]
+            {
+                typeof(bool),
+                typeof(byte),
+                typeof(sbyte),
+                typeof(ushort),
+                typeof(short),
+                typeof(uint),
+                typeof(int),
+                typeof(ulong),
+                typeof(long),
+                typeof(float),
+                typeof(double),
+                typeof(char),
+                typeof(E),
+            };
+
+            foreach (var t in convertValueTypes)
+            {
+                var n = typeof(Nullable<>).MakeGenericType(t);
+
+                foreach (var v in s_values[t])
+                {
+                    foreach (var f in factories)
+                    {
+                        yield return f(Expression.Constant(v, t), t);
+                        yield return f(Expression.Constant(v, t), n);
+                        yield return f(Expression.Constant(v, n), t);
+                        yield return f(Expression.Constant(v, n), n);
+                        yield return f(Expression.Constant(null, n), t);
+                        yield return f(Expression.Constant(null, n), n);
+
+                        yield return f(Expression.Constant(v, typeof(object)), t);
+                        yield return f(Expression.Constant(v, typeof(object)), n);
+                        yield return f(Expression.Constant(null, typeof(object)), t);
+                        yield return f(Expression.Constant(null, typeof(object)), n);
+                        yield return f(Expression.Constant(v, t), typeof(object));
+                        yield return f(Expression.Constant(v, n), typeof(object));
+                        yield return f(Expression.Constant(null, n), typeof(object));
+                    }
+                }
+            }
+
+            var convertEnumTypes = new[]
+            {
+                typeof(E),
+            };
+
+            foreach (var t in convertEnumTypes)
+            {
+                var tn = typeof(Nullable<>).MakeGenericType(t);
+                var u = Enum.GetUnderlyingType(t);
+                var un = typeof(Nullable<>).MakeGenericType(u);
+
+                foreach (var v in s_values[t])
+                {
+                    var i = System.Convert.ChangeType(v, u);
+
+                    foreach (var f in factories)
+                    {
+                        yield return f(Expression.Constant(v, t), u);
+                        yield return f(Expression.Constant(v, tn), u);
+                        yield return f(Expression.Constant(null, tn), u);
+
+                        yield return f(Expression.Constant(v, t), un);
+                        yield return f(Expression.Constant(v, tn), un);
+                        yield return f(Expression.Constant(null, tn), un);
+
+                        yield return f(Expression.Constant(i, u), t);
+                        yield return f(Expression.Constant(i, un), t);
+                        yield return f(Expression.Constant(null, un), t);
+
+                        yield return f(Expression.Constant(i, u), tn);
+                        yield return f(Expression.Constant(i, un), tn);
+                        yield return f(Expression.Constant(null, un), tn);
+                    }
+                }
+            }
+
+            foreach (var tf in convertValueTypes)
+            {
+                var tfn = typeof(Nullable<>).MakeGenericType(tf);
+
+                foreach (var tt in convertValueTypes)
+                {
+                    if (tt == typeof(bool))
+                    {
+                        continue;
+                    }
+
+                    var ttn = typeof(Nullable<>).MakeGenericType(tt);
+
+                    foreach (var v in s_values[tf])
+                    {
+                        foreach (var f in factories)
+                        {
+                            yield return f(Expression.Constant(v, tf), tt);
+                            yield return f(Expression.Constant(v, tf), ttn);
+                            yield return f(Expression.Constant(v, tfn), tt);
+                            yield return f(Expression.Constant(v, tfn), ttn);
+                            yield return f(Expression.Constant(null, tfn), tt);
+                            yield return f(Expression.Constant(null, tfn), ttn);
+                        }
+                    }
+                }
+            }
+
+            foreach (var f in factories)
+            {
+                yield return f(Expression.Constant(null, typeof(string)), typeof(string));
+                yield return f(Expression.Constant(null, typeof(string)), typeof(object));
+                yield return f(Expression.Constant(null, typeof(object)), typeof(string));
+
+                yield return f(Expression.Constant("bar", typeof(string)), typeof(string));
+                yield return f(Expression.Constant("bar", typeof(string)), typeof(object));
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(string));
+
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(int));
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(int?));
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(Array));
+
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(IComparable));
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(IEnumerable));
+                yield return f(Expression.Constant("bar", typeof(object)), typeof(IEnumerable<char>));
+
+                yield return f(Expression.Constant("bar", typeof(string)), typeof(IComparable));
+                yield return f(Expression.Constant("bar", typeof(string)), typeof(IEnumerable));
+                yield return f(Expression.Constant("bar", typeof(string)), typeof(IEnumerable<char>));
+            }
+
+            foreach (var f in factories)
+            {
+                yield return f(Expression.Constant(DateTime.Now, typeof(DateTime)), typeof(DateTimeOffset));
+                yield return f(Expression.Constant(DateTime.Now, typeof(DateTime)), typeof(DateTimeOffset?));
+                yield return f(Expression.Constant(DateTime.Now, typeof(DateTime?)), typeof(DateTimeOffset));
+                yield return f(Expression.Constant(DateTime.Now, typeof(DateTime?)), typeof(DateTimeOffset?));
+                yield return f(Expression.Constant(null, typeof(DateTime?)), typeof(DateTimeOffset));
+                yield return f(Expression.Constant(null, typeof(DateTime?)), typeof(DateTimeOffset?));
+            }
+        }
+
+        private static IEnumerable<Expression> TypeAs()
+        {
+            var convertValueTypes = new[]
+            {
+                typeof(bool),
+                typeof(byte),
+                typeof(sbyte),
+                typeof(ushort),
+                typeof(short),
+                typeof(uint),
+                typeof(int),
+                typeof(ulong),
+                typeof(long),
+                typeof(float),
+                typeof(double),
+                typeof(char),
+                typeof(E),
+            };
+
+            foreach (var t in convertValueTypes)
+            {
+                var n = typeof(Nullable<>).MakeGenericType(t);
+
+                foreach (var v in s_values[t])
+                {
+                    yield return Expression.TypeAs(Expression.Constant(v, t), n);
+                    yield return Expression.TypeAs(Expression.Constant(v, n), n);
+                    yield return Expression.TypeAs(Expression.Constant(null, n), n);
+
+                    yield return Expression.TypeAs(Expression.Constant(v, typeof(object)), n);
+                    yield return Expression.TypeAs(Expression.Constant(null, typeof(object)), n);
+                    yield return Expression.TypeAs(Expression.Constant(v, t), typeof(object));
+                    yield return Expression.TypeAs(Expression.Constant(v, n), typeof(object));
+                    yield return Expression.TypeAs(Expression.Constant(null, n), typeof(object));
+                }
+            }
+
+            var convertEnumTypes = new[]
+            {
+                typeof(E),
+            };
+
+            foreach (var t in convertEnumTypes)
+            {
+                var tn = typeof(Nullable<>).MakeGenericType(t);
+                var u = Enum.GetUnderlyingType(t);
+                var un = typeof(Nullable<>).MakeGenericType(u);
+
+                foreach (var v in s_values[t])
+                {
+                    var i = System.Convert.ChangeType(v, u);
+
+                    yield return Expression.TypeAs(Expression.Constant(v, t), un);
+                    yield return Expression.TypeAs(Expression.Constant(v, tn), un);
+                    yield return Expression.TypeAs(Expression.Constant(null, tn), un);
+
+                    yield return Expression.TypeAs(Expression.Constant(i, u), tn);
+                    yield return Expression.TypeAs(Expression.Constant(i, un), tn);
+                    yield return Expression.TypeAs(Expression.Constant(null, un), tn);
+                }
+            }
+
+            foreach (var tf in convertValueTypes)
+            {
+                var tfn = typeof(Nullable<>).MakeGenericType(tf);
+
+                foreach (var tt in convertValueTypes)
+                {
+                    if (tt == typeof(bool))
+                    {
+                        continue;
+                    }
+
+                    var ttn = typeof(Nullable<>).MakeGenericType(tt);
+
+                    foreach (var v in s_values[tf])
+                    {
+                        yield return Expression.TypeAs(Expression.Constant(v, tf), ttn);
+                        yield return Expression.TypeAs(Expression.Constant(v, tfn), ttn);
+                        yield return Expression.TypeAs(Expression.Constant(null, tfn), ttn);
+                    }
+                }
+            }
+
+            {
+                yield return Expression.TypeAs(Expression.Constant(null, typeof(string)), typeof(string));
+                yield return Expression.TypeAs(Expression.Constant(null, typeof(string)), typeof(object));
+                yield return Expression.TypeAs(Expression.Constant(null, typeof(object)), typeof(string));
+
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(string)), typeof(string));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(string)), typeof(object));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(object)), typeof(string));
+
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(object)), typeof(int?));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(object)), typeof(Array));
+
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(object)), typeof(IComparable));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(object)), typeof(IEnumerable));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(object)), typeof(IEnumerable<char>));
+
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(string)), typeof(IComparable));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(string)), typeof(IEnumerable));
+                yield return Expression.TypeAs(Expression.Constant("bar", typeof(string)), typeof(IEnumerable<char>));
+            }
+
+            {
+                yield return Expression.TypeAs(Expression.Constant(DateTime.Now, typeof(DateTime)), typeof(DateTimeOffset?));
+                yield return Expression.TypeAs(Expression.Constant(DateTime.Now, typeof(DateTime?)), typeof(DateTimeOffset?));
+                yield return Expression.TypeAs(Expression.Constant(null, typeof(DateTime?)), typeof(DateTimeOffset?));
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<ExpressionType, Expression>> Quote()
+        {
+            var expr = (Expression<Func<int>>)(() => Quoted.F(() => 42));
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Quote, expr.Body);
+
+            var f = ((MethodCallExpression)expr.Body).Method;
+            var x = Expression.Parameter(typeof(int));
+            var withClosure = Expression.Block(new[] { x }, Expression.Assign(x, Expression.Constant(42)), Expression.Call(f, Expression.Lambda(x)));
+
+            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Quote, withClosure);
+        }
+    }
+
+    static class Quoted
+    {
+        public static int F(Expression<Func<int>> f)
+        {
+            return f.Compile()();
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Tests.Expressions
+{
+    public static partial class ExpressionCatalog
+    {
+        private static IDictionary<ExpressionType, IEnumerable<Expression>> s_Catalog;
+        private static int s_countEx = 0;
+
+        internal static readonly IDictionary<Type, object[]> s_values = new Dictionary<Type, object[]>
+        {
+            { typeof(bool), new object[] { false, true } },
+            { typeof(byte), new object[] { (byte)0, (byte)1, (byte)2, (byte)(byte.MaxValue - 1), byte.MaxValue } },
+            { typeof(sbyte), new object[] { sbyte.MinValue, (sbyte)(sbyte.MinValue + 1), (sbyte)-2, (sbyte)-1, (sbyte)0, (sbyte)1, (sbyte)2, (sbyte)(sbyte.MaxValue - 1), sbyte.MaxValue } },
+            { typeof(ushort), new object[] { (ushort)0, (ushort)1, (ushort)2, (ushort)(ushort.MaxValue - 1), ushort.MaxValue } },
+            { typeof(short), new object[] { short.MinValue, (short)(short.MinValue + 1), (short)-2, (short)-1, (short)0, (short)1, (short)2, (short)(short.MaxValue - 1), short.MaxValue } },
+            { typeof(uint), new object[] { (uint)0, (uint)1, (uint)2, (uint)(uint.MaxValue - 1), uint.MaxValue } },
+            { typeof(int), new object[] { int.MinValue, (int)(int.MinValue + 1), (int)-2, (int)-1, (int)0, (int)1, (int)2, (int)(int.MaxValue - 1), int.MaxValue } },
+            { typeof(ulong), new object[] { (ulong)0, (ulong)1, (ulong)2, (ulong)(ulong.MaxValue - 1), ulong.MaxValue } },
+            { typeof(long), new object[] { long.MinValue, (long)(long.MinValue + 1), (long)-2, (long)-1, (long)0, (long)1, (long)2, (long)(long.MaxValue - 1), long.MaxValue } },
+            { typeof(double), new object[] { (double)0.0, (double)1.0, (double)-1.0, Math.PI, Math.E, double.NegativeInfinity, double.PositiveInfinity, double.NaN, double.MinValue, double.MaxValue } },
+            { typeof(float), new object[] { (float)0.0, (float)1.0, (float)-1.0, (float)Math.PI, (float)Math.E, float.NegativeInfinity, float.PositiveInfinity, float.NaN, float.MinValue, float.MaxValue } },
+            { typeof(string), new object[] { "", "bar", "foo" } },
+            { typeof(char), new object[] { char.MinValue, char.MaxValue, 'a', '0' } },
+            { typeof(S1), new[] { int.MinValue, (int)(int.MinValue + 1), (int)-2, (int)-1, (int)0, (int)1, (int)2, (int)(int.MaxValue - 1), int.MaxValue }.Select(x => (object)new S1(x)).ToArray() },
+            { typeof(S2), new[] { false, true }.Select(b => (object)new S2(b)).ToArray() },
+            { typeof(E), new object[] { E.Red, E.Green, E.Blue } },
+        };
+
+        internal static readonly IDictionary<Type, Expression[]> s_consts = s_values.ToDictionary(kv => kv.Key, kv => kv.Value.Select(v => (Expression)Expression.Constant(v, kv.Key)).ToArray());
+        internal static readonly IDictionary<Type, Expression[]> s_exprs = s_consts.ToDictionary(kv => kv.Key, kv => kv.Value.Concat(new Expression[] { Expression.Throw(Expression.Constant(new Exception("Error " + s_countEx++)), kv.Key) }).ToArray());
+        internal static readonly IDictionary<Type, Expression[]> s_nullableConsts = s_values.ToDictionary(kv => kv.Key, kv => GetNullableConstantExpressions(kv.Key, kv.Value));
+        internal static readonly IDictionary<Type, Expression[]> s_nullableExprs = s_nullableConsts.ToDictionary(kv => kv.Key, kv => kv.Value.Concat(new Expression[] { Expression.Throw(Expression.Constant(new Exception("Error " + s_countEx++)), GetNullableType(kv.Key)) }).ToArray());
+
+        private static Expression[] GetNullableConstantExpressions(Type type, object[] nonNulls)
+        {
+            var n = GetNullableType(type);
+            return nonNulls.Concat(new object[] { null }).Select(v => (Expression)Expression.Constant(v, n)).ToArray();
+        }
+
+        private static Type GetNullableType(Type type)
+        {
+            return type.GetTypeInfo().IsValueType ? typeof(Nullable<>).MakeGenericType(type) : type;
+        }
+
+        public static IEnumerable<Expression> Expressions
+        {
+            get
+            {
+                return Catalog.SelectMany(g => g.Value);
+            }
+        }
+
+        public static IDictionary<ExpressionType, IEnumerable<Expression>> Catalog
+        {
+            get
+            {
+                if (s_Catalog == null)
+                {
+                    var all = Enumerable.Empty<KeyValuePair<ExpressionType, Expression>>();
+
+                    var simpleMethods = typeof(ExpressionCatalog).GetTypeInfo().DeclaredMethods.Where(m => m.IsStatic && m.ReturnType == typeof(IEnumerable<Expression>) && m.GetParameters().Length == 0 && !m.Name.StartsWith("get_"));
+                    var richMethods = typeof(ExpressionCatalog).GetTypeInfo().DeclaredMethods.Where(m => m.IsStatic && m.ReturnType == typeof(IEnumerable<KeyValuePair<ExpressionType, Expression>>) && m.GetParameters().Length == 0 && !m.Name.StartsWith("get_"));
+
+                    foreach (var method in simpleMethods)
+                    {
+                        var values = (IEnumerable<Expression>)method.Invoke(null, new object[0]);
+                        all = all.Concat(values.Select(v => new KeyValuePair<ExpressionType, Expression>(v.NodeType, v)));
+                    }
+
+                    foreach (var method in richMethods)
+                    {
+                        var values = (IEnumerable<KeyValuePair<ExpressionType, Expression>>)method.Invoke(null, new object[0]);
+                        all = all.Concat(values);
+                    }
+
+                    s_Catalog = all.GroupBy(kv => kv.Key).ToDictionary(g => g.Key, g => g.Select(x => x.Value).ToList().AsEnumerable());
+                }
+
+                return s_Catalog;
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ReflectionExtensions.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ReflectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+namespace System.Reflection
+{
+    static class ReflectionExtensions
+    {
+        public static ConstructorInfo GetDeclaredConstructor(this TypeInfo type, Type[] parameterTypes)
+        {
+            return type.DeclaredConstructors.SingleOrDefault(c => c.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -1,0 +1,1461 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_INTERPRET
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.Expressions
+{
+	partial class InterpreterTests
+	{
+		[Fact]
+		public static void CompileInterpretCrossCheck_Add()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Add, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Add);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_AddChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AddChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.AddChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_And()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.And, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.And);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_AndAlso()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AndAlso, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.AndAlso);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_ArrayLength()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ArrayLength, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ArrayLength);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_ArrayIndex()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ArrayIndex, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ArrayIndex);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Call()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Call, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Call);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Coalesce()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Coalesce, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Coalesce);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Conditional()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Conditional, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Conditional);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Constant()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Constant, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Constant);
+			}
+		}
+
+		[Fact(Skip = "4019")]
+		public static void CompileInterpretCrossCheck_Convert()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Convert, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Convert);
+			}
+		}
+
+		[Fact(Skip = "4022")]
+		public static void CompileInterpretCrossCheck_ConvertChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ConvertChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ConvertChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Divide()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Divide, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Divide);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Equal()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Equal, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Equal);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_ExclusiveOr()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ExclusiveOr, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ExclusiveOr);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_GreaterThan()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.GreaterThan, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.GreaterThan);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_GreaterThanOrEqual()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.GreaterThanOrEqual, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.GreaterThanOrEqual);
+			}
+		}
+
+		[Fact(Skip = "4020")]
+		public static void CompileInterpretCrossCheck_Invoke()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Invoke, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Invoke);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Lambda()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Lambda, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Lambda);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_LeftShift()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.LeftShift, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.LeftShift);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_LessThan()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.LessThan, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.LessThan);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_LessThanOrEqual()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.LessThanOrEqual, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.LessThanOrEqual);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_ListInit()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ListInit, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ListInit);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_MemberAccess()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MemberAccess, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.MemberAccess);
+			}
+		}
+
+		[Fact(Skip = "4018")]
+		public static void CompileInterpretCrossCheck_MemberInit()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MemberInit, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.MemberInit);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Modulo()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Modulo, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Modulo);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Multiply()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Multiply, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Multiply);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_MultiplyChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MultiplyChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.MultiplyChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Negate()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Negate, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Negate);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_UnaryPlus()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.UnaryPlus, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.UnaryPlus);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_NegateChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.NegateChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.NegateChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_New()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.New, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.New);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_NewArrayInit()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.NewArrayInit, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.NewArrayInit);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_NewArrayBounds()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.NewArrayBounds, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.NewArrayBounds);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Not()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Not, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Not);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_NotEqual()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.NotEqual, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.NotEqual);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Or()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Or, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Or);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_OrElse()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.OrElse, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.OrElse);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Parameter()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Parameter, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Parameter);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Power()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Power, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Power);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Quote()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Quote, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Quote);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_RightShift()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.RightShift, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.RightShift);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Subtract()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Subtract, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Subtract);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_SubtractChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.SubtractChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.SubtractChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_TypeAs()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.TypeAs, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.TypeAs);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_TypeIs()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.TypeIs, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.TypeIs);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Assign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Assign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Assign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Block()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Block, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Block);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_DebugInfo()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.DebugInfo, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.DebugInfo);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Decrement()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Decrement, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Decrement);
+			}
+		}
+
+		[Fact(Skip = "3995")]
+		public static void CompileInterpretCrossCheck_Dynamic()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Dynamic, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Dynamic);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Default()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Default, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Default);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Extension()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Extension, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Extension);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Goto()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Goto, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Goto);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Increment()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Increment, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Increment);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Index()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Index, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Index);
+			}
+		}
+
+		[Fact(Skip = "3995")]
+		public static void CompileInterpretCrossCheck_Label()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Label, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Label);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_RuntimeVariables()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.RuntimeVariables, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.RuntimeVariables);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Loop()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Loop, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Loop);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_Switch()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Switch, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Switch);
+			}
+		}
+
+		[Fact(Skip = "3995")]
+		public static void CompileInterpretCrossCheck_Throw()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Throw, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Throw);
+			}
+		}
+
+		[Fact(Skip = "3995")]
+		public static void CompileInterpretCrossCheck_Try()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Try, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Try);
+			}
+		}
+
+		[Fact(Skip = "4021")]
+		public static void CompileInterpretCrossCheck_Unbox()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Unbox, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.Unbox);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_AddAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AddAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.AddAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_AndAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AndAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.AndAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_DivideAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.DivideAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.DivideAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_ExclusiveOrAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ExclusiveOrAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ExclusiveOrAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_LeftShiftAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.LeftShiftAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.LeftShiftAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_ModuloAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ModuloAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.ModuloAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_MultiplyAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MultiplyAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.MultiplyAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_OrAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.OrAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.OrAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_PowerAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PowerAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.PowerAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_RightShiftAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.RightShiftAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.RightShiftAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_SubtractAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.SubtractAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.SubtractAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_AddAssignChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AddAssignChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.AddAssignChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_MultiplyAssignChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MultiplyAssignChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.MultiplyAssignChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_SubtractAssignChecked()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.SubtractAssignChecked, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.SubtractAssignChecked);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_PreIncrementAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PreIncrementAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.PreIncrementAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_PreDecrementAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PreDecrementAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.PreDecrementAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_PostIncrementAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PostIncrementAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.PostIncrementAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_PostDecrementAssign()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PostDecrementAssign, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.PostDecrementAssign);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_TypeEqual()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.TypeEqual, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.TypeEqual);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_OnesComplement()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.OnesComplement, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.OnesComplement);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_IsTrue()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.IsTrue, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.IsTrue);
+			}
+		}
+
+		[Fact]
+		public static void CompileInterpretCrossCheck_IsFalse()
+		{
+			var exprs = default(IEnumerable<Expression>);
+			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.IsFalse, out exprs))
+			{
+				foreach (var e in exprs)
+				{
+					Verify(e);
+				}
+			}
+			else
+			{
+				MissingTest(ExpressionType.IsFalse);
+			}
+		}
+
+		static partial void MissingTest(ExpressionType nodeType);
+	}
+}
+#endif

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -674,7 +674,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_Power()
+        [ActiveIssue(/*coreclr*/ 1835, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_Power()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.Power, out exprs))
@@ -759,7 +760,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_TypeAs()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_TypeAs()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.TypeAs, out exprs))
@@ -1082,7 +1084,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_AddAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_AddAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AddAssign, out exprs))
@@ -1099,7 +1102,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_AndAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_AndAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AndAssign, out exprs))
@@ -1116,7 +1120,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_DivideAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_DivideAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.DivideAssign, out exprs))
@@ -1133,7 +1138,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_ExclusiveOrAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_ExclusiveOrAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ExclusiveOrAssign, out exprs))
@@ -1150,7 +1156,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_LeftShiftAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_LeftShiftAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.LeftShiftAssign, out exprs))
@@ -1167,7 +1174,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_ModuloAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_ModuloAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.ModuloAssign, out exprs))
@@ -1184,7 +1192,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_MultiplyAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_MultiplyAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MultiplyAssign, out exprs))
@@ -1201,7 +1210,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_OrAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_OrAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.OrAssign, out exprs))
@@ -1218,7 +1228,9 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_PowerAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        [ActiveIssue(/*coreclr*/ 1835, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_PowerAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PowerAssign, out exprs))
@@ -1235,7 +1247,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_RightShiftAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_RightShiftAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.RightShiftAssign, out exprs))
@@ -1252,7 +1265,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_SubtractAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_SubtractAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.SubtractAssign, out exprs))
@@ -1269,7 +1283,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_AddAssignChecked()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_AddAssignChecked()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.AddAssignChecked, out exprs))
@@ -1285,8 +1300,9 @@ namespace Tests.Expressions
 			}
 		}
 
-		[Fact]
-		public static void CompileInterpretCrossCheck_MultiplyAssignChecked()
+        [Fact]
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_MultiplyAssignChecked()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.MultiplyAssignChecked, out exprs))
@@ -1303,7 +1319,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_SubtractAssignChecked()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_SubtractAssignChecked()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.SubtractAssignChecked, out exprs))
@@ -1320,7 +1337,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_PreIncrementAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_PreIncrementAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PreIncrementAssign, out exprs))
@@ -1337,7 +1355,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_PreDecrementAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_PreDecrementAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PreDecrementAssign, out exprs))
@@ -1354,7 +1373,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_PostIncrementAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_PostIncrementAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PostIncrementAssign, out exprs))
@@ -1371,7 +1391,8 @@ namespace Tests.Expressions
 		}
 
 		[Fact]
-		public static void CompileInterpretCrossCheck_PostDecrementAssign()
+        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
+        public static void CompileInterpretCrossCheck_PostDecrementAssign()
 		{
 			var exprs = default(IEnumerable<Expression>);
 			if (ExpressionCatalog.Catalog.TryGetValue(ExpressionType.PostDecrementAssign, out exprs))

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="HelperTypes.cs" />
     <Compile Include="Interpreter\InterpreterTests.cs" />
+    <Compile Include="Interpreter\InterpreterTests.Generated.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />
     <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Lambda\LambdaAddNullableTests.cs" />

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -85,6 +85,37 @@
     <Compile Include="Cast\CastTests.cs" />
     <Compile Include="Cast\IsNullableTests.cs" />
     <Compile Include="Cast\IsTests.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Array.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Binary.Assign.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Binary.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Binary.Generated.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Block.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Call.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Call.Generated.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Conditional.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Constant.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.DebugInfo.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Default.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Extension.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Goto.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Invoke.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Lambda.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.ListInit.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Logging.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Loop.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.MemberAccess.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.MemberInit.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.New.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Parameter.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.RuntimeVariables.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Switch.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.TypeBinary.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Types.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Unary.Assign.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Unary.cs" />
+    <Compile Include="Catalog\ExpressionCatalog.Unary.Generated.cs" />
+    <Compile Include="Catalog\ReflectionExtensions.cs" />
     <Compile Include="Conditional\ConditionalOneOffTests.cs" />
     <Compile Include="Constant\ConstantArrayTests.cs" />
     <Compile Include="Constant\ConstantNullableTests.cs" />
@@ -163,6 +194,7 @@
     <Compile Include="Unary\UnaryUnaryPlusNullableTests.cs" />
     <Compile Include="Unary\UnaryOnesComplementTests.cs" />
     <Compile Include="Unary\UnaryUnaryPlusTests.cs" />
+    <Compile Include="Visitor\ExpressionVisitorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">

--- a/src/System.Linq.Expressions/tests/Visitor/ExpressionVisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/ExpressionVisitorTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.Expressions
+{
+    public static partial class ExpressionVisitorTests
+    {
+        [Fact]
+        public static void ExpressionVisitor_NoCloning()
+        {
+            var v = new NoOpVisitor();
+
+            foreach (var e in ExpressionCatalog.Expressions.Where(e => e.NodeType != ExpressionType.Extension))
+            {
+                Assert.Same(e, v.Visit(e));
+            }
+        }
+
+        class NoOpVisitor : ExpressionVisitor
+        {
+        }
+    }
+}


### PR DESCRIPTION
This addresses issue #3995 by

- adding an expression catalog
- using the catalog to run Compile(true) and Compile() to cross-check results

There's a total of 154428 expressions in the catalog. The large number is mostly due to the large number of variations of unary and binary expressions with primitive types and a series of interesting values for each of those types (e.g. to trigger overflow conditions etc.). A breakdown per type is shown below:

| Node type             | Count |
| --------------------- | ----: |
| Add                   | 1669  |
| AddAssign             | 7476  |
| AddAssignChecked      | 7476  |
| AddChecked            | 1669  |
| And                   | 1470  |
| AndAlso               | 50    |
| AndAssign             | 6680  |
| ArrayIndex            | 7     |
| ArrayLength           | 3     |
| Assign                | 8     |
| Block                 | 18    |
| Call                  | 129   |
| Coalesce              | 12    |
| Conditional           | 1928  |
| Constant              | 11    |
| Convert               | 7890  |
| ConvertChecked        | 6674  |
| DebugInfo             | 1     |
| Decrement             | 169   |
| Default               | 6     |
| Divide                | 1669  |
| DivideAssign          | 7476  |
| Dynamic               | 0     |
| Equal                 | 2016  |
| ExclusiveOr           | 1470  |
| ExclusiveOrAssign     | 6680  |
| Extension             | 1     |
| Goto                  | 3     |
| GreaterThan           | 1975  |
| GreaterThanOrEqual    | 1975  |
| Increment             | 169   |
| Index                 | 12    |
| Invoke                | 11    |
| IsFalse               | 14    |
| IsTrue                | 14    |
| Label                 | 0     |
| Lambda                | 34    |
| LeftShift             | 1653  |
| LeftShiftAssign       | 7412  |
| LessThan              | 1975  |
| LessThanOrEqual       | 1975  |
| ListInit              | 10    |
| Loop                  | 3     |
| MemberAccess          | 14    |
| MemberInit            | 19    |
| Modulo                | 1669  |
| ModuloAssign          | 7476  |
| Multiply              | 1669  |
| MultiplyAssign        | 7476  |
| MultiplyAssignChecked | 7476  |
| MultiplyChecked       | 1669  |
| Negate                | 130   |
| NegateChecked         | 130   |
| New                   | 13    |
| NewArrayBounds        | 6     |
| NewArrayInit          | 2     |
| Not                   | 14    |
| NotEqual              | 2016  |
| OnesComplement        | 123   |
| Or                    | 1470  |
| OrAssign              | 6680  |
| OrElse                | 50    |
| Parameter             | 5     |
| PostDecrementAssign   | 676   |
| PostIncrementAssign   | 676   |
| Power                 | 265   |
| PowerAssign           | 1460  |
| PreDecrementAssign    | 676   |
| PreIncrementAssign    | 676   |
| Quote                 | 2     |
| RightShift            | 1653  |
| RightShiftAssign      | 7412  |
| RuntimeVariables      | 1     |
| Subtract              | 1669  |
| SubtractAssign        | 7476  |
| SubtractAssignChecked | 7476  |
| SubtractChecked       | 1669  |
| Switch                | 611   |
| Throw                 | 0     |
| Try                   | 0     |
| TypeAs                | 3775  |
| TypeEqual             | 39    |
| TypeIs                | 39    |
| UnaryPlus             | 169   |
| Unbox                 | 8     |

Notice a few types lack tests, i.e. Try, Throw, Dynamic, and Label. Some have relatively few tests. All of those gaps will be addressed in a future iteration, but nothing should hold back this corpus of expressions from going in to the test suite.

Some issues were found while running those tests. Those are shown below:

     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Throw [SKIP]
        #3995
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Dynamic [SKIP]
        #3995
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Label [SKIP]
        #3995
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Try [SKIP]
        #3995
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_MemberInit [SKIP]
        #4018
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Convert [SKIP]
        #4019
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Invoke [SKIP]
        #4020
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_Unbox [SKIP]
        #4021
     Tests.Expressions.InterpreterTests.CompileInterpretCrossCheck_ConvertChecked [SKIP]
        #4022

Each of those has a separate issue tracking the problem. The ones referring back to #3995 are the ones that have zero tests thus far, but that will be addressed in a future iteration as explained above.