### PR TITLE
Reduce HashSet<T> memory consumption via StructLayout

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1499,8 +1499,8 @@ namespace System.Collections.Generic
         internal struct Slot
         {
             internal int hashCode;      // Lower 31 bits of hash code, -1 if unused
-            internal T value;
             internal int next;          // Index of next entry, -1 if last
+            internal T value;
         }
 
         public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
@@ -135,8 +135,8 @@ namespace System.Linq.Parallel
         internal struct Slot
         {
             internal int hashCode;
-            internal TElement value;
             internal int next;
+            internal TElement value;
         }
     }
 }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
@@ -181,9 +181,9 @@ namespace System.Linq.Parallel
         internal struct Slot
         {
             internal int hashCode;
+            internal int next;
             internal TKey key;
             internal TValue value;
-            internal int next;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -3617,8 +3617,8 @@ namespace System.Linq
         internal struct Slot
         {
             internal int hashCode;
-            internal TElement value;
             internal int next;
+            internal TElement value;
         }
     }
 


### PR DESCRIPTION
```HashSet<T>``` uses a struct Slot type to store each element in an array:
```C#
internal struct Slot
{
    internal int hashCode;
    internal T value;
    internal int next;
}
```
The C# compiler by default annotates structs to be sequential layout.  For alignment reasons, T may need to be 8-byte aligned on 64-bit, e.g. if T is a long or an object reference, in which case with sequential layout we'll end up with a 4-byte gap between hashCode and value, as well as padding at the end of the struct.  If we instead allow the runtime to lay this out optimally, e.g. ```hashCode``` then ```next``` then ```value```, all padding in such situations can be removed.

This commit simply adds ```[StructLayout(LayoutKind.Auto)]``` to the Slot struct. On a simple test:
```C#
using System;
using System.Collections.Generic;

class Test
{
    public static void Main()
    {
        var hs = new HashSet<long>();
        for (long i = 0; i < 1000000; i++)
        {
            hs.Add(i);
        }
    }
}
```
this change reduces the allocations for the internal ```Slot[]```s from 64MB to 43MB.

cc: @jkotas, @ellismg 
Jan, Matt, any reason not to do this?  Should we do something similar with ```Dictionary<TKey, TValue>``` in coreclr?