### PR TITLE
Fix TryGetIPPacketInformation on OS X.

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1112,7 +1112,7 @@ TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacket
     cmsghdr* controlMessage = CMSG_FIRSTHDR(&header);
     if (isIPv4 != 0)
     {
-        for (; controlMessage != nullptr; controlMessage = CMSG_NXTHDR(&header, controlMessage))
+        for (; controlMessage != nullptr && controlMessage->cmsg_len > 0; controlMessage = CMSG_NXTHDR(&header, controlMessage))
         {
             if (controlMessage->cmsg_level == IPPROTO_IP && controlMessage->cmsg_type == IP_PKTINFO)
             {
@@ -1122,7 +1122,7 @@ TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacket
     }
     else
     {
-        for (; controlMessage != nullptr; controlMessage = CMSG_NXTHDR(&header, controlMessage))
+        for (; controlMessage != nullptr && controlMessage->cmsg_len > 0; controlMessage = CMSG_NXTHDR(&header, controlMessage))
         {
             if (controlMessage->cmsg_level == IPPROTO_IPV6 && controlMessage->cmsg_type == IPV6_PKTINFO)
             {

--- a/src/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
@@ -54,8 +54,8 @@ namespace System.Net.Sockets.Tests
         {
             const int ReceiveTimeout = 5000;
 
-            using (var receiver = new Socket(SocketType.Dgram, ProtocolType.Udp))
-            using (var sender = new Socket(SocketType.Dgram, ProtocolType.Udp))
+            using (var receiver = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            using (var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 int port = receiver.BindToAnonymousPort(IPAddress.Loopback);
 


### PR DESCRIPTION
CMSG_FIRSTHDR returns a non-null but empty message on OS X if there is
room in the control message buffer. Check for the empty message to avoid
looping forever.