### PR TITLE
native: Uses kevent instead of kevent64

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -105,7 +105,6 @@ constexpr T Max(T left, T right)
     return left > right ? left : right;
 }
 
-
 static int IpStringToAddressHelper(const uint8_t* address, const uint8_t* port, bool isIPv6, addrinfo*& info)
 {
     assert(address != nullptr);
@@ -260,12 +259,8 @@ static void AppendScopeIfNecessary(uint8_t* string, int32_t stringLength, uint32
     (void)n; // Silence an unused variable warning in release mode
 }
 
-extern "C" int32_t IPAddressToString(const uint8_t* address,
-                                     int32_t addressLength,
-                                     bool isIPv6,
-                                     uint8_t* string,
-                                     int32_t stringLength,
-                                     uint32_t scope)
+extern "C" int32_t IPAddressToString(
+    const uint8_t* address, int32_t addressLength, bool isIPv6, uint8_t* string, int32_t stringLength, uint32_t scope)
 {
     assert(address != nullptr);
     assert((addressLength == NUM_BYTES_IN_IPV6_ADDRESS) || (addressLength == NUM_BYTES_IN_IPV4_ADDRESS));
@@ -328,7 +323,11 @@ extern "C" int32_t GetHostEntryForName(const uint8_t* address, HostEntry* entry)
         return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
     }
 
-    *entry = {.CanonicalName = nullptr, .Aliases = nullptr, .AddressListHandle = reinterpret_cast<void*>(info), .IPAddressCount = 0, .HandleType = HOST_ENTRY_HANDLE_ADDRINFO };
+    *entry = {.CanonicalName = nullptr,
+              .Aliases = nullptr,
+              .AddressListHandle = reinterpret_cast<void*>(info),
+              .IPAddressCount = 0,
+              .HandleType = HOST_ENTRY_HANDLE_ADDRINFO};
 
     // Find the canonical name for this host (if any) and count the number of IP end points.
     for (addrinfo* ai = info; ai != nullptr; ai = ai->ai_next)
@@ -372,13 +371,11 @@ static int ConvertGetHostErrorPlatformToPal(int error)
 
 static void ConvertHostEntPlatformToPal(HostEntry& hostEntry, hostent& entry)
 {
-    hostEntry = {
-        .CanonicalName = reinterpret_cast<uint8_t*>(entry.h_name),
-        .Aliases = reinterpret_cast<uint8_t**>(entry.h_aliases),
-        .AddressListHandle = reinterpret_cast<void*>(&entry),
-        .IPAddressCount = 0,
-        .HandleType = HOST_ENTRY_HANDLE_HOSTENT
-    };
+    hostEntry = {.CanonicalName = reinterpret_cast<uint8_t*>(entry.h_name),
+                 .Aliases = reinterpret_cast<uint8_t**>(entry.h_aliases),
+                 .AddressListHandle = reinterpret_cast<void*>(&entry),
+                 .IPAddressCount = 0,
+                 .HandleType = HOST_ENTRY_HANDLE_HOSTENT};
 
     for (int i = 0; entry.h_addr_list[i] != nullptr; i++)
     {
@@ -406,7 +403,8 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
         char* scratch = reinterpret_cast<char*>(&buffer[sizeof(hostent)]);
 
         int getHostErrno;
-        int err = gethostbyname_r(reinterpret_cast<const char*>(hostname), result, scratch, scratchLen, entry, &getHostErrno);
+        int err =
+            gethostbyname_r(reinterpret_cast<const char*>(hostname), result, scratch, scratchLen, entry, &getHostErrno);
         switch (err)
         {
             case 0:
@@ -641,7 +639,7 @@ extern "C" int32_t GetNextIPAddress(const HostEntry* hostEntry, void** addressLi
 
         case HOST_ENTRY_HANDLE_HOSTENT:
             return GetNextIPAddressFromHostEnt(reinterpret_cast<hostent**>(addressListHandle), endPoint);
-            
+
         default:
             return PAL_EAI_BADARG;
     }
@@ -665,7 +663,7 @@ extern "C" void FreeHostEntry(HostEntry* entry)
 #if !HAVE_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR
                 free(entry->AddressListHandle);
 #endif
-                break;   
+                break;
             }
 
             default:
@@ -1124,7 +1122,8 @@ TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacket
     cmsghdr* controlMessage = CMSG_FIRSTHDR(&header);
     if (isIPv4 != 0)
     {
-        for (; controlMessage != nullptr && controlMessage->cmsg_len > 0; controlMessage = CMSG_NXTHDR(&header, controlMessage))
+        for (; controlMessage != nullptr && controlMessage->cmsg_len > 0;
+             controlMessage = CMSG_NXTHDR(&header, controlMessage))
         {
             if (controlMessage->cmsg_level == IPPROTO_IP && controlMessage->cmsg_type == IP_PKTINFO)
             {
@@ -1134,7 +1133,8 @@ TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacket
     }
     else
     {
-        for (; controlMessage != nullptr && controlMessage->cmsg_len > 0; controlMessage = CMSG_NXTHDR(&header, controlMessage))
+        for (; controlMessage != nullptr && controlMessage->cmsg_len > 0;
+             controlMessage = CMSG_NXTHDR(&header, controlMessage))
         {
             if (controlMessage->cmsg_level == IPPROTO_IPV6 && controlMessage->cmsg_type == IPV6_PKTINFO)
             {
@@ -1331,11 +1331,7 @@ extern "C" Error SetLingerOption(int32_t socket, LingerOption* option)
 
 static bool ConvertSocketFlagsPalToPlatform(int32_t palFlags, int& platformFlags)
 {
-    const int32_t SupportedFlagsMask = PAL_MSG_OOB |
-        PAL_MSG_PEEK |
-        PAL_MSG_DONTROUTE |
-        PAL_MSG_TRUNC |
-        PAL_MSG_CTRUNC;
+    const int32_t SupportedFlagsMask = PAL_MSG_OOB | PAL_MSG_PEEK | PAL_MSG_DONTROUTE | PAL_MSG_TRUNC | PAL_MSG_CTRUNC;
 
     if ((palFlags & ~SupportedFlagsMask) != 0)
     {
@@ -1343,30 +1339,24 @@ static bool ConvertSocketFlagsPalToPlatform(int32_t palFlags, int& platformFlags
         return false;
     }
 
-    platformFlags = ((palFlags & PAL_MSG_OOB) == 0 ? 0 : MSG_OOB) |
-        ((palFlags & PAL_MSG_PEEK) == 0 ? 0 : MSG_PEEK) |
-        ((palFlags & PAL_MSG_DONTROUTE) == 0 ? 0 : MSG_DONTROUTE) |
-        ((palFlags & PAL_MSG_TRUNC) == 0 ? 0 : MSG_TRUNC) |
-        ((palFlags & PAL_MSG_CTRUNC) == 0 ? 0 : MSG_CTRUNC);
+    platformFlags = ((palFlags & PAL_MSG_OOB) == 0 ? 0 : MSG_OOB) | ((palFlags & PAL_MSG_PEEK) == 0 ? 0 : MSG_PEEK) |
+                    ((palFlags & PAL_MSG_DONTROUTE) == 0 ? 0 : MSG_DONTROUTE) |
+                    ((palFlags & PAL_MSG_TRUNC) == 0 ? 0 : MSG_TRUNC) |
+                    ((palFlags & PAL_MSG_CTRUNC) == 0 ? 0 : MSG_CTRUNC);
 
     return true;
 }
 
 static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
 {
-    const int SupportedFlagsMask = MSG_OOB |
-        MSG_PEEK |
-        MSG_DONTROUTE |
-        MSG_TRUNC |
-        MSG_CTRUNC;
+    const int SupportedFlagsMask = MSG_OOB | MSG_PEEK | MSG_DONTROUTE | MSG_TRUNC | MSG_CTRUNC;
 
     platformFlags &= SupportedFlagsMask;
 
-    return ((platformFlags & MSG_OOB) == 0 ? 0 : PAL_MSG_OOB) |
-        ((platformFlags & MSG_PEEK) == 0 ? 0 : PAL_MSG_PEEK) |
-        ((platformFlags & MSG_DONTROUTE) == 0 ? 0 : PAL_MSG_DONTROUTE) |
-        ((platformFlags & MSG_TRUNC) == 0 ? 0 : PAL_MSG_TRUNC) |
-        ((platformFlags & MSG_CTRUNC) == 0 ? 0 : PAL_MSG_CTRUNC);
+    return ((platformFlags & MSG_OOB) == 0 ? 0 : PAL_MSG_OOB) | ((platformFlags & MSG_PEEK) == 0 ? 0 : PAL_MSG_PEEK) |
+           ((platformFlags & MSG_DONTROUTE) == 0 ? 0 : PAL_MSG_DONTROUTE) |
+           ((platformFlags & MSG_TRUNC) == 0 ? 0 : PAL_MSG_TRUNC) |
+           ((platformFlags & MSG_CTRUNC) == 0 ? 0 : PAL_MSG_CTRUNC);
 }
 
 extern "C" Error ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
@@ -1780,7 +1770,8 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
     }
 }
 
-extern "C" Error GetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
+extern "C" Error GetSockOpt(
+    int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
 {
     if (optionLen == nullptr || *optionLen < 0)
     {
@@ -1805,7 +1796,8 @@ extern "C" Error GetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t s
     return PAL_SUCCESS;
 }
 
-extern "C" Error SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
+extern "C" Error
+SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
 {
     if (optionLen < 0)
     {
@@ -1829,7 +1821,7 @@ static bool TryConvertSocketTypePalToPlatform(int32_t palSocketType, int* platfo
     switch (palSocketType)
     {
         case PAL_SOCK_STREAM:
-           *platformSocketType = SOCK_STREAM;
+            *platformSocketType = SOCK_STREAM;
             return true;
 
         case PAL_SOCK_DGRAM:
@@ -1847,10 +1839,10 @@ static bool TryConvertSocketTypePalToPlatform(int32_t palSocketType, int* platfo
         case PAL_SOCK_SEQPACKET:
             *platformSocketType = SOCK_SEQPACKET;
             return true;
- 
+
         default:
             *platformSocketType = static_cast<int>(palSocketType);
-            return false;           
+            return false;
     }
 }
 
@@ -1972,7 +1964,8 @@ static void ConvertFdSetPalToPlatform(fd_set& platformSet, FdSet& palSet, int32_
 #endif
 }
 
-extern "C" Error Select(int32_t fdCount, FdSet* readFdSet, FdSet* writeFdSet, FdSet* errorFdSet, int32_t microseconds, int32_t* selected)
+extern "C" Error
+Select(int32_t fdCount, FdSet* readFdSet, FdSet* writeFdSet, FdSet* errorFdSet, int32_t microseconds, int32_t* selected)
 {
     if (selected == nullptr)
     {
@@ -2064,22 +2057,18 @@ const size_t SocketEventBufferElementSize = Max(sizeof(epoll_event), sizeof(Sock
 
 static SocketEvents GetSocketEvents(uint32_t events)
 {
-    int asyncEvents = (((events & EPOLLIN) != 0) ? PAL_SA_READ : 0) |
-        (((events & EPOLLOUT) != 0) ? PAL_SA_WRITE : 0) |
-        (((events & EPOLLRDHUP) != 0) ? PAL_SA_READCLOSE : 0) |
-        (((events & EPOLLHUP) != 0) ? PAL_SA_CLOSE : 0) |
-        (((events & EPOLLERR) != 0) ? PAL_SA_ERROR : 0);
+    int asyncEvents = (((events & EPOLLIN) != 0) ? PAL_SA_READ : 0) | (((events & EPOLLOUT) != 0) ? PAL_SA_WRITE : 0) |
+                      (((events & EPOLLRDHUP) != 0) ? PAL_SA_READCLOSE : 0) |
+                      (((events & EPOLLHUP) != 0) ? PAL_SA_CLOSE : 0) | (((events & EPOLLERR) != 0) ? PAL_SA_ERROR : 0);
 
     return static_cast<SocketEvents>(asyncEvents);
 }
 
 static uint32_t GetEPollEvents(SocketEvents events)
 {
-     return (((events & PAL_SA_READ) != 0) ? EPOLLIN : 0) |
-        (((events & PAL_SA_WRITE) != 0) ? EPOLLOUT : 0) |
-        (((events & PAL_SA_READCLOSE) != 0) ? EPOLLRDHUP : 0) |
-        (((events & PAL_SA_CLOSE) != 0) ? EPOLLHUP : 0) |
-        (((events & PAL_SA_ERROR) != 0) ? EPOLLERR : 0);
+    return (((events & PAL_SA_READ) != 0) ? EPOLLIN : 0) | (((events & PAL_SA_WRITE) != 0) ? EPOLLOUT : 0) |
+           (((events & PAL_SA_READCLOSE) != 0) ? EPOLLRDHUP : 0) | (((events & PAL_SA_CLOSE) != 0) ? EPOLLHUP : 0) |
+           (((events & PAL_SA_ERROR) != 0) ? EPOLLERR : 0);
 }
 
 static Error CreateSocketEventPortInner(int32_t* port)
@@ -2103,7 +2092,8 @@ static Error CloseSocketEventPortInner(int32_t port)
     return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
 }
 
-static Error TryChangeSocketEventRegistrationInner(int32_t port, int32_t socket, SocketEvents currentEvents, SocketEvents newEvents, uintptr_t data)
+static Error TryChangeSocketEventRegistrationInner(
+    int32_t port, int32_t socket, SocketEvents currentEvents, SocketEvents newEvents, uintptr_t data)
 {
     assert(currentEvents != newEvents);
 
@@ -2117,10 +2107,7 @@ static Error TryChangeSocketEventRegistrationInner(int32_t port, int32_t socket,
         op = EPOLL_CTL_DEL;
     }
 
-    epoll_event evt = {
-        .events = GetEPollEvents(newEvents) | EPOLLET,
-        .data = { .ptr = reinterpret_cast<void*>(data) }
-    };
+    epoll_event evt = {.events = GetEPollEvents(newEvents) | EPOLLET, .data = {.ptr = reinterpret_cast<void*>(data)}};
     int err = epoll_ctl(port, op, socket, &evt);
     return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
 }
@@ -2140,10 +2127,7 @@ static void ConvertEventEPollToSocketAsync(SocketEvent* sae, epoll_event* epoll)
         events = (events & ~EPOLLHUP) | EPOLLIN | EPOLLOUT;
     }
 
-    *sae = {
-        .Data = reinterpret_cast<uintptr_t>(epoll->data.ptr),
-        .Events = GetSocketEvents(events)
-    };
+    *sae = {.Data = reinterpret_cast<uintptr_t>(epoll->data.ptr), .Events = GetSocketEvents(events)};
 }
 
 static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t* count)
@@ -2257,7 +2241,8 @@ static Error CloseSocketEventPortInner(int32_t port)
     return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
 }
 
-static Error TryChangeSocketEventRegistrationInner(int32_t port, int32_t socket, SocketEvents currentEvents, SocketEvents newEvents, uintptr_t data)
+static Error TryChangeSocketEventRegistrationInner(
+    int32_t port, int32_t socket, SocketEvents currentEvents, SocketEvents newEvents, uintptr_t data)
 {
     const uint16_t AddFlags = EV_ADD | EV_CLEAR | EV_RECEIPT;
     const uint16_t RemoveFlags = EV_DELETE | EV_RECEIPT;
@@ -2277,16 +2262,20 @@ static Error TryChangeSocketEventRegistrationInner(int32_t port, int32_t socket,
                static_cast<uint64_t>(socket),
                EVFILT_READ,
                (newEvents & PAL_SA_READ) == 0 ? RemoveFlags : AddFlags,
-               0, data, 0);
+               0,
+               data,
+               0);
     }
 
     if (writeChanged)
     {
         EV_SET(&events[i++],
-                 static_cast<uint64_t>(socket),
-                 EVFILT_WRITE,
-                 (newEvents & PAL_SA_WRITE) == 0 ? RemoveFlags : AddFlags,
-                 0, data, 0);
+               static_cast<uint64_t>(socket),
+               EVFILT_WRITE,
+               (newEvents & PAL_SA_WRITE) == 0 ? RemoveFlags : AddFlags,
+               0,
+               data,
+               0);
     }
 
     int err = kevent(port, events, i, nullptr, 0, nullptr);
@@ -2318,10 +2307,7 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
     {
         // This copy is made deliberately to avoid overwriting data.
         struct kevent evt = events[i];
-        buffer[i] = {
-            .Data = reinterpret_cast<uintptr_t>(evt.udata),
-            .Events = GetSocketEvents(evt.filter, evt.flags)
-        };
+        buffer[i] = {.Data = reinterpret_cast<uintptr_t>(evt.udata), .Events = GetSocketEvents(evt.filter, evt.flags)};
     }
 
     *count = numEvents;
@@ -2371,13 +2357,10 @@ extern "C" Error FreeSocketEventBuffer(SocketEvent* buffer)
     return PAL_SUCCESS;
 }
 
-extern "C" Error TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
+extern "C" Error
+TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
 {
-    const int32_t SupportedEvents = PAL_SA_READ |
-        PAL_SA_WRITE |
-        PAL_SA_READCLOSE |
-        PAL_SA_CLOSE |
-        PAL_SA_ERROR;
+    const int32_t SupportedEvents = PAL_SA_READ | PAL_SA_WRITE | PAL_SA_READCLOSE | PAL_SA_CLOSE | PAL_SA_ERROR;
 
     if ((currentEvents & ~SupportedEvents) != 0 || (newEvents & ~SupportedEvents) != 0)
     {
@@ -2389,7 +2372,8 @@ extern "C" Error TryChangeSocketEventRegistration(int32_t port, int32_t socket, 
         return PAL_SUCCESS;
     }
 
-    return TryChangeSocketEventRegistrationInner(port, socket, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
+    return TryChangeSocketEventRegistrationInner(
+        port, socket, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
 }
 
 extern "C" Error WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)


### PR DESCRIPTION
Some operating systems, such as FreeBSD, do not provide kevent64_t but
instead have kevent. This change switches to use kevent for all
platforms.