### PR TITLE
Fix hang when writing request stream in WinHttpHandler

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1290,7 +1290,7 @@ namespace System.Net.Http
         
         private Task<bool> InternalSendRequestAsync(WinHttpRequestState state)
         {
-            state.TcsSendRequest = new TaskCompletionSource<bool>();
+            state.TcsSendRequest = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             lock (state.Lock)
             {
@@ -1323,7 +1323,8 @@ namespace System.Net.Http
         
         private Task<bool> InternalReceiveResponseHeadersAsync(WinHttpRequestState state)
         {
-            state.TcsReceiveResponseHeaders = new TaskCompletionSource<bool>();
+            state.TcsReceiveResponseHeaders =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             
             lock (state.Lock)
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -157,7 +157,7 @@ namespace System.Net.Http
         {
             if (_chunkedMode)
             {
-                await InternalWriteDataAsync(s_endChunk, 0, s_endChunk.Length, token);
+                await InternalWriteDataAsync(s_endChunk, 0, s_endChunk.Length, token).ConfigureAwait(false);
             }
         }
         
@@ -203,10 +203,10 @@ namespace System.Net.Http
             string chunkSizeString = String.Format("{0:x}\r\n", count);
             byte[] chunkSize = Encoding.UTF8.GetBytes(chunkSizeString);
 
-            await InternalWriteDataAsync(chunkSize, 0, chunkSize.Length, token);
+            await InternalWriteDataAsync(chunkSize, 0, chunkSize.Length, token).ConfigureAwait(false);
 
-            await InternalWriteDataAsync(buffer, offset, count, token);
-            await InternalWriteDataAsync(s_crLfTerminator, 0, s_crLfTerminator.Length, token);
+            await InternalWriteDataAsync(buffer, offset, count, token).ConfigureAwait(false);
+            await InternalWriteDataAsync(s_crLfTerminator, 0, s_crLfTerminator.Length, token).ConfigureAwait(false);
         }
 
         private Task<bool> InternalWriteDataAsync(byte[] buffer, int offset, int count, CancellationToken token)
@@ -222,7 +222,8 @@ namespace System.Net.Http
                 _cachedSendPinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             }
 
-            _state.TcsInternalWriteDataToRequestStream = new TaskCompletionSource<bool>();
+            _state.TcsInternalWriteDataToRequestStream = 
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             
             lock (_state.Lock)
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -128,7 +128,8 @@ namespace System.Net.Http
                 _cachedReceivePinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             }
 
-            _state.TcsReadFromResponseStream = new TaskCompletionSource<int>();
+            _state.TcsReadFromResponseStream =
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             lock (_state.Lock)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -57,6 +57,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("EchoServers")]
+        public async Task PostSyncBlockingContentUsingChunkedEncoding_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, ExpectedContent, new SyncBlockingContent(ExpectedContent),
+                useContentLengthUpload: false, useChunkedEncodingUpload: true);
+        }
+
+        [Theory, MemberData("EchoServers")]
         public async Task PostRepeatedFlushContentUsingChunkedEncoding_Success(Uri serverUri)
         {
             await PostHelper(serverUri, ExpectedContent, new RepeatedFlushContent(ExpectedContent),

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -57,6 +57,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("EchoServers")]
+        [ActiveIssue(4093, PlatformID.AnyUnix)]
         public async Task PostSyncBlockingContentUsingChunkedEncoding_Success(Uri serverUri)
         {
             await PostHelper(serverUri, ExpectedContent, new SyncBlockingContent(ExpectedContent),

--- a/src/System.Net.Http/tests/FunctionalTests/SyncBlockingContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SyncBlockingContent.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public sealed class SyncBlockingContent : StringContent
+    {
+        byte[] _content;
+
+        public SyncBlockingContent(string content) : base(content)
+        {
+            _content = Encoding.UTF8.GetBytes(content);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            stream.Write(_content, 0, _content.Length);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="ResponseStreamTest.cs" />
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="StringContentTest.cs" />
+    <Compile Include="SyncBlockingContent.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
WinHttpHandler was hanging due to blocking on the WinHTTP status callback thread. The blocking was coming from a task continuation resuming on the same thread and subsequently calling a blocking Stream.Write method in a custom HttpContent class being written onto the request stream.
    
 Blocking is not allowed on the WinHTTP callback thread. So any task continuations need to occur on a different thread. The fix is to create the TaskCompletionSources to use RunContinuationsAsynchronously. This allows them to unblock the WinHTTP thread. Additionally, I added some missing ConfigureAwait(false) settings to some await'd operations.
    
Added a new test which uses a custom HttpContent class that uses a blocking Write() call when serializing onto the request stream.
   
Fix #4077