### PR TITLE
Fixing interpreter for NullReferenceException behavior in Unbox.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -213,7 +213,7 @@ namespace System.Linq.Expressions.Compiler
         private void AddressOf(UnaryExpression node, Type type)
         {
             Debug.Assert(node.NodeType == ExpressionType.Unbox);
-            Debug.Assert(type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(type));
+            Debug.Assert(type.GetTypeInfo().IsValueType);
 
             // Unbox leaves a pointer to the boxed value on the stack
             EmitExpression(node.Operand);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitUnboxUnaryExpression(Expression expr)
         {
             var node = (UnaryExpression)expr;
-            Debug.Assert(node.Type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(node.Type));
+            Debug.Assert(node.Type.GetTypeInfo().IsValueType);
 
             // Unbox_Any leaves the value on the stack
             EmitExpression(node.Operand);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -66,6 +66,33 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
+    internal class NullCheckInstruction : Instruction
+    {
+        public static readonly Instruction Instance = new NullCheckInstruction();
+
+        private NullCheckInstruction() { }
+        public override int ConsumedStack { get { return 1; } }
+        public override int ProducedStack { get { return 1; } }
+
+        public override string InstructionName
+        {
+            get
+            {
+                return "Unbox";
+            }
+        }
+
+        public override int Run(InterpretedFrame frame)
+        {
+            if (frame.Peek() == null)
+            {
+                throw new NullReferenceException();
+            }
+            
+            return +1;
+        }
+    }
+
     internal abstract class NotInstruction : Instruction
     {
         public static Instruction _Bool, _Int64, _Int32, _Int16, _UInt64, _UInt32, _UInt16, _Byte, _SByte;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2771,8 +2771,13 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileUnboxUnaryExpression(Expression expr)
         {
             var node = (UnaryExpression)expr;
-            // unboxing is a nop:
+            
             Compile(node.Operand);
+
+            if (expr.Type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(expr.Type))
+            {
+                _instructions.Emit(NullCheckInstruction.Instance);
+            }
         }
 
         private void CompileTypeEqualExpression(Expression expr)

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Unary\UnaryIsFalseNullableTests.cs" />
     <Compile Include="Unary\UnaryIsFalseTests.cs" />
     <Compile Include="Unary\UnaryIsTrueNullableTests.cs" />
+    <Compile Include="Unary\UnaryUnboxTests.cs" />
     <Compile Include="Unary\UnaryIsTrueTests.cs" />
     <Compile Include="Unary\UnaryOnesComplementNullableTests.cs" />
     <Compile Include="Unary\UnaryUnaryPlusNullableTests.cs" />

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Unary
+{
+    public static class UnaryUnboxTests
+    {
+        #region Test methods
+
+        [Fact] //[WorkItem(4021, "https://github.com/dotnet/corefx/issues/4021")]
+        public static void CheckUnaryUnboxTest()
+        {
+            VerifyUnbox(42, typeof(int), false);
+            VerifyUnbox(42, typeof(int?), false);
+            VerifyUnbox(null, typeof(int?), false);
+            VerifyUnbox(null, typeof(int), true);
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyUnbox(object value, Type type, bool shouldThrow)
+        {
+            Expression<Func<object>> e =
+                Expression.Lambda<Func<object>>(
+                    Expression.Convert(
+                        Expression.Unbox(Expression.Constant(value, typeof(object)), type),
+                        typeof(object)),
+                    Enumerable.Empty<ParameterExpression>());
+
+            Func<object> f = e.Compile();
+
+            if (shouldThrow)
+            {
+                Assert.Throws<NullReferenceException>(() => f());
+            }
+            else
+            {
+                Assert.Equal(value, f());
+            }
+        }
+
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This fixes issue #4021 found via #3995. It includes two changes from #3874. Both PRs can go in separately and in any order.

@VSadov - Please review