### PR TITLE
Validate linger time.

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#if defined(__APPLE__) && __APPLE__
+#include <sys/socketvar.h>
+#endif
 #include <unistd.h>
 #include <vector>
 
@@ -1257,6 +1260,7 @@ extern "C" Error SetIPv6MulticastOption(int32_t socket, int32_t multicastOption,
 static int32_t GetMaxLingerTime()
 {
     static volatile int32_t MaxLingerTime = -1;
+    static_assert(sizeof(xsocket::so_linger) == 2, "");
 
     // OS X does not define the linger time in seconds by default, but in ticks.
     // Furthermore, when SO_LINGER_SEC is used, the value is simply scaled by

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -48,6 +48,15 @@ struct in_pktinfo
 
 enum
 {
+#if defined(__APPLE__) && __APPLE__
+    LINGER_OPTION_NAME = SO_LINGER_SEC
+#else
+    LINGER_OPTION_NAME = SO_LINGER,
+#endif
+};
+
+enum
+{
     HOST_ENTRY_HANDLE_ADDRINFO = 1,
     HOST_ENTRY_HANDLE_HOSTENT = 2,
 };
@@ -1244,6 +1253,42 @@ extern "C" Error SetIPv6MulticastOption(int32_t socket, int32_t multicastOption,
     return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
 }
 
+#if defined(__APPLE__) && __APPLE__
+static int32_t GetMaxLingerTime()
+{
+    static volatile int32_t MaxLingerTime = -1;
+
+    // OS X does not define the linger time in seconds by default, but in ticks.
+    // Furthermore, when SO_LINGER_SEC is used, the value is simply scaled by
+    // the number of ticks per second and then the result is used to set the
+    // underlying linger time. Unfortunately, the underlying linger time is
+    // stored as a `short` and out-of-range values are simply truncated to fit
+    // within 16 bits and then reinterpreted as 2's complement signed integers.
+    // This results in some *very* strange behavior and a rather low limit for
+    // the linger time. Instead of admitting this behavior, we determine the
+    // maximum linger time in seconds and return an error if the input is out
+    // of range.
+    int32_t maxLingerTime = MaxLingerTime;
+    if (maxLingerTime == -1)
+    {
+        long ticksPerSecond = sysconf(_SC_CLK_TCK);
+        maxLingerTime = static_cast<int32_t>(32767 / ticksPerSecond);
+        MaxLingerTime = maxLingerTime;
+    }
+
+    return maxLingerTime;
+}
+#else
+constexpr int32_t GetMaxLingerTime()
+{
+    // On other platforms, the maximum linger time is locked to the smaller of
+    // 65535 (the maximum time for winsock) and the maximum signed value that
+    // will fit in linger::l_linger.
+
+    return Min(65535U, (1U << (sizeof(linger::l_linger) * 8 - 1)) - 1);
+}
+#endif
+
 extern "C" Error GetLingerOption(int32_t socket, LingerOption* option)
 {
     if (option == nullptr)
@@ -1253,7 +1298,7 @@ extern "C" Error GetLingerOption(int32_t socket, LingerOption* option)
 
     linger opt;
     socklen_t len = sizeof(opt);
-    int err = getsockopt(socket, SOL_SOCKET, SO_LINGER, &opt, &len);
+    int err = getsockopt(socket, SOL_SOCKET, LINGER_OPTION_NAME, &opt, &len);
     if (err != 0)
     {
         return ConvertErrorPlatformToPal(errno);
@@ -1270,8 +1315,13 @@ extern "C" Error SetLingerOption(int32_t socket, LingerOption* option)
         return PAL_EFAULT;
     }
 
+    if (option->OnOff != 0 && (option->Seconds < 0 || option->Seconds > GetMaxLingerTime()))
+    {
+        return PAL_EINVAL;
+    }
+
     linger opt = {.l_onoff = option->OnOff, .l_linger = option->Seconds};
-    int err = setsockopt(socket, SOL_SOCKET, SO_LINGER, &opt, sizeof(opt));
+    int err = setsockopt(socket, SOL_SOCKET, LINGER_OPTION_NAME, &opt, sizeof(opt));
     return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
 }
 

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/LingerStateTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/LingerStateTest.cs
@@ -7,6 +7,11 @@ namespace System.Net.Sockets.Tests
 {
     public class LingerStateTest
     {
+        // NOTE: xUnit provides no way besides [ActiveIssue(int, PlatformId)] to exclude
+        //       a test from a specific set of platforms but not others. This dummy issue
+        //       is used to disable the boundary test for OS X.
+        const int DummyLingerStateOSXIssue = 0;
+
         private void TestLingerState_Success(Socket sock, bool enabled, int lingerTime)
         {
             sock.LingerState = new LingerOption(enabled, lingerTime);
@@ -24,8 +29,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4008, PlatformID.OSX)]
-        public void Socket_LingerState_Boundaries_CorrectBehavior()
+        public void Socket_LingerState_Common_Boundaries_CorrectBehavior()
         {
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
@@ -35,11 +39,43 @@ namespace System.Net.Sockets.Tests
             TestLingerState_ArgumentException(sock, true, -1);
 
             TestLingerState_Success(sock, true, 0);
+            TestLingerState_Success(sock, true, 120);
+
+            TestLingerState_ArgumentException(sock, true, UInt16.MaxValue + 1);
+        }
+
+        [Fact]
+        [ActiveIssue(DummyLingerStateOSXIssue, PlatformID.OSX)]
+        public void Socket_LingerState_Upper_Boundaries_CorrectBehavior()
+        {
+            Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
             TestLingerState_Success(sock, true, Int16.MaxValue);
             TestLingerState_Success(sock, true, Int16.MaxValue + 1);
             TestLingerState_Success(sock, true, UInt16.MaxValue);
+        }
 
-            TestLingerState_ArgumentException(sock, true, UInt16.MaxValue + 1);
+        [Fact]
+        [PlatformSpecific(PlatformID.OSX)]
+        public void Socket_LingerState_Upper_Boundaries_CorrectBehavior_OSX()
+        {
+            // The upper bound for linger time is drastically different on OS X.
+            Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            Assert.Throws<SocketException>(() =>
+            {
+                sock.LingerState = new LingerOption(true, Int16.MaxValue);
+            });
+
+            Assert.Throws<SocketException>(() =>
+            {
+                sock.LingerState = new LingerOption(true, Int16.MaxValue + 1);
+            });
+
+            Assert.Throws<SocketException>(() =>
+            {
+                sock.LingerState = new LingerOption(true, UInt16.MaxValue);
+            });
         }
     }
 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/LingerStateTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/LingerStateTest.cs
@@ -7,11 +7,6 @@ namespace System.Net.Sockets.Tests
 {
     public class LingerStateTest
     {
-        // NOTE: xUnit provides no way besides [ActiveIssue(int, PlatformId)] to exclude
-        //       a test from a specific set of platforms but not others. This dummy issue
-        //       is used to disable the boundary test for OS X.
-        const int DummyLingerStateOSXIssue = 0;
-
         private void TestLingerState_Success(Socket sock, bool enabled, int lingerTime)
         {
             sock.LingerState = new LingerOption(enabled, lingerTime);
@@ -45,7 +40,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(DummyLingerStateOSXIssue, PlatformID.OSX)]
+        [PlatformSpecific(~PlatformID.OSX)]
         public void Socket_LingerState_Upper_Boundaries_CorrectBehavior()
         {
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
Some platforms behave strangely when confronted with linger times that
are out-of-range. In particular, OS X silently truncates
`linger::l_linger` to 16 bits and interprets the results as a `short`.
This change validates the linger time before calling `setsockopt` to
ensure reliable behavior across platforms.

On OS X, the maximum linger time is actually in units of ticks, so
validation is a bit more involved than on other platforms (where the
max time is defined by the size of the integer used to store the
value): on the first call to `SetLingerOption`, the number of ticks
per second is obtained via `sysconf()` and is then used to derive
the maximum linger time by simple division. This does mean that the
maximum linger time on OS X may vary with the number of ticks per
second, and so may vary between machines.