### PR TITLE
Clean up current libssl shim work.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
@@ -18,9 +18,9 @@ internal static partial class Interop
         }
     }
 
-    internal static partial class Crypto
+    internal static partial class Ssl
     {
-        static partial void InitializeSsl()
+        static Ssl()
         {
             SslInitializer.Initialize();
         }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -16,10 +16,7 @@ internal static partial class Interop
         static Crypto()
         {
             CryptoInitializer.Initialize();
-            InitializeSsl();
         }
-
-        static partial void InitializeSsl();
     } 
 
     internal static class CryptoInitializer

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -7,7 +7,7 @@ using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
-    internal static partial class Crypto
+    internal static partial class Ssl
     {
         [DllImport(Interop.Libraries.CryptoNative)]
         internal static extern IntPtr SslV2_3Method();

--- a/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.libssl_types.cs
@@ -59,11 +59,11 @@ internal static partial class Interop
 
         internal static class SslMethods
         {
-            internal static readonly IntPtr TLSv1_method = Crypto.TlsV1Method();
-            internal static readonly IntPtr TLSv1_1_method = Crypto.TlsV1_1Method();
-            internal static readonly IntPtr TLSv1_2_method = Crypto.TlsV1_2Method();
-            internal static readonly IntPtr SSLv3_method = Crypto.SslV3Method();
-            internal static readonly IntPtr SSLv23_method = Crypto.SslV2_3Method();
+            internal static readonly IntPtr TLSv1_method = Ssl.TlsV1Method();
+            internal static readonly IntPtr TLSv1_1_method = Ssl.TlsV1_1Method();
+            internal static readonly IntPtr TLSv1_2_method = Ssl.TlsV1_2Method();
+            internal static readonly IntPtr SSLv3_method = Ssl.SslV3Method();
+            internal static readonly IntPtr SSLv23_method = Ssl.SslV2_3Method();
 
 #if DEBUG
             static SslMethods()

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -13,19 +13,6 @@ add_definitions(-DPIC=1)
 
 find_package(OpenSSL REQUIRED)
 
-# Check which versions of TLS the OpenSSL/ssl library supports
-include(CheckLibraryExists)
-
-CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_1_method" "" OPENSSL_TLSV11)
-if (OPENSSL_TLSV11)
-    add_definitions(-DHAVE_TLS_V1_1=1)
-endif()
-
-CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_2_method" "" OPENSSL_TLSV12)
-if (OPENSSL_TLSV12)
-    add_definitions(-DHAVE_TLS_V1_2=1)
-endif()
-
 set(NATIVECRYPTO_SOURCES
     openssl.c
     pal_asn1.cpp
@@ -62,5 +49,7 @@ target_link_libraries(System.Security.Cryptography.Native
   ${OPENSSL_CRYPTO_LIBRARY}
   ${OPENSSL_SSL_LIBRARY}
 )
+
+include(configure.cmake)
 
 install (TARGETS System.Security.Cryptography.Native DESTINATION .)

--- a/src/Native/System.Security.Cryptography.Native/configure.cmake
+++ b/src/Native/System.Security.Cryptography.Native/configure.cmake
@@ -1,0 +1,9 @@
+include(CheckLibraryExists)
+
+# Check which versions of TLS the OpenSSL/ssl library supports
+check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_1_method" "" HAVE_TLS_V1_1)
+check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_2_method" "" HAVE_TLS_V1_2)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/pal_crypto_config.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/pal_crypto_config.h)

--- a/src/Native/System.Security.Cryptography.Native/pal_crypto_config.h.in
+++ b/src/Native/System.Security.Cryptography.Native/pal_crypto_config.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+#cmakedefine01 HAVE_TLS_V1_1
+#cmakedefine01 HAVE_TLS_V1_2

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "pal_ssl.h"
+#include "pal_crypto_config.h"
 
 extern "C" const SSL_METHOD* SslV2_3Method()
 {
@@ -20,7 +21,7 @@ extern "C" const SSL_METHOD* TlsV1Method()
 
 extern "C" const SSL_METHOD* TlsV1_1Method()
 {
-#ifdef HAVE_TLS_V1_1
+#if HAVE_TLS_V1_1
     return TLSv1_1_method();
 #else
     return nullptr;
@@ -29,7 +30,7 @@ extern "C" const SSL_METHOD* TlsV1_1Method()
 
 extern "C" const SSL_METHOD* TlsV1_2Method()
 {
-#ifdef HAVE_TLS_V1_2
+#if HAVE_TLS_V1_2
     return TLSv1_2_method();
 #else
     return nullptr;

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -174,14 +174,7 @@ namespace System.Net
 
                 outputBuffer.size = outputSize;
                 outputBuffer.offset = 0;
-                if (outputSize > 0)
-                {
-                    outputBuffer.token = output;
-                }
-                else
-                {
-                    outputBuffer.token = null;
-                }
+                outputBuffer.token = outputSize > 0 ? output : null;
 
                 return done ? SecurityStatusPal.OK : SecurityStatusPal.ContinueNeeded;
             }
@@ -203,7 +196,7 @@ namespace System.Net
                 Interop.libssl.SafeSslHandle scHandle = securityContext.SslContext;
 
                 resultSize = encrypt ?
-                    Interop.OpenSsl.Encrypt(scHandle, buffer, offset, size, buffer.Length, out errorCode) :
+                    Interop.OpenSsl.Encrypt(scHandle, buffer, offset, size, out errorCode) :
                     Interop.OpenSsl.Decrypt(scHandle, buffer, size, out errorCode);
 
                 switch (errorCode)


### PR DESCRIPTION
There are a number of clean up tasks that came out of the first 2 reviews of libssl shim work.

1. Add some Debug.Asserts when reading/writing to buffers.
2. Split the SSL extern methods into a separate class from the Interop.Crypto class. This allows the minimum amount of intialization to occur as needed. It also better keeps libssl separate from libcrypto shims.
3. Use a configure.cmake and #cmakedefine01 feature in our CMake file to create defines. This is consistent with CoreCLR and the other of CoreFX shims.

@stephentoub @nguerrera @bartonjs @vijaykota @rajansingh10 @shrutigarg