### PR TITLE
Fix WinHttpHandler on Win7

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -748,6 +748,8 @@ namespace System.Net.Http
                             ref optionAssuredNonBlockingTrue,
                             (uint)Marshal.SizeOf<uint>()))
                         {
+                            // This option is not available on downlevel Windows versions. While it improves
+                            // performance, we can ignore the error that the option is not available.
                             int lastError = Marshal.GetLastWin32Error();
                             if (lastError != Interop.WinHttp.ERROR_WINHTTP_INVALID_OPTION)
                             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -748,7 +748,11 @@ namespace System.Net.Http
                             ref optionAssuredNonBlockingTrue,
                             (uint)Marshal.SizeOf<uint>()))
                         {
-                            WinHttpException.ThrowExceptionUsingLastError();
+                            int lastError = Marshal.GetLastWin32Error();
+                            if (lastError != Interop.WinHttp.ERROR_WINHTTP_INVALID_OPTION)
+                            {
+                                throw WinHttpException.CreateExceptionUsingError(lastError);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When WinHttpHandler was recently switched to use async WinHTTP pattern, it started setting an option which improves performance. However, the WINHTTP_OPTION_ASSURED_NON_BLOCKING_CALLBACKS option is not available on downlevel Windows versions. This was causing an exception to be thrown when sending an HTTP request.

The fix is to ignore the ERROR_WINHTTP_INVALID_OPTION error code when trying to set this option.