### PR TITLE
Fixing NullReferenceException in MemberInitExpression interpretation

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2398,7 +2398,6 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     _instructions.EmitLoadField(fi);
                 }
-                return;
             }
             else
             {
@@ -2413,7 +2412,7 @@ namespace System.Linq.Expressions.Interpreter
                     }
 
                     if (!method.IsStatic &&
-                        from.Type.IsNullableType())
+                        (from != null && from.Type.IsNullableType()))
                     {
                         // reflection doesn't let us call methods on Nullable<T> when the value
                         // is null...  so we get to special case those methods!
@@ -2423,8 +2422,6 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         _instructions.EmitCall(method);
                     }
-
-                    return;
                 }
             }
         }

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.MemberInit
+{
+    public static unsafe class MemberInitTests
+    {
+        #region Test methods
+
+        [Fact] // [Issue(4018, "https://github.com/dotnet/corefx/issues/4018")]
+        public static void CheckMemberInitTest()
+        {
+            VerifyMemberInit(() => new X { Y = { Z = 42, YS = { 2, 3 } }, XS = { 5, 7 } }, x => x.Y.Z == 42 && x.XS.Sum() == 5 + 7 && x.Y.YS.Sum() == 2 + 3);
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyMemberInit<T>(Expression<Func<T>> expr, Func<T, bool> check)
+        {
+            Func<T> c = expr.Compile();
+            Assert.True(check(c()));
+
+#if FEATURE_INTERPRET
+            Func<T> i = expr.Compile(true);
+            Assert.True(check(i()));
+#endif
+        }
+
+        #endregion
+
+        #region Helpers
+
+        class X
+        {
+            private readonly Y _y = new Y();
+            private readonly List<int> _xs = new List<int>();
+
+            public Y Y
+            {
+                get { return _y; }
+            }
+
+            public List<int> XS { get { return _xs; } }
+        }
+
+        class Y
+        {
+            private readonly List<int> _ys = new List<int>();
+
+            public int Z { get; set; }
+
+            public List<int> YS { get { return _ys; } }
+        }
+
+        #endregion
+    }
+}
+

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Lifted\NonLiftedComparisonLessThanNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonLessThanOrEqualNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonNotEqualNullableTests.cs" />
+    <Compile Include="MemberInit\MemberInitTests.cs" />
     <Compile Include="Member\MemberAccessTests.cs" />
     <Compile Include="New\NewTests.cs" />
     <Compile Include="New\NewWithParameterTests.cs" />


### PR DESCRIPTION
This fixes issue #4018.