### PR TITLE
Disabling a flaky Immutable collections test

### DIFF
--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
@@ -189,6 +189,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Throws<NotSupportedException>(() => map[3] = 5);
         }
 
+        [ActiveIssue(780)]
         [Fact]
         public void EqualsTest()
         {


### PR DESCRIPTION
This has been failing sporadically for a while, almost certainly due to the same issue we've seen with other immutable collection comparison tests previously, where the "default" comparer captured into one instance may (due to a race condition) be a different instance than one captured into another.

#780 
cc: @ellismg 