### PR TITLE
Normalize paths in Assembly.Location test

### DIFF
--- a/src/System.Reflection/tests/CoreCLR/Assembly/AssemblyTests.CoreCLR.cs
+++ b/src/System.Reflection/tests/CoreCLR/Assembly/AssemblyTests.CoreCLR.cs
@@ -18,10 +18,18 @@ namespace System.Reflection.Tests
             Assert.NotNull(location);
             Assert.NotEmpty(location);
 
-            string expectedDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
-            string actualDir = Path.GetDirectoryName(location).TrimEnd(Path.DirectorySeparatorChar);
-            Assert.Equal(expectedDir, actualDir, StringComparer.OrdinalIgnoreCase);
+            string expectedDir = AppContext.BaseDirectory;
+            string actualDir = Path.GetDirectoryName(location);
 
+            // Check that neither are relative
+            Assert.True(Path.IsPathRooted(expectedDir));
+            Assert.True(Path.IsPathRooted(actualDir));
+
+            // normalize paths before comparison
+            expectedDir = Path.GetFullPath(expectedDir).TrimEnd(Path.DirectorySeparatorChar);
+            actualDir = Path.GetFullPath(actualDir).TrimEnd(Path.DirectorySeparatorChar);
+
+            Assert.Equal(expectedDir, actualDir, StringComparer.OrdinalIgnoreCase);
             Assert.Equal("System.Reflection.CoreCLR.Tests.dll", Path.GetFileName(location), StringComparer.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
Fix #4055 

@ellismg This is a speculative fix as I don't have a mac available at the moment, could you try applying the patch to see if it resolves the issue? 