### PR TITLE
Stop emitting a BOM into stdin when using System.Diagnostics.Process

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -230,8 +230,8 @@ namespace System.Diagnostics
             if (startInfo.RedirectStandardInput)
             {
                 Debug.Assert(stdinFd >= 0);
-                _standardInput = new StreamWriter(OpenStream(stdinFd, FileAccess.Write), 
-                    Encoding.UTF8, StreamBufferSize) { AutoFlush = true };
+                _standardInput = new StreamWriter(OpenStream(stdinFd, FileAccess.Write),
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), StreamBufferSize) { AutoFlush = true };
             }
             if (startInfo.RedirectStandardOutput)
             {


### PR DESCRIPTION
When using standard input redirection on Unix with System.Diagnostics.Process, the code would emit a BOM. This screws up many unix tools which don't understand the BOM.