### PR TITLE
native: Removes redundant check

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -33,8 +33,6 @@
 #cmakedefine01 HAVE_ICANON
 #cmakedefine01 HAVE_TCSANOW
 #cmakedefine01 HAVE_IN_PKTINFO
-#cmakedefine01 HAVE_AF_PACKET
-#cmakedefine01 HAVE_AF_LINK
 #cmakedefine01 HAVE_TCP_VAR_H
 #cmakedefine01 HAVE_RT_MSGHDR
 #cmakedefine01 HAVE_LINUX_RTNETLINK_H

--- a/src/Native/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/System.Native/pal_interfaceaddresses.cpp
@@ -13,9 +13,9 @@
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 
-#if HAVE_AF_PACKET
+#if defined(AF_PACKET)
 #include <linux/if_packet.h>
-#elif HAVE_AF_LINK
+#elif defined(AF_LINK)
 #include <net/if_dl.h>
 #include <net/if_types.h>
 #else
@@ -76,7 +76,7 @@ extern "C" int32_t EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
         }
 
         // LINUX : AF_PACKET = 17        
-#if HAVE_AF_PACKET
+#if defined(AF_PACKET)
         else if (family == AF_PACKET)
         {
             sockaddr_ll* sall = reinterpret_cast<sockaddr_ll*>(current->ifa_addr);
@@ -90,8 +90,7 @@ extern "C" int32_t EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
             memcpy(&lla.AddressBytes, &sall->sll_addr, sall->sll_halen);
             onLinkLayerFound(current->ifa_name, &lla);
         }
-
-#elif HAVE_AF_LINK
+#elif defined(AF_LINK)
         // OSX/BSD : AF_LINK = 18
         else if (family == AF_LINK)
         {

--- a/src/Native/System.Native/pal_maphardwaretype.cpp
+++ b/src/Native/System.Native/pal_maphardwaretype.cpp
@@ -5,11 +5,12 @@
 #include "pal_maphardwaretype.h"
 
 #include <sys/socket.h>
+#include <sys/types.h>
 
-#if HAVE_AF_PACKET
+#if defined(AF_PACKET)
 #include <linux/if_packet.h>
 #include <linux/if_arp.h>
-#elif HAVE_AF_LINK
+#elif defined(AF_LINK)
 #include <net/if_dl.h>
 #include <net/if_types.h>
 #else
@@ -18,7 +19,7 @@
 
 NetworkInterfaceType MapHardwareType(uint16_t nativeType)
 {
-#if HAVE_AF_PACKET
+#if defined(AF_PACKET)
     switch (nativeType)
     {
         case ARPHRD_ETHER:
@@ -49,7 +50,7 @@ NetworkInterfaceType MapHardwareType(uint16_t nativeType)
         default:
             return Unknown;
     }
-#else
+#elif defined(AF_LINK)
     switch (nativeType)
     {
         case IFT_ETHER:

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -203,18 +203,6 @@ check_prototype_definition(
 
 check_cxx_source_compiles(
     "
-    #include <netdb.h>
-    #include <net/if_dl.h>
-    int main() { return 0; }
-    "
-    HAVE_AF_LINK)
-
-check_include_files(
-    linux/if_packet.h
-    HAVE_AF_PACKET)
-
-check_cxx_source_compiles(
-    "
     #include <sys/types.h>
     #include <sys/socketvar.h>
     #include <netinet/ip.h>


### PR DESCRIPTION
`sys/socket.h` has the definition of `AP_PACKET` on Linux and `AP_LINK`
on OSX and BSD. We were testing the capability by compiling the source
in cmake, which was failing on FreeBSD because of the missing
`sys/types.h`, but as it turned out this check was not required.