### PR TITLE
Fixing some of the tests throwing different expected exceptions

### DIFF
--- a/src/Common/src/System/Net/Sockets/SocketAPMExtensions.cs
+++ b/src/Common/src/System/Net/Sockets/SocketAPMExtensions.cs
@@ -833,15 +833,12 @@ namespace System.Net.Sockets
         // Behavior adapter.
         private static ArraySegment<byte> CreateArraySegment(byte[] buffer, int offset, int size)
         {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException("buffer");
-            }
-
             try
             {
                 return new ArraySegment<byte>(buffer, offset, size);
             }
+            catch (ArgumentNullException) { throw; }
+            catch (ArgumentOutOfRangeException) { throw; }
             catch (ArgumentException ae)
             {
                 throw new ArgumentOutOfRangeException(ae.Message, ae);

--- a/src/Common/src/System/Net/Sockets/SocketAPMExtensions.cs
+++ b/src/Common/src/System/Net/Sockets/SocketAPMExtensions.cs
@@ -833,16 +833,19 @@ namespace System.Net.Sockets
         // Behavior adapter.
         private static ArraySegment<byte> CreateArraySegment(byte[] buffer, int offset, int size)
         {
-            try
+            if (buffer == null)
             {
-                return new ArraySegment<byte>(buffer, offset, size);
+                throw new ArgumentNullException("buffer");
             }
-            catch (ArgumentNullException) { throw; }
-            catch (ArgumentOutOfRangeException) { throw; }
-            catch (ArgumentException ae)
+            if (offset < 0 || offset > buffer.Length)
             {
-                throw new ArgumentOutOfRangeException(ae.Message, ae);
+                throw new ArgumentOutOfRangeException("offset");
             }
+            if (size < 0 || size > buffer.Length - offset)
+            {
+                throw new ArgumentOutOfRangeException("size");
+            }
+            return new ArraySegment<byte>(buffer, offset, size);
         }
     }
 

--- a/src/Common/src/System/Net/Sockets/SocketAPMExtensions.cs
+++ b/src/Common/src/System/Net/Sockets/SocketAPMExtensions.cs
@@ -316,7 +316,7 @@ namespace System.Net.Sockets
         //     of the offset parameter.
         public static IAsyncResult BeginReceive(this Socket socket, byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback callback, object state)
         {
-            return TaskToApm.Begin(socket.ReceiveAsync(new ArraySegment<byte>(buffer, offset, size), socketFlags), callback, state);
+            return TaskToApm.Begin(socket.ReceiveAsync(CreateArraySegment(buffer, offset, size), socketFlags), callback, state);
         }
 
         //
@@ -370,7 +370,7 @@ namespace System.Net.Sockets
         public static IAsyncResult BeginReceiveFrom(this Socket socket, byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, AsyncCallback callback, object state)
         {
             // remoteEP will not change in the sync portion.
-            return TaskToApm.Begin(socket.ReceiveFromAsync(new ArraySegment<byte>(buffer, offset, size), socketFlags, remoteEP), callback, state);
+            return TaskToApm.Begin(socket.ReceiveFromAsync(CreateArraySegment(buffer, offset, size), socketFlags, remoteEP), callback, state);
         }
 
         //
@@ -426,7 +426,7 @@ namespace System.Net.Sockets
         public static IAsyncResult BeginReceiveMessageFrom(this Socket socket, byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, AsyncCallback callback, object state)
         {
             // remoteEP will not change in the sync portion.
-            return TaskToApm.Begin(socket.ReceiveMessageFromAsync(new ArraySegment<byte>(buffer, offset, size), socketFlags, remoteEP), callback, state);
+            return TaskToApm.Begin(socket.ReceiveMessageFromAsync(CreateArraySegment(buffer, offset, size), socketFlags, remoteEP), callback, state);
         }
 
         //
@@ -508,7 +508,7 @@ namespace System.Net.Sockets
         //     The System.Net.Sockets.Socket has been closed.
         public static IAsyncResult BeginSend(this Socket socket, byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback callback, object state)
         {
-            return TaskToApm.Begin(socket.SendAsync(new ArraySegment<byte>(buffer, offset, size), socketFlags), callback, state);
+            return TaskToApm.Begin(socket.SendAsync(CreateArraySegment(buffer, offset, size), socketFlags), callback, state);
         }
 
         //
@@ -561,7 +561,7 @@ namespace System.Net.Sockets
         //     operation.
         public static IAsyncResult BeginSendTo(this Socket socket, byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP, AsyncCallback callback, object state)
         {
-            return TaskToApm.Begin(socket.SendToAsync(new ArraySegment<byte>(buffer, offset, size), socketFlags, remoteEP), callback, state);
+            return TaskToApm.Begin(socket.SendToAsync(CreateArraySegment(buffer, offset, size), socketFlags, remoteEP), callback, state);
         }
 
         //
@@ -828,6 +828,24 @@ namespace System.Net.Sockets
         public static int EndSendTo(this Socket socket, IAsyncResult asyncResult)
         {
             return TaskToApm.End<int>(asyncResult);
+        }
+
+        // Behavior adapter.
+        private static ArraySegment<byte> CreateArraySegment(byte[] buffer, int offset, int size)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException("buffer");
+            }
+
+            try
+            {
+                return new ArraySegment<byte>(buffer, offset, size);
+            }
+            catch (ArgumentException ae)
+            {
+                throw new ArgumentOutOfRangeException(ae.Message, ae);
+            }
         }
     }
 

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -165,7 +165,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginSend_Buffer_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, -1, 0, SocketFlags.None, TheAsyncCallback, null));
@@ -173,7 +172,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginSend_Buffer_InvalidCount_Throws_ArgumentOutOfRange()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, 0, -1, SocketFlags.None, TheAsyncCallback, null));
@@ -212,7 +210,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginSendTo_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
@@ -221,7 +218,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginSendTo_InvalidSize_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
@@ -243,7 +239,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginReceive_Buffer_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, -1, 0, SocketFlags.None, TheAsyncCallback, null));
@@ -251,7 +246,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginReceive_Buffer_InvalidCount_Throws_ArgumentOutOfRange()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, 0, -1, SocketFlags.None, TheAsyncCallback, null));
@@ -299,7 +293,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginReceiveFrom_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
@@ -308,7 +301,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginReceiveFrom_InvalidSize_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
@@ -356,7 +348,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginReceiveMessageFrom_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
@@ -366,7 +357,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4083)]
         public void BeginReceiveMessageFrom_InvalidSize_Throws_ArgumentOutOfRange()
         {
             EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);


### PR DESCRIPTION
A method CreateArraySegment for correctly throw
ArgumentOutOfRangeException instead of ArgumentException is added to fix
the Tests in ArgumentValidationTests.

Fix #4083