### PR TITLE
Change some dual-mode tests to accommodate platform differences.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -645,6 +645,10 @@ namespace System.Net.Sockets
             }
         }
 
+        // NOTE: on *nix, the OS IP stack changes a dual-mode socket back to a
+        //       normal IPv6 socket once the socket is bound to an IPv6-specific
+        //       address. This can cause behavioral differences in code that checks
+        //       the value of DualMode (e.g. the checks in CanTryAddressFamily).
         public bool DualMode
         {
             get


### PR DESCRIPTION
On *nix, the OS IP stack changes a dual-mode socket back to a normal IPv6
socket once the socket is bound to an IPv6-specific address. This can
cause behavioral differences in code that checks the value of DualMode
(e.g. the checks in CanTryAddressFamily). We've decided not to emulate the
Winsock behavior (which does not change the value of `IPV6_V6ONLY` for
dual-mode sockets bound to IPv6-specific addresses) due to the cost of
caching the expected value on each socket instance; some tests needed
changes as a consequence of this decision.

Fixes #4005.