### PR TITLE
Fix System.Console.Tests to not leave cursor hidden

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -26,8 +26,8 @@ public class WindowAndCursorProps
     public static void NonRedirectedCursorVisible()
     {
         // Validate that Console.CursorVisible adds something to the stream when in a non-redirected environment.
-        Helpers.RunInNonRedirectedOutput((data) => { Console.CursorVisible = true; Assert.True(data.ToArray().Length > 0); });
         Helpers.RunInNonRedirectedOutput((data) => { Console.CursorVisible = false; Assert.True(data.ToArray().Length > 0); });
+        Helpers.RunInNonRedirectedOutput((data) => { Console.CursorVisible = true; Assert.True(data.ToArray().Length > 0); });
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class WindowAndCursorProps
         Assert.Throws<PlatformNotSupportedException>(() => { bool unused = Console.CursorVisible; });
 
         // Validate that the Console.CursorVisible does nothing in a redirected stream.
-        Helpers.RunInRedirectedOutput((data) => { Console.CursorVisible = true; Assert.Equal(0, data.ToArray().Length); });
         Helpers.RunInRedirectedOutput((data) => { Console.CursorVisible = false; Assert.Equal(0, data.ToArray().Length); });
+        Helpers.RunInRedirectedOutput((data) => { Console.CursorVisible = true; Assert.Equal(0, data.ToArray().Length); });
     }
 }


### PR DESCRIPTION
When I run the console tests locally, my cursor disappears and remains
hidden after the tests have completed.

cc: @pallavit 