### PR TITLE
Malformed XML comment

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -4,7 +4,7 @@
 namespace System.Net.Http
 {
     /// <summary>
-    /// Defines default values for http handler properties which is meant to be re-used across WinHttp & UnixHttp Handlers
+    /// Defines default values for http handler properties which is meant to be re-used across WinHttp &amp; UnixHttp Handlers
     /// </summary>
     internal static class HttpHandlerDefaults
     {

--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -4,7 +4,7 @@
 namespace System.Net.Http
 {
     /// <summary>
-    /// Defines default values for http handler properties which is meant to be re-used across WinHttp &amp; UnixHttp Handlers
+    /// Defines default values for http handler properties which is meant to be re-used across WinHttp and UnixHttp Handlers
     /// </summary>
     internal static class HttpHandlerDefaults
     {


### PR DESCRIPTION
Fails the build when XML doc generation is enabled.