### PR TITLE
Fixing expression interpreter behavior for initialization of hoisted locals

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -364,33 +364,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal sealed class ImmutableRefValue : InitializeLocalInstruction, IBoxableInstruction
-        {
-            private readonly Type _type;
-
-            internal ImmutableRefValue(int index, Type type)
-                : base(index)
-            {
-                _type = type;
-            }
-
-            public override int Run(InterpretedFrame frame)
-            {
-                frame.Data[_index] = null;
-                return 1;
-            }
-
-            public Instruction BoxIfIndexMatches(int index)
-            {
-                return (index == _index) ? new ImmutableRefBox(index) : null;
-            }
-
-            public override string InstructionName
-            {
-                get { return "InitImmutableValue"; }
-            }
-        }
-
         internal sealed class ImmutableRefBox : InitializeLocalInstruction
         {
             // immutable value:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -331,7 +331,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public Instruction BoxIfIndexMatches(int index)
             {
-                return (index == _index) ? new ImmutableBox(index) : null;
+                return (index == _index) ? new ImmutableBox(index, _defaultValue) : null;
             }
 
             public override string InstructionName
@@ -344,14 +344,17 @@ namespace System.Linq.Expressions.Interpreter
         {
             // immutable value:
 
-            internal ImmutableBox(int index)
+            private readonly object _defaultValue;
+
+            internal ImmutableBox(int index, object defaultValue)
                 : base(index)
             {
+                _defaultValue = defaultValue;
             }
 
             public override int Run(InterpretedFrame frame)
             {
-                frame.Data[_index] = new StrongBox<object>();
+                frame.Data[_index] = new StrongBox<object>(_defaultValue);
                 return 1;
             }
 
@@ -482,7 +485,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public Instruction BoxIfIndexMatches(int index)
             {
-                return (index == _index) ? new MutableBox(index) : null;
+                return (index == _index) ? new MutableBox(index, _type) : null;
             }
 
             public override string InstructionName
@@ -493,14 +496,30 @@ namespace System.Linq.Expressions.Interpreter
 
         internal sealed class MutableBox : InitializeLocalInstruction
         {
-            internal MutableBox(int index)
+            private readonly Type _type;
+
+            internal MutableBox(int index, Type type)
                 : base(index)
             {
+                _type = type;
             }
 
             public override int Run(InterpretedFrame frame)
             {
-                frame.Data[_index] = new StrongBox<object>();
+                var value = default(object);
+
+                try
+                {
+                    value = Activator.CreateInstance(_type);
+                }
+                catch (TargetInvocationException e)
+                {
+                    ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                    throw e.InnerException;
+                }
+
+                frame.Data[_index] = new StrongBox<object>(value);
+
                 return 1;
             }
 

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Block
+{
+    public static unsafe class BlockTests
+    {
+        #region Test methods
+
+        [Fact] // [Issue(4020, "https://github.com/dotnet/corefx/issues/4020")]
+        public static void CheckBlockClosureVariableInitializationTest()
+        {
+            foreach (var kv in BlockClosureVariableInitialization())
+            {
+                VerifyBlockClosureVariableInitialization(kv.Key, kv.Value);
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<Expression, object>> BlockClosureVariableInitialization()
+        {
+            {
+                var p = Expression.Parameter(typeof(int));
+                var q = Expression.Parameter(typeof(Func<int>));
+                var l = Expression.Lambda<Func<int>>(p);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(int));
+                var q = Expression.Parameter(typeof(Action<int>));
+                var x = Expression.Parameter(typeof(int));
+                var l = Expression.Lambda<Action<int>>(Expression.Assign(p, x), x);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(TimeSpan));
+                var q = Expression.Parameter(typeof(Func<TimeSpan>));
+                var l = Expression.Lambda<Func<TimeSpan>>(p);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(TimeSpan));
+                var q = Expression.Parameter(typeof(Action<TimeSpan>));
+                var x = Expression.Parameter(typeof(TimeSpan));
+                var l = Expression.Lambda<Action<TimeSpan>>(Expression.Assign(p, x), x);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(string));
+                var q = Expression.Parameter(typeof(Func<string>));
+                var l = Expression.Lambda<Func<string>>(p);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(string));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(string));
+                var q = Expression.Parameter(typeof(Action<string>));
+                var x = Expression.Parameter(typeof(string));
+                var l = Expression.Lambda<Action<string>>(Expression.Assign(p, x), x);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(string));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(int?));
+                var q = Expression.Parameter(typeof(Func<int?>));
+                var l = Expression.Lambda<Func<int?>>(p);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int?));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(int?));
+                var q = Expression.Parameter(typeof(Action<int?>));
+                var x = Expression.Parameter(typeof(int?));
+                var l = Expression.Lambda<Action<int?>>(Expression.Assign(p, x), x);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int?));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(TimeSpan?));
+                var q = Expression.Parameter(typeof(Func<TimeSpan?>));
+                var l = Expression.Lambda<Func<TimeSpan?>>(p);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan?));
+            }
+
+            {
+                var p = Expression.Parameter(typeof(TimeSpan?));
+                var q = Expression.Parameter(typeof(Action<TimeSpan?>));
+                var x = Expression.Parameter(typeof(TimeSpan?));
+                var l = Expression.Lambda<Action<TimeSpan?>>(Expression.Assign(p, x), x);
+                yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan?));
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyBlockClosureVariableInitialization(Expression e, object o)
+        {
+            Expression<Func<object>> f =
+                Expression.Lambda<Func<object>>(
+                    Expression.Convert(e, typeof(object)));
+
+            Func<object> c = f.Compile();
+            Assert.Equal(o, c());
+
+#if FEATURE_INTERPRET
+            Func<object> i = f.Compile(true);
+            Assert.Equal(o, i());
+#endif
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="BinaryOperators\ReferenceComparison\ReferenceEqualityTests.cs" />
     <Compile Include="BinaryOperators\ReferenceComparison\ReferenceNotEqual.cs" />
     <Compile Include="Block\BlockFactoryTests.cs" />
+    <Compile Include="Block\BlockTests.cs" />
     <Compile Include="Call\CallFactoryTests.cs" />
     <Compile Include="Cast\AsNullable.cs" />
     <Compile Include="Cast\AsTests.cs" />


### PR DESCRIPTION
This fixes issue #4020. When a local gets hoisted to a closure, it lost its default value or initialization logic (cf. the IBoxableInstruction trick played by EnsureAvailableForClosure). This change ensures this initialization logic is carried forward.