### PR TITLE
Enable NetworkInformation tests on Linux, OSX

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
@@ -35,7 +35,7 @@ namespace System.Net.NetworkInformation
                 {
                     if (s_addressChangedSubscribers == null)
                     {
-                        Debug.Assert(s_socket == 0);
+                        Debug.Assert(s_socket == 0, "s_socket != 0, but there are no subscribers to NetworkAddressChanged.");
                         return;
                     }
 
@@ -50,7 +50,7 @@ namespace System.Net.NetworkInformation
 
         private static void CreateSocket()
         {
-            Debug.Assert(s_socket == 0);
+            Debug.Assert(s_socket == 0, "s_socket != 0, must close existing socket before opening another.");
             int newSocket;
             Interop.Error result = Interop.Sys.CreateNetworkChangeListenerSocket(out newSocket);
             if (result != Interop.Error.SUCCESS)
@@ -66,12 +66,15 @@ namespace System.Net.NetworkInformation
 
         private static void CloseSocket()
         {
+            Debug.Assert(s_socket != 0, "s_socket was 0 when CloseSocket was called.");
             Interop.Error result = Interop.Sys.CloseNetworkChangeListenerSocket(s_socket);
             if (result != Interop.Error.SUCCESS)
             {
                 string message = Interop.Sys.GetLastErrorInfo().GetErrorMessage();
                 throw new NetworkInformationException(message);
             }
+
+            s_socket = 0;
         }
 
         private static void LoopReadSocket(int socket)

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
@@ -82,7 +82,11 @@ namespace System.Net.NetworkInformation
         {
             get
             {
-                throw new PlatformNotSupportedException();
+                // TODO: This is a crude approximation, but does allow us to determine
+                // whether an interface is operational or not. The OS exposes more information
+                // (see ifconfig and the "Status" label), but it's unclear how closely
+                // that information maps to the OperationalStatus enum we expose here.
+                return Addresses.Count > 0 ? OperationalStatus.Up : OperationalStatus.Unknown;
             }
         }
 

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPv4InterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPv4InterfaceProperties.cs
@@ -5,13 +5,13 @@ namespace System.Net.NetworkInformation
 {
     internal abstract class UnixIPv4InterfaceProperties : IPv4InterfaceProperties
     {
-        private readonly int _index;
+        private readonly UnixNetworkInterface _uni;
 
         public UnixIPv4InterfaceProperties(UnixNetworkInterface uni)
         {
-            _index = uni.Index;
+            _uni = uni;
         }
 
-        public sealed override int Index { get { return _index; } }
+        public sealed override int Index { get { return _uni.Index; } }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPv6InterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPv6InterfaceProperties.cs
@@ -5,13 +5,13 @@ namespace System.Net.NetworkInformation
 {
     internal abstract class UnixIPv6InterfaceProperties : IPv6InterfaceProperties
     {
-        private readonly int _index;
+        private readonly UnixNetworkInterface _uni;
 
         public UnixIPv6InterfaceProperties(UnixNetworkInterface uni)
         {
-            _index = uni.Index;
+            _uni = uni;
         }
 
-        public sealed override int Index { get { return _index; } }
+        public sealed override int Index { get { return _uni.Index; } }
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest.cs
@@ -19,6 +19,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these
         public void IPInfoTest_AccessAllProperties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -109,6 +110,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these
         public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -139,6 +141,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these
         public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -172,6 +175,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support GetScopeId
         public void IPv6ScopeId_GetLinkLevel_MatchesIndex()
         {
             Assert.True(Capability.IPv6Support());
@@ -190,8 +194,10 @@ namespace System.Net.NetworkInformation.Tests
                 Assert.Equal(ipv6Properties.Index, ipv6Properties.GetScopeId(ScopeLevel.Link));
             }
         }
+
         [Fact]
         [Trait("IPv6", "true")]
+        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support GetScopeId
         public void IPv6ScopeId_AccessAllValues_Success()
         {
             Assert.True(Capability.IPv6Support());

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
@@ -8,6 +8,7 @@ namespace System.Net.NetworkInformation.Tests
     public class NetworkChangeTest
     {
         [Fact]
+        [ActiveIssue(4058, PlatformID.OSX)]
         public void NetworkAddressChanged_AddRemove_Success()
         {
             NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;
@@ -16,6 +17,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue(4058, PlatformID.OSX)]
         public void NetworkAddressChanged_JustRemove_Success()
         {
             NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BasicTest_AccessInstanceProperties_NoExceptions()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -106,6 +107,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these.
         public void BasicTest_GetIPInterfaceStatistics_Success()
         {
             // This API is not actually IPv4 specific.

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DCBB8805-4658-44BF-B5E8-B6714EC8936B}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />


### PR DESCRIPTION
cc: @stephentoub , @CIPop 

This removes the "Unsupported" tag for OSX and Linux from the NetworkInformation tests. Some of the tests just attempt to enumerate all of the properties and statistics that the library exposes. I've disabled those test cases on Linux and OSX because many of those members are not supported.

I encountered a couple small issues after running the tests and fixed the issues in subsequent commits:

* In Linux's NetworkChange implementation, the field storing the netlink socket's file descriptor was not being set to 0 after it was closed. This means if you tried to close the socket, and then re-open or re-close it, you'd hit a debug assertion I had in place. I've set the field to 0 after it is closed, and clarified the debug assertion messages.

* UnixIP(v4/v6)InterfaceProperties was caching the network interface's index too early, and was always storing 0. The network interface's index isn't initialized until the link-layer address is enumerated from the native shim call. To avoid timing issues like this, I might consider storing all of the information from the address enumeration in a separate object, and then constructing the UnixNetworkInterface object all at once.

* OSX didn't implement OperationalStatus. I've added a very crude implementation which just determines whether an interface is "Up" or not by checking if it has any addresses assigned to it. I think the OS exposes a bit more information here, but I don't think that we can necessarily map that info to our enum values (except perhaps "Dormant").