### PR TITLE
Re-enable process tests broken by coreclr change.

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -10,7 +10,6 @@ namespace System.Diagnostics.Tests
 {
     public class ProcessStreamReadTests : ProcessTestBase
     {
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/1837", PlatformID.AnyUnix)]
         [Fact]
         public void TestSyncErrorStream()
         {
@@ -23,7 +22,6 @@ namespace System.Diagnostics.Tests
             Assert.True(p.WaitForExit(WaitInMS));
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/1837", PlatformID.AnyUnix)]
         [Fact]
         public void TestAsyncErrorStream()
         {


### PR DESCRIPTION
Re-enable the process tests that were disabled earlier today (#4070) due to a coreclr change.  A workaround has been added to the CI system.

Fundamentally, the issue is that the LTTng package that is published by Ubuntu appears to have debug logging compiled in and enabled by default using a compilation flag.  LTTng makes debug logging controllable by environment variable (the default) or enabled by compilation flag.  I'll be following up with the maintainers of LTTng on this, but in the meantime, we can unblock these tests with a change to the CI environment.

Customers can also work around this by either (a) using an LTTng package that doesn't enable debug logging at compile time or (b) don't install LTTng-ust if tracing facilities aren't needed.