### PR TITLE
More cross-check tests for expression compiler and interpreter

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
@@ -1928,7 +1928,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(bool[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1939,7 +1939,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(byte[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1950,7 +1950,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(C[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1961,7 +1961,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(char[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1972,7 +1972,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(D[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1983,7 +1983,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(decimal[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1994,7 +1994,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Delegate[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2005,7 +2005,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(double[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2016,7 +2016,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(E[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2027,7 +2027,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(El[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2038,7 +2038,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(float[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2049,7 +2049,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Func<object>[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2060,7 +2060,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(I[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2071,7 +2071,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(IEquatable<C>[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2082,7 +2082,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(IEquatable<D>[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2093,7 +2093,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(int[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2104,7 +2104,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(long[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2115,7 +2115,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(object[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2126,7 +2126,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(S[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2137,7 +2137,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(sbyte[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2148,7 +2148,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Sc[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2159,7 +2159,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Scs[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2170,7 +2170,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(short[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2181,7 +2181,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Sp[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2192,7 +2192,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Ss[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2203,7 +2203,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(string[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2214,7 +2214,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(uint[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2225,7 +2225,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(ulong[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2236,7 +2236,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(ushort[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2247,7 +2247,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(T[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2258,7 +2258,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(T[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2269,7 +2269,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Tc[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2280,7 +2280,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Tcn[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2291,7 +2291,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(TC[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2302,7 +2302,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(TCn[][])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -1214,7 +1214,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(bool[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1224,7 +1224,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(byte[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1234,7 +1234,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(C[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1244,7 +1244,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(char[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1254,7 +1254,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(D[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1264,7 +1264,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(decimal[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1274,7 +1274,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Delegate[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1284,7 +1284,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(double[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1294,7 +1294,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(E[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1304,7 +1304,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(El[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1314,7 +1314,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(float[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1324,7 +1324,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Func<object>[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1334,7 +1334,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(I[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1344,7 +1344,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(IEquatable<C>[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1354,7 +1354,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(IEquatable<D>[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1364,7 +1364,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(int[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1374,7 +1374,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(long[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1384,7 +1384,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(object[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1394,7 +1394,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(S[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1404,7 +1404,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(sbyte[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1414,7 +1414,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Sc[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1424,7 +1424,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Scs[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1434,7 +1434,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(short[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1444,7 +1444,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Sp[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1454,7 +1454,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Ss[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1464,7 +1464,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(string[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1474,7 +1474,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(uint[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1484,7 +1484,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(ulong[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1494,7 +1494,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(ushort[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1504,7 +1504,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(T[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1514,7 +1514,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Tc[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1524,7 +1524,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(TC[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1534,7 +1534,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Tcn[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1544,7 +1544,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(TCn[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1554,7 +1554,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Ts[][]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
@@ -13,7 +13,7 @@ namespace Tests.ExpressionCompiler.Array
         public static void CompileWithCastTest()
         {
             Expression<Func<object[]>> expr = () => (object[])new BaseClass[1];
-            expr.Compile();
+            expr.CompileForTest();
         }
 
         [Fact]
@@ -22,7 +22,7 @@ namespace Tests.ExpressionCompiler.Array
             Expression<Func<int, object>> x = c => new double[c, c];
             Assert.Equal("c => new System.Double[,](c, c)", x.ToString());
 
-            object y = x.Compile()(2);
+            object y = x.CompileForTest()(2);
             Assert.Equal("System.Double[,]", y.ToString());
         }
 
@@ -30,7 +30,7 @@ namespace Tests.ExpressionCompiler.Array
         public static void ArrayBoundsVectorNegativeThrowsOverflowException()
         {
             Expression<Func<int, int[]>> e = a => new int[a];
-            Func<int, int[]> f = e.Compile();
+            Func<int, int[]> f = e.CompileForTest();
 
             Assert.Throws<OverflowException>(() => f(-1));
         }
@@ -39,7 +39,7 @@ namespace Tests.ExpressionCompiler.Array
         public static void ArrayBoundsMultiDimensionalNegativeThrowsOverflowException()
         {
             Expression<Func<int, int, int[,]>> e = (a, b) => new int[a, b];
-            Func<int, int, int[,]> f = e.Compile();
+            Func<int, int, int[,]> f = e.CompileForTest();
 
             Assert.Throws<OverflowException>(() => f(-1, 1));
             Assert.Throws<OverflowException>(() => f(1, -1));

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
@@ -1354,7 +1354,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -1406,7 +1406,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -1458,7 +1458,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -1510,7 +1510,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -1562,7 +1562,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -1614,7 +1614,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -1666,7 +1666,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -1718,7 +1718,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -1770,7 +1770,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -1822,7 +1822,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -1874,7 +1874,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -1926,7 +1926,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -1978,7 +1978,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -2030,7 +2030,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -2082,7 +2082,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -2134,7 +2134,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -2186,7 +2186,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -2238,7 +2238,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -2294,7 +2294,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -2346,7 +2346,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -2398,7 +2398,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -2450,7 +2450,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -2502,7 +2502,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -2554,7 +2554,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -2606,7 +2606,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -2658,7 +2658,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -2710,7 +2710,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -2762,7 +2762,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -2814,7 +2814,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -2866,7 +2866,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -2918,7 +2918,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -2970,7 +2970,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -3022,7 +3022,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -3074,7 +3074,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -3126,7 +3126,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -3178,7 +3178,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -3234,7 +3234,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -3286,7 +3286,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -3338,7 +3338,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -3390,7 +3390,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -3442,7 +3442,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -3494,7 +3494,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -3546,7 +3546,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -3598,7 +3598,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -3650,7 +3650,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -3702,7 +3702,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -3754,7 +3754,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -3806,7 +3806,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -3858,7 +3858,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -3910,7 +3910,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -3962,7 +3962,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -4014,7 +4014,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -4066,7 +4066,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -4118,7 +4118,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -4174,7 +4174,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -4226,7 +4226,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -4278,7 +4278,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -4330,7 +4330,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -4382,7 +4382,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -4434,7 +4434,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -4486,7 +4486,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -4538,7 +4538,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -4590,7 +4590,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -4642,7 +4642,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -4694,7 +4694,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -4746,7 +4746,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -4798,7 +4798,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -4850,7 +4850,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -4902,7 +4902,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -4954,7 +4954,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -5006,7 +5006,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -5058,7 +5058,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -5114,7 +5114,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -5166,7 +5166,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -5218,7 +5218,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -5270,7 +5270,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -5322,7 +5322,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -5374,7 +5374,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -5426,7 +5426,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -5478,7 +5478,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -5530,7 +5530,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -5582,7 +5582,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -5634,7 +5634,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -5686,7 +5686,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -5738,7 +5738,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -5790,7 +5790,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -5842,7 +5842,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -5894,7 +5894,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -5946,7 +5946,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -5998,7 +5998,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -6054,7 +6054,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -6106,7 +6106,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -6158,7 +6158,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -6210,7 +6210,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -6262,7 +6262,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -6314,7 +6314,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -6366,7 +6366,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -6418,7 +6418,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -6470,7 +6470,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -6522,7 +6522,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -6574,7 +6574,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -6626,7 +6626,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -6678,7 +6678,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -6730,7 +6730,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -6782,7 +6782,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -6834,7 +6834,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -6886,7 +6886,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -6938,7 +6938,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -6994,7 +6994,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -7046,7 +7046,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -7098,7 +7098,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -7150,7 +7150,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -7202,7 +7202,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -7254,7 +7254,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -7306,7 +7306,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -7358,7 +7358,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -7410,7 +7410,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -7462,7 +7462,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -7514,7 +7514,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -7566,7 +7566,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -7618,7 +7618,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -7670,7 +7670,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -7722,7 +7722,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -7774,7 +7774,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -7826,7 +7826,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -7878,7 +7878,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -7934,7 +7934,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -7986,7 +7986,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -8038,7 +8038,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -8090,7 +8090,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -8142,7 +8142,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -8194,7 +8194,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -8246,7 +8246,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -8298,7 +8298,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -8350,7 +8350,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -8402,7 +8402,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -8454,7 +8454,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -8506,7 +8506,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -8558,7 +8558,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -8610,7 +8610,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -8662,7 +8662,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -8714,7 +8714,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -8766,7 +8766,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -8818,7 +8818,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -1966,7 +1966,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(bool[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1977,7 +1977,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(byte[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1988,7 +1988,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(C[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1999,7 +1999,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(char[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2010,7 +2010,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(D[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2021,7 +2021,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(decimal[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2032,7 +2032,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Delegate[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2043,7 +2043,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(double[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2054,7 +2054,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(E[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2065,7 +2065,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(El[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2076,7 +2076,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(float[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2087,7 +2087,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Func<object>[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2098,7 +2098,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(I[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2109,7 +2109,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(IEquatable<C>[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2120,7 +2120,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(IEquatable<D>[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2131,7 +2131,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(int[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2142,7 +2142,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(long[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2153,7 +2153,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(object[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2164,7 +2164,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(S[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2175,7 +2175,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(sbyte[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2186,7 +2186,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Sc[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc> f = e.Compile();
+            Func<Sc> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2197,7 +2197,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Scs[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f = e.Compile();
+            Func<Scs> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2208,7 +2208,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(short[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2219,7 +2219,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Sp[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f = e.Compile();
+            Func<Sp> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2230,7 +2230,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Ss[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss> f = e.Compile();
+            Func<Ss> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2241,7 +2241,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(string[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string> f = e.Compile();
+            Func<string> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2252,7 +2252,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(uint[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2263,7 +2263,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(ulong[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2274,7 +2274,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(ushort[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2285,7 +2285,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(T[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T> f = e.Compile();
+            Func<T> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2296,7 +2296,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Tc[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2307,7 +2307,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Tc[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2318,7 +2318,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Tcn[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn> f = e.Compile();
+            Func<Tcn> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2329,7 +2329,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Tcn[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn> f = e.Compile();
+            Func<Tcn> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -2340,7 +2340,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Ts[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -1212,7 +1212,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(bool[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1222,7 +1222,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(byte[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1232,7 +1232,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(C[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1242,7 +1242,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(char[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1252,7 +1252,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(D[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1262,7 +1262,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(decimal[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1272,7 +1272,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Delegate[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1282,7 +1282,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(double[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1292,7 +1292,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(E[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1302,7 +1302,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(El[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1312,7 +1312,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(float[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1322,7 +1322,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Func<object>[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1332,7 +1332,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(I[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1342,7 +1342,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(IEquatable<C>[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1352,7 +1352,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(IEquatable<D>[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1362,7 +1362,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(int[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1372,7 +1372,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(long[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1382,7 +1382,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(object[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1392,7 +1392,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(S[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1402,7 +1402,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(sbyte[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1412,7 +1412,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Sc[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1422,7 +1422,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Scs[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1432,7 +1432,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(short[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1442,7 +1442,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Sp[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1452,7 +1452,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Ss[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1462,7 +1462,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(string[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1472,7 +1472,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(uint[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1482,7 +1482,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(ulong[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1492,7 +1492,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(ushort[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1502,7 +1502,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(T[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1512,7 +1512,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Tc[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1522,7 +1522,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Tcn[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1532,7 +1532,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(TC[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1542,7 +1542,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(TCn[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -1552,7 +1552,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Ts[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -1014,7 +1014,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<bool[]>>(
                     Expression.NewArrayInit(typeof(bool), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
             bool[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1029,7 +1029,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<byte[]>>(
                     Expression.NewArrayInit(typeof(byte), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
             byte[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1044,7 +1044,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<C[]>>(
                     Expression.NewArrayInit(typeof(C), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
             C[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1059,7 +1059,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<char[]>>(
                     Expression.NewArrayInit(typeof(char), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
             char[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1074,7 +1074,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<D[]>>(
                     Expression.NewArrayInit(typeof(D), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
             D[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1089,7 +1089,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<decimal[]>>(
                     Expression.NewArrayInit(typeof(decimal), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
             decimal[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1104,7 +1104,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Delegate[]>>(
                     Expression.NewArrayInit(typeof(Delegate), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
             Delegate[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1119,7 +1119,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<double[]>>(
                     Expression.NewArrayInit(typeof(double), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
             double[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1134,7 +1134,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<E[]>>(
                     Expression.NewArrayInit(typeof(E), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
             E[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1149,7 +1149,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<El[]>>(
                     Expression.NewArrayInit(typeof(El), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
             El[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1164,7 +1164,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<float[]>>(
                     Expression.NewArrayInit(typeof(float), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
             float[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1179,7 +1179,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Func<object>[]>>(
                     Expression.NewArrayInit(typeof(Func<object>), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
             Func<object>[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1194,7 +1194,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<I[]>>(
                     Expression.NewArrayInit(typeof(I), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
             I[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1209,7 +1209,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<IEquatable<C>[]>>(
                     Expression.NewArrayInit(typeof(IEquatable<C>), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
             IEquatable<C>[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1224,7 +1224,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<IEquatable<D>[]>>(
                     Expression.NewArrayInit(typeof(IEquatable<D>), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
             IEquatable<D>[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1239,7 +1239,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int[]>>(
                     Expression.NewArrayInit(typeof(int), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
             int[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1254,7 +1254,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<long[]>>(
                     Expression.NewArrayInit(typeof(long), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
             long[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1269,7 +1269,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<object[]>>(
                     Expression.NewArrayInit(typeof(object), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
             object[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1284,7 +1284,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<S[]>>(
                     Expression.NewArrayInit(typeof(S), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
             S[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1299,7 +1299,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<sbyte[]>>(
                     Expression.NewArrayInit(typeof(sbyte), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
             sbyte[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1314,7 +1314,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Sc[]>>(
                     Expression.NewArrayInit(typeof(Sc), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
             Sc[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1329,7 +1329,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Scs[]>>(
                     Expression.NewArrayInit(typeof(Scs), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
             Scs[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1344,7 +1344,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<short[]>>(
                     Expression.NewArrayInit(typeof(short), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
             short[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1359,7 +1359,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Sp[]>>(
                     Expression.NewArrayInit(typeof(Sp), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
             Sp[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1374,7 +1374,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Ss[]>>(
                     Expression.NewArrayInit(typeof(Ss), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
             Ss[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1389,7 +1389,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<string[]>>(
                     Expression.NewArrayInit(typeof(string), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
             string[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1404,7 +1404,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<uint[]>>(
                     Expression.NewArrayInit(typeof(uint), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
             uint[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1419,7 +1419,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<ulong[]>>(
                     Expression.NewArrayInit(typeof(ulong), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
             ulong[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1434,7 +1434,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<ushort[]>>(
                     Expression.NewArrayInit(typeof(ushort), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
             ushort[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1449,7 +1449,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<T[]>>(
                     Expression.NewArrayInit(typeof(T), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
             T[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1464,7 +1464,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Tc[]>>(
                     Expression.NewArrayInit(typeof(Tc), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
             Tc[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1479,7 +1479,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<TC[]>>(
                     Expression.NewArrayInit(typeof(TC), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
             TC[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1494,7 +1494,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Tcn[]>>(
                     Expression.NewArrayInit(typeof(Tcn), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
             Tcn[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1509,7 +1509,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<TCn[]>>(
                     Expression.NewArrayInit(typeof(TCn), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
             TCn[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -1524,7 +1524,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Ts[]>>(
                     Expression.NewArrayInit(typeof(Ts), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
             Ts[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayBoundsTests.cs
@@ -1354,7 +1354,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -1406,7 +1406,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -1458,7 +1458,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -1510,7 +1510,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -1562,7 +1562,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -1614,7 +1614,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -1666,7 +1666,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -1718,7 +1718,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -1770,7 +1770,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -1822,7 +1822,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -1874,7 +1874,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -1926,7 +1926,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -1978,7 +1978,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -2030,7 +2030,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -2082,7 +2082,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -2134,7 +2134,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -2186,7 +2186,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -2238,7 +2238,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -2294,7 +2294,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -2346,7 +2346,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -2398,7 +2398,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -2450,7 +2450,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -2502,7 +2502,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -2554,7 +2554,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -2606,7 +2606,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -2658,7 +2658,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -2710,7 +2710,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -2762,7 +2762,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -2814,7 +2814,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -2866,7 +2866,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -2918,7 +2918,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -2970,7 +2970,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -3022,7 +3022,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -3074,7 +3074,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -3126,7 +3126,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -3178,7 +3178,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -3234,7 +3234,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -3286,7 +3286,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -3338,7 +3338,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -3390,7 +3390,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -3442,7 +3442,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -3494,7 +3494,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -3546,7 +3546,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -3598,7 +3598,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -3650,7 +3650,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -3702,7 +3702,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -3754,7 +3754,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -3806,7 +3806,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -3858,7 +3858,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -3910,7 +3910,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -3962,7 +3962,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -4014,7 +4014,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -4066,7 +4066,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -4118,7 +4118,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -4174,7 +4174,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -4226,7 +4226,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -4278,7 +4278,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -4330,7 +4330,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -4382,7 +4382,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -4434,7 +4434,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -4486,7 +4486,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -4538,7 +4538,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -4590,7 +4590,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -4642,7 +4642,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -4694,7 +4694,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -4746,7 +4746,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -4798,7 +4798,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -4850,7 +4850,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -4902,7 +4902,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -4954,7 +4954,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -5006,7 +5006,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -5058,7 +5058,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -5114,7 +5114,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -5166,7 +5166,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -5218,7 +5218,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -5270,7 +5270,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -5322,7 +5322,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -5374,7 +5374,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -5426,7 +5426,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -5478,7 +5478,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -5530,7 +5530,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -5582,7 +5582,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -5634,7 +5634,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -5686,7 +5686,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -5738,7 +5738,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -5790,7 +5790,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -5842,7 +5842,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -5894,7 +5894,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -5946,7 +5946,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -5998,7 +5998,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -6054,7 +6054,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -6106,7 +6106,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -6158,7 +6158,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -6210,7 +6210,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -6262,7 +6262,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -6314,7 +6314,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -6366,7 +6366,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -6418,7 +6418,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -6470,7 +6470,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -6522,7 +6522,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -6574,7 +6574,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -6626,7 +6626,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -6678,7 +6678,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -6730,7 +6730,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -6782,7 +6782,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -6834,7 +6834,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -6886,7 +6886,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -6938,7 +6938,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -6994,7 +6994,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -7046,7 +7046,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -7098,7 +7098,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -7150,7 +7150,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -7202,7 +7202,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -7254,7 +7254,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -7306,7 +7306,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -7358,7 +7358,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -7410,7 +7410,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -7462,7 +7462,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -7514,7 +7514,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -7566,7 +7566,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -7618,7 +7618,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -7670,7 +7670,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -7722,7 +7722,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -7774,7 +7774,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -7826,7 +7826,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -7878,7 +7878,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;
@@ -7934,7 +7934,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(bool),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             // get the array
             bool[] result = null;
@@ -7986,7 +7986,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(byte),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             // get the array
             byte[] result = null;
@@ -8038,7 +8038,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(char),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             // get the array
             char[] result = null;
@@ -8090,7 +8090,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(decimal),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             // get the array
             decimal[] result = null;
@@ -8142,7 +8142,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(double),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             // get the array
             double[] result = null;
@@ -8194,7 +8194,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(float),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             // get the array
             float[] result = null;
@@ -8246,7 +8246,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(int),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             // get the array
             int[] result = null;
@@ -8298,7 +8298,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(long),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             // get the array
             long[] result = null;
@@ -8350,7 +8350,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(S),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // get the array
             S[] result = null;
@@ -8402,7 +8402,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(sbyte),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             // get the array
             sbyte[] result = null;
@@ -8454,7 +8454,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sc),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             // get the array
             Sc[] result = null;
@@ -8506,7 +8506,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Scs),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             // get the array
             Scs[] result = null;
@@ -8558,7 +8558,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(short),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             // get the array
             short[] result = null;
@@ -8610,7 +8610,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Sp),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             // get the array
             Sp[] result = null;
@@ -8662,7 +8662,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ss),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             // get the array
             Ss[] result = null;
@@ -8714,7 +8714,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(uint),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             // get the array
             uint[] result = null;
@@ -8766,7 +8766,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ulong),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             // get the array
             ulong[] result = null;
@@ -8818,7 +8818,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(ushort),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             // get the array
             ushort[] result = null;

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
@@ -1155,7 +1155,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(bool?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1166,7 +1166,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(byte?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1177,7 +1177,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(char?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1188,7 +1188,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(decimal?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1199,7 +1199,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(double?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1210,7 +1210,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(E?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1221,7 +1221,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(El?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1232,7 +1232,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(float?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1243,7 +1243,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(int?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1254,7 +1254,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(long?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1265,7 +1265,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(sbyte?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1276,7 +1276,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(short?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1287,7 +1287,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(S?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f = e.Compile();
+            Func<S?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1298,7 +1298,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Sc?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1309,7 +1309,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Scs?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f = e.Compile();
+            Func<Scs?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1320,7 +1320,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Sp?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f = e.Compile();
+            Func<Sp?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1331,7 +1331,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Ss?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?> f = e.Compile();
+            Func<Ss?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1342,7 +1342,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(uint?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1353,7 +1353,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(ulong?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1364,7 +1364,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(ushort?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 
@@ -1375,7 +1375,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.ArrayIndex(Expression.Constant(array, typeof(Ts?[])),
                         Expression.Constant(index, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f = e.Compile();
+            Func<Ts?> f = e.CompileForTest();
             return object.Equals(f(), array[index]);
         }
 

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
@@ -690,7 +690,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(bool?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -700,7 +700,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(byte?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -710,7 +710,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(char?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -720,7 +720,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(decimal?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -730,7 +730,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(double?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -740,7 +740,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(E?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -750,7 +750,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(El?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -760,7 +760,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(float?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -770,7 +770,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(int?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -780,7 +780,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(long?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -790,7 +790,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(sbyte?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -800,7 +800,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(S?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -810,7 +810,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Sc?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -820,7 +820,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Scs?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -830,7 +830,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Sp?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -840,7 +840,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Ss?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -850,7 +850,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(short?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -860,7 +860,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(uint?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -870,7 +870,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(ulong?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -880,7 +880,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(ushort?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 
@@ -890,7 +890,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int>>(
                     Expression.ArrayLength(Expression.Constant(array, typeof(Ts?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(array.Length, f());
         }
 

--- a/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
@@ -589,7 +589,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<bool?[]>>(
                     Expression.NewArrayInit(typeof(bool?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?[]> f = e.Compile();
+            Func<bool?[]> f = e.CompileForTest();
             bool?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -604,7 +604,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<byte?[]>>(
                     Expression.NewArrayInit(typeof(byte?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?[]> f = e.Compile();
+            Func<byte?[]> f = e.CompileForTest();
             byte?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -619,7 +619,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<char?[]>>(
                     Expression.NewArrayInit(typeof(char?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?[]> f = e.Compile();
+            Func<char?[]> f = e.CompileForTest();
             char?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -634,7 +634,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<decimal?[]>>(
                     Expression.NewArrayInit(typeof(decimal?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?[]> f = e.Compile();
+            Func<decimal?[]> f = e.CompileForTest();
             decimal?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -649,7 +649,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<double?[]>>(
                     Expression.NewArrayInit(typeof(double?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?[]> f = e.Compile();
+            Func<double?[]> f = e.CompileForTest();
             double?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -664,7 +664,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<E?[]>>(
                     Expression.NewArrayInit(typeof(E?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?[]> f = e.Compile();
+            Func<E?[]> f = e.CompileForTest();
             E?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -679,7 +679,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<El?[]>>(
                     Expression.NewArrayInit(typeof(El?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?[]> f = e.Compile();
+            Func<El?[]> f = e.CompileForTest();
             El?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -694,7 +694,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<float?[]>>(
                     Expression.NewArrayInit(typeof(float?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?[]> f = e.Compile();
+            Func<float?[]> f = e.CompileForTest();
             float?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -709,7 +709,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<int?[]>>(
                     Expression.NewArrayInit(typeof(int?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?[]> f = e.Compile();
+            Func<int?[]> f = e.CompileForTest();
             int?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -724,7 +724,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<long?[]>>(
                     Expression.NewArrayInit(typeof(long?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?[]> f = e.Compile();
+            Func<long?[]> f = e.CompileForTest();
             long?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -739,7 +739,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<S?[]>>(
                     Expression.NewArrayInit(typeof(S?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?[]> f = e.Compile();
+            Func<S?[]> f = e.CompileForTest();
             S?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -754,7 +754,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<sbyte?[]>>(
                     Expression.NewArrayInit(typeof(sbyte?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?[]> f = e.Compile();
+            Func<sbyte?[]> f = e.CompileForTest();
             sbyte?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Sc?[]>>(
                     Expression.NewArrayInit(typeof(Sc?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?[]> f = e.Compile();
+            Func<Sc?[]> f = e.CompileForTest();
             Sc?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -784,7 +784,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Scs?[]>>(
                     Expression.NewArrayInit(typeof(Scs?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?[]> f = e.Compile();
+            Func<Scs?[]> f = e.CompileForTest();
             Scs?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -799,7 +799,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<short?[]>>(
                     Expression.NewArrayInit(typeof(short?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?[]> f = e.Compile();
+            Func<short?[]> f = e.CompileForTest();
             short?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -814,7 +814,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Sp?[]>>(
                     Expression.NewArrayInit(typeof(Sp?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?[]> f = e.Compile();
+            Func<Sp?[]> f = e.CompileForTest();
             Sp?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -829,7 +829,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Ss?[]>>(
                     Expression.NewArrayInit(typeof(Ss?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?[]> f = e.Compile();
+            Func<Ss?[]> f = e.CompileForTest();
             Ss?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -844,7 +844,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<uint?[]>>(
                     Expression.NewArrayInit(typeof(uint?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?[]> f = e.Compile();
+            Func<uint?[]> f = e.CompileForTest();
             uint?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -859,7 +859,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<ulong?[]>>(
                     Expression.NewArrayInit(typeof(ulong?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?[]> f = e.Compile();
+            Func<ulong?[]> f = e.CompileForTest();
             ulong?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -874,7 +874,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<ushort?[]>>(
                     Expression.NewArrayInit(typeof(ushort?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?[]> f = e.Compile();
+            Func<ushort?[]> f = e.CompileForTest();
             ushort?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Array
                 Expression.Lambda<Func<Ts?[]>>(
                     Expression.NewArrayInit(typeof(Ts?), exprs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?[]> f = e.Compile();
+            Func<Ts?[]> f = e.CompileForTest();
             Ts?[] result = f();
             Assert.Equal(val.Length, result.Length);
             for (int i = 0; i < result.Length; i++)

--- a/src/System.Linq.Expressions/tests/Array/ObjectArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ObjectArrayBoundsTests.cs
@@ -1858,7 +1858,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -1910,7 +1910,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -1962,7 +1962,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -2014,7 +2014,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -2066,7 +2066,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -2118,7 +2118,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -2170,7 +2170,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -2222,7 +2222,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -2274,7 +2274,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -2326,7 +2326,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -2378,7 +2378,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -2434,7 +2434,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -2486,7 +2486,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -2538,7 +2538,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -2590,7 +2590,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -2642,7 +2642,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -2694,7 +2694,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -2746,7 +2746,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -2798,7 +2798,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -2850,7 +2850,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -2902,7 +2902,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -2954,7 +2954,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -3010,7 +3010,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -3062,7 +3062,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -3114,7 +3114,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -3166,7 +3166,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -3218,7 +3218,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -3270,7 +3270,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -3322,7 +3322,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -3374,7 +3374,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -3426,7 +3426,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -3478,7 +3478,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -3530,7 +3530,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -3586,7 +3586,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -3638,7 +3638,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -3690,7 +3690,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -3742,7 +3742,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -3794,7 +3794,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -3846,7 +3846,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -3898,7 +3898,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -3950,7 +3950,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -4002,7 +4002,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -4054,7 +4054,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -4106,7 +4106,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -4162,7 +4162,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -4214,7 +4214,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -4266,7 +4266,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -4318,7 +4318,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -4370,7 +4370,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -4422,7 +4422,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -4474,7 +4474,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -4526,7 +4526,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -4578,7 +4578,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -4630,7 +4630,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -4682,7 +4682,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -4738,7 +4738,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -4790,7 +4790,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -4842,7 +4842,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -4894,7 +4894,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -4946,7 +4946,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -4998,7 +4998,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -5050,7 +5050,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -5102,7 +5102,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -5154,7 +5154,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -5206,7 +5206,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -5258,7 +5258,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -5314,7 +5314,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -5366,7 +5366,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -5418,7 +5418,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -5470,7 +5470,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -5522,7 +5522,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -5574,7 +5574,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -5626,7 +5626,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -5678,7 +5678,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -5730,7 +5730,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -5782,7 +5782,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -5834,7 +5834,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -5890,7 +5890,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -5942,7 +5942,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -5994,7 +5994,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -6046,7 +6046,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -6098,7 +6098,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -6150,7 +6150,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -6202,7 +6202,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -6254,7 +6254,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -6306,7 +6306,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -6358,7 +6358,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -6410,7 +6410,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -6462,7 +6462,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6514,7 +6514,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6566,7 +6566,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6618,7 +6618,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6670,7 +6670,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6722,7 +6722,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6774,7 +6774,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6826,7 +6826,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6878,7 +6878,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -6930,7 +6930,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -6982,7 +6982,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7034,7 +7034,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7086,7 +7086,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7138,7 +7138,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7190,7 +7190,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7242,7 +7242,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7294,7 +7294,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7346,7 +7346,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7398,7 +7398,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7450,7 +7450,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7502,7 +7502,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7554,7 +7554,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7606,7 +7606,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7658,7 +7658,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7710,7 +7710,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7762,7 +7762,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7814,7 +7814,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7866,7 +7866,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7918,7 +7918,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7970,7 +7970,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -8022,7 +8022,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -8074,7 +8074,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -8126,7 +8126,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8178,7 +8178,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8230,7 +8230,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8282,7 +8282,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8334,7 +8334,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8386,7 +8386,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8438,7 +8438,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8490,7 +8490,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8542,7 +8542,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8594,7 +8594,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8646,7 +8646,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8698,7 +8698,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8750,7 +8750,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8802,7 +8802,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8854,7 +8854,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8906,7 +8906,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;

--- a/src/System.Linq.Expressions/tests/Array/ObjectNullableArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ObjectNullableArrayBoundsTests.cs
@@ -1852,7 +1852,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -1904,7 +1904,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -1956,7 +1956,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -2008,7 +2008,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -2060,7 +2060,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -2112,7 +2112,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -2164,7 +2164,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -2216,7 +2216,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -2268,7 +2268,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -2320,7 +2320,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -2372,7 +2372,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -2427,7 +2427,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -2479,7 +2479,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -2531,7 +2531,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -2583,7 +2583,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -2635,7 +2635,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -2687,7 +2687,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -2739,7 +2739,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -2791,7 +2791,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -2843,7 +2843,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -2895,7 +2895,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -2947,7 +2947,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -3002,7 +3002,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -3054,7 +3054,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -3106,7 +3106,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -3158,7 +3158,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -3210,7 +3210,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -3262,7 +3262,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -3314,7 +3314,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -3366,7 +3366,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -3418,7 +3418,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -3470,7 +3470,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -3522,7 +3522,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -3577,7 +3577,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -3629,7 +3629,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -3681,7 +3681,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -3733,7 +3733,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -3785,7 +3785,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -3837,7 +3837,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -3889,7 +3889,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -3941,7 +3941,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -3993,7 +3993,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -4045,7 +4045,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -4097,7 +4097,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -4152,7 +4152,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -4204,7 +4204,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -4256,7 +4256,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -4308,7 +4308,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -4360,7 +4360,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -4412,7 +4412,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -4464,7 +4464,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -4516,7 +4516,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -4568,7 +4568,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -4620,7 +4620,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -4672,7 +4672,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -4727,7 +4727,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -4779,7 +4779,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -4831,7 +4831,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -4883,7 +4883,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -4935,7 +4935,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -4987,7 +4987,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -5039,7 +5039,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -5091,7 +5091,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -5143,7 +5143,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -5195,7 +5195,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -5247,7 +5247,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -5302,7 +5302,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -5354,7 +5354,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -5406,7 +5406,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -5458,7 +5458,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -5510,7 +5510,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -5562,7 +5562,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -5614,7 +5614,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -5666,7 +5666,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -5718,7 +5718,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -5770,7 +5770,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -5822,7 +5822,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -5877,7 +5877,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(C),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // get the array
             C[] result = null;
@@ -5929,7 +5929,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(D),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // get the array
             D[] result = null;
@@ -5981,7 +5981,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Delegate),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             // get the array
             Delegate[] result = null;
@@ -6033,7 +6033,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(E),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             // get the array
             E[] result = null;
@@ -6085,7 +6085,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(El),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             // get the array
             El[] result = null;
@@ -6137,7 +6137,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Func<object>),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             // get the array
             Func<object>[] result = null;
@@ -6189,7 +6189,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(I),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             // get the array
             I[] result = null;
@@ -6241,7 +6241,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<C>),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<C>[] result = null;
@@ -6293,7 +6293,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(IEquatable<D>),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             // get the array
             IEquatable<D>[] result = null;
@@ -6345,7 +6345,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(object),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // get the array
             object[] result = null;
@@ -6397,7 +6397,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(string),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             // get the array
             string[] result = null;
@@ -6449,7 +6449,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6501,7 +6501,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6553,7 +6553,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6605,7 +6605,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6657,7 +6657,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6709,7 +6709,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6761,7 +6761,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6813,7 +6813,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(T),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             // get the array
             T[] result = null;
@@ -6865,7 +6865,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -6917,7 +6917,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -6969,7 +6969,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7021,7 +7021,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7073,7 +7073,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7125,7 +7125,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7177,7 +7177,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7229,7 +7229,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tc),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             // get the array
             Tc[] result = null;
@@ -7281,7 +7281,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7333,7 +7333,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7385,7 +7385,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7437,7 +7437,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7489,7 +7489,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7541,7 +7541,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7593,7 +7593,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7645,7 +7645,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TC),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             // get the array
             TC[] result = null;
@@ -7697,7 +7697,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7749,7 +7749,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7801,7 +7801,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7853,7 +7853,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7905,7 +7905,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -7957,7 +7957,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -8009,7 +8009,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -8061,7 +8061,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Tcn),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             // get the array
             Tcn[] result = null;
@@ -8113,7 +8113,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8165,7 +8165,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8217,7 +8217,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8269,7 +8269,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8321,7 +8321,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8373,7 +8373,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8425,7 +8425,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8477,7 +8477,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(TCn),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             // get the array
             TCn[] result = null;
@@ -8529,7 +8529,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8581,7 +8581,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8633,7 +8633,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8685,7 +8685,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8737,7 +8737,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8789,7 +8789,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8841,7 +8841,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;
@@ -8893,7 +8893,7 @@ namespace Tests.ExpressionCompiler.Array
                     Expression.NewArrayBounds(typeof(Ts),
                         Expression.Constant(size, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             // get the array
             Ts[] result = null;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -201,7 +201,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -249,7 +249,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -297,7 +297,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -345,7 +345,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -393,7 +393,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -441,7 +441,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -489,7 +489,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -537,7 +537,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -633,7 +633,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -681,7 +681,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -777,7 +777,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // add with expression tree
             float etResult = default(float);
@@ -825,7 +825,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // add with expression tree
             double etResult = default(double);
@@ -873,7 +873,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // add with expression tree
             decimal etResult = default(decimal);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // add with expression tree
             float etResult = default(float);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // add with expression tree
             double etResult = default(double);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // add with expression tree
             decimal etResult = default(decimal);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // add with expression tree
             float etResult = default(float);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // add with expression tree
             double etResult = default(double);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // add with expression tree
             decimal etResult = default(decimal);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -214,7 +214,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -308,7 +308,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -355,7 +355,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -402,7 +402,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -449,7 +449,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -496,7 +496,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -543,7 +543,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -590,7 +590,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -637,7 +637,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -684,7 +684,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -731,7 +731,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -778,7 +778,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // add with expression tree
             float etResult = default(float);
@@ -825,7 +825,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // add with expression tree
             double etResult = default(double);
@@ -872,7 +872,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // add with expression tree
             decimal etResult = default(decimal);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // add with expression tree
             ushort? etResult = default(ushort?);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // add with expression tree
             short? etResult = default(short?);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // add with expression tree
             uint? etResult = default(uint?);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // add with expression tree
             int? etResult = default(int?);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // add with expression tree
             ulong? etResult = default(ulong?);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // add with expression tree
             long? etResult = default(long?);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // add with expression tree
             float? etResult = default(float?);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // add with expression tree
             double? etResult = default(double?);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // add with expression tree
             decimal? etResult = default(decimal?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // add with expression tree
             ushort? etResult = default(ushort?);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // add with expression tree
             short? etResult = default(short?);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // add with expression tree
             uint? etResult = default(uint?);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // add with expression tree
             int? etResult = default(int?);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // add with expression tree
             ulong? etResult = default(ulong?);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // add with expression tree
             long? etResult = default(long?);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // add with expression tree
             float? etResult = default(float?);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // add with expression tree
             double? etResult = default(double?);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // add with expression tree
             decimal? etResult = default(decimal?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // add with expression tree
             ushort? etResult = default(ushort?);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // add with expression tree
             short? etResult = default(short?);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // add with expression tree
             uint? etResult = default(uint?);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // add with expression tree
             int? etResult = default(int?);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // add with expression tree
             ulong? etResult = default(ulong?);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // add with expression tree
             long? etResult = default(long?);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // add with expression tree
             float? etResult = default(float?);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // add with expression tree
             double? etResult = default(double?);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // add with expression tree
             decimal? etResult = default(decimal?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // add with expression tree
             ushort? etResult = default(ushort?);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // add with expression tree
             short? etResult = default(short?);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // add with expression tree
             uint? etResult = default(uint?);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // add with expression tree
             int? etResult = default(int?);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // add with expression tree
             ulong? etResult = default(ulong?);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // add with expression tree
             long? etResult = default(long?);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // add with expression tree
             float? etResult = default(float?);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // add with expression tree
             double? etResult = default(double?);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // add with expression tree
             decimal? etResult = default(decimal?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
@@ -182,7 +182,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(byte?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerByte")
                     ));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute with expression tree
             byte? etResult = default(byte);
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerSByte")
                     ));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte? etResult = default(sbyte);
@@ -292,7 +292,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerUShort")
                     ));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute with expression tree
             ushort? etResult = default(ushort);
@@ -347,7 +347,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(short?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerShort")
                     ));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute with expression tree
             short? etResult = default(short);
@@ -402,7 +402,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(uint?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerUInt")
                     ));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute with expression tree
             uint? etResult = default(uint);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerInt")
                     ));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute with expression tree
             int? etResult = default(int);
@@ -512,7 +512,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerULong")
                     ));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute with expression tree
             ulong? etResult = default(ulong);
@@ -567,7 +567,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(long?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerLong")
                     ));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute with expression tree
             long? etResult = default(long);
@@ -622,7 +622,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(float?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerFloat")
                     ));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute with expression tree
             float? etResult = default(float);
@@ -677,7 +677,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(double?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerDouble")
                     ));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute with expression tree
             double? etResult = default(double);
@@ -732,7 +732,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerDecimal")
                     ));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute with expression tree
             decimal? etResult = default(decimal);
@@ -787,7 +787,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(char?)),
                         typeof(BinaryNullablePowerTests).GetTypeInfo().GetDeclaredMethod("PowerChar")
                     ));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute with expression tree
             char? etResult = default(char);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // add with expression tree
             ushort? etResult = default(ushort?);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // add with expression tree
             short? etResult = default(short?);
@@ -288,7 +288,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // add with expression tree
             uint? etResult = default(uint?);
@@ -335,7 +335,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // add with expression tree
             int? etResult = default(int?);
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // add with expression tree
             ulong? etResult = default(ulong?);
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // add with expression tree
             long? etResult = default(long?);
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // add with expression tree
             float? etResult = default(float?);
@@ -523,7 +523,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // add with expression tree
             double? etResult = default(double?);
@@ -570,7 +570,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // add with expression tree
             decimal? etResult = default(decimal?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -121,7 +121,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // shift with expression tree
             byte etResult = default(byte);
@@ -184,7 +184,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // shift with expression tree
             sbyte etResult = default(sbyte);
@@ -247,7 +247,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // shift with expression tree
             ushort etResult = default(ushort);
@@ -310,7 +310,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // shift with expression tree
             short etResult = default(short);
@@ -373,7 +373,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // shift with expression tree
             uint etResult = default(uint);
@@ -436,7 +436,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // shift with expression tree
             int etResult = default(int);
@@ -499,7 +499,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // shift with expression tree
             ulong etResult = default(ulong);
@@ -562,7 +562,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(b, typeof(int)))
                     );
 
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // shift with expression tree
             long etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -200,7 +200,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -247,7 +247,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // add with expression tree
             ushort etResult = default(ushort);
@@ -294,7 +294,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);
@@ -388,7 +388,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -435,7 +435,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // add with expression tree
             uint etResult = default(uint);
@@ -482,7 +482,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -529,7 +529,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -576,7 +576,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -623,7 +623,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // add with expression tree
             ulong etResult = default(ulong);
@@ -670,7 +670,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -717,7 +717,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -764,7 +764,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // add with expression tree
             float etResult = default(float);
@@ -811,7 +811,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // add with expression tree
             double etResult = default(double);
@@ -858,7 +858,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // add with expression tree
             decimal etResult = default(decimal);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -19,7 +19,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Return(target, variable),
                 Expression.Label(target, Expression.Default(typeof(int)))
                 );
-            Assert.Equal(42, Expression.Lambda<Func<int>>(exp).Compile()());
+            Assert.Equal(42, Expression.Lambda<Func<int>>(exp).CompileForTest()());
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace System.Linq.Expressions.Tests
                 new ParameterExpression[] { variable },
                 Expression.Assign(variable, Expression.Constant(42))
                 );
-            Assert.Equal(42, Expression.Lambda<Func<int>>(exp).Compile()());
+            Assert.Equal(42, Expression.Lambda<Func<int>>(exp).CompileForTest()());
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Return(target, variable),
                 Expression.Label(target, Expression.Default(typeof(object)))
                 );
-            Assert.Equal("Hello", Expression.Lambda<Func<object>>(exp).Compile()());
+            Assert.Equal("Hello", Expression.Lambda<Func<object>>(exp).CompileForTest()());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -128,7 +128,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute with expression tree
             byte etResult = default(byte);
@@ -175,7 +175,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte etResult = default(sbyte);
@@ -222,7 +222,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute with expression tree
             ushort etResult = default(ushort);
@@ -269,7 +269,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute with expression tree
             short etResult = default(short);
@@ -316,7 +316,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute with expression tree
             uint etResult = default(uint);
@@ -363,7 +363,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute with expression tree
             int etResult = default(int);
@@ -410,7 +410,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute with expression tree
             ulong etResult = default(ulong);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute with expression tree
             long etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -128,7 +128,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute with expression tree
             byte etResult = default(byte);
@@ -175,7 +175,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte etResult = default(sbyte);
@@ -222,7 +222,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute with expression tree
             ushort etResult = default(ushort);
@@ -269,7 +269,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute with expression tree
             short etResult = default(short);
@@ -316,7 +316,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute with expression tree
             uint etResult = default(uint);
@@ -363,7 +363,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute with expression tree
             int etResult = default(int);
@@ -410,7 +410,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute with expression tree
             ulong etResult = default(ulong);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute with expression tree
             long etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
@@ -128,7 +128,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute with expression tree
             byte? etResult = default(byte);
@@ -175,7 +175,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte? etResult = default(sbyte);
@@ -222,7 +222,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute with expression tree
             ushort? etResult = default(ushort);
@@ -269,7 +269,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute with expression tree
             short? etResult = default(short);
@@ -316,7 +316,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute with expression tree
             uint? etResult = default(uint);
@@ -363,7 +363,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute with expression tree
             int? etResult = default(int);
@@ -410,7 +410,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute with expression tree
             ulong? etResult = default(ulong);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute with expression tree
             long? etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
@@ -128,7 +128,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute with expression tree
             byte? etResult = default(byte);
@@ -175,7 +175,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte? etResult = default(sbyte);
@@ -222,7 +222,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute with expression tree
             ushort? etResult = default(ushort);
@@ -269,7 +269,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute with expression tree
             short? etResult = default(short);
@@ -316,7 +316,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute with expression tree
             uint? etResult = default(uint);
@@ -363,7 +363,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute with expression tree
             int? etResult = default(int);
@@ -410,7 +410,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute with expression tree
             ulong? etResult = default(ulong);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute with expression tree
             long? etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
@@ -128,7 +128,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute with expression tree
             byte? etResult = default(byte);
@@ -175,7 +175,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte? etResult = default(sbyte);
@@ -222,7 +222,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute with expression tree
             ushort? etResult = default(ushort);
@@ -269,7 +269,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute with expression tree
             short? etResult = default(short);
@@ -316,7 +316,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute with expression tree
             uint? etResult = default(uint);
@@ -363,7 +363,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute with expression tree
             int? etResult = default(int);
@@ -410,7 +410,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute with expression tree
             ulong? etResult = default(ulong);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute with expression tree
             long? etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -128,7 +128,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute with expression tree
             byte etResult = default(byte);
@@ -175,7 +175,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte etResult = default(sbyte);
@@ -222,7 +222,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute with expression tree
             ushort etResult = default(ushort);
@@ -269,7 +269,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute with expression tree
             short etResult = default(short);
@@ -316,7 +316,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute with expression tree
             uint etResult = default(uint);
@@ -363,7 +363,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute with expression tree
             int etResult = default(int);
@@ -410,7 +410,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute with expression tree
             ulong etResult = default(ulong);
@@ -457,7 +457,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute with expression tree
             long etResult = default(long);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -600,7 +600,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute with expression tree
             byte etResult = default(byte);
@@ -647,7 +647,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(C)),
                         Expression.Constant(b, typeof(C))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute with expression tree
             C etResult = default(C);
@@ -694,7 +694,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute with expression tree
             char etResult = default(char);
@@ -741,7 +741,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(D)),
                         Expression.Constant(b, typeof(D))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute with expression tree
             D etResult = default(D);
@@ -788,7 +788,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute with expression tree
             decimal etResult = default(decimal);
@@ -835,7 +835,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Delegate)),
                         Expression.Constant(b, typeof(Delegate))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
 
             // compute with expression tree
             Delegate etResult = default(Delegate);
@@ -882,7 +882,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute with expression tree
             double etResult = default(double);
@@ -929,7 +929,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(E?)),
                         Expression.Constant(b, typeof(E))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute with expression tree
             E etResult = default(E);
@@ -976,7 +976,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(El?)),
                         Expression.Constant(b, typeof(El))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute with expression tree
             El etResult = default(El);
@@ -1023,7 +1023,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute with expression tree
             float etResult = default(float);
@@ -1070,7 +1070,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Func<object>)),
                         Expression.Constant(b, typeof(Func<object>))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.CompileForTest();
 
             // compute with expression tree
             Func<object> etResult = default(Func<object>);
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(I)),
                         Expression.Constant(b, typeof(I))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute with expression tree
             I etResult = default(I);
@@ -1164,7 +1164,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(IEquatable<C>)),
                         Expression.Constant(b, typeof(IEquatable<C>))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute with expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -1211,7 +1211,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(IEquatable<D>)),
                         Expression.Constant(b, typeof(IEquatable<D>))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute with expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -1258,7 +1258,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute with expression tree
             int etResult = default(int);
@@ -1305,7 +1305,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute with expression tree
             long etResult = default(long);
@@ -1352,7 +1352,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(object)),
                         Expression.Constant(b, typeof(object))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute with expression tree
             object etResult = default(object);
@@ -1399,7 +1399,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(S?)),
                         Expression.Constant(b, typeof(S))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
 
             // compute with expression tree
             S etResult = default(S);
@@ -1446,7 +1446,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte etResult = default(sbyte);
@@ -1493,7 +1493,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Sc?)),
                         Expression.Constant(b, typeof(Sc))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc> f = e.Compile();
+            Func<Sc> f = e.CompileForTest();
 
             // compute with expression tree
             Sc etResult = default(Sc);
@@ -1540,7 +1540,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Scs?)),
                         Expression.Constant(b, typeof(Scs))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f = e.Compile();
+            Func<Scs> f = e.CompileForTest();
 
             // compute with expression tree
             Scs etResult = default(Scs);
@@ -1587,7 +1587,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute with expression tree
             short etResult = default(short);
@@ -1634,7 +1634,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Sp?)),
                         Expression.Constant(b, typeof(Sp))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f = e.Compile();
+            Func<Sp> f = e.CompileForTest();
 
             // compute with expression tree
             Sp etResult = default(Sp);
@@ -1681,7 +1681,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Ss?)),
                         Expression.Constant(b, typeof(Ss))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss> f = e.Compile();
+            Func<Ss> f = e.CompileForTest();
 
             // compute with expression tree
             Ss etResult = default(Ss);
@@ -1728,7 +1728,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(string)),
                         Expression.Constant(b, typeof(string))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string> f = e.Compile();
+            Func<string> f = e.CompileForTest();
 
             // compute with expression tree
             string etResult = default(string);
@@ -1775,7 +1775,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute with expression tree
             uint etResult = default(uint);
@@ -1822,7 +1822,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute with expression tree
             ulong etResult = default(ulong);
@@ -1869,7 +1869,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute with expression tree
             ushort etResult = default(ushort);
@@ -1916,7 +1916,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Tc)),
                         Expression.Constant(b, typeof(Tc))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.CompileForTest();
 
             // compute with expression tree
             Tc etResult = default(Tc);
@@ -1963,7 +1963,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(TC)),
                         Expression.Constant(b, typeof(TC))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC> f = e.Compile();
+            Func<TC> f = e.CompileForTest();
 
             // compute with expression tree
             TC etResult = default(TC);
@@ -2010,7 +2010,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Tcn)),
                         Expression.Constant(b, typeof(Tcn))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn> f = e.Compile();
+            Func<Tcn> f = e.CompileForTest();
 
             // compute with expression tree
             Tcn etResult = default(Tcn);
@@ -2057,7 +2057,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(TCn)),
                         Expression.Constant(b, typeof(TCn))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn> f = e.Compile();
+            Func<TCn> f = e.CompileForTest();
 
             // compute with expression tree
             TCn etResult = default(TCn);
@@ -2104,7 +2104,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Ts?)),
                         Expression.Constant(b, typeof(Ts))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
 
             // compute with expression tree
             Ts etResult = default(Ts);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryNullableCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryNullableCoalesceTests.cs
@@ -339,7 +339,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             // compute with expression tree
             bool? etResult = default(bool?);
@@ -386,7 +386,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute with expression tree
             byte? etResult = default(byte?);
@@ -433,7 +433,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute with expression tree
             char? etResult = default(char?);
@@ -480,7 +480,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute with expression tree
             decimal? etResult = default(decimal?);
@@ -527,7 +527,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute with expression tree
             double? etResult = default(double?);
@@ -574,7 +574,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(E?)),
                         Expression.Constant(b, typeof(E?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute with expression tree
             E? etResult = default(E?);
@@ -621,7 +621,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(El?)),
                         Expression.Constant(b, typeof(El?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute with expression tree
             El? etResult = default(El?);
@@ -668,7 +668,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute with expression tree
             float? etResult = default(float?);
@@ -715,7 +715,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute with expression tree
             int? etResult = default(int?);
@@ -762,7 +762,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute with expression tree
             long? etResult = default(long?);
@@ -809,7 +809,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(S?)),
                         Expression.Constant(b, typeof(S?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f = e.Compile();
+            Func<S?> f = e.CompileForTest();
 
             // compute with expression tree
             S? etResult = default(S?);
@@ -856,7 +856,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute with expression tree
             sbyte? etResult = default(sbyte?);
@@ -903,7 +903,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Sc?)),
                         Expression.Constant(b, typeof(Sc?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
 
             // compute with expression tree
             Sc? etResult = default(Sc?);
@@ -950,7 +950,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Scs?)),
                         Expression.Constant(b, typeof(Scs?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f = e.Compile();
+            Func<Scs?> f = e.CompileForTest();
 
             // compute with expression tree
             Scs? etResult = default(Scs?);
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute with expression tree
             short? etResult = default(short?);
@@ -1044,7 +1044,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Sp?)),
                         Expression.Constant(b, typeof(Sp?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f = e.Compile();
+            Func<Sp?> f = e.CompileForTest();
 
             // compute with expression tree
             Sp? etResult = default(Sp?);
@@ -1091,7 +1091,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Ss?)),
                         Expression.Constant(b, typeof(Ss?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?> f = e.Compile();
+            Func<Ss?> f = e.CompileForTest();
 
             // compute with expression tree
             Ss? etResult = default(Ss?);
@@ -1138,7 +1138,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute with expression tree
             uint? etResult = default(uint?);
@@ -1185,7 +1185,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute with expression tree
             ulong? etResult = default(ulong?);
@@ -1232,7 +1232,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute with expression tree
             ushort? etResult = default(ushort?);
@@ -1279,7 +1279,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(Ts?)),
                         Expression.Constant(b, typeof(Ts?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f = e.Compile();
+            Func<Ts?> f = e.CompileForTest();
 
             // compute with expression tree
             Ts? etResult = default(Ts?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
@@ -193,7 +193,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -240,7 +240,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -287,7 +287,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -334,7 +334,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -428,7 +428,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -475,7 +475,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -522,7 +522,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -569,7 +569,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -616,7 +616,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -663,7 +663,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -710,7 +710,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -757,7 +757,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
@@ -193,7 +193,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -240,7 +240,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -287,7 +287,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -334,7 +334,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -428,7 +428,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -475,7 +475,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -522,7 +522,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -569,7 +569,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -616,7 +616,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -663,7 +663,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -710,7 +710,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -757,7 +757,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableEqualTests.cs
@@ -193,7 +193,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -240,7 +240,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -287,7 +287,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -334,7 +334,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -428,7 +428,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -475,7 +475,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -522,7 +522,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -569,7 +569,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -616,7 +616,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -663,7 +663,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -710,7 +710,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -757,7 +757,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanOrEqualTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanOrEqualTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanTests.cs
@@ -180,7 +180,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -321,7 +321,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -368,7 +368,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -415,7 +415,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -462,7 +462,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -556,7 +556,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -603,7 +603,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -650,7 +650,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -697,7 +697,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableNotEqualTests.cs
@@ -193,7 +193,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -240,7 +240,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -287,7 +287,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -334,7 +334,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -428,7 +428,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -475,7 +475,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -522,7 +522,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -569,7 +569,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -616,7 +616,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -663,7 +663,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -710,7 +710,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -757,7 +757,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -76,7 +76,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -170,7 +170,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute with expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
@@ -76,7 +76,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             // compute with expression tree
             bool? etResult = default(bool?);
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             // compute with expression tree
             bool? etResult = default(bool?);
@@ -170,7 +170,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             // compute with expression tree
             bool? etResult = default(bool?);
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Binary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             // compute with expression tree
             bool? etResult = default(bool?);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(item, item.GetType()),
                     Expression.Constant(item, item.GetType())
                 );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(null, type),
                 Expression.Constant(null, type)
                 );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -38,7 +38,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(null, item.GetType()),
                     Expression.Constant(item, item.GetType())
                 );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(item, item.GetType()),
                     Expression.Constant(null, item.GetType())
                 );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(x, typeof(object)),
                     Expression.Constant(y, typeof(object))
                 );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(x),
                     Expression.Constant(y)
                 );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -102,7 +102,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(item, typeof(IComparable)),
                 Expression.Constant(item, typeof(IComparable))
             );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(x, typeof(IComparable)),
                 Expression.Constant(y, typeof(IComparable))
             );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(item, typeof(IComparable)),
                 Expression.Constant(item)
             );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(item),
                 Expression.Constant(item, typeof(IComparable))
             );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(item, item.GetType()),
                     Expression.Constant(item, item.GetType())
                 );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(null, type),
                 Expression.Constant(null, type)
                 );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -38,7 +38,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(null, item.GetType()),
                     Expression.Constant(item, item.GetType())
                 );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(item, item.GetType()),
                     Expression.Constant(null, item.GetType())
                 );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(x, typeof(object)),
                     Expression.Constant(y, typeof(object))
                 );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(x),
                     Expression.Constant(y)
                 );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -102,7 +102,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(item, typeof(IComparable)),
                 Expression.Constant(item, typeof(IComparable))
             );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(x, typeof(IComparable)),
                 Expression.Constant(y, typeof(IComparable))
             );
-            Assert.True(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.True(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(item, typeof(IComparable)),
                 Expression.Constant(item)
             );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Theory]
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(item),
                 Expression.Constant(item, typeof(IComparable))
             );
-            Assert.False(Expression.Lambda<Func<bool>>(exp).Compile()());
+            Assert.False(Expression.Lambda<Func<bool>>(exp).CompileForTest()());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -111,7 +111,7 @@ namespace Tests.ExpressionCompiler.Block
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(e, typeof(object)));
 
-            Func<object> c = f.Compile();
+            Func<object> c = f.CompileForTest();
             Assert.Equal(o, c());
 
 #if FEATURE_INTERPRET

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -151,7 +151,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Enum>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E?)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Enum etResult = default(Enum);
@@ -196,7 +196,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -286,7 +286,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -331,7 +331,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S?)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<S> etResult = default(IEquatable<S>);
@@ -376,7 +376,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -466,7 +466,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -511,7 +511,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -891,7 +891,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -936,7 +936,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<I>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute the value with the expression tree
             I etResult = default(I);
@@ -981,7 +981,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -1026,7 +1026,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -1071,7 +1071,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -1116,7 +1116,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D[] etResult = default(D[]);
@@ -1161,7 +1161,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<C> etResult = default(IEnumerable<C>);
@@ -1206,7 +1206,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<D>> f = e.Compile();
+            Func<IEnumerable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<D> etResult = default(IEnumerable<D>);
@@ -1251,7 +1251,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<I> etResult = default(IEnumerable<I>);
@@ -1296,7 +1296,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<object> etResult = default(IEnumerable<object>);
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<C> etResult = default(IList<C>);
@@ -1386,7 +1386,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<D>> f = e.Compile();
+            Func<IList<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<D> etResult = default(IList<D>);
@@ -1431,7 +1431,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<I> etResult = default(IList<I>);
@@ -1476,7 +1476,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<object> etResult = default(IList<object>);
@@ -1521,7 +1521,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -1566,7 +1566,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -1611,7 +1611,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<I>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute the value with the expression tree
             I etResult = default(I);
@@ -1656,7 +1656,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -1701,7 +1701,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -1746,7 +1746,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -1791,7 +1791,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -1836,7 +1836,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Func<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Delegate)), typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Func<object> etResult = default(Func<object>);
@@ -1881,7 +1881,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Delegate)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -1926,7 +1926,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Enum>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Enum etResult = default(Enum);
@@ -1971,7 +1971,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2016,7 +2016,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Enum)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2061,7 +2061,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Delegate>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Func<object>)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Delegate etResult = default(Delegate);
@@ -2106,7 +2106,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(I)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -2151,7 +2151,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(I)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -2196,7 +2196,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(I)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2241,7 +2241,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2286,7 +2286,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2331,7 +2331,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -2376,7 +2376,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -2421,7 +2421,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2466,7 +2466,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2511,7 +2511,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -2556,7 +2556,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -2601,7 +2601,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2646,7 +2646,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2691,7 +2691,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2736,7 +2736,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2781,7 +2781,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2826,7 +2826,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S[] etResult = default(S[]);
@@ -2871,7 +2871,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2916,7 +2916,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2961,7 +2961,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3006,7 +3006,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3051,7 +3051,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -3096,7 +3096,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3141,7 +3141,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -3186,7 +3186,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S[] etResult = default(S[]);
@@ -3231,7 +3231,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -3276,7 +3276,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -3321,7 +3321,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -3366,7 +3366,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -3411,7 +3411,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Delegate>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Delegate etResult = default(Delegate);
@@ -3456,7 +3456,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Enum>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Enum etResult = default(Enum);
@@ -3501,7 +3501,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<I>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute the value with the expression tree
             I etResult = default(I);
@@ -3546,7 +3546,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -3591,7 +3591,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -3636,7 +3636,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -3681,7 +3681,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3726,7 +3726,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<C> etResult = default(IEnumerable<C>);
@@ -3771,7 +3771,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<I> etResult = default(IEnumerable<I>);
@@ -3816,7 +3816,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<object> etResult = default(IEnumerable<object>);
@@ -3861,7 +3861,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<C> etResult = default(IList<C>);
@@ -3906,7 +3906,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<I> etResult = default(IList<I>);
@@ -3951,7 +3951,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<object> etResult = default(IList<object>);
@@ -3996,7 +3996,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<S> etResult = default(IEquatable<S>);
@@ -4041,7 +4041,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4086,7 +4086,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -4131,7 +4131,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S[])), typeof(IEnumerable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<S>> f = e.Compile();
+            Func<IEnumerable<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<S> etResult = default(IEnumerable<S>);
@@ -4176,7 +4176,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S[])), typeof(IList<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<S>> f = e.Compile();
+            Func<IList<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<S> etResult = default(IList<S>);
@@ -4221,7 +4221,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(ValueType)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4266,7 +4266,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(T)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4311,7 +4311,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Tc)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4356,7 +4356,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4401,7 +4401,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);

--- a/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
@@ -151,7 +151,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Enum>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Enum etResult = default(Enum);
@@ -196,7 +196,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -286,7 +286,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -331,7 +331,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S?)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<S> etResult = default(IEquatable<S>);
@@ -376,7 +376,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(S?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(S?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -466,7 +466,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -511,7 +511,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -1075,7 +1075,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -1120,7 +1120,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<I>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute the value with the expression tree
             I etResult = default(I);
@@ -1165,7 +1165,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -1210,7 +1210,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -1255,7 +1255,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -1300,7 +1300,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D[] etResult = default(D[]);
@@ -1345,7 +1345,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<C> etResult = default(IEnumerable<C>);
@@ -1390,7 +1390,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<D>> f = e.Compile();
+            Func<IEnumerable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<D> etResult = default(IEnumerable<D>);
@@ -1435,7 +1435,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<I> etResult = default(IEnumerable<I>);
@@ -1480,7 +1480,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<object> etResult = default(IEnumerable<object>);
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<C> etResult = default(IList<C>);
@@ -1570,7 +1570,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<D>> f = e.Compile();
+            Func<IList<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<D> etResult = default(IList<D>);
@@ -1615,7 +1615,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<I> etResult = default(IList<I>);
@@ -1660,7 +1660,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<object> etResult = default(IList<object>);
@@ -1705,7 +1705,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -1750,7 +1750,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -1795,7 +1795,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<I>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute the value with the expression tree
             I etResult = default(I);
@@ -1840,7 +1840,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -1885,7 +1885,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -1930,7 +1930,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -1975,7 +1975,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(D[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2020,7 +2020,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Func<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(Delegate)), typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Func<object> etResult = default(Func<object>);
@@ -2065,7 +2065,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Delegate)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2110,7 +2110,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Enum>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Enum etResult = default(Enum);
@@ -2155,7 +2155,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2200,7 +2200,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(Enum)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -2245,7 +2245,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Enum)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2290,7 +2290,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Delegate>>(
                     Expression.Convert(Expression.Constant(value, typeof(Func<object>)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Delegate etResult = default(Delegate);
@@ -2335,7 +2335,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(I)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -2380,7 +2380,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(I)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -2425,7 +2425,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(I)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2470,7 +2470,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2515,7 +2515,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2560,7 +2560,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2605,7 +2605,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2650,7 +2650,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2695,7 +2695,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -2740,7 +2740,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -2785,7 +2785,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S[] etResult = default(S[]);
@@ -2830,7 +2830,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<C>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -2875,7 +2875,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<C>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -2920,7 +2920,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<C>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -2965,7 +2965,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<D>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -3010,7 +3010,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<D>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -3055,7 +3055,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<D>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -3100,7 +3100,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<S>)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S etResult = default(S);
@@ -3145,7 +3145,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3190,7 +3190,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -3235,7 +3235,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3280,7 +3280,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3325,7 +3325,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -3370,7 +3370,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -3415,7 +3415,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object[] etResult = default(object[]);
@@ -3460,7 +3460,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S[] etResult = default(S[]);
@@ -3505,7 +3505,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -3550,7 +3550,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -3595,7 +3595,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C etResult = default(C);
@@ -3640,7 +3640,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             // compute the value with the expression tree
             D etResult = default(D);
@@ -3685,7 +3685,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Delegate>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Delegate etResult = default(Delegate);
@@ -3730,7 +3730,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -3775,7 +3775,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Enum>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Enum etResult = default(Enum);
@@ -3820,7 +3820,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<I>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             // compute the value with the expression tree
             I etResult = default(I);
@@ -3865,7 +3865,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<C> etResult = default(IEquatable<C>);
@@ -3910,7 +3910,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<D> etResult = default(IEquatable<D>);
@@ -3955,7 +3955,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -4000,7 +4000,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S etResult = default(S);
@@ -4045,7 +4045,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -4090,7 +4090,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             // compute the value with the expression tree
             C[] etResult = default(C[]);
@@ -4135,7 +4135,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<C> etResult = default(IEnumerable<C>);
@@ -4180,7 +4180,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<I> etResult = default(IEnumerable<I>);
@@ -4225,7 +4225,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<object> etResult = default(IEnumerable<object>);
@@ -4270,7 +4270,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<C> etResult = default(IList<C>);
@@ -4315,7 +4315,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<I> etResult = default(IList<I>);
@@ -4360,7 +4360,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<object> etResult = default(IList<object>);
@@ -4405,7 +4405,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEquatable<S> etResult = default(IEquatable<S>);
@@ -4450,7 +4450,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(S)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4495,7 +4495,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(S)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -4540,7 +4540,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IEnumerable<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S[])), typeof(IEnumerable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<S>> f = e.Compile();
+            Func<IEnumerable<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IEnumerable<S> etResult = default(IEnumerable<S>);
@@ -4585,7 +4585,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<IList<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S[])), typeof(IList<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<S>> f = e.Compile();
+            Func<IList<S>> f = e.CompileForTest();
 
             // compute the value with the expression tree
             IList<S> etResult = default(IList<S>);
@@ -4630,7 +4630,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -4675,7 +4675,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4720,7 +4720,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<S>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
 
             // compute the value with the expression tree
             S etResult = default(S);
@@ -4765,7 +4765,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<T>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(T)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T> f = e.Compile();
+            Func<T> f = e.CompileForTest();
 
             // compute the value with the expression tree
             T etResult = default(T);
@@ -4810,7 +4810,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Tc>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Tc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Tc etResult = default(Tc);
@@ -4855,7 +4855,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Ts>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Ts etResult = default(Ts);
@@ -4900,7 +4900,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(T)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4945,7 +4945,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Tc)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -4990,7 +4990,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             // compute the value with the expression tree
             object etResult = default(object);
@@ -5035,7 +5035,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ValueType etResult = default(ValueType);
@@ -5080,7 +5080,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<Ts>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
 
             // compute the value with the expression tree
             Ts etResult = default(Ts);

--- a/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
@@ -151,7 +151,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E?)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -196,7 +196,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -241,7 +241,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -286,7 +286,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -331,7 +331,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S?)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -376,7 +376,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -466,7 +466,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -476,7 +476,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 

--- a/src/System.Linq.Expressions/tests/Cast/IsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsTests.cs
@@ -1075,7 +1075,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1120,7 +1120,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1165,7 +1165,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1210,7 +1210,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1255,7 +1255,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1300,7 +1300,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1345,7 +1345,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1390,7 +1390,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1435,7 +1435,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1480,7 +1480,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1570,7 +1570,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1615,7 +1615,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1660,7 +1660,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1705,7 +1705,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1750,7 +1750,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1795,7 +1795,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1840,7 +1840,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1885,7 +1885,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1930,7 +1930,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -1975,7 +1975,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2020,7 +2020,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Delegate)), typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2065,7 +2065,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Delegate)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2110,7 +2110,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -2120,7 +2120,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -2130,7 +2130,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Enum)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2175,7 +2175,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Enum)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2220,7 +2220,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Func<object>)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2265,7 +2265,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(I)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2310,7 +2310,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(I)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2355,7 +2355,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(I)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2400,7 +2400,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2445,7 +2445,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2490,7 +2490,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2535,7 +2535,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2580,7 +2580,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2625,7 +2625,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2670,7 +2670,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2715,7 +2715,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2760,7 +2760,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<C>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2805,7 +2805,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<C>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2850,7 +2850,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<C>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2895,7 +2895,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<D>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2940,7 +2940,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<D>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -2985,7 +2985,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<D>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3030,7 +3030,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<S>)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3075,7 +3075,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3120,7 +3120,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3165,7 +3165,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3210,7 +3210,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3255,7 +3255,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3300,7 +3300,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3345,7 +3345,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3390,7 +3390,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3435,7 +3435,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -3445,7 +3445,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -3455,7 +3455,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3500,7 +3500,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3545,7 +3545,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3590,7 +3590,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3635,7 +3635,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3680,7 +3680,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3725,7 +3725,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3770,7 +3770,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3815,7 +3815,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3860,7 +3860,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3905,7 +3905,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3950,7 +3950,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -3995,7 +3995,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4040,7 +4040,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4085,7 +4085,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4130,7 +4130,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4175,7 +4175,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4220,7 +4220,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4265,7 +4265,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -4275,7 +4275,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -4285,7 +4285,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -4295,7 +4295,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S[])), typeof(IEnumerable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4340,7 +4340,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S[])), typeof(IList<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4385,7 +4385,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4430,7 +4430,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4475,7 +4475,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4520,7 +4520,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(T)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4565,7 +4565,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Tc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4610,7 +4610,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4655,7 +4655,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(T)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4700,7 +4700,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Tc)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);
@@ -4745,7 +4745,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -4755,7 +4755,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -4765,7 +4765,7 @@ namespace Tests.ExpressionCompiler.Cast
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             // compute the value with the expression tree
             bool etResult = default(bool);

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.cs
@@ -305,7 +305,7 @@ namespace Tests.Expressions
     {
         public static int F(Expression<Func<int>> f)
         {
-            return f.Compile()();
+            return f.CompileForTest()();
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
@@ -419,7 +419,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<bool[]>>(
                     Expression.Constant(value, typeof(bool[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<byte[]>>(
                     Expression.Constant(value, typeof(byte[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -439,7 +439,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<C[]>>(
                     Expression.Constant(value, typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -449,7 +449,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<char[]>>(
                     Expression.Constant(value, typeof(char[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -459,7 +459,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<D[]>>(
                     Expression.Constant(value, typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -469,7 +469,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<decimal[]>>(
                     Expression.Constant(value, typeof(decimal[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -479,7 +479,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Delegate[]>>(
                     Expression.Constant(value, typeof(Delegate[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -489,7 +489,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<double[]>>(
                     Expression.Constant(value, typeof(double[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -499,7 +499,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<E[]>>(
                     Expression.Constant(value, typeof(E[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<El[]>>(
                     Expression.Constant(value, typeof(El[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -519,7 +519,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<float[]>>(
                     Expression.Constant(value, typeof(float[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -529,7 +529,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Func<object>[]>>(
                     Expression.Constant(value, typeof(Func<object>[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -539,7 +539,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<I[]>>(
                     Expression.Constant(value, typeof(I[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -549,7 +549,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<IEquatable<C>[]>>(
                     Expression.Constant(value, typeof(IEquatable<C>[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -559,7 +559,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<IEquatable<D>[]>>(
                     Expression.Constant(value, typeof(IEquatable<D>[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -569,7 +569,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<int[]>>(
                     Expression.Constant(value, typeof(int[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -579,7 +579,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<long[]>>(
                     Expression.Constant(value, typeof(long[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -589,7 +589,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<object[]>>(
                     Expression.Constant(value, typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -599,7 +599,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<S[]>>(
                     Expression.Constant(value, typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -609,7 +609,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<sbyte[]>>(
                     Expression.Constant(value, typeof(sbyte[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -619,7 +619,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Sc[]>>(
                     Expression.Constant(value, typeof(Sc[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Scs[]>>(
                     Expression.Constant(value, typeof(Scs[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -639,7 +639,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<short[]>>(
                     Expression.Constant(value, typeof(short[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -649,7 +649,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Sp[]>>(
                     Expression.Constant(value, typeof(Sp[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -659,7 +659,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Ss[]>>(
                     Expression.Constant(value, typeof(Ss[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -669,7 +669,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<string[]>>(
                     Expression.Constant(value, typeof(string[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -679,7 +679,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<uint[]>>(
                     Expression.Constant(value, typeof(uint[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -689,7 +689,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<ulong[]>>(
                     Expression.Constant(value, typeof(ulong[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -699,7 +699,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<ushort[]>>(
                     Expression.Constant(value, typeof(ushort[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -709,7 +709,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Ts[]>>(
                     Expression.Constant(value, typeof(Ts[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -719,7 +719,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<T[]>>(
                     Expression.Constant(value, typeof(T[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Tc[]>>(
                     Expression.Constant(value, typeof(Tc[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -739,7 +739,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Tcn[]>>(
                     Expression.Constant(value, typeof(Tcn[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<TC[]>>(
                     Expression.Constant(value, typeof(TC[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -759,7 +759,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<TCn[]>>(
                     Expression.Constant(value, typeof(TCn[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
@@ -232,7 +232,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<bool?>>(
                     Expression.Constant(value, typeof(bool?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -242,7 +242,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<byte?>>(
                     Expression.Constant(value, typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -252,7 +252,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<char?>>(
                     Expression.Constant(value, typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -262,7 +262,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Constant(value, typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -272,7 +272,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<double?>>(
                     Expression.Constant(value, typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -282,7 +282,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<E?>>(
                     Expression.Constant(value, typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -292,7 +292,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<El?>>(
                     Expression.Constant(value, typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -302,7 +302,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<float?>>(
                     Expression.Constant(value, typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -312,7 +312,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<int?>>(
                     Expression.Constant(value, typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -322,7 +322,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<long?>>(
                     Expression.Constant(value, typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -332,7 +332,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<S?>>(
                     Expression.Constant(value, typeof(S?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f = e.Compile();
+            Func<S?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -342,7 +342,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Constant(value, typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -352,7 +352,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Sc?>>(
                     Expression.Constant(value, typeof(Sc?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -362,7 +362,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Scs?>>(
                     Expression.Constant(value, typeof(Scs?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f = e.Compile();
+            Func<Scs?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -372,7 +372,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<short?>>(
                     Expression.Constant(value, typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -382,7 +382,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Sp?>>(
                     Expression.Constant(value, typeof(Sp?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f = e.Compile();
+            Func<Sp?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -392,7 +392,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Ss?>>(
                     Expression.Constant(value, typeof(Ss?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?> f = e.Compile();
+            Func<Ss?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -402,7 +402,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<uint?>>(
                     Expression.Constant(value, typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -412,7 +412,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Constant(value, typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -422,7 +422,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Constant(value, typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -432,7 +432,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Ts?>>(
                     Expression.Constant(value, typeof(Ts?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f = e.Compile();
+            Func<Ts?> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -419,7 +419,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<bool>>(
                     Expression.Constant(value, typeof(bool)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -429,7 +429,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<byte>>(
                     Expression.Constant(value, typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -439,7 +439,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<C>>(
                     Expression.Constant(value, typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -449,7 +449,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<char>>(
                     Expression.Constant(value, typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -459,7 +459,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<D>>(
                     Expression.Constant(value, typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -469,7 +469,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<decimal>>(
                     Expression.Constant(value, typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -479,7 +479,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Delegate>>(
                     Expression.Constant(value, typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -489,7 +489,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<double>>(
                     Expression.Constant(value, typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -499,7 +499,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<E>>(
                     Expression.Constant(value, typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<El>>(
                     Expression.Constant(value, typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -519,7 +519,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<float>>(
                     Expression.Constant(value, typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -529,7 +529,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Func<object>>>(
                     Expression.Constant(value, typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -539,7 +539,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<I>>(
                     Expression.Constant(value, typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -549,7 +549,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Constant(value, typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -559,7 +559,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Constant(value, typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -569,7 +569,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<int>>(
                     Expression.Constant(value, typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -579,7 +579,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<long>>(
                     Expression.Constant(value, typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -589,7 +589,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<object>>(
                     Expression.Constant(value, typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -599,7 +599,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<S>>(
                     Expression.Constant(value, typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -609,7 +609,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Constant(value, typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -619,7 +619,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Sc>>(
                     Expression.Constant(value, typeof(Sc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc> f = e.Compile();
+            Func<Sc> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Scs>>(
                     Expression.Constant(value, typeof(Scs)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f = e.Compile();
+            Func<Scs> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -639,7 +639,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<short>>(
                     Expression.Constant(value, typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -649,7 +649,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Sp>>(
                     Expression.Constant(value, typeof(Sp)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f = e.Compile();
+            Func<Sp> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -659,7 +659,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Ss>>(
                     Expression.Constant(value, typeof(Ss)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss> f = e.Compile();
+            Func<Ss> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -669,7 +669,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<string>>(
                     Expression.Constant(value, typeof(string)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string> f = e.Compile();
+            Func<string> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -679,7 +679,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<uint>>(
                     Expression.Constant(value, typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -689,7 +689,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<ulong>>(
                     Expression.Constant(value, typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -699,7 +699,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<ushort>>(
                     Expression.Constant(value, typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -709,7 +709,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Ts>>(
                     Expression.Constant(value, typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -719,7 +719,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<T>>(
                     Expression.Constant(value, typeof(T)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T> f = e.Compile();
+            Func<T> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Tc>>(
                     Expression.Constant(value, typeof(Tc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -739,7 +739,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<Tcn>>(
                     Expression.Constant(value, typeof(Tcn)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn> f = e.Compile();
+            Func<Tcn> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<TC>>(
                     Expression.Constant(value, typeof(TC)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC> f = e.Compile();
+            Func<TC> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 
@@ -759,7 +759,7 @@ namespace Tests.ExpressionCompiler.Constant
                 Expression.Lambda<Func<TCn>>(
                     Expression.Constant(value, typeof(TCn)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn> f = e.Compile();
+            Func<TCn> f = e.CompileForTest();
             Assert.Equal(value, f());
         }
 

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -6935,7 +6935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -6983,7 +6983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -7031,7 +7031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -7079,7 +7079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -7127,7 +7127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -7175,7 +7175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -7223,7 +7223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -7271,7 +7271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -7319,7 +7319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -7367,7 +7367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -7415,7 +7415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -7463,7 +7463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -7511,7 +7511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -7559,7 +7559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -7607,7 +7607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -7655,7 +7655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -7703,7 +7703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -7751,7 +7751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -7799,7 +7799,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -7847,7 +7847,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -7895,7 +7895,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -7943,7 +7943,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -7991,7 +7991,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -8039,7 +8039,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -8087,7 +8087,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -8135,7 +8135,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -8183,7 +8183,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -8231,7 +8231,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -8279,7 +8279,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -8327,7 +8327,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -8375,7 +8375,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -8423,7 +8423,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -8471,7 +8471,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -8519,7 +8519,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -8567,7 +8567,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -8615,7 +8615,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -8663,7 +8663,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -8711,7 +8711,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -8759,7 +8759,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -8807,7 +8807,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -8855,7 +8855,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -8903,7 +8903,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -8951,7 +8951,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -8999,7 +8999,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -9047,7 +9047,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -9095,7 +9095,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -9143,7 +9143,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -9191,7 +9191,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -9239,7 +9239,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -9287,7 +9287,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -9335,7 +9335,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -9383,7 +9383,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -9431,7 +9431,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -9479,7 +9479,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -9527,7 +9527,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -9575,7 +9575,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(byte?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -9623,7 +9623,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -9671,7 +9671,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -9719,7 +9719,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -9767,7 +9767,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -9815,7 +9815,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -9863,7 +9863,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -9911,7 +9911,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -9959,7 +9959,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -10007,7 +10007,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -10055,7 +10055,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -10103,7 +10103,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -10151,7 +10151,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -10199,7 +10199,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -10247,7 +10247,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -10295,7 +10295,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -10343,7 +10343,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -10391,7 +10391,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -10439,7 +10439,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -10487,7 +10487,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -10535,7 +10535,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -10583,7 +10583,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -10631,7 +10631,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -10679,7 +10679,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -10727,7 +10727,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -10775,7 +10775,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -10823,7 +10823,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -10871,7 +10871,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -10919,7 +10919,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -10967,7 +10967,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -11015,7 +11015,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -11063,7 +11063,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -11111,7 +11111,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -11159,7 +11159,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -11207,7 +11207,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -11255,7 +11255,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -11303,7 +11303,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -11351,7 +11351,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -11399,7 +11399,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -11447,7 +11447,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -11495,7 +11495,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -11543,7 +11543,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -11591,7 +11591,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -11639,7 +11639,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -11687,7 +11687,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -11735,7 +11735,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -11783,7 +11783,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -11831,7 +11831,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -11879,7 +11879,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -11927,7 +11927,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -11975,7 +11975,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -12023,7 +12023,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -12071,7 +12071,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -12119,7 +12119,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -12167,7 +12167,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -12215,7 +12215,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -12263,7 +12263,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(char?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -12311,7 +12311,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -12359,7 +12359,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -12407,7 +12407,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -12455,7 +12455,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -12503,7 +12503,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -12551,7 +12551,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -12599,7 +12599,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -12647,7 +12647,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -12695,7 +12695,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -12743,7 +12743,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -12791,7 +12791,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -12839,7 +12839,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -12887,7 +12887,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -12935,7 +12935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -12983,7 +12983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -13031,7 +13031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -13079,7 +13079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -13127,7 +13127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -13175,7 +13175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -13223,7 +13223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -13271,7 +13271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -13319,7 +13319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -13367,7 +13367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -13415,7 +13415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -13463,7 +13463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -13511,7 +13511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -13559,7 +13559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -13607,7 +13607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -13655,7 +13655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -13703,7 +13703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -13751,7 +13751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -13799,7 +13799,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -13847,7 +13847,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -13895,7 +13895,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -13943,7 +13943,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -13991,7 +13991,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -14039,7 +14039,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -14087,7 +14087,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -14135,7 +14135,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -14183,7 +14183,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -14231,7 +14231,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -14279,7 +14279,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -14327,7 +14327,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -14375,7 +14375,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -14423,7 +14423,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -14471,7 +14471,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -14519,7 +14519,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -14567,7 +14567,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(decimal?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -14615,7 +14615,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -14663,7 +14663,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -14711,7 +14711,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -14759,7 +14759,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -14807,7 +14807,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -14855,7 +14855,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -14903,7 +14903,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -14951,7 +14951,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -14999,7 +14999,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -15047,7 +15047,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -15095,7 +15095,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -15143,7 +15143,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -15191,7 +15191,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -15239,7 +15239,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -15287,7 +15287,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -15335,7 +15335,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -15383,7 +15383,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -15431,7 +15431,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -15479,7 +15479,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -15527,7 +15527,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -15575,7 +15575,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -15623,7 +15623,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -15671,7 +15671,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -15719,7 +15719,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -15767,7 +15767,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -15815,7 +15815,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -15863,7 +15863,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -15911,7 +15911,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -15959,7 +15959,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -16007,7 +16007,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -16055,7 +16055,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -16103,7 +16103,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -16151,7 +16151,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -16199,7 +16199,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -16247,7 +16247,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -16295,7 +16295,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -16343,7 +16343,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -16391,7 +16391,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -16439,7 +16439,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -16487,7 +16487,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -16535,7 +16535,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -16583,7 +16583,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -16631,7 +16631,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -16679,7 +16679,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -16727,7 +16727,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -16775,7 +16775,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -16823,7 +16823,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -16871,7 +16871,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -16919,7 +16919,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -16967,7 +16967,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -17015,7 +17015,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -17063,7 +17063,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -17111,7 +17111,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -17159,7 +17159,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -17207,7 +17207,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -17255,7 +17255,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(double?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -17303,7 +17303,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -17351,7 +17351,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -17399,7 +17399,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -17447,7 +17447,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -17495,7 +17495,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -17543,7 +17543,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -17591,7 +17591,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -17639,7 +17639,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -17687,7 +17687,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -17735,7 +17735,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -17783,7 +17783,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -17831,7 +17831,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -17879,7 +17879,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -17927,7 +17927,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -17975,7 +17975,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -18023,7 +18023,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -18071,7 +18071,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -18119,7 +18119,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -18167,7 +18167,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -18215,7 +18215,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -18263,7 +18263,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -18311,7 +18311,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -18359,7 +18359,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -18407,7 +18407,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -18455,7 +18455,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -18503,7 +18503,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -18551,7 +18551,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -18599,7 +18599,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -18647,7 +18647,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -18695,7 +18695,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -18743,7 +18743,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -18791,7 +18791,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -18839,7 +18839,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -18887,7 +18887,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -18935,7 +18935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -18983,7 +18983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -19031,7 +19031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -19079,7 +19079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -19127,7 +19127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -19175,7 +19175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -19223,7 +19223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -19271,7 +19271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -19319,7 +19319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -19367,7 +19367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -19415,7 +19415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -19463,7 +19463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -19511,7 +19511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -19559,7 +19559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -19607,7 +19607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -19655,7 +19655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -19703,7 +19703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -19751,7 +19751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(E?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -19799,7 +19799,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -19847,7 +19847,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -19895,7 +19895,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -19943,7 +19943,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -19991,7 +19991,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -20039,7 +20039,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -20087,7 +20087,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -20135,7 +20135,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -20183,7 +20183,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -20231,7 +20231,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -20279,7 +20279,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -20327,7 +20327,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -20375,7 +20375,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -20423,7 +20423,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -20471,7 +20471,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -20519,7 +20519,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -20567,7 +20567,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -20615,7 +20615,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -20663,7 +20663,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -20711,7 +20711,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -20759,7 +20759,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -20807,7 +20807,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -20855,7 +20855,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -20903,7 +20903,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -20951,7 +20951,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -20999,7 +20999,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -21047,7 +21047,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -21095,7 +21095,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -21143,7 +21143,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -21191,7 +21191,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -21239,7 +21239,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -21287,7 +21287,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -21335,7 +21335,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -21383,7 +21383,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -21431,7 +21431,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -21479,7 +21479,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -21527,7 +21527,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -21575,7 +21575,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -21623,7 +21623,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -21671,7 +21671,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -21719,7 +21719,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -21767,7 +21767,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -21815,7 +21815,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -21863,7 +21863,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -21911,7 +21911,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -21959,7 +21959,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -22007,7 +22007,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -22055,7 +22055,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -22103,7 +22103,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -22151,7 +22151,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -22199,7 +22199,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -22247,7 +22247,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(El?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -22295,7 +22295,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -22343,7 +22343,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -22391,7 +22391,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -22439,7 +22439,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -22487,7 +22487,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -22535,7 +22535,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -22583,7 +22583,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -22631,7 +22631,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -22679,7 +22679,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -22727,7 +22727,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -22775,7 +22775,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -22823,7 +22823,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -22871,7 +22871,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -22919,7 +22919,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -22967,7 +22967,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -23015,7 +23015,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -23063,7 +23063,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -23111,7 +23111,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -23159,7 +23159,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -23207,7 +23207,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -23255,7 +23255,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -23303,7 +23303,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -23351,7 +23351,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -23399,7 +23399,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -23447,7 +23447,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -23495,7 +23495,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -23543,7 +23543,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -23591,7 +23591,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -23639,7 +23639,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -23687,7 +23687,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -23735,7 +23735,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -23783,7 +23783,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -23831,7 +23831,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -23879,7 +23879,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -23927,7 +23927,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -23975,7 +23975,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -24023,7 +24023,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -24071,7 +24071,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -24119,7 +24119,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -24167,7 +24167,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -24215,7 +24215,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -24263,7 +24263,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -24311,7 +24311,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -24359,7 +24359,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -24407,7 +24407,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -24455,7 +24455,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -24503,7 +24503,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -24551,7 +24551,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -24599,7 +24599,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -24647,7 +24647,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -24695,7 +24695,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -24743,7 +24743,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -24791,7 +24791,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -24839,7 +24839,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -24887,7 +24887,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -24935,7 +24935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(float?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -24983,7 +24983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -25031,7 +25031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -25079,7 +25079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -25127,7 +25127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -25175,7 +25175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -25223,7 +25223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -25271,7 +25271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -25319,7 +25319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -25367,7 +25367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -25415,7 +25415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -25463,7 +25463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -25511,7 +25511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -25559,7 +25559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -25607,7 +25607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -25655,7 +25655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -25703,7 +25703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -25751,7 +25751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -25799,7 +25799,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -25847,7 +25847,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -25895,7 +25895,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -25943,7 +25943,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -25991,7 +25991,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -26039,7 +26039,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -26087,7 +26087,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -26135,7 +26135,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -26183,7 +26183,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -26231,7 +26231,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -26279,7 +26279,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -26327,7 +26327,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -26375,7 +26375,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -26423,7 +26423,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -26471,7 +26471,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -26519,7 +26519,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -26567,7 +26567,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -26615,7 +26615,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -26663,7 +26663,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -26711,7 +26711,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -26759,7 +26759,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -26807,7 +26807,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -26855,7 +26855,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -26903,7 +26903,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -26951,7 +26951,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -26999,7 +26999,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -27047,7 +27047,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -27095,7 +27095,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -27143,7 +27143,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -27191,7 +27191,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -27239,7 +27239,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -27287,7 +27287,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -27335,7 +27335,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -27383,7 +27383,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -27431,7 +27431,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -27479,7 +27479,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -27527,7 +27527,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -27575,7 +27575,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -27623,7 +27623,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(int?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -27671,7 +27671,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -27719,7 +27719,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -27767,7 +27767,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -27815,7 +27815,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -27863,7 +27863,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -27911,7 +27911,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -27959,7 +27959,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -28007,7 +28007,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -28055,7 +28055,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -28103,7 +28103,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -28151,7 +28151,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -28199,7 +28199,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -28247,7 +28247,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -28295,7 +28295,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -28343,7 +28343,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -28391,7 +28391,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -28439,7 +28439,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -28487,7 +28487,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -28535,7 +28535,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -28583,7 +28583,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -28631,7 +28631,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -28679,7 +28679,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -28727,7 +28727,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -28775,7 +28775,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -28823,7 +28823,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -28871,7 +28871,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -28919,7 +28919,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -28967,7 +28967,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -29015,7 +29015,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -29063,7 +29063,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -29111,7 +29111,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -29159,7 +29159,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -29207,7 +29207,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -29255,7 +29255,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -29303,7 +29303,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -29351,7 +29351,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -29399,7 +29399,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -29447,7 +29447,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -29495,7 +29495,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -29543,7 +29543,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -29591,7 +29591,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -29639,7 +29639,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -29687,7 +29687,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -29735,7 +29735,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -29783,7 +29783,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -29831,7 +29831,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -29879,7 +29879,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -29927,7 +29927,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -29975,7 +29975,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -30023,7 +30023,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -30071,7 +30071,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -30119,7 +30119,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -30167,7 +30167,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -30215,7 +30215,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -30263,7 +30263,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -30311,7 +30311,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(long?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -30359,7 +30359,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -30407,7 +30407,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -30455,7 +30455,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -30503,7 +30503,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -30551,7 +30551,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -30599,7 +30599,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -30647,7 +30647,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -30695,7 +30695,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -30743,7 +30743,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -30791,7 +30791,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -30839,7 +30839,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -30887,7 +30887,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -30935,7 +30935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -30983,7 +30983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -31031,7 +31031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -31079,7 +31079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -31127,7 +31127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -31175,7 +31175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -31223,7 +31223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -31271,7 +31271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -31319,7 +31319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -31367,7 +31367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -31415,7 +31415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -31463,7 +31463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -31511,7 +31511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -31559,7 +31559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -31607,7 +31607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -31655,7 +31655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -31703,7 +31703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -31751,7 +31751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -31799,7 +31799,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -31847,7 +31847,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -31895,7 +31895,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -31943,7 +31943,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -31991,7 +31991,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -32039,7 +32039,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -32087,7 +32087,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -32135,7 +32135,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -32183,7 +32183,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -32231,7 +32231,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -32279,7 +32279,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -32327,7 +32327,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -32375,7 +32375,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -32423,7 +32423,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -32471,7 +32471,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -32519,7 +32519,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -32567,7 +32567,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -32615,7 +32615,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -32663,7 +32663,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -32711,7 +32711,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -32759,7 +32759,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -32807,7 +32807,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -32855,7 +32855,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -32903,7 +32903,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -32951,7 +32951,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -32999,7 +32999,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(sbyte?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -33047,7 +33047,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -33095,7 +33095,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -33143,7 +33143,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -33191,7 +33191,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -33239,7 +33239,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -33287,7 +33287,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -33335,7 +33335,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -33383,7 +33383,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -33431,7 +33431,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -33479,7 +33479,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -33527,7 +33527,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -33575,7 +33575,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -33623,7 +33623,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -33671,7 +33671,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -33719,7 +33719,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -33767,7 +33767,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -33815,7 +33815,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -33863,7 +33863,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -33911,7 +33911,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -33959,7 +33959,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -34007,7 +34007,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -34055,7 +34055,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -34103,7 +34103,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -34151,7 +34151,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -34199,7 +34199,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -34247,7 +34247,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -34295,7 +34295,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -34343,7 +34343,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -34391,7 +34391,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -34439,7 +34439,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -34487,7 +34487,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -34535,7 +34535,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -34583,7 +34583,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -34631,7 +34631,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -34679,7 +34679,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -34727,7 +34727,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -34775,7 +34775,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -34823,7 +34823,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -34871,7 +34871,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -34919,7 +34919,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -34967,7 +34967,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -35015,7 +35015,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -35063,7 +35063,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -35111,7 +35111,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -35159,7 +35159,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -35207,7 +35207,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -35255,7 +35255,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -35303,7 +35303,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -35351,7 +35351,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -35399,7 +35399,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -35447,7 +35447,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -35495,7 +35495,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -35543,7 +35543,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -35591,7 +35591,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -35639,7 +35639,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -35687,7 +35687,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(short?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -35735,7 +35735,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -35783,7 +35783,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -35831,7 +35831,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -35879,7 +35879,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -35927,7 +35927,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -35975,7 +35975,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -36023,7 +36023,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -36071,7 +36071,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -36119,7 +36119,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -36167,7 +36167,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -36215,7 +36215,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -36263,7 +36263,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -36311,7 +36311,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -36359,7 +36359,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -36407,7 +36407,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -36455,7 +36455,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -36503,7 +36503,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -36551,7 +36551,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -36599,7 +36599,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -36647,7 +36647,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -36695,7 +36695,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -36743,7 +36743,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -36791,7 +36791,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -36839,7 +36839,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -36887,7 +36887,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -36935,7 +36935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -36983,7 +36983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -37031,7 +37031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -37079,7 +37079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -37127,7 +37127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -37175,7 +37175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -37223,7 +37223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -37271,7 +37271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -37319,7 +37319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -37367,7 +37367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -37415,7 +37415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -37463,7 +37463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -37511,7 +37511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -37559,7 +37559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -37607,7 +37607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -37655,7 +37655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -37703,7 +37703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -37751,7 +37751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -37799,7 +37799,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -37847,7 +37847,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -37895,7 +37895,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -37943,7 +37943,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -37991,7 +37991,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -38039,7 +38039,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -38087,7 +38087,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -38135,7 +38135,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -38183,7 +38183,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -38231,7 +38231,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -38279,7 +38279,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -38327,7 +38327,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -38375,7 +38375,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(uint?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -38423,7 +38423,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -38471,7 +38471,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -38519,7 +38519,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -38567,7 +38567,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -38615,7 +38615,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -38663,7 +38663,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -38711,7 +38711,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -38759,7 +38759,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -38807,7 +38807,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -38855,7 +38855,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -38903,7 +38903,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -38951,7 +38951,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -38999,7 +38999,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -39047,7 +39047,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -39095,7 +39095,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -39143,7 +39143,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -39191,7 +39191,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -39239,7 +39239,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -39287,7 +39287,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -39335,7 +39335,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -39383,7 +39383,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -39431,7 +39431,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -39479,7 +39479,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -39527,7 +39527,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -39575,7 +39575,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -39623,7 +39623,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -39671,7 +39671,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -39719,7 +39719,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -39767,7 +39767,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -39815,7 +39815,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -39863,7 +39863,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -39911,7 +39911,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -39959,7 +39959,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -40007,7 +40007,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -40055,7 +40055,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -40103,7 +40103,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -40151,7 +40151,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -40199,7 +40199,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -40247,7 +40247,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -40295,7 +40295,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -40343,7 +40343,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -40391,7 +40391,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -40439,7 +40439,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -40487,7 +40487,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -40535,7 +40535,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -40583,7 +40583,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -40631,7 +40631,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -40679,7 +40679,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -40727,7 +40727,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -40775,7 +40775,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -40823,7 +40823,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -40871,7 +40871,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -40919,7 +40919,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -40967,7 +40967,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -41015,7 +41015,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -41063,7 +41063,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ulong?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -41111,7 +41111,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -41159,7 +41159,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -41207,7 +41207,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -41255,7 +41255,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -41303,7 +41303,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -41351,7 +41351,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -41399,7 +41399,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -41447,7 +41447,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -41495,7 +41495,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -41543,7 +41543,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -41591,7 +41591,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -41639,7 +41639,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -41687,7 +41687,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -41735,7 +41735,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -41783,7 +41783,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -41831,7 +41831,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -41879,7 +41879,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -41927,7 +41927,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -41975,7 +41975,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -42023,7 +42023,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -42071,7 +42071,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -42119,7 +42119,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -42167,7 +42167,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -42215,7 +42215,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -42263,7 +42263,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -42311,7 +42311,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -42359,7 +42359,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -42407,7 +42407,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -42455,7 +42455,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -42503,7 +42503,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -42551,7 +42551,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -42599,7 +42599,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -42647,7 +42647,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -42695,7 +42695,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -42743,7 +42743,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -42791,7 +42791,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -42839,7 +42839,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -42887,7 +42887,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -42935,7 +42935,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -42983,7 +42983,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -43031,7 +43031,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -43079,7 +43079,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -43127,7 +43127,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -43175,7 +43175,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -43223,7 +43223,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -43271,7 +43271,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -43319,7 +43319,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -43367,7 +43367,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -43415,7 +43415,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -43463,7 +43463,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -43511,7 +43511,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -43559,7 +43559,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -43607,7 +43607,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -43655,7 +43655,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -43703,7 +43703,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -43751,7 +43751,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.ConvertChecked(Expression.Constant(value, typeof(ushort?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -6934,7 +6934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -6982,7 +6982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -7030,7 +7030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -7078,7 +7078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -7126,7 +7126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -7174,7 +7174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -7222,7 +7222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -7270,7 +7270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -7318,7 +7318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -7366,7 +7366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -7414,7 +7414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -7462,7 +7462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -7510,7 +7510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -7558,7 +7558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -7606,7 +7606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -7654,7 +7654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -7702,7 +7702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -7750,7 +7750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -7798,7 +7798,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -7846,7 +7846,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -7894,7 +7894,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -7942,7 +7942,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -7990,7 +7990,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -8038,7 +8038,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -8086,7 +8086,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -8134,7 +8134,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -8182,7 +8182,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -8230,7 +8230,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -8278,7 +8278,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -8326,7 +8326,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -8374,7 +8374,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -8422,7 +8422,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -8470,7 +8470,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -8518,7 +8518,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -8566,7 +8566,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -8614,7 +8614,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -8662,7 +8662,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -8710,7 +8710,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -8758,7 +8758,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -8806,7 +8806,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -8854,7 +8854,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -8902,7 +8902,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -8950,7 +8950,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -8998,7 +8998,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -9046,7 +9046,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -9094,7 +9094,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -9142,7 +9142,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -9190,7 +9190,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -9238,7 +9238,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -9286,7 +9286,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -9334,7 +9334,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -9382,7 +9382,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -9430,7 +9430,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -9478,7 +9478,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -9526,7 +9526,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -9574,7 +9574,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(byte?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -9622,7 +9622,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -9670,7 +9670,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -9718,7 +9718,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -9766,7 +9766,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -9814,7 +9814,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -9862,7 +9862,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -9910,7 +9910,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -9958,7 +9958,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -10006,7 +10006,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -10054,7 +10054,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -10102,7 +10102,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -10150,7 +10150,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -10198,7 +10198,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -10246,7 +10246,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -10294,7 +10294,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -10342,7 +10342,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -10390,7 +10390,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -10438,7 +10438,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -10486,7 +10486,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -10534,7 +10534,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -10582,7 +10582,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -10630,7 +10630,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -10678,7 +10678,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -10726,7 +10726,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -10774,7 +10774,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -10822,7 +10822,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -10870,7 +10870,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -10918,7 +10918,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -10966,7 +10966,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -11014,7 +11014,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -11062,7 +11062,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -11110,7 +11110,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -11158,7 +11158,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -11206,7 +11206,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -11254,7 +11254,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -11302,7 +11302,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -11350,7 +11350,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -11398,7 +11398,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -11446,7 +11446,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -11494,7 +11494,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -11542,7 +11542,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -11590,7 +11590,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -11638,7 +11638,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -11686,7 +11686,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -11734,7 +11734,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -11782,7 +11782,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -11830,7 +11830,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -11878,7 +11878,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -11926,7 +11926,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -11974,7 +11974,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -12022,7 +12022,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -12070,7 +12070,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -12118,7 +12118,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -12166,7 +12166,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -12214,7 +12214,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -12262,7 +12262,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(char?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -12310,7 +12310,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -12358,7 +12358,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -12406,7 +12406,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -12454,7 +12454,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -12502,7 +12502,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -12550,7 +12550,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -12598,7 +12598,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -12646,7 +12646,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -12694,7 +12694,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -12742,7 +12742,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -12790,7 +12790,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -12838,7 +12838,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -12886,7 +12886,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -12934,7 +12934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -12982,7 +12982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -13030,7 +13030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -13078,7 +13078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -13126,7 +13126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -13174,7 +13174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -13222,7 +13222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -13270,7 +13270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -13318,7 +13318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -13366,7 +13366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -13414,7 +13414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -13462,7 +13462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -13510,7 +13510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -13558,7 +13558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -13606,7 +13606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -13654,7 +13654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -13702,7 +13702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -13750,7 +13750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -13798,7 +13798,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -13846,7 +13846,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -13894,7 +13894,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -13942,7 +13942,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -13990,7 +13990,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -14038,7 +14038,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -14086,7 +14086,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -14134,7 +14134,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -14182,7 +14182,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -14230,7 +14230,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -14278,7 +14278,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -14326,7 +14326,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -14374,7 +14374,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -14422,7 +14422,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -14470,7 +14470,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -14518,7 +14518,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -14566,7 +14566,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(decimal?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -14614,7 +14614,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -14662,7 +14662,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -14710,7 +14710,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -14758,7 +14758,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -14806,7 +14806,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -14854,7 +14854,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -14902,7 +14902,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -14950,7 +14950,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -14998,7 +14998,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -15046,7 +15046,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -15094,7 +15094,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -15142,7 +15142,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -15190,7 +15190,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -15238,7 +15238,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -15286,7 +15286,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -15334,7 +15334,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -15382,7 +15382,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -15430,7 +15430,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -15478,7 +15478,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -15526,7 +15526,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -15574,7 +15574,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -15622,7 +15622,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -15670,7 +15670,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -15718,7 +15718,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -15766,7 +15766,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -15814,7 +15814,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -15862,7 +15862,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -15910,7 +15910,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -15958,7 +15958,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -16006,7 +16006,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -16054,7 +16054,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -16102,7 +16102,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -16150,7 +16150,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -16198,7 +16198,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -16246,7 +16246,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -16294,7 +16294,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -16342,7 +16342,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -16390,7 +16390,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -16438,7 +16438,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -16486,7 +16486,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -16534,7 +16534,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -16582,7 +16582,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -16630,7 +16630,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -16678,7 +16678,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -16726,7 +16726,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -16774,7 +16774,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -16822,7 +16822,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -16870,7 +16870,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -16918,7 +16918,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -16966,7 +16966,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -17014,7 +17014,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -17062,7 +17062,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -17110,7 +17110,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -17158,7 +17158,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -17206,7 +17206,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -17254,7 +17254,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(double?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -17302,7 +17302,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -17350,7 +17350,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -17398,7 +17398,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -17446,7 +17446,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -17494,7 +17494,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -17542,7 +17542,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -17590,7 +17590,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -17638,7 +17638,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -17686,7 +17686,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -17734,7 +17734,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -17782,7 +17782,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -17830,7 +17830,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -17878,7 +17878,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -17926,7 +17926,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -17974,7 +17974,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -18022,7 +18022,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -18070,7 +18070,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -18118,7 +18118,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -18166,7 +18166,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -18214,7 +18214,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -18262,7 +18262,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -18310,7 +18310,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -18358,7 +18358,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -18406,7 +18406,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -18454,7 +18454,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -18502,7 +18502,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -18550,7 +18550,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -18598,7 +18598,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -18646,7 +18646,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -18694,7 +18694,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -18742,7 +18742,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -18790,7 +18790,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -18838,7 +18838,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -18886,7 +18886,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -18934,7 +18934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -18982,7 +18982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -19030,7 +19030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -19078,7 +19078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -19126,7 +19126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -19174,7 +19174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -19222,7 +19222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -19270,7 +19270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -19318,7 +19318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -19366,7 +19366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -19414,7 +19414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -19462,7 +19462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -19510,7 +19510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -19558,7 +19558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -19606,7 +19606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -19654,7 +19654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -19702,7 +19702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -19750,7 +19750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -19798,7 +19798,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -19846,7 +19846,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -19894,7 +19894,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -19942,7 +19942,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -19990,7 +19990,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -20038,7 +20038,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -20086,7 +20086,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -20134,7 +20134,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -20182,7 +20182,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -20230,7 +20230,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -20278,7 +20278,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -20326,7 +20326,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -20374,7 +20374,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -20422,7 +20422,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -20470,7 +20470,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -20518,7 +20518,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -20566,7 +20566,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -20614,7 +20614,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -20662,7 +20662,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -20710,7 +20710,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -20758,7 +20758,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -20806,7 +20806,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -20854,7 +20854,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -20902,7 +20902,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -20950,7 +20950,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -20998,7 +20998,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -21046,7 +21046,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -21094,7 +21094,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -21142,7 +21142,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -21190,7 +21190,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -21238,7 +21238,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -21286,7 +21286,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -21334,7 +21334,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -21382,7 +21382,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -21430,7 +21430,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -21478,7 +21478,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -21526,7 +21526,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -21574,7 +21574,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -21622,7 +21622,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -21670,7 +21670,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -21718,7 +21718,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -21766,7 +21766,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -21814,7 +21814,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -21862,7 +21862,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -21910,7 +21910,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -21958,7 +21958,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -22006,7 +22006,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -22054,7 +22054,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -22102,7 +22102,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -22150,7 +22150,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -22198,7 +22198,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -22246,7 +22246,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(El?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -22294,7 +22294,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -22342,7 +22342,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -22390,7 +22390,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -22438,7 +22438,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -22486,7 +22486,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -22534,7 +22534,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -22582,7 +22582,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -22630,7 +22630,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -22678,7 +22678,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -22726,7 +22726,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -22774,7 +22774,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -22822,7 +22822,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -22870,7 +22870,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -22918,7 +22918,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -22966,7 +22966,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -23014,7 +23014,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -23062,7 +23062,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -23110,7 +23110,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -23158,7 +23158,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -23206,7 +23206,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -23254,7 +23254,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -23302,7 +23302,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -23350,7 +23350,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -23398,7 +23398,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -23446,7 +23446,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -23494,7 +23494,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -23542,7 +23542,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -23590,7 +23590,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -23638,7 +23638,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -23686,7 +23686,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -23734,7 +23734,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -23782,7 +23782,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -23830,7 +23830,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -23878,7 +23878,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -23926,7 +23926,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -23974,7 +23974,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -24022,7 +24022,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -24070,7 +24070,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -24118,7 +24118,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -24166,7 +24166,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -24214,7 +24214,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -24262,7 +24262,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -24310,7 +24310,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -24358,7 +24358,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -24406,7 +24406,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -24454,7 +24454,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -24502,7 +24502,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -24550,7 +24550,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -24598,7 +24598,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -24646,7 +24646,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -24694,7 +24694,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -24742,7 +24742,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -24790,7 +24790,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -24838,7 +24838,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -24886,7 +24886,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -24934,7 +24934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(float?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -24982,7 +24982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -25030,7 +25030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -25078,7 +25078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -25126,7 +25126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -25174,7 +25174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -25222,7 +25222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -25270,7 +25270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -25318,7 +25318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -25366,7 +25366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -25414,7 +25414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -25462,7 +25462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -25510,7 +25510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -25558,7 +25558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -25606,7 +25606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -25654,7 +25654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -25702,7 +25702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -25750,7 +25750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -25798,7 +25798,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -25846,7 +25846,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -25894,7 +25894,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -25942,7 +25942,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -25990,7 +25990,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -26038,7 +26038,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -26086,7 +26086,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -26134,7 +26134,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -26182,7 +26182,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -26230,7 +26230,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -26278,7 +26278,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -26326,7 +26326,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -26374,7 +26374,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -26422,7 +26422,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -26470,7 +26470,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -26518,7 +26518,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -26566,7 +26566,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -26614,7 +26614,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -26662,7 +26662,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -26710,7 +26710,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -26758,7 +26758,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -26806,7 +26806,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -26854,7 +26854,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -26902,7 +26902,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -26950,7 +26950,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -26998,7 +26998,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -27046,7 +27046,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -27094,7 +27094,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -27142,7 +27142,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -27190,7 +27190,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -27238,7 +27238,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -27286,7 +27286,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -27334,7 +27334,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -27382,7 +27382,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -27430,7 +27430,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -27478,7 +27478,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -27526,7 +27526,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -27574,7 +27574,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -27622,7 +27622,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -27670,7 +27670,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -27718,7 +27718,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -27766,7 +27766,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -27814,7 +27814,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -27862,7 +27862,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -27910,7 +27910,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -27958,7 +27958,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -28006,7 +28006,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -28054,7 +28054,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -28102,7 +28102,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -28150,7 +28150,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -28198,7 +28198,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -28246,7 +28246,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -28294,7 +28294,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -28342,7 +28342,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -28390,7 +28390,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -28438,7 +28438,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -28486,7 +28486,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -28534,7 +28534,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -28582,7 +28582,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -28630,7 +28630,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -28678,7 +28678,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -28726,7 +28726,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -28774,7 +28774,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -28822,7 +28822,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -28870,7 +28870,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -28918,7 +28918,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -28966,7 +28966,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -29014,7 +29014,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -29062,7 +29062,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -29110,7 +29110,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -29158,7 +29158,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -29206,7 +29206,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -29254,7 +29254,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -29302,7 +29302,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -29350,7 +29350,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -29398,7 +29398,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -29446,7 +29446,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -29494,7 +29494,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -29542,7 +29542,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -29590,7 +29590,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -29638,7 +29638,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -29686,7 +29686,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -29734,7 +29734,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -29782,7 +29782,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -29830,7 +29830,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -29878,7 +29878,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -29926,7 +29926,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -29974,7 +29974,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -30022,7 +30022,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -30070,7 +30070,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -30118,7 +30118,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -30166,7 +30166,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -30214,7 +30214,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -30262,7 +30262,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -30310,7 +30310,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(long?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -30358,7 +30358,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -30406,7 +30406,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -30454,7 +30454,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -30502,7 +30502,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -30550,7 +30550,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -30598,7 +30598,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -30646,7 +30646,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -30694,7 +30694,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -30742,7 +30742,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -30790,7 +30790,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -30838,7 +30838,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -30886,7 +30886,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -30934,7 +30934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -30982,7 +30982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -31030,7 +31030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -31078,7 +31078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -31126,7 +31126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -31174,7 +31174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -31222,7 +31222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -31270,7 +31270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -31318,7 +31318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -31366,7 +31366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -31414,7 +31414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -31462,7 +31462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -31510,7 +31510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -31558,7 +31558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -31606,7 +31606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -31654,7 +31654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -31702,7 +31702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -31750,7 +31750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -31798,7 +31798,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -31846,7 +31846,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -31894,7 +31894,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -31942,7 +31942,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -31990,7 +31990,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -32038,7 +32038,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -32086,7 +32086,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -32134,7 +32134,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -32182,7 +32182,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -32230,7 +32230,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -32278,7 +32278,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -32326,7 +32326,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -32374,7 +32374,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -32422,7 +32422,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -32470,7 +32470,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -32518,7 +32518,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -32566,7 +32566,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -32614,7 +32614,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -32662,7 +32662,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -32710,7 +32710,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -32758,7 +32758,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -32806,7 +32806,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -32854,7 +32854,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -32902,7 +32902,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -32950,7 +32950,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -32998,7 +32998,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(sbyte?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -33046,7 +33046,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -33094,7 +33094,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -33142,7 +33142,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -33190,7 +33190,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -33238,7 +33238,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -33286,7 +33286,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -33334,7 +33334,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -33382,7 +33382,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -33430,7 +33430,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -33478,7 +33478,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -33526,7 +33526,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -33574,7 +33574,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -33622,7 +33622,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -33670,7 +33670,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -33718,7 +33718,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -33766,7 +33766,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -33814,7 +33814,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -33862,7 +33862,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -33910,7 +33910,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -33958,7 +33958,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -34006,7 +34006,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -34054,7 +34054,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -34102,7 +34102,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -34150,7 +34150,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -34198,7 +34198,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -34246,7 +34246,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -34294,7 +34294,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -34342,7 +34342,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -34390,7 +34390,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -34438,7 +34438,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -34486,7 +34486,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -34534,7 +34534,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -34582,7 +34582,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -34630,7 +34630,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -34678,7 +34678,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -34726,7 +34726,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -34774,7 +34774,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -34822,7 +34822,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -34870,7 +34870,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -34918,7 +34918,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -34966,7 +34966,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -35014,7 +35014,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -35062,7 +35062,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -35110,7 +35110,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -35158,7 +35158,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -35206,7 +35206,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -35254,7 +35254,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -35302,7 +35302,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -35350,7 +35350,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -35398,7 +35398,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -35446,7 +35446,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -35494,7 +35494,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -35542,7 +35542,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -35590,7 +35590,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -35638,7 +35638,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -35686,7 +35686,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(short?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -35734,7 +35734,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -35782,7 +35782,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -35830,7 +35830,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -35878,7 +35878,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -35926,7 +35926,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -35974,7 +35974,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -36022,7 +36022,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -36070,7 +36070,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -36118,7 +36118,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -36166,7 +36166,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -36214,7 +36214,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -36262,7 +36262,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -36310,7 +36310,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -36358,7 +36358,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -36406,7 +36406,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -36454,7 +36454,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -36502,7 +36502,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -36550,7 +36550,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -36598,7 +36598,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -36646,7 +36646,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -36694,7 +36694,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -36742,7 +36742,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -36790,7 +36790,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -36838,7 +36838,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -36886,7 +36886,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -36934,7 +36934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -36982,7 +36982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -37030,7 +37030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -37078,7 +37078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -37126,7 +37126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -37174,7 +37174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -37222,7 +37222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -37270,7 +37270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -37318,7 +37318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -37366,7 +37366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -37414,7 +37414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -37462,7 +37462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -37510,7 +37510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -37558,7 +37558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -37606,7 +37606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -37654,7 +37654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -37702,7 +37702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -37750,7 +37750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -37798,7 +37798,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -37846,7 +37846,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -37894,7 +37894,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -37942,7 +37942,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -37990,7 +37990,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -38038,7 +38038,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -38086,7 +38086,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -38134,7 +38134,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -38182,7 +38182,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -38230,7 +38230,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -38278,7 +38278,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -38326,7 +38326,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -38374,7 +38374,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(uint?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -38422,7 +38422,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -38470,7 +38470,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -38518,7 +38518,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -38566,7 +38566,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -38614,7 +38614,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -38662,7 +38662,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -38710,7 +38710,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -38758,7 +38758,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -38806,7 +38806,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -38854,7 +38854,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -38902,7 +38902,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -38950,7 +38950,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -38998,7 +38998,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -39046,7 +39046,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -39094,7 +39094,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -39142,7 +39142,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -39190,7 +39190,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -39238,7 +39238,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -39286,7 +39286,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -39334,7 +39334,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -39382,7 +39382,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -39430,7 +39430,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -39478,7 +39478,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -39526,7 +39526,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -39574,7 +39574,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -39622,7 +39622,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -39670,7 +39670,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -39718,7 +39718,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -39766,7 +39766,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -39814,7 +39814,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -39862,7 +39862,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -39910,7 +39910,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -39958,7 +39958,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -40006,7 +40006,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -40054,7 +40054,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -40102,7 +40102,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -40150,7 +40150,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -40198,7 +40198,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -40246,7 +40246,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -40294,7 +40294,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -40342,7 +40342,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -40390,7 +40390,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -40438,7 +40438,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -40486,7 +40486,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -40534,7 +40534,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -40582,7 +40582,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -40630,7 +40630,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -40678,7 +40678,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -40726,7 +40726,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -40774,7 +40774,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -40822,7 +40822,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -40870,7 +40870,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -40918,7 +40918,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -40966,7 +40966,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -41014,7 +41014,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -41062,7 +41062,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ulong?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -41110,7 +41110,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -41158,7 +41158,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -41206,7 +41206,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -41254,7 +41254,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -41302,7 +41302,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -41350,7 +41350,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -41398,7 +41398,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -41446,7 +41446,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -41494,7 +41494,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -41542,7 +41542,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -41590,7 +41590,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -41638,7 +41638,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -41686,7 +41686,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -41734,7 +41734,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -41782,7 +41782,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -41830,7 +41830,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -41878,7 +41878,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -41926,7 +41926,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -41974,7 +41974,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -42022,7 +42022,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -42070,7 +42070,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -42118,7 +42118,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -42166,7 +42166,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -42214,7 +42214,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -42262,7 +42262,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -42310,7 +42310,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -42358,7 +42358,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -42406,7 +42406,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);
@@ -42454,7 +42454,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(byte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte etResult = default(byte);
@@ -42502,7 +42502,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<byte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(byte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             byte? etResult = default(byte?);
@@ -42550,7 +42550,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(char)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char etResult = default(char);
@@ -42598,7 +42598,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<char?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(char?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             char? etResult = default(char?);
@@ -42646,7 +42646,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(decimal)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal etResult = default(decimal);
@@ -42694,7 +42694,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(decimal?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             decimal? etResult = default(decimal?);
@@ -42742,7 +42742,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(double)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double etResult = default(double);
@@ -42790,7 +42790,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<double?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(double?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             double? etResult = default(double?);
@@ -42838,7 +42838,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E etResult = default(E);
@@ -42886,7 +42886,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<E?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             E? etResult = default(E?);
@@ -42934,7 +42934,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(El)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El etResult = default(El);
@@ -42982,7 +42982,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<El?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(El?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             El? etResult = default(El?);
@@ -43030,7 +43030,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(float)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float etResult = default(float);
@@ -43078,7 +43078,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<float?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(float?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             float? etResult = default(float?);
@@ -43126,7 +43126,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int etResult = default(int);
@@ -43174,7 +43174,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<int?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             int? etResult = default(int?);
@@ -43222,7 +43222,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(long)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long etResult = default(long);
@@ -43270,7 +43270,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<long?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(long?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             long? etResult = default(long?);
@@ -43318,7 +43318,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(sbyte)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte etResult = default(sbyte);
@@ -43366,7 +43366,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(sbyte?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             sbyte? etResult = default(sbyte?);
@@ -43414,7 +43414,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(short)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short etResult = default(short);
@@ -43462,7 +43462,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<short?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(short?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             short? etResult = default(short?);
@@ -43510,7 +43510,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(uint)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint etResult = default(uint);
@@ -43558,7 +43558,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<uint?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(uint?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             uint? etResult = default(uint?);
@@ -43606,7 +43606,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(ulong)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong etResult = default(ulong);
@@ -43654,7 +43654,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(ulong?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ulong? etResult = default(ulong?);
@@ -43702,7 +43702,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(ushort)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort etResult = default(ushort);
@@ -43750,7 +43750,7 @@ namespace Tests.ExpressionCompiler.Convert
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Convert(Expression.Constant(value, typeof(ushort?)), typeof(ushort?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             // compute the value with the expression tree
             ushort? etResult = default(ushort?);

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_INTERPRET
+#if FEATURE_INTERPRET && ENABLE_CROSSCHECK
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_INTERPRET
+#if FEATURE_INTERPRET && ENABLE_CROSSCHECK
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -20,12 +20,12 @@ namespace Tests
             Expression<X> f = Expression.Lambda<X>(Expression.Empty(), Expression.Parameter(typeof(X)));
             var a = Expression.Lambda(Expression.Invoke(f, f));
 
-            a.Compile().DynamicInvoke();
+            a.CompileForTest().DynamicInvoke();
 
             var it = Expression.Parameter(f.Type);
             var b = Expression.Lambda(Expression.Invoke(Expression.Lambda(Expression.Invoke(it, it), it), f));
 
-            b.Compile().DynamicInvoke();
+            b.CompileForTest().DynamicInvoke();
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f1 = e1.Compile();
+            Func<decimal?> f1 = e1.CompileForTest();
 
             decimal? f1Result = default(decimal?);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.Compile();
+            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.CompileForTest();
 
             decimal? f2Result = default(decimal?);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?, decimal?> f3 = e3.Compile()();
+            Func<decimal?, decimal?, decimal?> f3 = e3.CompileForTest()();
 
             decimal? f3Result = default(decimal?);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.Compile();
+            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.CompileForTest();
 
             decimal? f4Result = default(decimal?);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.Compile();
+            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.CompileForTest();
 
             decimal? f5Result = default(decimal?);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?> f6 = e6.Compile()();
+            Func<decimal?, decimal?> f6 = e6.CompileForTest()();
 
             decimal? f6Result = default(decimal?);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f1 = e1.Compile();
+            Func<double?> f1 = e1.CompileForTest();
 
             double? f1Result = default(double?);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double?, double?, Func<double?>> f2 = e2.Compile();
+            Func<double?, double?, Func<double?>> f2 = e2.CompileForTest();
 
             double? f2Result = default(double?);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?, double?> f3 = e3.Compile()();
+            Func<double?, double?, double?> f3 = e3.CompileForTest()();
 
             double? f3Result = default(double?);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double?, double?, double?>> f4 = e4.Compile();
+            Func<Func<double?, double?, double?>> f4 = e4.CompileForTest();
 
             double? f4Result = default(double?);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double?, Func<double?, double?>> f5 = e5.Compile();
+            Func<double?, Func<double?, double?>> f5 = e5.CompileForTest();
 
             double? f5Result = default(double?);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?> f6 = e6.Compile()();
+            Func<double?, double?> f6 = e6.CompileForTest()();
 
             double? f6Result = default(double?);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f1 = e1.Compile();
+            Func<float?> f1 = e1.CompileForTest();
 
             float? f1Result = default(float?);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float?, float?, Func<float?>> f2 = e2.Compile();
+            Func<float?, float?, Func<float?>> f2 = e2.CompileForTest();
 
             float? f2Result = default(float?);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?, float?> f3 = e3.Compile()();
+            Func<float?, float?, float?> f3 = e3.CompileForTest()();
 
             float? f3Result = default(float?);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float?, float?, float?>> f4 = e4.Compile();
+            Func<Func<float?, float?, float?>> f4 = e4.CompileForTest();
 
             float? f4Result = default(float?);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float?, Func<float?, float?>> f5 = e5.Compile();
+            Func<float?, Func<float?, float?>> f5 = e5.CompileForTest();
 
             float? f5Result = default(float?);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?> f6 = e6.Compile()();
+            Func<float?, float?> f6 = e6.CompileForTest()();
 
             float? f6Result = default(float?);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             int? f1Result = default(int?);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int?, int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, int?, Func<int?>> f2 = e2.CompileForTest();
 
             int? f2Result = default(int?);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?, int?> f3 = e3.Compile()();
+            Func<int?, int?, int?> f3 = e3.CompileForTest()();
 
             int? f3Result = default(int?);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?, int?>> f4 = e4.CompileForTest();
 
             int? f4Result = default(int?);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int?, Func<int?, int?>> f5 = e5.Compile();
+            Func<int?, Func<int?, int?>> f5 = e5.CompileForTest();
 
             int? f5Result = default(int?);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f6 = e6.Compile()();
+            Func<int?, int?> f6 = e6.CompileForTest()();
 
             int? f6Result = default(int?);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             long? f1Result = default(long?);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long?, long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, long?, Func<long?>> f2 = e2.CompileForTest();
 
             long? f2Result = default(long?);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?, long?> f3 = e3.Compile()();
+            Func<long?, long?, long?> f3 = e3.CompileForTest()();
 
             long? f3Result = default(long?);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?, long?>> f4 = e4.CompileForTest();
 
             long? f4Result = default(long?);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long?, Func<long?, long?>> f5 = e5.Compile();
+            Func<long?, Func<long?, long?>> f5 = e5.CompileForTest();
 
             long? f5Result = default(long?);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f6 = e6.Compile()();
+            Func<long?, long?> f6 = e6.CompileForTest()();
 
             long? f6Result = default(long?);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             short? f1Result = default(short?);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short?, short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, short?, Func<short?>> f2 = e2.CompileForTest();
 
             short? f2Result = default(short?);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?, short?> f3 = e3.Compile()();
+            Func<short?, short?, short?> f3 = e3.CompileForTest()();
 
             short? f3Result = default(short?);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?, short?>> f4 = e4.CompileForTest();
 
             short? f4Result = default(short?);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short?, Func<short?, short?>> f5 = e5.Compile();
+            Func<short?, Func<short?, short?>> f5 = e5.CompileForTest();
 
             short? f5Result = default(short?);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f6 = e6.Compile()();
+            Func<short?, short?> f6 = e6.CompileForTest()();
 
             short? f6Result = default(short?);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             uint? f1Result = default(uint?);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint?, uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             uint? f2Result = default(uint?);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?, uint?> f3 = e3.CompileForTest()();
 
             uint? f3Result = default(uint?);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?, uint?>> f4 = e4.CompileForTest();
 
             uint? f4Result = default(uint?);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint?, Func<uint?, uint?>> f5 = e5.Compile();
+            Func<uint?, Func<uint?, uint?>> f5 = e5.CompileForTest();
 
             uint? f5Result = default(uint?);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f6 = e6.Compile()();
+            Func<uint?, uint?> f6 = e6.CompileForTest()();
 
             uint? f6Result = default(uint?);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             ulong? f1Result = default(ulong?);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             ulong? f2Result = default(ulong?);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?, ulong?> f3 = e3.CompileForTest()();
 
             ulong? f3Result = default(ulong?);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.CompileForTest();
 
             ulong? f4Result = default(ulong?);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.Compile();
+            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.CompileForTest();
 
             ulong? f5Result = default(ulong?);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f6 = e6.Compile()();
+            Func<ulong?, ulong?> f6 = e6.CompileForTest()();
 
             ulong? f6Result = default(ulong?);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             ushort? f1Result = default(ushort?);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             ushort? f2Result = default(ushort?);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?, ushort?> f3 = e3.CompileForTest()();
 
             ushort? f3Result = default(ushort?);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.CompileForTest();
 
             ushort? f4Result = default(ushort?);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.Compile();
+            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.CompileForTest();
 
             ushort? f5Result = default(ushort?);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f6 = e6.Compile()();
+            Func<ushort?, ushort?> f6 = e6.CompileForTest()();
 
             ushort? f6Result = default(ushort?);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
@@ -166,7 +166,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant((int)b, typeof(int))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             byte f1Result = default(byte);
             Exception f1Ex = null;
@@ -186,7 +186,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int, int, Func<int>> f2 = e2.Compile();
+            Func<int, int, Func<int>> f2 = e2.CompileForTest();
 
             byte f2Result = default(byte);
             Exception f2Ex = null;
@@ -210,7 +210,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int, int> f3 = e3.Compile()();
+            Func<int, int, int> f3 = e3.CompileForTest()();
 
             byte f3Result = default(byte);
             Exception f3Ex = null;
@@ -230,7 +230,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int, int>> f4 = e4.Compile();
+            Func<Func<int, int, int>> f4 = e4.CompileForTest();
 
             byte f4Result = default(byte);
             Exception f4Ex = null;
@@ -250,7 +250,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int, Func<int, int>> f5 = e5.Compile();
+            Func<int, Func<int, int>> f5 = e5.CompileForTest();
 
             byte f5Result = default(byte);
             Exception f5Ex = null;
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant((int)a, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f6 = e6.Compile()();
+            Func<int, int> f6 = e6.CompileForTest()();
 
             byte f6Result = default(byte);
             Exception f6Ex = null;
@@ -350,7 +350,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f1 = e1.Compile();
+            Func<decimal> f1 = e1.CompileForTest();
 
             decimal f1Result = default(decimal);
             Exception f1Ex = null;
@@ -370,7 +370,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal, decimal, Func<decimal>> f2 = e2.Compile();
+            Func<decimal, decimal, Func<decimal>> f2 = e2.CompileForTest();
 
             decimal f2Result = default(decimal);
             Exception f2Ex = null;
@@ -394,7 +394,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal, decimal> f3 = e3.Compile()();
+            Func<decimal, decimal, decimal> f3 = e3.CompileForTest()();
 
             decimal f3Result = default(decimal);
             Exception f3Ex = null;
@@ -414,7 +414,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal, decimal, decimal>> f4 = e4.Compile();
+            Func<Func<decimal, decimal, decimal>> f4 = e4.CompileForTest();
 
             decimal f4Result = default(decimal);
             Exception f4Ex = null;
@@ -434,7 +434,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal, Func<decimal, decimal>> f5 = e5.Compile();
+            Func<decimal, Func<decimal, decimal>> f5 = e5.CompileForTest();
 
             decimal f5Result = default(decimal);
             Exception f5Ex = null;
@@ -458,7 +458,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal> f6 = e6.Compile()();
+            Func<decimal, decimal> f6 = e6.CompileForTest()();
 
             decimal f6Result = default(decimal);
             Exception f6Ex = null;
@@ -534,7 +534,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f1 = e1.Compile();
+            Func<double> f1 = e1.CompileForTest();
 
             double f1Result = default(double);
             Exception f1Ex = null;
@@ -554,7 +554,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double, double, Func<double>> f2 = e2.Compile();
+            Func<double, double, Func<double>> f2 = e2.CompileForTest();
 
             double f2Result = default(double);
             Exception f2Ex = null;
@@ -578,7 +578,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double, double> f3 = e3.Compile()();
+            Func<double, double, double> f3 = e3.CompileForTest()();
 
             double f3Result = default(double);
             Exception f3Ex = null;
@@ -598,7 +598,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double, double, double>> f4 = e4.Compile();
+            Func<Func<double, double, double>> f4 = e4.CompileForTest();
 
             double f4Result = default(double);
             Exception f4Ex = null;
@@ -618,7 +618,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double, Func<double, double>> f5 = e5.Compile();
+            Func<double, Func<double, double>> f5 = e5.CompileForTest();
 
             double f5Result = default(double);
             Exception f5Ex = null;
@@ -642,7 +642,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double> f6 = e6.Compile()();
+            Func<double, double> f6 = e6.CompileForTest()();
 
             double f6Result = default(double);
             Exception f6Ex = null;
@@ -718,7 +718,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f1 = e1.Compile();
+            Func<float> f1 = e1.CompileForTest();
 
             float f1Result = default(float);
             Exception f1Ex = null;
@@ -738,7 +738,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float, float, Func<float>> f2 = e2.Compile();
+            Func<float, float, Func<float>> f2 = e2.CompileForTest();
 
             float f2Result = default(float);
             Exception f2Ex = null;
@@ -762,7 +762,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float, float> f3 = e3.Compile()();
+            Func<float, float, float> f3 = e3.CompileForTest()();
 
             float f3Result = default(float);
             Exception f3Ex = null;
@@ -782,7 +782,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float, float, float>> f4 = e4.Compile();
+            Func<Func<float, float, float>> f4 = e4.CompileForTest();
 
             float f4Result = default(float);
             Exception f4Ex = null;
@@ -802,7 +802,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float, Func<float, float>> f5 = e5.Compile();
+            Func<float, Func<float, float>> f5 = e5.CompileForTest();
 
             float f5Result = default(float);
             Exception f5Ex = null;
@@ -826,7 +826,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float> f6 = e6.Compile()();
+            Func<float, float> f6 = e6.CompileForTest()();
 
             float f6Result = default(float);
             Exception f6Ex = null;
@@ -902,7 +902,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             int f1Result = default(int);
             Exception f1Ex = null;
@@ -922,7 +922,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int, int, Func<int>> f2 = e2.Compile();
+            Func<int, int, Func<int>> f2 = e2.CompileForTest();
 
             int f2Result = default(int);
             Exception f2Ex = null;
@@ -946,7 +946,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int, int> f3 = e3.Compile()();
+            Func<int, int, int> f3 = e3.CompileForTest()();
 
             int f3Result = default(int);
             Exception f3Ex = null;
@@ -966,7 +966,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int, int>> f4 = e4.Compile();
+            Func<Func<int, int, int>> f4 = e4.CompileForTest();
 
             int f4Result = default(int);
             Exception f4Ex = null;
@@ -986,7 +986,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int, Func<int, int>> f5 = e5.Compile();
+            Func<int, Func<int, int>> f5 = e5.CompileForTest();
 
             int f5Result = default(int);
             Exception f5Ex = null;
@@ -1010,7 +1010,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f6 = e6.Compile()();
+            Func<int, int> f6 = e6.CompileForTest()();
 
             int f6Result = default(int);
             Exception f6Ex = null;
@@ -1086,7 +1086,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             long f1Result = default(long);
             Exception f1Ex = null;
@@ -1106,7 +1106,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long, long, Func<long>> f2 = e2.Compile();
+            Func<long, long, Func<long>> f2 = e2.CompileForTest();
 
             long f2Result = default(long);
             Exception f2Ex = null;
@@ -1130,7 +1130,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long, long> f3 = e3.Compile()();
+            Func<long, long, long> f3 = e3.CompileForTest()();
 
             long f3Result = default(long);
             Exception f3Ex = null;
@@ -1150,7 +1150,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long, long>> f4 = e4.Compile();
+            Func<Func<long, long, long>> f4 = e4.CompileForTest();
 
             long f4Result = default(long);
             Exception f4Ex = null;
@@ -1170,7 +1170,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long, Func<long, long>> f5 = e5.Compile();
+            Func<long, Func<long, long>> f5 = e5.CompileForTest();
 
             long f5Result = default(long);
             Exception f5Ex = null;
@@ -1194,7 +1194,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f6 = e6.Compile()();
+            Func<long, long> f6 = e6.CompileForTest()();
 
             long f6Result = default(long);
             Exception f6Ex = null;
@@ -1270,7 +1270,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             short f1Result = default(short);
             Exception f1Ex = null;
@@ -1290,7 +1290,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short, short, Func<short>> f2 = e2.Compile();
+            Func<short, short, Func<short>> f2 = e2.CompileForTest();
 
             short f2Result = default(short);
             Exception f2Ex = null;
@@ -1314,7 +1314,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short, short> f3 = e3.Compile()();
+            Func<short, short, short> f3 = e3.CompileForTest()();
 
             short f3Result = default(short);
             Exception f3Ex = null;
@@ -1334,7 +1334,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short, short>> f4 = e4.Compile();
+            Func<Func<short, short, short>> f4 = e4.CompileForTest();
 
             short f4Result = default(short);
             Exception f4Ex = null;
@@ -1354,7 +1354,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short, Func<short, short>> f5 = e5.Compile();
+            Func<short, Func<short, short>> f5 = e5.CompileForTest();
 
             short f5Result = default(short);
             Exception f5Ex = null;
@@ -1378,7 +1378,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f6 = e6.Compile()();
+            Func<short, short> f6 = e6.CompileForTest()();
 
             short f6Result = default(short);
             Exception f6Ex = null;
@@ -1454,7 +1454,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             uint f1Result = default(uint);
             Exception f1Ex = null;
@@ -1474,7 +1474,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint, uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, uint, Func<uint>> f2 = e2.CompileForTest();
 
             uint f2Result = default(uint);
             Exception f2Ex = null;
@@ -1498,7 +1498,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint, uint> f3 = e3.Compile()();
+            Func<uint, uint, uint> f3 = e3.CompileForTest()();
 
             uint f3Result = default(uint);
             Exception f3Ex = null;
@@ -1518,7 +1518,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint, uint>> f4 = e4.CompileForTest();
 
             uint f4Result = default(uint);
             Exception f4Ex = null;
@@ -1538,7 +1538,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint, Func<uint, uint>> f5 = e5.Compile();
+            Func<uint, Func<uint, uint>> f5 = e5.CompileForTest();
 
             uint f5Result = default(uint);
             Exception f5Ex = null;
@@ -1562,7 +1562,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f6 = e6.Compile()();
+            Func<uint, uint> f6 = e6.CompileForTest()();
 
             uint f6Result = default(uint);
             Exception f6Ex = null;
@@ -1638,7 +1638,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             ulong f1Result = default(ulong);
             Exception f1Ex = null;
@@ -1658,7 +1658,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong, ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             ulong f2Result = default(ulong);
             Exception f2Ex = null;
@@ -1682,7 +1682,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong, ulong> f3 = e3.CompileForTest()();
 
             ulong f3Result = default(ulong);
             Exception f3Ex = null;
@@ -1702,7 +1702,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong, ulong>> f4 = e4.CompileForTest();
 
             ulong f4Result = default(ulong);
             Exception f4Ex = null;
@@ -1722,7 +1722,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong, Func<ulong, ulong>> f5 = e5.Compile();
+            Func<ulong, Func<ulong, ulong>> f5 = e5.CompileForTest();
 
             ulong f5Result = default(ulong);
             Exception f5Ex = null;
@@ -1746,7 +1746,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f6 = e6.Compile()();
+            Func<ulong, ulong> f6 = e6.CompileForTest()();
 
             ulong f6Result = default(ulong);
             Exception f6Ex = null;
@@ -1822,7 +1822,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             ushort f1Result = default(ushort);
             Exception f1Ex = null;
@@ -1842,7 +1842,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort, ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             ushort f2Result = default(ushort);
             Exception f2Ex = null;
@@ -1866,7 +1866,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort, ushort> f3 = e3.CompileForTest()();
 
             ushort f3Result = default(ushort);
             Exception f3Ex = null;
@@ -1886,7 +1886,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort, ushort>> f4 = e4.CompileForTest();
 
             ushort f4Result = default(ushort);
             Exception f4Ex = null;
@@ -1906,7 +1906,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Add(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort, Func<ushort, ushort>> f5 = e5.Compile();
+            Func<ushort, Func<ushort, ushort>> f5 = e5.CompileForTest();
 
             ushort f5Result = default(ushort);
             Exception f5Ex = null;
@@ -1930,7 +1930,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f6 = e6.Compile()();
+            Func<ushort, ushort> f6 = e6.CompileForTest()();
 
             ushort f6Result = default(ushort);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f1 = e1.Compile();
+            Func<decimal?> f1 = e1.CompileForTest();
 
             decimal? f1Result = default(decimal?);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.Compile();
+            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.CompileForTest();
 
             decimal? f2Result = default(decimal?);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?, decimal?> f3 = e3.Compile()();
+            Func<decimal?, decimal?, decimal?> f3 = e3.CompileForTest()();
 
             decimal? f3Result = default(decimal?);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.Compile();
+            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.CompileForTest();
 
             decimal? f4Result = default(decimal?);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.Compile();
+            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.CompileForTest();
 
             decimal? f5Result = default(decimal?);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?> f6 = e6.Compile()();
+            Func<decimal?, decimal?> f6 = e6.CompileForTest()();
 
             decimal? f6Result = default(decimal?);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f1 = e1.Compile();
+            Func<double?> f1 = e1.CompileForTest();
 
             double? f1Result = default(double?);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double?, double?, Func<double?>> f2 = e2.Compile();
+            Func<double?, double?, Func<double?>> f2 = e2.CompileForTest();
 
             double? f2Result = default(double?);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?, double?> f3 = e3.Compile()();
+            Func<double?, double?, double?> f3 = e3.CompileForTest()();
 
             double? f3Result = default(double?);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double?, double?, double?>> f4 = e4.Compile();
+            Func<Func<double?, double?, double?>> f4 = e4.CompileForTest();
 
             double? f4Result = default(double?);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double?, Func<double?, double?>> f5 = e5.Compile();
+            Func<double?, Func<double?, double?>> f5 = e5.CompileForTest();
 
             double? f5Result = default(double?);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?> f6 = e6.Compile()();
+            Func<double?, double?> f6 = e6.CompileForTest()();
 
             double? f6Result = default(double?);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f1 = e1.Compile();
+            Func<float?> f1 = e1.CompileForTest();
 
             float? f1Result = default(float?);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float?, float?, Func<float?>> f2 = e2.Compile();
+            Func<float?, float?, Func<float?>> f2 = e2.CompileForTest();
 
             float? f2Result = default(float?);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?, float?> f3 = e3.Compile()();
+            Func<float?, float?, float?> f3 = e3.CompileForTest()();
 
             float? f3Result = default(float?);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float?, float?, float?>> f4 = e4.Compile();
+            Func<Func<float?, float?, float?>> f4 = e4.CompileForTest();
 
             float? f4Result = default(float?);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float?, Func<float?, float?>> f5 = e5.Compile();
+            Func<float?, Func<float?, float?>> f5 = e5.CompileForTest();
 
             float? f5Result = default(float?);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?> f6 = e6.Compile()();
+            Func<float?, float?> f6 = e6.CompileForTest()();
 
             float? f6Result = default(float?);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             int? f1Result = default(int?);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int?, int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, int?, Func<int?>> f2 = e2.CompileForTest();
 
             int? f2Result = default(int?);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?, int?> f3 = e3.Compile()();
+            Func<int?, int?, int?> f3 = e3.CompileForTest()();
 
             int? f3Result = default(int?);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?, int?>> f4 = e4.CompileForTest();
 
             int? f4Result = default(int?);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int?, Func<int?, int?>> f5 = e5.Compile();
+            Func<int?, Func<int?, int?>> f5 = e5.CompileForTest();
 
             int? f5Result = default(int?);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f6 = e6.Compile()();
+            Func<int?, int?> f6 = e6.CompileForTest()();
 
             int? f6Result = default(int?);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             long? f1Result = default(long?);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long?, long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, long?, Func<long?>> f2 = e2.CompileForTest();
 
             long? f2Result = default(long?);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?, long?> f3 = e3.Compile()();
+            Func<long?, long?, long?> f3 = e3.CompileForTest()();
 
             long? f3Result = default(long?);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?, long?>> f4 = e4.CompileForTest();
 
             long? f4Result = default(long?);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long?, Func<long?, long?>> f5 = e5.Compile();
+            Func<long?, Func<long?, long?>> f5 = e5.CompileForTest();
 
             long? f5Result = default(long?);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f6 = e6.Compile()();
+            Func<long?, long?> f6 = e6.CompileForTest()();
 
             long? f6Result = default(long?);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             short? f1Result = default(short?);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short?, short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, short?, Func<short?>> f2 = e2.CompileForTest();
 
             short? f2Result = default(short?);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?, short?> f3 = e3.Compile()();
+            Func<short?, short?, short?> f3 = e3.CompileForTest()();
 
             short? f3Result = default(short?);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?, short?>> f4 = e4.CompileForTest();
 
             short? f4Result = default(short?);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short?, Func<short?, short?>> f5 = e5.Compile();
+            Func<short?, Func<short?, short?>> f5 = e5.CompileForTest();
 
             short? f5Result = default(short?);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f6 = e6.Compile()();
+            Func<short?, short?> f6 = e6.CompileForTest()();
 
             short? f6Result = default(short?);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             uint? f1Result = default(uint?);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint?, uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             uint? f2Result = default(uint?);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?, uint?> f3 = e3.CompileForTest()();
 
             uint? f3Result = default(uint?);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?, uint?>> f4 = e4.CompileForTest();
 
             uint? f4Result = default(uint?);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint?, Func<uint?, uint?>> f5 = e5.Compile();
+            Func<uint?, Func<uint?, uint?>> f5 = e5.CompileForTest();
 
             uint? f5Result = default(uint?);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f6 = e6.Compile()();
+            Func<uint?, uint?> f6 = e6.CompileForTest()();
 
             uint? f6Result = default(uint?);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             ulong? f1Result = default(ulong?);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             ulong? f2Result = default(ulong?);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?, ulong?> f3 = e3.CompileForTest()();
 
             ulong? f3Result = default(ulong?);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.CompileForTest();
 
             ulong? f4Result = default(ulong?);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.Compile();
+            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.CompileForTest();
 
             ulong? f5Result = default(ulong?);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f6 = e6.Compile()();
+            Func<ulong?, ulong?> f6 = e6.CompileForTest()();
 
             ulong? f6Result = default(ulong?);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             ushort? f1Result = default(ushort?);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             ushort? f2Result = default(ushort?);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?, ushort?> f3 = e3.CompileForTest()();
 
             ushort? f3Result = default(ushort?);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.CompileForTest();
 
             ushort? f4Result = default(ushort?);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.Compile();
+            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.CompileForTest();
 
             ushort? f5Result = default(ushort?);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f6 = e6.Compile()();
+            Func<ushort?, ushort?> f6 = e6.CompileForTest()();
 
             ushort? f6Result = default(ushort?);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f1 = e1.Compile();
+            Func<decimal> f1 = e1.CompileForTest();
 
             decimal f1Result = default(decimal);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal, decimal, Func<decimal>> f2 = e2.Compile();
+            Func<decimal, decimal, Func<decimal>> f2 = e2.CompileForTest();
 
             decimal f2Result = default(decimal);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal, decimal> f3 = e3.Compile()();
+            Func<decimal, decimal, decimal> f3 = e3.CompileForTest()();
 
             decimal f3Result = default(decimal);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal, decimal, decimal>> f4 = e4.Compile();
+            Func<Func<decimal, decimal, decimal>> f4 = e4.CompileForTest();
 
             decimal f4Result = default(decimal);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal, Func<decimal, decimal>> f5 = e5.Compile();
+            Func<decimal, Func<decimal, decimal>> f5 = e5.CompileForTest();
 
             decimal f5Result = default(decimal);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal> f6 = e6.Compile()();
+            Func<decimal, decimal> f6 = e6.CompileForTest()();
 
             decimal f6Result = default(decimal);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f1 = e1.Compile();
+            Func<double> f1 = e1.CompileForTest();
 
             double f1Result = default(double);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double, double, Func<double>> f2 = e2.Compile();
+            Func<double, double, Func<double>> f2 = e2.CompileForTest();
 
             double f2Result = default(double);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double, double> f3 = e3.Compile()();
+            Func<double, double, double> f3 = e3.CompileForTest()();
 
             double f3Result = default(double);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double, double, double>> f4 = e4.Compile();
+            Func<Func<double, double, double>> f4 = e4.CompileForTest();
 
             double f4Result = default(double);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double, Func<double, double>> f5 = e5.Compile();
+            Func<double, Func<double, double>> f5 = e5.CompileForTest();
 
             double f5Result = default(double);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double> f6 = e6.Compile()();
+            Func<double, double> f6 = e6.CompileForTest()();
 
             double f6Result = default(double);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f1 = e1.Compile();
+            Func<float> f1 = e1.CompileForTest();
 
             float f1Result = default(float);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float, float, Func<float>> f2 = e2.Compile();
+            Func<float, float, Func<float>> f2 = e2.CompileForTest();
 
             float f2Result = default(float);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float, float> f3 = e3.Compile()();
+            Func<float, float, float> f3 = e3.CompileForTest()();
 
             float f3Result = default(float);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float, float, float>> f4 = e4.Compile();
+            Func<Func<float, float, float>> f4 = e4.CompileForTest();
 
             float f4Result = default(float);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float, Func<float, float>> f5 = e5.Compile();
+            Func<float, Func<float, float>> f5 = e5.CompileForTest();
 
             float f5Result = default(float);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float> f6 = e6.Compile()();
+            Func<float, float> f6 = e6.CompileForTest()();
 
             float f6Result = default(float);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             int f1Result = default(int);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int, int, Func<int>> f2 = e2.Compile();
+            Func<int, int, Func<int>> f2 = e2.CompileForTest();
 
             int f2Result = default(int);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int, int> f3 = e3.Compile()();
+            Func<int, int, int> f3 = e3.CompileForTest()();
 
             int f3Result = default(int);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int, int>> f4 = e4.Compile();
+            Func<Func<int, int, int>> f4 = e4.CompileForTest();
 
             int f4Result = default(int);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int, Func<int, int>> f5 = e5.Compile();
+            Func<int, Func<int, int>> f5 = e5.CompileForTest();
 
             int f5Result = default(int);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f6 = e6.Compile()();
+            Func<int, int> f6 = e6.CompileForTest()();
 
             int f6Result = default(int);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             long f1Result = default(long);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long, long, Func<long>> f2 = e2.Compile();
+            Func<long, long, Func<long>> f2 = e2.CompileForTest();
 
             long f2Result = default(long);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long, long> f3 = e3.Compile()();
+            Func<long, long, long> f3 = e3.CompileForTest()();
 
             long f3Result = default(long);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long, long>> f4 = e4.Compile();
+            Func<Func<long, long, long>> f4 = e4.CompileForTest();
 
             long f4Result = default(long);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long, Func<long, long>> f5 = e5.Compile();
+            Func<long, Func<long, long>> f5 = e5.CompileForTest();
 
             long f5Result = default(long);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f6 = e6.Compile()();
+            Func<long, long> f6 = e6.CompileForTest()();
 
             long f6Result = default(long);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             short f1Result = default(short);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short, short, Func<short>> f2 = e2.Compile();
+            Func<short, short, Func<short>> f2 = e2.CompileForTest();
 
             short f2Result = default(short);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short, short> f3 = e3.Compile()();
+            Func<short, short, short> f3 = e3.CompileForTest()();
 
             short f3Result = default(short);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short, short>> f4 = e4.Compile();
+            Func<Func<short, short, short>> f4 = e4.CompileForTest();
 
             short f4Result = default(short);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short, Func<short, short>> f5 = e5.Compile();
+            Func<short, Func<short, short>> f5 = e5.CompileForTest();
 
             short f5Result = default(short);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f6 = e6.Compile()();
+            Func<short, short> f6 = e6.CompileForTest()();
 
             short f6Result = default(short);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             uint f1Result = default(uint);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint, uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, uint, Func<uint>> f2 = e2.CompileForTest();
 
             uint f2Result = default(uint);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint, uint> f3 = e3.Compile()();
+            Func<uint, uint, uint> f3 = e3.CompileForTest()();
 
             uint f3Result = default(uint);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint, uint>> f4 = e4.CompileForTest();
 
             uint f4Result = default(uint);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint, Func<uint, uint>> f5 = e5.Compile();
+            Func<uint, Func<uint, uint>> f5 = e5.CompileForTest();
 
             uint f5Result = default(uint);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f6 = e6.Compile()();
+            Func<uint, uint> f6 = e6.CompileForTest()();
 
             uint f6Result = default(uint);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             ulong f1Result = default(ulong);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong, ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             ulong f2Result = default(ulong);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong, ulong> f3 = e3.CompileForTest()();
 
             ulong f3Result = default(ulong);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong, ulong>> f4 = e4.CompileForTest();
 
             ulong f4Result = default(ulong);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong, Func<ulong, ulong>> f5 = e5.Compile();
+            Func<ulong, Func<ulong, ulong>> f5 = e5.CompileForTest();
 
             ulong f5Result = default(ulong);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f6 = e6.Compile()();
+            Func<ulong, ulong> f6 = e6.CompileForTest()();
 
             ulong f6Result = default(ulong);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             ushort f1Result = default(ushort);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort, ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             ushort f2Result = default(ushort);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort, ushort> f3 = e3.CompileForTest()();
 
             ushort f3Result = default(ushort);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort, ushort>> f4 = e4.CompileForTest();
 
             ushort f4Result = default(ushort);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Divide(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort, Func<ushort, ushort>> f5 = e5.Compile();
+            Func<ushort, Func<ushort, ushort>> f5 = e5.CompileForTest();
 
             ushort f5Result = default(ushort);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f6 = e6.Compile()();
+            Func<ushort, ushort> f6 = e6.CompileForTest()();
 
             ushort f6Result = default(ushort);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
@@ -237,14 +237,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<bool?, bool?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(bool?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f1 = e1.Compile();
+            Func<bool?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<bool?, Func<bool?>>> e2 =
                 Expression.Lambda<Func<bool?, Func<bool?>>>(
                     Expression.Lambda<Func<bool?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<bool?, Func<bool?>> f2 = e2.Compile();
+            Func<bool?, Func<bool?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<bool?, bool?>>> e3 =
@@ -255,14 +255,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?, bool?> f3 = e3.Compile()();
+            Func<bool?, bool?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<bool?, bool?>>> e4 =
                 Expression.Lambda<Func<Func<bool?, bool?>>>(
                     Expression.Lambda<Func<bool?, bool?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<bool?, bool?>> f4 = e4.Compile();
+            Func<Func<bool?, bool?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -281,14 +281,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<byte?, byte?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(byte?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f1 = e1.Compile();
+            Func<byte?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<byte?, Func<byte?>>> e2 =
                 Expression.Lambda<Func<byte?, Func<byte?>>>(
                     Expression.Lambda<Func<byte?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<byte?, Func<byte?>> f2 = e2.Compile();
+            Func<byte?, Func<byte?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<byte?, byte?>>> e3 =
@@ -299,14 +299,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?, byte?> f3 = e3.Compile()();
+            Func<byte?, byte?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<byte?, byte?>>> e4 =
                 Expression.Lambda<Func<Func<byte?, byte?>>>(
                     Expression.Lambda<Func<byte?, byte?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<byte?, byte?>> f4 = e4.Compile();
+            Func<Func<byte?, byte?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -325,14 +325,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<char?, char?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(char?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f1 = e1.Compile();
+            Func<char?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<char?, Func<char?>>> e2 =
                 Expression.Lambda<Func<char?, Func<char?>>>(
                     Expression.Lambda<Func<char?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<char?, Func<char?>> f2 = e2.Compile();
+            Func<char?, Func<char?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<char?, char?>>> e3 =
@@ -343,14 +343,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?, char?> f3 = e3.Compile()();
+            Func<char?, char?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<char?, char?>>> e4 =
                 Expression.Lambda<Func<Func<char?, char?>>>(
                     Expression.Lambda<Func<char?, char?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<char?, char?>> f4 = e4.Compile();
+            Func<Func<char?, char?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -369,14 +369,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<decimal?, decimal?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(decimal?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f1 = e1.Compile();
+            Func<decimal?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<decimal?, Func<decimal?>>> e2 =
                 Expression.Lambda<Func<decimal?, Func<decimal?>>>(
                     Expression.Lambda<Func<decimal?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<decimal?, Func<decimal?>> f2 = e2.Compile();
+            Func<decimal?, Func<decimal?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<decimal?, decimal?>>> e3 =
@@ -387,14 +387,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?> f3 = e3.Compile()();
+            Func<decimal?, decimal?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<decimal?, decimal?>>> e4 =
                 Expression.Lambda<Func<Func<decimal?, decimal?>>>(
                     Expression.Lambda<Func<decimal?, decimal?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal?, decimal?>> f4 = e4.Compile();
+            Func<Func<decimal?, decimal?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -413,14 +413,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<double?, double?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(double?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f1 = e1.Compile();
+            Func<double?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<double?, Func<double?>>> e2 =
                 Expression.Lambda<Func<double?, Func<double?>>>(
                     Expression.Lambda<Func<double?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<double?, Func<double?>> f2 = e2.Compile();
+            Func<double?, Func<double?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<double?, double?>>> e3 =
@@ -431,14 +431,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?> f3 = e3.Compile()();
+            Func<double?, double?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<double?, double?>>> e4 =
                 Expression.Lambda<Func<Func<double?, double?>>>(
                     Expression.Lambda<Func<double?, double?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double?, double?>> f4 = e4.Compile();
+            Func<Func<double?, double?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -457,14 +457,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<E?, E?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(E?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f1 = e1.Compile();
+            Func<E?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<E?, Func<E?>>> e2 =
                 Expression.Lambda<Func<E?, Func<E?>>>(
                     Expression.Lambda<Func<E?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<E?, Func<E?>> f2 = e2.Compile();
+            Func<E?, Func<E?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<E?, E?>>> e3 =
@@ -475,14 +475,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?, E?> f3 = e3.Compile()();
+            Func<E?, E?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<E?, E?>>> e4 =
                 Expression.Lambda<Func<Func<E?, E?>>>(
                     Expression.Lambda<Func<E?, E?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<E?, E?>> f4 = e4.Compile();
+            Func<Func<E?, E?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -501,14 +501,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<El?, El?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(El?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f1 = e1.Compile();
+            Func<El?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<El?, Func<El?>>> e2 =
                 Expression.Lambda<Func<El?, Func<El?>>>(
                     Expression.Lambda<Func<El?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<El?, Func<El?>> f2 = e2.Compile();
+            Func<El?, Func<El?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<El?, El?>>> e3 =
@@ -519,14 +519,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?, El?> f3 = e3.Compile()();
+            Func<El?, El?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<El?, El?>>> e4 =
                 Expression.Lambda<Func<Func<El?, El?>>>(
                     Expression.Lambda<Func<El?, El?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<El?, El?>> f4 = e4.Compile();
+            Func<Func<El?, El?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -545,14 +545,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<float?, float?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(float?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f1 = e1.Compile();
+            Func<float?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<float?, Func<float?>>> e2 =
                 Expression.Lambda<Func<float?, Func<float?>>>(
                     Expression.Lambda<Func<float?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<float?, Func<float?>> f2 = e2.Compile();
+            Func<float?, Func<float?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<float?, float?>>> e3 =
@@ -563,14 +563,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?> f3 = e3.Compile()();
+            Func<float?, float?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<float?, float?>>> e4 =
                 Expression.Lambda<Func<Func<float?, float?>>>(
                     Expression.Lambda<Func<float?, float?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float?, float?>> f4 = e4.Compile();
+            Func<Func<float?, float?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -589,14 +589,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<int?, int?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<int?, Func<int?>>> e2 =
                 Expression.Lambda<Func<int?, Func<int?>>>(
                     Expression.Lambda<Func<int?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, Func<int?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<int?, int?>>> e3 =
@@ -607,14 +607,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f3 = e3.Compile()();
+            Func<int?, int?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<int?, int?>>> e4 =
                 Expression.Lambda<Func<Func<int?, int?>>>(
                     Expression.Lambda<Func<int?, int?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -633,14 +633,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<long?, long?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<long?, Func<long?>>> e2 =
                 Expression.Lambda<Func<long?, Func<long?>>>(
                     Expression.Lambda<Func<long?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, Func<long?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<long?, long?>>> e3 =
@@ -651,14 +651,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f3 = e3.Compile()();
+            Func<long?, long?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<long?, long?>>> e4 =
                 Expression.Lambda<Func<Func<long?, long?>>>(
                     Expression.Lambda<Func<long?, long?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -677,14 +677,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<S?, S?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(S?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f1 = e1.Compile();
+            Func<S?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<S?, Func<S?>>> e2 =
                 Expression.Lambda<Func<S?, Func<S?>>>(
                     Expression.Lambda<Func<S?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<S?, Func<S?>> f2 = e2.Compile();
+            Func<S?, Func<S?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<S?, S?>>> e3 =
@@ -695,14 +695,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?, S?> f3 = e3.Compile()();
+            Func<S?, S?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<S?, S?>>> e4 =
                 Expression.Lambda<Func<Func<S?, S?>>>(
                     Expression.Lambda<Func<S?, S?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<S?, S?>> f4 = e4.Compile();
+            Func<Func<S?, S?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -721,14 +721,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<sbyte?, sbyte?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(sbyte?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f1 = e1.Compile();
+            Func<sbyte?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<sbyte?, Func<sbyte?>>> e2 =
                 Expression.Lambda<Func<sbyte?, Func<sbyte?>>>(
                     Expression.Lambda<Func<sbyte?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<sbyte?, Func<sbyte?>> f2 = e2.Compile();
+            Func<sbyte?, Func<sbyte?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<sbyte?, sbyte?>>> e3 =
@@ -739,14 +739,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?, sbyte?> f3 = e3.Compile()();
+            Func<sbyte?, sbyte?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<sbyte?, sbyte?>>> e4 =
                 Expression.Lambda<Func<Func<sbyte?, sbyte?>>>(
                     Expression.Lambda<Func<sbyte?, sbyte?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<sbyte?, sbyte?>> f4 = e4.Compile();
+            Func<Func<sbyte?, sbyte?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -765,14 +765,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Sc?, Sc?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Sc?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f1 = e1.Compile();
+            Func<Sc?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Sc?, Func<Sc?>>> e2 =
                 Expression.Lambda<Func<Sc?, Func<Sc?>>>(
                     Expression.Lambda<Func<Sc?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Sc?, Func<Sc?>> f2 = e2.Compile();
+            Func<Sc?, Func<Sc?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Sc?, Sc?>>> e3 =
@@ -783,14 +783,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?, Sc?> f3 = e3.Compile()();
+            Func<Sc?, Sc?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Sc?, Sc?>>> e4 =
                 Expression.Lambda<Func<Func<Sc?, Sc?>>>(
                     Expression.Lambda<Func<Sc?, Sc?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Sc?, Sc?>> f4 = e4.Compile();
+            Func<Func<Sc?, Sc?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -809,14 +809,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Scs?, Scs?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Scs?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f1 = e1.Compile();
+            Func<Scs?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Scs?, Func<Scs?>>> e2 =
                 Expression.Lambda<Func<Scs?, Func<Scs?>>>(
                     Expression.Lambda<Func<Scs?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Scs?, Func<Scs?>> f2 = e2.Compile();
+            Func<Scs?, Func<Scs?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Scs?, Scs?>>> e3 =
@@ -827,14 +827,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?, Scs?> f3 = e3.Compile()();
+            Func<Scs?, Scs?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Scs?, Scs?>>> e4 =
                 Expression.Lambda<Func<Func<Scs?, Scs?>>>(
                     Expression.Lambda<Func<Scs?, Scs?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Scs?, Scs?>> f4 = e4.Compile();
+            Func<Func<Scs?, Scs?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -853,14 +853,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<short?, short?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<short?, Func<short?>>> e2 =
                 Expression.Lambda<Func<short?, Func<short?>>>(
                     Expression.Lambda<Func<short?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, Func<short?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<short?, short?>>> e3 =
@@ -871,14 +871,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f3 = e3.Compile()();
+            Func<short?, short?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<short?, short?>>> e4 =
                 Expression.Lambda<Func<Func<short?, short?>>>(
                     Expression.Lambda<Func<short?, short?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -897,14 +897,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Sp?, Sp?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Sp?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f1 = e1.Compile();
+            Func<Sp?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Sp?, Func<Sp?>>> e2 =
                 Expression.Lambda<Func<Sp?, Func<Sp?>>>(
                     Expression.Lambda<Func<Sp?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Sp?, Func<Sp?>> f2 = e2.Compile();
+            Func<Sp?, Func<Sp?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Sp?, Sp?>>> e3 =
@@ -915,14 +915,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?, Sp?> f3 = e3.Compile()();
+            Func<Sp?, Sp?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Sp?, Sp?>>> e4 =
                 Expression.Lambda<Func<Func<Sp?, Sp?>>>(
                     Expression.Lambda<Func<Sp?, Sp?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Sp?, Sp?>> f4 = e4.Compile();
+            Func<Func<Sp?, Sp?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -941,14 +941,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Ss?, Ss?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Ss?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?> f1 = e1.Compile();
+            Func<Ss?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Ss?, Func<Ss?>>> e2 =
                 Expression.Lambda<Func<Ss?, Func<Ss?>>>(
                     Expression.Lambda<Func<Ss?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Ss?, Func<Ss?>> f2 = e2.Compile();
+            Func<Ss?, Func<Ss?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Ss?, Ss?>>> e3 =
@@ -959,14 +959,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?, Ss?> f3 = e3.Compile()();
+            Func<Ss?, Ss?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Ss?, Ss?>>> e4 =
                 Expression.Lambda<Func<Func<Ss?, Ss?>>>(
                     Expression.Lambda<Func<Ss?, Ss?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Ss?, Ss?>> f4 = e4.Compile();
+            Func<Func<Ss?, Ss?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -985,14 +985,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<uint?, uint?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<uint?, Func<uint?>>> e2 =
                 Expression.Lambda<Func<uint?, Func<uint?>>>(
                     Expression.Lambda<Func<uint?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<uint?, uint?>>> e3 =
@@ -1003,14 +1003,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<uint?, uint?>>> e4 =
                 Expression.Lambda<Func<Func<uint?, uint?>>>(
                     Expression.Lambda<Func<uint?, uint?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1029,14 +1029,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<ulong?, ulong?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<ulong?, Func<ulong?>>> e2 =
                 Expression.Lambda<Func<ulong?, Func<ulong?>>>(
                     Expression.Lambda<Func<ulong?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<ulong?, ulong?>>> e3 =
@@ -1047,14 +1047,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<ulong?, ulong?>>> e4 =
                 Expression.Lambda<Func<Func<ulong?, ulong?>>>(
                     Expression.Lambda<Func<ulong?, ulong?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1073,14 +1073,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<ushort?, ushort?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<ushort?, Func<ushort?>>> e2 =
                 Expression.Lambda<Func<ushort?, Func<ushort?>>>(
                     Expression.Lambda<Func<ushort?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<ushort?, ushort?>>> e3 =
@@ -1091,14 +1091,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<ushort?, ushort?>>> e4 =
                 Expression.Lambda<Func<Func<ushort?, ushort?>>>(
                     Expression.Lambda<Func<ushort?, ushort?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1117,14 +1117,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Ts?, Ts?>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Ts?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f1 = e1.Compile();
+            Func<Ts?> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Ts?, Func<Ts?>>> e2 =
                 Expression.Lambda<Func<Ts?, Func<Ts?>>>(
                     Expression.Lambda<Func<Ts?>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Ts?, Func<Ts?>> f2 = e2.Compile();
+            Func<Ts?, Func<Ts?>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Ts?, Ts?>>> e3 =
@@ -1135,14 +1135,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?, Ts?> f3 = e3.Compile()();
+            Func<Ts?, Ts?> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Ts?, Ts?>>> e4 =
                 Expression.Lambda<Func<Func<Ts?, Ts?>>>(
                     Expression.Lambda<Func<Ts?, Ts?>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Ts?, Ts?>> f4 = e4.Compile();
+            Func<Func<Ts?, Ts?>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
@@ -423,14 +423,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<bool, bool>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(bool)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f1 = e1.Compile();
+            Func<bool> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<bool, Func<bool>>> e2 =
                 Expression.Lambda<Func<bool, Func<bool>>>(
                     Expression.Lambda<Func<bool>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<bool, Func<bool>> f2 = e2.Compile();
+            Func<bool, Func<bool>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<bool, bool>>> e3 =
@@ -441,14 +441,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool, bool> f3 = e3.Compile()();
+            Func<bool, bool> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<bool, bool>>> e4 =
                 Expression.Lambda<Func<Func<bool, bool>>>(
                     Expression.Lambda<Func<bool, bool>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<bool, bool>> f4 = e4.Compile();
+            Func<Func<bool, bool>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -468,14 +468,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<byte, byte>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(byte)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f1 = e1.Compile();
+            Func<byte> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<byte, Func<byte>>> e2 =
                 Expression.Lambda<Func<byte, Func<byte>>>(
                     Expression.Lambda<Func<byte>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<byte, Func<byte>> f2 = e2.Compile();
+            Func<byte, Func<byte>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<byte, byte>>> e3 =
@@ -486,14 +486,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte, byte> f3 = e3.Compile()();
+            Func<byte, byte> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<byte, byte>>> e4 =
                 Expression.Lambda<Func<Func<byte, byte>>>(
                     Expression.Lambda<Func<byte, byte>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<byte, byte>> f4 = e4.Compile();
+            Func<Func<byte, byte>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -513,14 +513,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<C, C>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(C)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f1 = e1.Compile();
+            Func<C> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<C, Func<C>>> e2 =
                 Expression.Lambda<Func<C, Func<C>>>(
                     Expression.Lambda<Func<C>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<C, Func<C>> f2 = e2.Compile();
+            Func<C, Func<C>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<C, C>>> e3 =
@@ -531,14 +531,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C, C> f3 = e3.Compile()();
+            Func<C, C> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<C, C>>> e4 =
                 Expression.Lambda<Func<Func<C, C>>>(
                     Expression.Lambda<Func<C, C>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<C, C>> f4 = e4.Compile();
+            Func<Func<C, C>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -558,14 +558,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<char, char>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(char)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f1 = e1.Compile();
+            Func<char> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<char, Func<char>>> e2 =
                 Expression.Lambda<Func<char, Func<char>>>(
                     Expression.Lambda<Func<char>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<char, Func<char>> f2 = e2.Compile();
+            Func<char, Func<char>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<char, char>>> e3 =
@@ -576,14 +576,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char, char> f3 = e3.Compile()();
+            Func<char, char> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<char, char>>> e4 =
                 Expression.Lambda<Func<Func<char, char>>>(
                     Expression.Lambda<Func<char, char>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<char, char>> f4 = e4.Compile();
+            Func<Func<char, char>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -603,14 +603,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<D, D>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(D)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f1 = e1.Compile();
+            Func<D> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<D, Func<D>>> e2 =
                 Expression.Lambda<Func<D, Func<D>>>(
                     Expression.Lambda<Func<D>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<D, Func<D>> f2 = e2.Compile();
+            Func<D, Func<D>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<D, D>>> e3 =
@@ -621,14 +621,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D, D> f3 = e3.Compile()();
+            Func<D, D> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<D, D>>> e4 =
                 Expression.Lambda<Func<Func<D, D>>>(
                     Expression.Lambda<Func<D, D>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<D, D>> f4 = e4.Compile();
+            Func<Func<D, D>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -648,14 +648,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<decimal, decimal>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(decimal)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f1 = e1.Compile();
+            Func<decimal> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<decimal, Func<decimal>>> e2 =
                 Expression.Lambda<Func<decimal, Func<decimal>>>(
                     Expression.Lambda<Func<decimal>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<decimal, Func<decimal>> f2 = e2.Compile();
+            Func<decimal, Func<decimal>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<decimal, decimal>>> e3 =
@@ -666,14 +666,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal> f3 = e3.Compile()();
+            Func<decimal, decimal> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<decimal, decimal>>> e4 =
                 Expression.Lambda<Func<Func<decimal, decimal>>>(
                     Expression.Lambda<Func<decimal, decimal>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal, decimal>> f4 = e4.Compile();
+            Func<Func<decimal, decimal>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -693,14 +693,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Delegate, Delegate>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Delegate)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f1 = e1.Compile();
+            Func<Delegate> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Delegate, Func<Delegate>>> e2 =
                 Expression.Lambda<Func<Delegate, Func<Delegate>>>(
                     Expression.Lambda<Func<Delegate>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Delegate, Func<Delegate>> f2 = e2.Compile();
+            Func<Delegate, Func<Delegate>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Delegate, Delegate>>> e3 =
@@ -711,14 +711,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate, Delegate> f3 = e3.Compile()();
+            Func<Delegate, Delegate> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Delegate, Delegate>>> e4 =
                 Expression.Lambda<Func<Func<Delegate, Delegate>>>(
                     Expression.Lambda<Func<Delegate, Delegate>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Delegate, Delegate>> f4 = e4.Compile();
+            Func<Func<Delegate, Delegate>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -738,14 +738,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<double, double>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(double)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f1 = e1.Compile();
+            Func<double> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<double, Func<double>>> e2 =
                 Expression.Lambda<Func<double, Func<double>>>(
                     Expression.Lambda<Func<double>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<double, Func<double>> f2 = e2.Compile();
+            Func<double, Func<double>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<double, double>>> e3 =
@@ -756,14 +756,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double> f3 = e3.Compile()();
+            Func<double, double> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<double, double>>> e4 =
                 Expression.Lambda<Func<Func<double, double>>>(
                     Expression.Lambda<Func<double, double>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double, double>> f4 = e4.Compile();
+            Func<Func<double, double>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -783,14 +783,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<E, E>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(E)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f1 = e1.Compile();
+            Func<E> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<E, Func<E>>> e2 =
                 Expression.Lambda<Func<E, Func<E>>>(
                     Expression.Lambda<Func<E>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<E, Func<E>> f2 = e2.Compile();
+            Func<E, Func<E>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<E, E>>> e3 =
@@ -801,14 +801,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E, E> f3 = e3.Compile()();
+            Func<E, E> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<E, E>>> e4 =
                 Expression.Lambda<Func<Func<E, E>>>(
                     Expression.Lambda<Func<E, E>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<E, E>> f4 = e4.Compile();
+            Func<Func<E, E>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -828,14 +828,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<El, El>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(El)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f1 = e1.Compile();
+            Func<El> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<El, Func<El>>> e2 =
                 Expression.Lambda<Func<El, Func<El>>>(
                     Expression.Lambda<Func<El>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<El, Func<El>> f2 = e2.Compile();
+            Func<El, Func<El>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<El, El>>> e3 =
@@ -846,14 +846,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El, El> f3 = e3.Compile()();
+            Func<El, El> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<El, El>>> e4 =
                 Expression.Lambda<Func<Func<El, El>>>(
                     Expression.Lambda<Func<El, El>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<El, El>> f4 = e4.Compile();
+            Func<Func<El, El>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -873,14 +873,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<float, float>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(float)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f1 = e1.Compile();
+            Func<float> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<float, Func<float>>> e2 =
                 Expression.Lambda<Func<float, Func<float>>>(
                     Expression.Lambda<Func<float>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<float, Func<float>> f2 = e2.Compile();
+            Func<float, Func<float>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<float, float>>> e3 =
@@ -891,14 +891,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float> f3 = e3.Compile()();
+            Func<float, float> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<float, float>>> e4 =
                 Expression.Lambda<Func<Func<float, float>>>(
                     Expression.Lambda<Func<float, float>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float, float>> f4 = e4.Compile();
+            Func<Func<float, float>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -918,14 +918,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Func<object>, Func<object>>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Func<object>)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f1 = e1.Compile();
+            Func<Func<object>> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Func<object>, Func<Func<object>>>> e2 =
                 Expression.Lambda<Func<Func<object>, Func<Func<object>>>>(
                     Expression.Lambda<Func<Func<object>>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Func<object>, Func<Func<object>>> f2 = e2.Compile();
+            Func<Func<object>, Func<Func<object>>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Func<object>, Func<object>>>> e3 =
@@ -936,14 +936,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>, Func<object>> f3 = e3.Compile()();
+            Func<Func<object>, Func<object>> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Func<object>, Func<object>>>> e4 =
                 Expression.Lambda<Func<Func<Func<object>, Func<object>>>>(
                     Expression.Lambda<Func<Func<object>, Func<object>>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Func<object>, Func<object>>> f4 = e4.Compile();
+            Func<Func<Func<object>, Func<object>>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -963,14 +963,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<I, I>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(I)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f1 = e1.Compile();
+            Func<I> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<I, Func<I>>> e2 =
                 Expression.Lambda<Func<I, Func<I>>>(
                     Expression.Lambda<Func<I>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<I, Func<I>> f2 = e2.Compile();
+            Func<I, Func<I>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<I, I>>> e3 =
@@ -981,14 +981,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I, I> f3 = e3.Compile()();
+            Func<I, I> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<I, I>>> e4 =
                 Expression.Lambda<Func<Func<I, I>>>(
                     Expression.Lambda<Func<I, I>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<I, I>> f4 = e4.Compile();
+            Func<Func<I, I>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1008,14 +1008,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<IEquatable<C>, IEquatable<C>>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(IEquatable<C>)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f1 = e1.Compile();
+            Func<IEquatable<C>> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<IEquatable<C>, Func<IEquatable<C>>>> e2 =
                 Expression.Lambda<Func<IEquatable<C>, Func<IEquatable<C>>>>(
                     Expression.Lambda<Func<IEquatable<C>>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<IEquatable<C>, Func<IEquatable<C>>> f2 = e2.Compile();
+            Func<IEquatable<C>, Func<IEquatable<C>>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<IEquatable<C>, IEquatable<C>>>> e3 =
@@ -1026,14 +1026,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>, IEquatable<C>> f3 = e3.Compile()();
+            Func<IEquatable<C>, IEquatable<C>> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<IEquatable<C>, IEquatable<C>>>> e4 =
                 Expression.Lambda<Func<Func<IEquatable<C>, IEquatable<C>>>>(
                     Expression.Lambda<Func<IEquatable<C>, IEquatable<C>>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<IEquatable<C>, IEquatable<C>>> f4 = e4.Compile();
+            Func<Func<IEquatable<C>, IEquatable<C>>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1053,14 +1053,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<IEquatable<D>, IEquatable<D>>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(IEquatable<D>)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f1 = e1.Compile();
+            Func<IEquatable<D>> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<IEquatable<D>, Func<IEquatable<D>>>> e2 =
                 Expression.Lambda<Func<IEquatable<D>, Func<IEquatable<D>>>>(
                     Expression.Lambda<Func<IEquatable<D>>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<IEquatable<D>, Func<IEquatable<D>>> f2 = e2.Compile();
+            Func<IEquatable<D>, Func<IEquatable<D>>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<IEquatable<D>, IEquatable<D>>>> e3 =
@@ -1071,14 +1071,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>, IEquatable<D>> f3 = e3.Compile()();
+            Func<IEquatable<D>, IEquatable<D>> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<IEquatable<D>, IEquatable<D>>>> e4 =
                 Expression.Lambda<Func<Func<IEquatable<D>, IEquatable<D>>>>(
                     Expression.Lambda<Func<IEquatable<D>, IEquatable<D>>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<IEquatable<D>, IEquatable<D>>> f4 = e4.Compile();
+            Func<Func<IEquatable<D>, IEquatable<D>>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1098,14 +1098,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<int, int>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<int, Func<int>>> e2 =
                 Expression.Lambda<Func<int, Func<int>>>(
                     Expression.Lambda<Func<int>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<int, Func<int>> f2 = e2.Compile();
+            Func<int, Func<int>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<int, int>>> e3 =
@@ -1116,14 +1116,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f3 = e3.Compile()();
+            Func<int, int> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<int, int>>> e4 =
                 Expression.Lambda<Func<Func<int, int>>>(
                     Expression.Lambda<Func<int, int>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int>> f4 = e4.Compile();
+            Func<Func<int, int>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1143,14 +1143,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<long, long>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<long, Func<long>>> e2 =
                 Expression.Lambda<Func<long, Func<long>>>(
                     Expression.Lambda<Func<long>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<long, Func<long>> f2 = e2.Compile();
+            Func<long, Func<long>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<long, long>>> e3 =
@@ -1161,14 +1161,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f3 = e3.Compile()();
+            Func<long, long> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<long, long>>> e4 =
                 Expression.Lambda<Func<Func<long, long>>>(
                     Expression.Lambda<Func<long, long>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long>> f4 = e4.Compile();
+            Func<Func<long, long>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1188,14 +1188,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<object, object>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(object)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f1 = e1.Compile();
+            Func<object> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<object, Func<object>>> e2 =
                 Expression.Lambda<Func<object, Func<object>>>(
                     Expression.Lambda<Func<object>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<object, Func<object>> f2 = e2.Compile();
+            Func<object, Func<object>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<object, object>>> e3 =
@@ -1206,14 +1206,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object, object> f3 = e3.Compile()();
+            Func<object, object> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<object, object>>> e4 =
                 Expression.Lambda<Func<Func<object, object>>>(
                     Expression.Lambda<Func<object, object>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object, object>> f4 = e4.Compile();
+            Func<Func<object, object>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1233,14 +1233,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<S, S>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(S)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f1 = e1.Compile();
+            Func<S> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<S, Func<S>>> e2 =
                 Expression.Lambda<Func<S, Func<S>>>(
                     Expression.Lambda<Func<S>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<S, Func<S>> f2 = e2.Compile();
+            Func<S, Func<S>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<S, S>>> e3 =
@@ -1251,14 +1251,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S, S> f3 = e3.Compile()();
+            Func<S, S> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<S, S>>> e4 =
                 Expression.Lambda<Func<Func<S, S>>>(
                     Expression.Lambda<Func<S, S>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<S, S>> f4 = e4.Compile();
+            Func<Func<S, S>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1278,14 +1278,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<sbyte, sbyte>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(sbyte)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f1 = e1.Compile();
+            Func<sbyte> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<sbyte, Func<sbyte>>> e2 =
                 Expression.Lambda<Func<sbyte, Func<sbyte>>>(
                     Expression.Lambda<Func<sbyte>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<sbyte, Func<sbyte>> f2 = e2.Compile();
+            Func<sbyte, Func<sbyte>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<sbyte, sbyte>>> e3 =
@@ -1296,14 +1296,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte, sbyte> f3 = e3.Compile()();
+            Func<sbyte, sbyte> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<sbyte, sbyte>>> e4 =
                 Expression.Lambda<Func<Func<sbyte, sbyte>>>(
                     Expression.Lambda<Func<sbyte, sbyte>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<sbyte, sbyte>> f4 = e4.Compile();
+            Func<Func<sbyte, sbyte>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1323,14 +1323,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Sc, Sc>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Sc)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc> f1 = e1.Compile();
+            Func<Sc> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Sc, Func<Sc>>> e2 =
                 Expression.Lambda<Func<Sc, Func<Sc>>>(
                     Expression.Lambda<Func<Sc>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Sc, Func<Sc>> f2 = e2.Compile();
+            Func<Sc, Func<Sc>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Sc, Sc>>> e3 =
@@ -1341,14 +1341,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc, Sc> f3 = e3.Compile()();
+            Func<Sc, Sc> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Sc, Sc>>> e4 =
                 Expression.Lambda<Func<Func<Sc, Sc>>>(
                     Expression.Lambda<Func<Sc, Sc>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Sc, Sc>> f4 = e4.Compile();
+            Func<Func<Sc, Sc>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1368,14 +1368,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Scs, Scs>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Scs)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f1 = e1.Compile();
+            Func<Scs> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Scs, Func<Scs>>> e2 =
                 Expression.Lambda<Func<Scs, Func<Scs>>>(
                     Expression.Lambda<Func<Scs>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Scs, Func<Scs>> f2 = e2.Compile();
+            Func<Scs, Func<Scs>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Scs, Scs>>> e3 =
@@ -1386,14 +1386,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs, Scs> f3 = e3.Compile()();
+            Func<Scs, Scs> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Scs, Scs>>> e4 =
                 Expression.Lambda<Func<Func<Scs, Scs>>>(
                     Expression.Lambda<Func<Scs, Scs>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Scs, Scs>> f4 = e4.Compile();
+            Func<Func<Scs, Scs>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1413,14 +1413,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<short, short>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<short, Func<short>>> e2 =
                 Expression.Lambda<Func<short, Func<short>>>(
                     Expression.Lambda<Func<short>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<short, Func<short>> f2 = e2.Compile();
+            Func<short, Func<short>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<short, short>>> e3 =
@@ -1431,14 +1431,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f3 = e3.Compile()();
+            Func<short, short> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<short, short>>> e4 =
                 Expression.Lambda<Func<Func<short, short>>>(
                     Expression.Lambda<Func<short, short>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short>> f4 = e4.Compile();
+            Func<Func<short, short>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1458,14 +1458,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Sp, Sp>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Sp)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f1 = e1.Compile();
+            Func<Sp> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Sp, Func<Sp>>> e2 =
                 Expression.Lambda<Func<Sp, Func<Sp>>>(
                     Expression.Lambda<Func<Sp>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Sp, Func<Sp>> f2 = e2.Compile();
+            Func<Sp, Func<Sp>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Sp, Sp>>> e3 =
@@ -1476,14 +1476,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp, Sp> f3 = e3.Compile()();
+            Func<Sp, Sp> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Sp, Sp>>> e4 =
                 Expression.Lambda<Func<Func<Sp, Sp>>>(
                     Expression.Lambda<Func<Sp, Sp>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Sp, Sp>> f4 = e4.Compile();
+            Func<Func<Sp, Sp>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1503,14 +1503,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Ss, Ss>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Ss)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss> f1 = e1.Compile();
+            Func<Ss> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Ss, Func<Ss>>> e2 =
                 Expression.Lambda<Func<Ss, Func<Ss>>>(
                     Expression.Lambda<Func<Ss>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Ss, Func<Ss>> f2 = e2.Compile();
+            Func<Ss, Func<Ss>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Ss, Ss>>> e3 =
@@ -1521,14 +1521,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss, Ss> f3 = e3.Compile()();
+            Func<Ss, Ss> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Ss, Ss>>> e4 =
                 Expression.Lambda<Func<Func<Ss, Ss>>>(
                     Expression.Lambda<Func<Ss, Ss>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Ss, Ss>> f4 = e4.Compile();
+            Func<Func<Ss, Ss>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1548,14 +1548,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<string, string>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(string)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string> f1 = e1.Compile();
+            Func<string> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<string, Func<string>>> e2 =
                 Expression.Lambda<Func<string, Func<string>>>(
                     Expression.Lambda<Func<string>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<string, Func<string>> f2 = e2.Compile();
+            Func<string, Func<string>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<string, string>>> e3 =
@@ -1566,14 +1566,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string, string> f3 = e3.Compile()();
+            Func<string, string> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<string, string>>> e4 =
                 Expression.Lambda<Func<Func<string, string>>>(
                     Expression.Lambda<Func<string, string>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<string, string>> f4 = e4.Compile();
+            Func<Func<string, string>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1593,14 +1593,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<uint, uint>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<uint, Func<uint>>> e2 =
                 Expression.Lambda<Func<uint, Func<uint>>>(
                     Expression.Lambda<Func<uint>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, Func<uint>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<uint, uint>>> e3 =
@@ -1611,14 +1611,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f3 = e3.Compile()();
+            Func<uint, uint> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<uint, uint>>> e4 =
                 Expression.Lambda<Func<Func<uint, uint>>>(
                     Expression.Lambda<Func<uint, uint>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1638,14 +1638,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<ulong, ulong>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<ulong, Func<ulong>>> e2 =
                 Expression.Lambda<Func<ulong, Func<ulong>>>(
                     Expression.Lambda<Func<ulong>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<ulong, ulong>>> e3 =
@@ -1656,14 +1656,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<ulong, ulong>>> e4 =
                 Expression.Lambda<Func<Func<ulong, ulong>>>(
                     Expression.Lambda<Func<ulong, ulong>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1683,14 +1683,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<ushort, ushort>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<ushort, Func<ushort>>> e2 =
                 Expression.Lambda<Func<ushort, Func<ushort>>>(
                     Expression.Lambda<Func<ushort>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<ushort, ushort>>> e3 =
@@ -1701,14 +1701,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<ushort, ushort>>> e4 =
                 Expression.Lambda<Func<Func<ushort, ushort>>>(
                     Expression.Lambda<Func<ushort, ushort>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1728,14 +1728,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<T, T>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(T)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T> f1 = e1.Compile();
+            Func<T> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<T, Func<T>>> e2 =
                 Expression.Lambda<Func<T, Func<T>>>(
                     Expression.Lambda<Func<T>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<T, Func<T>> f2 = e2.Compile();
+            Func<T, Func<T>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<T, T>>> e3 =
@@ -1746,14 +1746,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T, T> f3 = e3.Compile()();
+            Func<T, T> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<T, T>>> e4 =
                 Expression.Lambda<Func<Func<T, T>>>(
                     Expression.Lambda<Func<T, T>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<T, T>> f4 = e4.Compile();
+            Func<Func<T, T>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1773,14 +1773,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Tc, Tc>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Tc)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f1 = e1.Compile();
+            Func<Tc> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Tc, Func<Tc>>> e2 =
                 Expression.Lambda<Func<Tc, Func<Tc>>>(
                     Expression.Lambda<Func<Tc>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Tc, Func<Tc>> f2 = e2.Compile();
+            Func<Tc, Func<Tc>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Tc, Tc>>> e3 =
@@ -1791,14 +1791,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc, Tc> f3 = e3.Compile()();
+            Func<Tc, Tc> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Tc, Tc>>> e4 =
                 Expression.Lambda<Func<Func<Tc, Tc>>>(
                     Expression.Lambda<Func<Tc, Tc>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Tc, Tc>> f4 = e4.Compile();
+            Func<Func<Tc, Tc>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1818,14 +1818,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<TC, TC>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(TC)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC> f1 = e1.Compile();
+            Func<TC> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<TC, Func<TC>>> e2 =
                 Expression.Lambda<Func<TC, Func<TC>>>(
                     Expression.Lambda<Func<TC>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<TC, Func<TC>> f2 = e2.Compile();
+            Func<TC, Func<TC>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<TC, TC>>> e3 =
@@ -1836,14 +1836,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC, TC> f3 = e3.Compile()();
+            Func<TC, TC> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<TC, TC>>> e4 =
                 Expression.Lambda<Func<Func<TC, TC>>>(
                     Expression.Lambda<Func<TC, TC>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<TC, TC>> f4 = e4.Compile();
+            Func<Func<TC, TC>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1863,14 +1863,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Tcn, Tcn>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Tcn)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn> f1 = e1.Compile();
+            Func<Tcn> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Tcn, Func<Tcn>>> e2 =
                 Expression.Lambda<Func<Tcn, Func<Tcn>>>(
                     Expression.Lambda<Func<Tcn>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Tcn, Func<Tcn>> f2 = e2.Compile();
+            Func<Tcn, Func<Tcn>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Tcn, Tcn>>> e3 =
@@ -1881,14 +1881,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn, Tcn> f3 = e3.Compile()();
+            Func<Tcn, Tcn> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Tcn, Tcn>>> e4 =
                 Expression.Lambda<Func<Func<Tcn, Tcn>>>(
                     Expression.Lambda<Func<Tcn, Tcn>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Tcn, Tcn>> f4 = e4.Compile();
+            Func<Func<Tcn, Tcn>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1908,14 +1908,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<TCn, TCn>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(TCn)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn> f1 = e1.Compile();
+            Func<TCn> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<TCn, Func<TCn>>> e2 =
                 Expression.Lambda<Func<TCn, Func<TCn>>>(
                     Expression.Lambda<Func<TCn>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<TCn, Func<TCn>> f2 = e2.Compile();
+            Func<TCn, Func<TCn>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<TCn, TCn>>> e3 =
@@ -1926,14 +1926,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn, TCn> f3 = e3.Compile()();
+            Func<TCn, TCn> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<TCn, TCn>>> e4 =
                 Expression.Lambda<Func<Func<TCn, TCn>>>(
                     Expression.Lambda<Func<TCn, TCn>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<TCn, TCn>> f4 = e4.Compile();
+            Func<Func<TCn, TCn>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());
@@ -1953,14 +1953,14 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Lambda<Func<Ts, Ts>>(p, new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(Ts)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f1 = e1.Compile();
+            Func<Ts> f1 = e1.CompileForTest();
 
             // parameter passed into function generator
             Expression<Func<Ts, Func<Ts>>> e2 =
                 Expression.Lambda<Func<Ts, Func<Ts>>>(
                     Expression.Lambda<Func<Ts>>(p, Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<Ts, Func<Ts>> f2 = e2.Compile();
+            Func<Ts, Func<Ts>> f2 = e2.CompileForTest();
 
             // parameter passed into invoked generated function
             Expression<Func<Func<Ts, Ts>>> e3 =
@@ -1971,14 +1971,14 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts, Ts> f3 = e3.Compile()();
+            Func<Ts, Ts> f3 = e3.CompileForTest()();
 
             // parameter passed into generated function
             Expression<Func<Func<Ts, Ts>>> e4 =
                 Expression.Lambda<Func<Func<Ts, Ts>>>(
                     Expression.Lambda<Func<Ts, Ts>>(p, new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<Ts, Ts>> f4 = e4.Compile();
+            Func<Func<Ts, Ts>> f4 = e4.CompileForTest();
 
             Assert.Equal(value, f1());
             Assert.Equal(value, f2(value)());

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f1 = e1.Compile();
+            Func<decimal?> f1 = e1.CompileForTest();
 
             decimal? f1Result = default(decimal?);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.Compile();
+            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.CompileForTest();
 
             decimal? f2Result = default(decimal?);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?, decimal?> f3 = e3.Compile()();
+            Func<decimal?, decimal?, decimal?> f3 = e3.CompileForTest()();
 
             decimal? f3Result = default(decimal?);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.Compile();
+            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.CompileForTest();
 
             decimal? f4Result = default(decimal?);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.Compile();
+            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.CompileForTest();
 
             decimal? f5Result = default(decimal?);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?> f6 = e6.Compile()();
+            Func<decimal?, decimal?> f6 = e6.CompileForTest()();
 
             decimal? f6Result = default(decimal?);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f1 = e1.Compile();
+            Func<double?> f1 = e1.CompileForTest();
 
             double? f1Result = default(double?);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double?, double?, Func<double?>> f2 = e2.Compile();
+            Func<double?, double?, Func<double?>> f2 = e2.CompileForTest();
 
             double? f2Result = default(double?);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?, double?> f3 = e3.Compile()();
+            Func<double?, double?, double?> f3 = e3.CompileForTest()();
 
             double? f3Result = default(double?);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double?, double?, double?>> f4 = e4.Compile();
+            Func<Func<double?, double?, double?>> f4 = e4.CompileForTest();
 
             double? f4Result = default(double?);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double?, Func<double?, double?>> f5 = e5.Compile();
+            Func<double?, Func<double?, double?>> f5 = e5.CompileForTest();
 
             double? f5Result = default(double?);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?> f6 = e6.Compile()();
+            Func<double?, double?> f6 = e6.CompileForTest()();
 
             double? f6Result = default(double?);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f1 = e1.Compile();
+            Func<float?> f1 = e1.CompileForTest();
 
             float? f1Result = default(float?);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float?, float?, Func<float?>> f2 = e2.Compile();
+            Func<float?, float?, Func<float?>> f2 = e2.CompileForTest();
 
             float? f2Result = default(float?);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?, float?> f3 = e3.Compile()();
+            Func<float?, float?, float?> f3 = e3.CompileForTest()();
 
             float? f3Result = default(float?);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float?, float?, float?>> f4 = e4.Compile();
+            Func<Func<float?, float?, float?>> f4 = e4.CompileForTest();
 
             float? f4Result = default(float?);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float?, Func<float?, float?>> f5 = e5.Compile();
+            Func<float?, Func<float?, float?>> f5 = e5.CompileForTest();
 
             float? f5Result = default(float?);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?> f6 = e6.Compile()();
+            Func<float?, float?> f6 = e6.CompileForTest()();
 
             float? f6Result = default(float?);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             int? f1Result = default(int?);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int?, int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, int?, Func<int?>> f2 = e2.CompileForTest();
 
             int? f2Result = default(int?);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?, int?> f3 = e3.Compile()();
+            Func<int?, int?, int?> f3 = e3.CompileForTest()();
 
             int? f3Result = default(int?);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?, int?>> f4 = e4.CompileForTest();
 
             int? f4Result = default(int?);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int?, Func<int?, int?>> f5 = e5.Compile();
+            Func<int?, Func<int?, int?>> f5 = e5.CompileForTest();
 
             int? f5Result = default(int?);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f6 = e6.Compile()();
+            Func<int?, int?> f6 = e6.CompileForTest()();
 
             int? f6Result = default(int?);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             long? f1Result = default(long?);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long?, long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, long?, Func<long?>> f2 = e2.CompileForTest();
 
             long? f2Result = default(long?);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?, long?> f3 = e3.Compile()();
+            Func<long?, long?, long?> f3 = e3.CompileForTest()();
 
             long? f3Result = default(long?);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?, long?>> f4 = e4.CompileForTest();
 
             long? f4Result = default(long?);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long?, Func<long?, long?>> f5 = e5.Compile();
+            Func<long?, Func<long?, long?>> f5 = e5.CompileForTest();
 
             long? f5Result = default(long?);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f6 = e6.Compile()();
+            Func<long?, long?> f6 = e6.CompileForTest()();
 
             long? f6Result = default(long?);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             short? f1Result = default(short?);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short?, short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, short?, Func<short?>> f2 = e2.CompileForTest();
 
             short? f2Result = default(short?);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?, short?> f3 = e3.Compile()();
+            Func<short?, short?, short?> f3 = e3.CompileForTest()();
 
             short? f3Result = default(short?);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?, short?>> f4 = e4.CompileForTest();
 
             short? f4Result = default(short?);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short?, Func<short?, short?>> f5 = e5.Compile();
+            Func<short?, Func<short?, short?>> f5 = e5.CompileForTest();
 
             short? f5Result = default(short?);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f6 = e6.Compile()();
+            Func<short?, short?> f6 = e6.CompileForTest()();
 
             short? f6Result = default(short?);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             uint? f1Result = default(uint?);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint?, uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             uint? f2Result = default(uint?);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?, uint?> f3 = e3.CompileForTest()();
 
             uint? f3Result = default(uint?);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?, uint?>> f4 = e4.CompileForTest();
 
             uint? f4Result = default(uint?);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint?, Func<uint?, uint?>> f5 = e5.Compile();
+            Func<uint?, Func<uint?, uint?>> f5 = e5.CompileForTest();
 
             uint? f5Result = default(uint?);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f6 = e6.Compile()();
+            Func<uint?, uint?> f6 = e6.CompileForTest()();
 
             uint? f6Result = default(uint?);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             ulong? f1Result = default(ulong?);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             ulong? f2Result = default(ulong?);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?, ulong?> f3 = e3.CompileForTest()();
 
             ulong? f3Result = default(ulong?);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.CompileForTest();
 
             ulong? f4Result = default(ulong?);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.Compile();
+            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.CompileForTest();
 
             ulong? f5Result = default(ulong?);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f6 = e6.Compile()();
+            Func<ulong?, ulong?> f6 = e6.CompileForTest()();
 
             ulong? f6Result = default(ulong?);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             ushort? f1Result = default(ushort?);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             ushort? f2Result = default(ushort?);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?, ushort?> f3 = e3.CompileForTest()();
 
             ushort? f3Result = default(ushort?);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.CompileForTest();
 
             ushort? f4Result = default(ushort?);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.Compile();
+            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.CompileForTest();
 
             ushort? f5Result = default(ushort?);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f6 = e6.Compile()();
+            Func<ushort?, ushort?> f6 = e6.CompileForTest()();
 
             ushort? f6Result = default(ushort?);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f1 = e1.Compile();
+            Func<decimal> f1 = e1.CompileForTest();
 
             decimal f1Result = default(decimal);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal, decimal, Func<decimal>> f2 = e2.Compile();
+            Func<decimal, decimal, Func<decimal>> f2 = e2.CompileForTest();
 
             decimal f2Result = default(decimal);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal, decimal> f3 = e3.Compile()();
+            Func<decimal, decimal, decimal> f3 = e3.CompileForTest()();
 
             decimal f3Result = default(decimal);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal, decimal, decimal>> f4 = e4.Compile();
+            Func<Func<decimal, decimal, decimal>> f4 = e4.CompileForTest();
 
             decimal f4Result = default(decimal);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal, Func<decimal, decimal>> f5 = e5.Compile();
+            Func<decimal, Func<decimal, decimal>> f5 = e5.CompileForTest();
 
             decimal f5Result = default(decimal);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal> f6 = e6.Compile()();
+            Func<decimal, decimal> f6 = e6.CompileForTest()();
 
             decimal f6Result = default(decimal);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f1 = e1.Compile();
+            Func<double> f1 = e1.CompileForTest();
 
             double f1Result = default(double);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double, double, Func<double>> f2 = e2.Compile();
+            Func<double, double, Func<double>> f2 = e2.CompileForTest();
 
             double f2Result = default(double);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double, double> f3 = e3.Compile()();
+            Func<double, double, double> f3 = e3.CompileForTest()();
 
             double f3Result = default(double);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double, double, double>> f4 = e4.Compile();
+            Func<Func<double, double, double>> f4 = e4.CompileForTest();
 
             double f4Result = default(double);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double, Func<double, double>> f5 = e5.Compile();
+            Func<double, Func<double, double>> f5 = e5.CompileForTest();
 
             double f5Result = default(double);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double> f6 = e6.Compile()();
+            Func<double, double> f6 = e6.CompileForTest()();
 
             double f6Result = default(double);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f1 = e1.Compile();
+            Func<float> f1 = e1.CompileForTest();
 
             float f1Result = default(float);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float, float, Func<float>> f2 = e2.Compile();
+            Func<float, float, Func<float>> f2 = e2.CompileForTest();
 
             float f2Result = default(float);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float, float> f3 = e3.Compile()();
+            Func<float, float, float> f3 = e3.CompileForTest()();
 
             float f3Result = default(float);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float, float, float>> f4 = e4.Compile();
+            Func<Func<float, float, float>> f4 = e4.CompileForTest();
 
             float f4Result = default(float);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float, Func<float, float>> f5 = e5.Compile();
+            Func<float, Func<float, float>> f5 = e5.CompileForTest();
 
             float f5Result = default(float);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float> f6 = e6.Compile()();
+            Func<float, float> f6 = e6.CompileForTest()();
 
             float f6Result = default(float);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             int f1Result = default(int);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int, int, Func<int>> f2 = e2.Compile();
+            Func<int, int, Func<int>> f2 = e2.CompileForTest();
 
             int f2Result = default(int);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int, int> f3 = e3.Compile()();
+            Func<int, int, int> f3 = e3.CompileForTest()();
 
             int f3Result = default(int);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int, int>> f4 = e4.Compile();
+            Func<Func<int, int, int>> f4 = e4.CompileForTest();
 
             int f4Result = default(int);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int, Func<int, int>> f5 = e5.Compile();
+            Func<int, Func<int, int>> f5 = e5.CompileForTest();
 
             int f5Result = default(int);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f6 = e6.Compile()();
+            Func<int, int> f6 = e6.CompileForTest()();
 
             int f6Result = default(int);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             long f1Result = default(long);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long, long, Func<long>> f2 = e2.Compile();
+            Func<long, long, Func<long>> f2 = e2.CompileForTest();
 
             long f2Result = default(long);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long, long> f3 = e3.Compile()();
+            Func<long, long, long> f3 = e3.CompileForTest()();
 
             long f3Result = default(long);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long, long>> f4 = e4.Compile();
+            Func<Func<long, long, long>> f4 = e4.CompileForTest();
 
             long f4Result = default(long);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long, Func<long, long>> f5 = e5.Compile();
+            Func<long, Func<long, long>> f5 = e5.CompileForTest();
 
             long f5Result = default(long);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f6 = e6.Compile()();
+            Func<long, long> f6 = e6.CompileForTest()();
 
             long f6Result = default(long);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             short f1Result = default(short);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short, short, Func<short>> f2 = e2.Compile();
+            Func<short, short, Func<short>> f2 = e2.CompileForTest();
 
             short f2Result = default(short);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short, short> f3 = e3.Compile()();
+            Func<short, short, short> f3 = e3.CompileForTest()();
 
             short f3Result = default(short);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short, short>> f4 = e4.Compile();
+            Func<Func<short, short, short>> f4 = e4.CompileForTest();
 
             short f4Result = default(short);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short, Func<short, short>> f5 = e5.Compile();
+            Func<short, Func<short, short>> f5 = e5.CompileForTest();
 
             short f5Result = default(short);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f6 = e6.Compile()();
+            Func<short, short> f6 = e6.CompileForTest()();
 
             short f6Result = default(short);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             uint f1Result = default(uint);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint, uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, uint, Func<uint>> f2 = e2.CompileForTest();
 
             uint f2Result = default(uint);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint, uint> f3 = e3.Compile()();
+            Func<uint, uint, uint> f3 = e3.CompileForTest()();
 
             uint f3Result = default(uint);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint, uint>> f4 = e4.CompileForTest();
 
             uint f4Result = default(uint);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint, Func<uint, uint>> f5 = e5.Compile();
+            Func<uint, Func<uint, uint>> f5 = e5.CompileForTest();
 
             uint f5Result = default(uint);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f6 = e6.Compile()();
+            Func<uint, uint> f6 = e6.CompileForTest()();
 
             uint f6Result = default(uint);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             ulong f1Result = default(ulong);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong, ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             ulong f2Result = default(ulong);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong, ulong> f3 = e3.CompileForTest()();
 
             ulong f3Result = default(ulong);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong, ulong>> f4 = e4.CompileForTest();
 
             ulong f4Result = default(ulong);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong, Func<ulong, ulong>> f5 = e5.Compile();
+            Func<ulong, Func<ulong, ulong>> f5 = e5.CompileForTest();
 
             ulong f5Result = default(ulong);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f6 = e6.Compile()();
+            Func<ulong, ulong> f6 = e6.CompileForTest()();
 
             ulong f6Result = default(ulong);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             ushort f1Result = default(ushort);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort, ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             ushort f2Result = default(ushort);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort, ushort> f3 = e3.CompileForTest()();
 
             ushort f3Result = default(ushort);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort, ushort>> f4 = e4.CompileForTest();
 
             ushort f4Result = default(ushort);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Modulo(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort, Func<ushort, ushort>> f5 = e5.Compile();
+            Func<ushort, Func<ushort, ushort>> f5 = e5.CompileForTest();
 
             ushort f5Result = default(ushort);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f6 = e6.Compile()();
+            Func<ushort, ushort> f6 = e6.CompileForTest()();
 
             ushort f6Result = default(ushort);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f1 = e1.Compile();
+            Func<decimal?> f1 = e1.CompileForTest();
 
             decimal? f1Result = default(decimal?);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.Compile();
+            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.CompileForTest();
 
             decimal? f2Result = default(decimal?);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?, decimal?> f3 = e3.Compile()();
+            Func<decimal?, decimal?, decimal?> f3 = e3.CompileForTest()();
 
             decimal? f3Result = default(decimal?);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.Compile();
+            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.CompileForTest();
 
             decimal? f4Result = default(decimal?);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.Compile();
+            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.CompileForTest();
 
             decimal? f5Result = default(decimal?);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?> f6 = e6.Compile()();
+            Func<decimal?, decimal?> f6 = e6.CompileForTest()();
 
             decimal? f6Result = default(decimal?);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f1 = e1.Compile();
+            Func<double?> f1 = e1.CompileForTest();
 
             double? f1Result = default(double?);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double?, double?, Func<double?>> f2 = e2.Compile();
+            Func<double?, double?, Func<double?>> f2 = e2.CompileForTest();
 
             double? f2Result = default(double?);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?, double?> f3 = e3.Compile()();
+            Func<double?, double?, double?> f3 = e3.CompileForTest()();
 
             double? f3Result = default(double?);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double?, double?, double?>> f4 = e4.Compile();
+            Func<Func<double?, double?, double?>> f4 = e4.CompileForTest();
 
             double? f4Result = default(double?);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double?, Func<double?, double?>> f5 = e5.Compile();
+            Func<double?, Func<double?, double?>> f5 = e5.CompileForTest();
 
             double? f5Result = default(double?);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?> f6 = e6.Compile()();
+            Func<double?, double?> f6 = e6.CompileForTest()();
 
             double? f6Result = default(double?);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f1 = e1.Compile();
+            Func<float?> f1 = e1.CompileForTest();
 
             float? f1Result = default(float?);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float?, float?, Func<float?>> f2 = e2.Compile();
+            Func<float?, float?, Func<float?>> f2 = e2.CompileForTest();
 
             float? f2Result = default(float?);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?, float?> f3 = e3.Compile()();
+            Func<float?, float?, float?> f3 = e3.CompileForTest()();
 
             float? f3Result = default(float?);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float?, float?, float?>> f4 = e4.Compile();
+            Func<Func<float?, float?, float?>> f4 = e4.CompileForTest();
 
             float? f4Result = default(float?);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float?, Func<float?, float?>> f5 = e5.Compile();
+            Func<float?, Func<float?, float?>> f5 = e5.CompileForTest();
 
             float? f5Result = default(float?);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?> f6 = e6.Compile()();
+            Func<float?, float?> f6 = e6.CompileForTest()();
 
             float? f6Result = default(float?);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             int? f1Result = default(int?);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int?, int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, int?, Func<int?>> f2 = e2.CompileForTest();
 
             int? f2Result = default(int?);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?, int?> f3 = e3.Compile()();
+            Func<int?, int?, int?> f3 = e3.CompileForTest()();
 
             int? f3Result = default(int?);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?, int?>> f4 = e4.CompileForTest();
 
             int? f4Result = default(int?);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int?, Func<int?, int?>> f5 = e5.Compile();
+            Func<int?, Func<int?, int?>> f5 = e5.CompileForTest();
 
             int? f5Result = default(int?);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f6 = e6.Compile()();
+            Func<int?, int?> f6 = e6.CompileForTest()();
 
             int? f6Result = default(int?);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             long? f1Result = default(long?);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long?, long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, long?, Func<long?>> f2 = e2.CompileForTest();
 
             long? f2Result = default(long?);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?, long?> f3 = e3.Compile()();
+            Func<long?, long?, long?> f3 = e3.CompileForTest()();
 
             long? f3Result = default(long?);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?, long?>> f4 = e4.CompileForTest();
 
             long? f4Result = default(long?);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long?, Func<long?, long?>> f5 = e5.Compile();
+            Func<long?, Func<long?, long?>> f5 = e5.CompileForTest();
 
             long? f5Result = default(long?);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f6 = e6.Compile()();
+            Func<long?, long?> f6 = e6.CompileForTest()();
 
             long? f6Result = default(long?);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             short? f1Result = default(short?);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short?, short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, short?, Func<short?>> f2 = e2.CompileForTest();
 
             short? f2Result = default(short?);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?, short?> f3 = e3.Compile()();
+            Func<short?, short?, short?> f3 = e3.CompileForTest()();
 
             short? f3Result = default(short?);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?, short?>> f4 = e4.CompileForTest();
 
             short? f4Result = default(short?);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short?, Func<short?, short?>> f5 = e5.Compile();
+            Func<short?, Func<short?, short?>> f5 = e5.CompileForTest();
 
             short? f5Result = default(short?);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f6 = e6.Compile()();
+            Func<short?, short?> f6 = e6.CompileForTest()();
 
             short? f6Result = default(short?);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             uint? f1Result = default(uint?);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint?, uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             uint? f2Result = default(uint?);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?, uint?> f3 = e3.CompileForTest()();
 
             uint? f3Result = default(uint?);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?, uint?>> f4 = e4.CompileForTest();
 
             uint? f4Result = default(uint?);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint?, Func<uint?, uint?>> f5 = e5.Compile();
+            Func<uint?, Func<uint?, uint?>> f5 = e5.CompileForTest();
 
             uint? f5Result = default(uint?);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f6 = e6.Compile()();
+            Func<uint?, uint?> f6 = e6.CompileForTest()();
 
             uint? f6Result = default(uint?);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             ulong? f1Result = default(ulong?);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             ulong? f2Result = default(ulong?);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?, ulong?> f3 = e3.CompileForTest()();
 
             ulong? f3Result = default(ulong?);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.CompileForTest();
 
             ulong? f4Result = default(ulong?);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.Compile();
+            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.CompileForTest();
 
             ulong? f5Result = default(ulong?);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f6 = e6.Compile()();
+            Func<ulong?, ulong?> f6 = e6.CompileForTest()();
 
             ulong? f6Result = default(ulong?);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             ushort? f1Result = default(ushort?);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             ushort? f2Result = default(ushort?);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?, ushort?> f3 = e3.CompileForTest()();
 
             ushort? f3Result = default(ushort?);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.CompileForTest();
 
             ushort? f4Result = default(ushort?);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.Compile();
+            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.CompileForTest();
 
             ushort? f5Result = default(ushort?);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f6 = e6.Compile()();
+            Func<ushort?, ushort?> f6 = e6.CompileForTest()();
 
             ushort? f6Result = default(ushort?);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f1 = e1.Compile();
+            Func<decimal> f1 = e1.CompileForTest();
 
             decimal f1Result = default(decimal);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal, decimal, Func<decimal>> f2 = e2.Compile();
+            Func<decimal, decimal, Func<decimal>> f2 = e2.CompileForTest();
 
             decimal f2Result = default(decimal);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal, decimal> f3 = e3.Compile()();
+            Func<decimal, decimal, decimal> f3 = e3.CompileForTest()();
 
             decimal f3Result = default(decimal);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal, decimal, decimal>> f4 = e4.Compile();
+            Func<Func<decimal, decimal, decimal>> f4 = e4.CompileForTest();
 
             decimal f4Result = default(decimal);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal, Func<decimal, decimal>> f5 = e5.Compile();
+            Func<decimal, Func<decimal, decimal>> f5 = e5.CompileForTest();
 
             decimal f5Result = default(decimal);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal> f6 = e6.Compile()();
+            Func<decimal, decimal> f6 = e6.CompileForTest()();
 
             decimal f6Result = default(decimal);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f1 = e1.Compile();
+            Func<double> f1 = e1.CompileForTest();
 
             double f1Result = default(double);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double, double, Func<double>> f2 = e2.Compile();
+            Func<double, double, Func<double>> f2 = e2.CompileForTest();
 
             double f2Result = default(double);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double, double> f3 = e3.Compile()();
+            Func<double, double, double> f3 = e3.CompileForTest()();
 
             double f3Result = default(double);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double, double, double>> f4 = e4.Compile();
+            Func<Func<double, double, double>> f4 = e4.CompileForTest();
 
             double f4Result = default(double);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double, Func<double, double>> f5 = e5.Compile();
+            Func<double, Func<double, double>> f5 = e5.CompileForTest();
 
             double f5Result = default(double);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double> f6 = e6.Compile()();
+            Func<double, double> f6 = e6.CompileForTest()();
 
             double f6Result = default(double);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f1 = e1.Compile();
+            Func<float> f1 = e1.CompileForTest();
 
             float f1Result = default(float);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float, float, Func<float>> f2 = e2.Compile();
+            Func<float, float, Func<float>> f2 = e2.CompileForTest();
 
             float f2Result = default(float);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float, float> f3 = e3.Compile()();
+            Func<float, float, float> f3 = e3.CompileForTest()();
 
             float f3Result = default(float);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float, float, float>> f4 = e4.Compile();
+            Func<Func<float, float, float>> f4 = e4.CompileForTest();
 
             float f4Result = default(float);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float, Func<float, float>> f5 = e5.Compile();
+            Func<float, Func<float, float>> f5 = e5.CompileForTest();
 
             float f5Result = default(float);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float> f6 = e6.Compile()();
+            Func<float, float> f6 = e6.CompileForTest()();
 
             float f6Result = default(float);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             int f1Result = default(int);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int, int, Func<int>> f2 = e2.Compile();
+            Func<int, int, Func<int>> f2 = e2.CompileForTest();
 
             int f2Result = default(int);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int, int> f3 = e3.Compile()();
+            Func<int, int, int> f3 = e3.CompileForTest()();
 
             int f3Result = default(int);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int, int>> f4 = e4.Compile();
+            Func<Func<int, int, int>> f4 = e4.CompileForTest();
 
             int f4Result = default(int);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int, Func<int, int>> f5 = e5.Compile();
+            Func<int, Func<int, int>> f5 = e5.CompileForTest();
 
             int f5Result = default(int);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f6 = e6.Compile()();
+            Func<int, int> f6 = e6.CompileForTest()();
 
             int f6Result = default(int);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             long f1Result = default(long);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long, long, Func<long>> f2 = e2.Compile();
+            Func<long, long, Func<long>> f2 = e2.CompileForTest();
 
             long f2Result = default(long);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long, long> f3 = e3.Compile()();
+            Func<long, long, long> f3 = e3.CompileForTest()();
 
             long f3Result = default(long);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long, long>> f4 = e4.Compile();
+            Func<Func<long, long, long>> f4 = e4.CompileForTest();
 
             long f4Result = default(long);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long, Func<long, long>> f5 = e5.Compile();
+            Func<long, Func<long, long>> f5 = e5.CompileForTest();
 
             long f5Result = default(long);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f6 = e6.Compile()();
+            Func<long, long> f6 = e6.CompileForTest()();
 
             long f6Result = default(long);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             short f1Result = default(short);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short, short, Func<short>> f2 = e2.Compile();
+            Func<short, short, Func<short>> f2 = e2.CompileForTest();
 
             short f2Result = default(short);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short, short> f3 = e3.Compile()();
+            Func<short, short, short> f3 = e3.CompileForTest()();
 
             short f3Result = default(short);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short, short>> f4 = e4.Compile();
+            Func<Func<short, short, short>> f4 = e4.CompileForTest();
 
             short f4Result = default(short);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short, Func<short, short>> f5 = e5.Compile();
+            Func<short, Func<short, short>> f5 = e5.CompileForTest();
 
             short f5Result = default(short);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f6 = e6.Compile()();
+            Func<short, short> f6 = e6.CompileForTest()();
 
             short f6Result = default(short);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             uint f1Result = default(uint);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint, uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, uint, Func<uint>> f2 = e2.CompileForTest();
 
             uint f2Result = default(uint);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint, uint> f3 = e3.Compile()();
+            Func<uint, uint, uint> f3 = e3.CompileForTest()();
 
             uint f3Result = default(uint);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint, uint>> f4 = e4.CompileForTest();
 
             uint f4Result = default(uint);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint, Func<uint, uint>> f5 = e5.Compile();
+            Func<uint, Func<uint, uint>> f5 = e5.CompileForTest();
 
             uint f5Result = default(uint);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f6 = e6.Compile()();
+            Func<uint, uint> f6 = e6.CompileForTest()();
 
             uint f6Result = default(uint);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             ulong f1Result = default(ulong);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong, ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             ulong f2Result = default(ulong);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong, ulong> f3 = e3.CompileForTest()();
 
             ulong f3Result = default(ulong);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong, ulong>> f4 = e4.CompileForTest();
 
             ulong f4Result = default(ulong);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong, Func<ulong, ulong>> f5 = e5.Compile();
+            Func<ulong, Func<ulong, ulong>> f5 = e5.CompileForTest();
 
             ulong f5Result = default(ulong);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f6 = e6.Compile()();
+            Func<ulong, ulong> f6 = e6.CompileForTest()();
 
             ulong f6Result = default(ulong);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             ushort f1Result = default(ushort);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort, ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             ushort f2Result = default(ushort);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort, ushort> f3 = e3.CompileForTest()();
 
             ushort f3Result = default(ushort);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort, ushort>> f4 = e4.CompileForTest();
 
             ushort f4Result = default(ushort);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Multiply(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort, Func<ushort, ushort>> f5 = e5.Compile();
+            Func<ushort, Func<ushort, ushort>> f5 = e5.CompileForTest();
 
             ushort f5Result = default(ushort);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f6 = e6.Compile()();
+            Func<ushort, ushort> f6 = e6.CompileForTest()();
 
             ushort f6Result = default(ushort);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f1 = e1.Compile();
+            Func<decimal?> f1 = e1.CompileForTest();
 
             decimal? f1Result = default(decimal?);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.Compile();
+            Func<decimal?, decimal?, Func<decimal?>> f2 = e2.CompileForTest();
 
             decimal? f2Result = default(decimal?);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?, decimal?> f3 = e3.Compile()();
+            Func<decimal?, decimal?, decimal?> f3 = e3.CompileForTest()();
 
             decimal? f3Result = default(decimal?);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.Compile();
+            Func<Func<decimal?, decimal?, decimal?>> f4 = e4.CompileForTest();
 
             decimal? f4Result = default(decimal?);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.Compile();
+            Func<decimal?, Func<decimal?, decimal?>> f5 = e5.CompileForTest();
 
             decimal? f5Result = default(decimal?);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?, decimal?> f6 = e6.Compile()();
+            Func<decimal?, decimal?> f6 = e6.CompileForTest()();
 
             decimal? f6Result = default(decimal?);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f1 = e1.Compile();
+            Func<double?> f1 = e1.CompileForTest();
 
             double? f1Result = default(double?);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double?, double?, Func<double?>> f2 = e2.Compile();
+            Func<double?, double?, Func<double?>> f2 = e2.CompileForTest();
 
             double? f2Result = default(double?);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?, double?> f3 = e3.Compile()();
+            Func<double?, double?, double?> f3 = e3.CompileForTest()();
 
             double? f3Result = default(double?);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double?, double?, double?>> f4 = e4.Compile();
+            Func<Func<double?, double?, double?>> f4 = e4.CompileForTest();
 
             double? f4Result = default(double?);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double?, Func<double?, double?>> f5 = e5.Compile();
+            Func<double?, Func<double?, double?>> f5 = e5.CompileForTest();
 
             double? f5Result = default(double?);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?, double?> f6 = e6.Compile()();
+            Func<double?, double?> f6 = e6.CompileForTest()();
 
             double? f6Result = default(double?);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f1 = e1.Compile();
+            Func<float?> f1 = e1.CompileForTest();
 
             float? f1Result = default(float?);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float?, float?, Func<float?>> f2 = e2.Compile();
+            Func<float?, float?, Func<float?>> f2 = e2.CompileForTest();
 
             float? f2Result = default(float?);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?, float?> f3 = e3.Compile()();
+            Func<float?, float?, float?> f3 = e3.CompileForTest()();
 
             float? f3Result = default(float?);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float?, float?, float?>> f4 = e4.Compile();
+            Func<Func<float?, float?, float?>> f4 = e4.CompileForTest();
 
             float? f4Result = default(float?);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float?, Func<float?, float?>> f5 = e5.Compile();
+            Func<float?, Func<float?, float?>> f5 = e5.CompileForTest();
 
             float? f5Result = default(float?);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?, float?> f6 = e6.Compile()();
+            Func<float?, float?> f6 = e6.CompileForTest()();
 
             float? f6Result = default(float?);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             int? f1Result = default(int?);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int?, int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, int?, Func<int?>> f2 = e2.CompileForTest();
 
             int? f2Result = default(int?);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?, int?> f3 = e3.Compile()();
+            Func<int?, int?, int?> f3 = e3.CompileForTest()();
 
             int? f3Result = default(int?);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?, int?>> f4 = e4.CompileForTest();
 
             int? f4Result = default(int?);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int?, Func<int?, int?>> f5 = e5.Compile();
+            Func<int?, Func<int?, int?>> f5 = e5.CompileForTest();
 
             int? f5Result = default(int?);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f6 = e6.Compile()();
+            Func<int?, int?> f6 = e6.CompileForTest()();
 
             int? f6Result = default(int?);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             long? f1Result = default(long?);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long?, long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, long?, Func<long?>> f2 = e2.CompileForTest();
 
             long? f2Result = default(long?);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?, long?> f3 = e3.Compile()();
+            Func<long?, long?, long?> f3 = e3.CompileForTest()();
 
             long? f3Result = default(long?);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?, long?>> f4 = e4.CompileForTest();
 
             long? f4Result = default(long?);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long?, Func<long?, long?>> f5 = e5.Compile();
+            Func<long?, Func<long?, long?>> f5 = e5.CompileForTest();
 
             long? f5Result = default(long?);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f6 = e6.Compile()();
+            Func<long?, long?> f6 = e6.CompileForTest()();
 
             long? f6Result = default(long?);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             short? f1Result = default(short?);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short?, short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, short?, Func<short?>> f2 = e2.CompileForTest();
 
             short? f2Result = default(short?);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?, short?> f3 = e3.Compile()();
+            Func<short?, short?, short?> f3 = e3.CompileForTest()();
 
             short? f3Result = default(short?);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?, short?>> f4 = e4.CompileForTest();
 
             short? f4Result = default(short?);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short?, Func<short?, short?>> f5 = e5.Compile();
+            Func<short?, Func<short?, short?>> f5 = e5.CompileForTest();
 
             short? f5Result = default(short?);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f6 = e6.Compile()();
+            Func<short?, short?> f6 = e6.CompileForTest()();
 
             short? f6Result = default(short?);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             uint? f1Result = default(uint?);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint?, uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             uint? f2Result = default(uint?);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?, uint?> f3 = e3.CompileForTest()();
 
             uint? f3Result = default(uint?);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?, uint?>> f4 = e4.CompileForTest();
 
             uint? f4Result = default(uint?);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint?, Func<uint?, uint?>> f5 = e5.Compile();
+            Func<uint?, Func<uint?, uint?>> f5 = e5.CompileForTest();
 
             uint? f5Result = default(uint?);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f6 = e6.Compile()();
+            Func<uint?, uint?> f6 = e6.CompileForTest()();
 
             uint? f6Result = default(uint?);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             ulong? f1Result = default(ulong?);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             ulong? f2Result = default(ulong?);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?, ulong?> f3 = e3.CompileForTest()();
 
             ulong? f3Result = default(ulong?);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?, ulong?>> f4 = e4.CompileForTest();
 
             ulong? f4Result = default(ulong?);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.Compile();
+            Func<ulong?, Func<ulong?, ulong?>> f5 = e5.CompileForTest();
 
             ulong? f5Result = default(ulong?);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f6 = e6.Compile()();
+            Func<ulong?, ulong?> f6 = e6.CompileForTest()();
 
             ulong? f6Result = default(ulong?);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort?))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             ushort? f1Result = default(ushort?);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             ushort? f2Result = default(ushort?);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?, ushort?> f3 = e3.CompileForTest()();
 
             ushort? f3Result = default(ushort?);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?, ushort?>> f4 = e4.CompileForTest();
 
             ushort? f4Result = default(ushort?);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.Compile();
+            Func<ushort?, Func<ushort?, ushort?>> f5 = e5.CompileForTest();
 
             ushort? f5Result = default(ushort?);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f6 = e6.Compile()();
+            Func<ushort?, ushort?> f6 = e6.CompileForTest()();
 
             ushort? f6Result = default(ushort?);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(decimal))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f1 = e1.Compile();
+            Func<decimal> f1 = e1.CompileForTest();
 
             decimal f1Result = default(decimal);
             Exception f1Ex = null;
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<decimal, decimal, Func<decimal>> f2 = e2.Compile();
+            Func<decimal, decimal, Func<decimal>> f2 = e2.CompileForTest();
 
             decimal f2Result = default(decimal);
             Exception f2Ex = null;
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal, decimal> f3 = e3.Compile()();
+            Func<decimal, decimal, decimal> f3 = e3.CompileForTest()();
 
             decimal f3Result = default(decimal);
             Exception f3Ex = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<decimal, decimal, decimal>> f4 = e4.Compile();
+            Func<Func<decimal, decimal, decimal>> f4 = e4.CompileForTest();
 
             decimal f4Result = default(decimal);
             Exception f4Ex = null;
@@ -237,7 +237,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<decimal, Func<decimal, decimal>> f5 = e5.Compile();
+            Func<decimal, Func<decimal, decimal>> f5 = e5.CompileForTest();
 
             decimal f5Result = default(decimal);
             Exception f5Ex = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(decimal)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal, decimal> f6 = e6.Compile()();
+            Func<decimal, decimal> f6 = e6.CompileForTest()();
 
             decimal f6Result = default(decimal);
             Exception f6Ex = null;
@@ -337,7 +337,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(double))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f1 = e1.Compile();
+            Func<double> f1 = e1.CompileForTest();
 
             double f1Result = default(double);
             Exception f1Ex = null;
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<double, double, Func<double>> f2 = e2.Compile();
+            Func<double, double, Func<double>> f2 = e2.CompileForTest();
 
             double f2Result = default(double);
             Exception f2Ex = null;
@@ -381,7 +381,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double, double> f3 = e3.Compile()();
+            Func<double, double, double> f3 = e3.CompileForTest()();
 
             double f3Result = default(double);
             Exception f3Ex = null;
@@ -401,7 +401,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<double, double, double>> f4 = e4.Compile();
+            Func<Func<double, double, double>> f4 = e4.CompileForTest();
 
             double f4Result = default(double);
             Exception f4Ex = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<double, Func<double, double>> f5 = e5.Compile();
+            Func<double, Func<double, double>> f5 = e5.CompileForTest();
 
             double f5Result = default(double);
             Exception f5Ex = null;
@@ -445,7 +445,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(double)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double, double> f6 = e6.Compile()();
+            Func<double, double> f6 = e6.CompileForTest()();
 
             double f6Result = default(double);
             Exception f6Ex = null;
@@ -521,7 +521,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(float))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f1 = e1.Compile();
+            Func<float> f1 = e1.CompileForTest();
 
             float f1Result = default(float);
             Exception f1Ex = null;
@@ -541,7 +541,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<float, float, Func<float>> f2 = e2.Compile();
+            Func<float, float, Func<float>> f2 = e2.CompileForTest();
 
             float f2Result = default(float);
             Exception f2Ex = null;
@@ -565,7 +565,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float, float> f3 = e3.Compile()();
+            Func<float, float, float> f3 = e3.CompileForTest()();
 
             float f3Result = default(float);
             Exception f3Ex = null;
@@ -585,7 +585,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<float, float, float>> f4 = e4.Compile();
+            Func<Func<float, float, float>> f4 = e4.CompileForTest();
 
             float f4Result = default(float);
             Exception f4Ex = null;
@@ -605,7 +605,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<float, Func<float, float>> f5 = e5.Compile();
+            Func<float, Func<float, float>> f5 = e5.CompileForTest();
 
             float f5Result = default(float);
             Exception f5Ex = null;
@@ -629,7 +629,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(float)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float, float> f6 = e6.Compile()();
+            Func<float, float> f6 = e6.CompileForTest()();
 
             float f6Result = default(float);
             Exception f6Ex = null;
@@ -705,7 +705,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(int))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             int f1Result = default(int);
             Exception f1Ex = null;
@@ -725,7 +725,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<int, int, Func<int>> f2 = e2.Compile();
+            Func<int, int, Func<int>> f2 = e2.CompileForTest();
 
             int f2Result = default(int);
             Exception f2Ex = null;
@@ -749,7 +749,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int, int> f3 = e3.Compile()();
+            Func<int, int, int> f3 = e3.CompileForTest()();
 
             int f3Result = default(int);
             Exception f3Ex = null;
@@ -769,7 +769,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int, int>> f4 = e4.Compile();
+            Func<Func<int, int, int>> f4 = e4.CompileForTest();
 
             int f4Result = default(int);
             Exception f4Ex = null;
@@ -789,7 +789,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<int, Func<int, int>> f5 = e5.Compile();
+            Func<int, Func<int, int>> f5 = e5.CompileForTest();
 
             int f5Result = default(int);
             Exception f5Ex = null;
@@ -813,7 +813,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f6 = e6.Compile()();
+            Func<int, int> f6 = e6.CompileForTest()();
 
             int f6Result = default(int);
             Exception f6Ex = null;
@@ -889,7 +889,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(long))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             long f1Result = default(long);
             Exception f1Ex = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<long, long, Func<long>> f2 = e2.Compile();
+            Func<long, long, Func<long>> f2 = e2.CompileForTest();
 
             long f2Result = default(long);
             Exception f2Ex = null;
@@ -933,7 +933,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long, long> f3 = e3.Compile()();
+            Func<long, long, long> f3 = e3.CompileForTest()();
 
             long f3Result = default(long);
             Exception f3Ex = null;
@@ -953,7 +953,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long, long>> f4 = e4.Compile();
+            Func<Func<long, long, long>> f4 = e4.CompileForTest();
 
             long f4Result = default(long);
             Exception f4Ex = null;
@@ -973,7 +973,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<long, Func<long, long>> f5 = e5.Compile();
+            Func<long, Func<long, long>> f5 = e5.CompileForTest();
 
             long f5Result = default(long);
             Exception f5Ex = null;
@@ -997,7 +997,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f6 = e6.Compile()();
+            Func<long, long> f6 = e6.CompileForTest()();
 
             long f6Result = default(long);
             Exception f6Ex = null;
@@ -1073,7 +1073,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(short))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             short f1Result = default(short);
             Exception f1Ex = null;
@@ -1093,7 +1093,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<short, short, Func<short>> f2 = e2.Compile();
+            Func<short, short, Func<short>> f2 = e2.CompileForTest();
 
             short f2Result = default(short);
             Exception f2Ex = null;
@@ -1117,7 +1117,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short, short> f3 = e3.Compile()();
+            Func<short, short, short> f3 = e3.CompileForTest()();
 
             short f3Result = default(short);
             Exception f3Ex = null;
@@ -1137,7 +1137,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short, short>> f4 = e4.Compile();
+            Func<Func<short, short, short>> f4 = e4.CompileForTest();
 
             short f4Result = default(short);
             Exception f4Ex = null;
@@ -1157,7 +1157,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<short, Func<short, short>> f5 = e5.Compile();
+            Func<short, Func<short, short>> f5 = e5.CompileForTest();
 
             short f5Result = default(short);
             Exception f5Ex = null;
@@ -1181,7 +1181,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f6 = e6.Compile()();
+            Func<short, short> f6 = e6.CompileForTest()();
 
             short f6Result = default(short);
             Exception f6Ex = null;
@@ -1257,7 +1257,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(uint))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             uint f1Result = default(uint);
             Exception f1Ex = null;
@@ -1277,7 +1277,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<uint, uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, uint, Func<uint>> f2 = e2.CompileForTest();
 
             uint f2Result = default(uint);
             Exception f2Ex = null;
@@ -1301,7 +1301,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint, uint> f3 = e3.Compile()();
+            Func<uint, uint, uint> f3 = e3.CompileForTest()();
 
             uint f3Result = default(uint);
             Exception f3Ex = null;
@@ -1321,7 +1321,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint, uint>> f4 = e4.CompileForTest();
 
             uint f4Result = default(uint);
             Exception f4Ex = null;
@@ -1341,7 +1341,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<uint, Func<uint, uint>> f5 = e5.Compile();
+            Func<uint, Func<uint, uint>> f5 = e5.CompileForTest();
 
             uint f5Result = default(uint);
             Exception f5Ex = null;
@@ -1365,7 +1365,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f6 = e6.Compile()();
+            Func<uint, uint> f6 = e6.CompileForTest()();
 
             uint f6Result = default(uint);
             Exception f6Ex = null;
@@ -1441,7 +1441,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ulong))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             ulong f1Result = default(ulong);
             Exception f1Ex = null;
@@ -1461,7 +1461,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ulong, ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             ulong f2Result = default(ulong);
             Exception f2Ex = null;
@@ -1485,7 +1485,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong, ulong> f3 = e3.CompileForTest()();
 
             ulong f3Result = default(ulong);
             Exception f3Ex = null;
@@ -1505,7 +1505,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong, ulong>> f4 = e4.CompileForTest();
 
             ulong f4Result = default(ulong);
             Exception f4Ex = null;
@@ -1525,7 +1525,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ulong, Func<ulong, ulong>> f5 = e5.Compile();
+            Func<ulong, Func<ulong, ulong>> f5 = e5.CompileForTest();
 
             ulong f5Result = default(ulong);
             Exception f5Ex = null;
@@ -1549,7 +1549,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f6 = e6.Compile()();
+            Func<ulong, ulong> f6 = e6.CompileForTest()();
 
             ulong f6Result = default(ulong);
             Exception f6Ex = null;
@@ -1625,7 +1625,7 @@ namespace Tests.ExpressionCompiler.Lambda
                     Expression.Constant(b, typeof(ushort))
                 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             ushort f1Result = default(ushort);
             Exception f1Ex = null;
@@ -1645,7 +1645,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p0, p1 });
-            Func<ushort, ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             ushort f2Result = default(ushort);
             Exception f2Ex = null;
@@ -1669,7 +1669,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort, ushort> f3 = e3.CompileForTest()();
 
             ushort f3Result = default(ushort);
             Exception f3Ex = null;
@@ -1689,7 +1689,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p0, p1 }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort, ushort>> f4 = e4.CompileForTest();
 
             ushort f4Result = default(ushort);
             Exception f4Ex = null;
@@ -1709,7 +1709,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Subtract(p0, p1),
                         new ParameterExpression[] { p1 }),
                     new ParameterExpression[] { p0 });
-            Func<ushort, Func<ushort, ushort>> f5 = e5.Compile();
+            Func<ushort, Func<ushort, ushort>> f5 = e5.CompileForTest();
 
             ushort f5Result = default(ushort);
             Exception f5Ex = null;
@@ -1733,7 +1733,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p0 }),
                         new Expression[] { Expression.Constant(a, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f6 = e6.Compile()();
+            Func<ushort, ushort> f6 = e6.CompileForTest()();
 
             ushort f6Result = default(ushort);
             Exception f6Ex = null;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
@@ -101,7 +101,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(byte?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f1 = e1.Compile();
+            Func<byte?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<byte?, Func<byte?>>> e2 =
@@ -110,7 +110,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<byte?, Func<byte?>> f2 = e2.Compile();
+            Func<byte?, Func<byte?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<byte?, byte?>>> e3 =
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?, byte?> f3 = e3.Compile()();
+            Func<byte?, byte?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<byte?, byte?>>> e4 =
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<byte?, byte?>> f4 = e4.Compile();
+            Func<Func<byte?, byte?>> f4 = e4.CompileForTest();
 
             byte? expected = (byte?)~value;
 
@@ -155,7 +155,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(int?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f1 = e1.Compile();
+            Func<int?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<int?, Func<int?>>> e2 =
@@ -164,7 +164,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<int?, Func<int?>> f2 = e2.Compile();
+            Func<int?, Func<int?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<int?, int?>>> e3 =
@@ -177,7 +177,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?, int?> f3 = e3.Compile()();
+            Func<int?, int?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<int?, int?>>> e4 =
@@ -186,7 +186,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int?, int?>> f4 = e4.Compile();
+            Func<Func<int?, int?>> f4 = e4.CompileForTest();
 
             int? expected = (int?)~value;
 
@@ -209,7 +209,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(long?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f1 = e1.Compile();
+            Func<long?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<long?, Func<long?>>> e2 =
@@ -218,7 +218,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<long?, Func<long?>> f2 = e2.Compile();
+            Func<long?, Func<long?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<long?, long?>>> e3 =
@@ -231,7 +231,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?, long?> f3 = e3.Compile()();
+            Func<long?, long?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<long?, long?>>> e4 =
@@ -240,7 +240,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long?, long?>> f4 = e4.Compile();
+            Func<Func<long?, long?>> f4 = e4.CompileForTest();
 
             long? expected = (long?)~value;
 
@@ -263,7 +263,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(sbyte?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f1 = e1.Compile();
+            Func<sbyte?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<sbyte?, Func<sbyte?>>> e2 =
@@ -272,7 +272,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<sbyte?, Func<sbyte?>> f2 = e2.Compile();
+            Func<sbyte?, Func<sbyte?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<sbyte?, sbyte?>>> e3 =
@@ -285,7 +285,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?, sbyte?> f3 = e3.Compile()();
+            Func<sbyte?, sbyte?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<sbyte?, sbyte?>>> e4 =
@@ -294,7 +294,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<sbyte?, sbyte?>> f4 = e4.Compile();
+            Func<Func<sbyte?, sbyte?>> f4 = e4.CompileForTest();
 
             sbyte? expected = (sbyte?)~value;
 
@@ -317,7 +317,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(short?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f1 = e1.Compile();
+            Func<short?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<short?, Func<short?>>> e2 =
@@ -326,7 +326,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<short?, Func<short?>> f2 = e2.Compile();
+            Func<short?, Func<short?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<short?, short?>>> e3 =
@@ -339,7 +339,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?, short?> f3 = e3.Compile()();
+            Func<short?, short?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<short?, short?>>> e4 =
@@ -348,7 +348,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short?, short?>> f4 = e4.Compile();
+            Func<Func<short?, short?>> f4 = e4.CompileForTest();
 
             short? expected = (short?)~value;
 
@@ -371,7 +371,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(uint?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f1 = e1.Compile();
+            Func<uint?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<uint?, Func<uint?>>> e2 =
@@ -380,7 +380,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<uint?, Func<uint?>> f2 = e2.Compile();
+            Func<uint?, Func<uint?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<uint?, uint?>>> e3 =
@@ -393,7 +393,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?, uint?> f3 = e3.Compile()();
+            Func<uint?, uint?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<uint?, uint?>>> e4 =
@@ -402,7 +402,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint?, uint?>> f4 = e4.Compile();
+            Func<Func<uint?, uint?>> f4 = e4.CompileForTest();
 
             uint? expected = (uint?)~value;
 
@@ -425,7 +425,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ulong?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f1 = e1.Compile();
+            Func<ulong?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<ulong?, Func<ulong?>>> e2 =
@@ -434,7 +434,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ulong?, Func<ulong?>> f2 = e2.Compile();
+            Func<ulong?, Func<ulong?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<ulong?, ulong?>>> e3 =
@@ -447,7 +447,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?, ulong?> f3 = e3.Compile()();
+            Func<ulong?, ulong?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<ulong?, ulong?>>> e4 =
@@ -456,7 +456,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong?, ulong?>> f4 = e4.Compile();
+            Func<Func<ulong?, ulong?>> f4 = e4.CompileForTest();
 
             ulong? expected = (ulong?)~value;
 
@@ -479,7 +479,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ushort?)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f1 = e1.Compile();
+            Func<ushort?> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<ushort?, Func<ushort?>>> e2 =
@@ -488,7 +488,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ushort?, Func<ushort?>> f2 = e2.Compile();
+            Func<ushort?, Func<ushort?>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<ushort?, ushort?>>> e3 =
@@ -501,7 +501,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?, ushort?> f3 = e3.Compile()();
+            Func<ushort?, ushort?> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<ushort?, ushort?>>> e4 =
@@ -510,7 +510,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort?, ushort?>> f4 = e4.Compile();
+            Func<Func<ushort?, ushort?>> f4 = e4.CompileForTest();
 
             ushort? expected = (ushort?)~value;
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
@@ -101,7 +101,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(byte)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f1 = e1.Compile();
+            Func<byte> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<byte, Func<byte>>> e2 =
@@ -110,7 +110,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<byte, Func<byte>> f2 = e2.Compile();
+            Func<byte, Func<byte>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<byte, byte>>> e3 =
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte, byte> f3 = e3.Compile()();
+            Func<byte, byte> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<byte, byte>>> e4 =
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<byte, byte>> f4 = e4.Compile();
+            Func<Func<byte, byte>> f4 = e4.CompileForTest();
 
             byte expected = (byte)~value;
 
@@ -155,7 +155,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(int)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f1 = e1.Compile();
+            Func<int> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<int, Func<int>>> e2 =
@@ -164,7 +164,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<int, Func<int>> f2 = e2.Compile();
+            Func<int, Func<int>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<int, int>>> e3 =
@@ -177,7 +177,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int, int> f3 = e3.Compile()();
+            Func<int, int> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<int, int>>> e4 =
@@ -186,7 +186,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<int, int>> f4 = e4.Compile();
+            Func<Func<int, int>> f4 = e4.CompileForTest();
 
             int expected = (int)~value;
 
@@ -209,7 +209,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(long)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f1 = e1.Compile();
+            Func<long> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<long, Func<long>>> e2 =
@@ -218,7 +218,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<long, Func<long>> f2 = e2.Compile();
+            Func<long, Func<long>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<long, long>>> e3 =
@@ -231,7 +231,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long, long> f3 = e3.Compile()();
+            Func<long, long> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<long, long>>> e4 =
@@ -240,7 +240,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<long, long>> f4 = e4.Compile();
+            Func<Func<long, long>> f4 = e4.CompileForTest();
 
             long expected = (long)~value;
 
@@ -263,7 +263,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(sbyte)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f1 = e1.Compile();
+            Func<sbyte> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<sbyte, Func<sbyte>>> e2 =
@@ -272,7 +272,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<sbyte, Func<sbyte>> f2 = e2.Compile();
+            Func<sbyte, Func<sbyte>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<sbyte, sbyte>>> e3 =
@@ -285,7 +285,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte, sbyte> f3 = e3.Compile()();
+            Func<sbyte, sbyte> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<sbyte, sbyte>>> e4 =
@@ -294,7 +294,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<sbyte, sbyte>> f4 = e4.Compile();
+            Func<Func<sbyte, sbyte>> f4 = e4.CompileForTest();
 
             sbyte expected = (sbyte)~value;
 
@@ -317,7 +317,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(short)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f1 = e1.Compile();
+            Func<short> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<short, Func<short>>> e2 =
@@ -326,7 +326,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<short, Func<short>> f2 = e2.Compile();
+            Func<short, Func<short>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<short, short>>> e3 =
@@ -339,7 +339,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short, short> f3 = e3.Compile()();
+            Func<short, short> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<short, short>>> e4 =
@@ -348,7 +348,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<short, short>> f4 = e4.Compile();
+            Func<Func<short, short>> f4 = e4.CompileForTest();
 
             short expected = (short)~value;
 
@@ -371,7 +371,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(uint)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f1 = e1.Compile();
+            Func<uint> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<uint, Func<uint>>> e2 =
@@ -380,7 +380,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<uint, Func<uint>> f2 = e2.Compile();
+            Func<uint, Func<uint>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<uint, uint>>> e3 =
@@ -393,7 +393,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint, uint> f3 = e3.Compile()();
+            Func<uint, uint> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<uint, uint>>> e4 =
@@ -402,7 +402,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<uint, uint>> f4 = e4.Compile();
+            Func<Func<uint, uint>> f4 = e4.CompileForTest();
 
             uint expected = (uint)~value;
 
@@ -425,7 +425,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ulong)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f1 = e1.Compile();
+            Func<ulong> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<ulong, Func<ulong>>> e2 =
@@ -434,7 +434,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ulong, Func<ulong>> f2 = e2.Compile();
+            Func<ulong, Func<ulong>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<ulong, ulong>>> e3 =
@@ -447,7 +447,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong, ulong> f3 = e3.Compile()();
+            Func<ulong, ulong> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<ulong, ulong>>> e4 =
@@ -456,7 +456,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ulong, ulong>> f4 = e4.Compile();
+            Func<Func<ulong, ulong>> f4 = e4.CompileForTest();
 
             ulong expected = (ulong)~value;
 
@@ -479,7 +479,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             new ParameterExpression[] { p }),
                         new Expression[] { Expression.Constant(value, typeof(ushort)) }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f1 = e1.Compile();
+            Func<ushort> f1 = e1.CompileForTest();
 
             // function generator that takes a parameter
             Expression<Func<ushort, Func<ushort>>> e2 =
@@ -488,7 +488,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         Enumerable.Empty<ParameterExpression>()),
                     new ParameterExpression[] { p });
-            Func<ushort, Func<ushort>> f2 = e2.Compile();
+            Func<ushort, Func<ushort>> f2 = e2.CompileForTest();
 
             // function generator
             Expression<Func<Func<ushort, ushort>>> e3 =
@@ -501,7 +501,7 @@ namespace Tests.ExpressionCompiler.Lambda
                             Enumerable.Empty<ParameterExpression>()),
                         Enumerable.Empty<Expression>()),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort, ushort> f3 = e3.Compile()();
+            Func<ushort, ushort> f3 = e3.CompileForTest()();
 
             // parameter-taking function generator
             Expression<Func<Func<ushort, ushort>>> e4 =
@@ -510,7 +510,7 @@ namespace Tests.ExpressionCompiler.Lambda
                         Expression.Not(p),
                         new ParameterExpression[] { p }),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<ushort, ushort>> f4 = e4.Compile();
+            Func<Func<ushort, ushort>> f4 = e4.CompileForTest();
 
             ushort expected = (ushort)~value;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedAddCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("AddCheckedNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -216,7 +216,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -260,7 +260,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -304,7 +304,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -348,7 +348,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -392,7 +392,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -436,7 +436,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -480,7 +480,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedBitwiseAndNullableTests).GetTypeInfo().GetDeclaredMethod("AndNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -305,7 +305,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -349,7 +349,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -393,7 +393,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -437,7 +437,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -481,7 +481,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedBitwiseExclusiveOrNullableTests).GetTypeInfo().GetDeclaredMethod("ExclusiveOrNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -217,7 +217,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -305,7 +305,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -349,7 +349,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -393,7 +393,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -437,7 +437,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -481,7 +481,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedBitwiseOrNullableTests).GetTypeInfo().GetDeclaredMethod("OrNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -210,7 +210,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -226,7 +226,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -242,7 +242,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -258,7 +258,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -290,7 +290,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -306,7 +306,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -322,7 +322,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -338,7 +338,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -354,7 +354,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -370,7 +370,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();
@@ -386,7 +386,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == b;
             bool? result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a > b;
             bool? result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a >= b;
             bool? result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a < b;
             bool? result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a <= b;
             bool? result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -210,7 +210,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -226,7 +226,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -242,7 +242,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -258,7 +258,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -290,7 +290,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -306,7 +306,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -322,7 +322,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -338,7 +338,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -354,7 +354,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -370,7 +370,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();
@@ -386,7 +386,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         true,
                         null));
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a != b;
             bool? result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedDivideNullableTests).GetTypeInfo().GetDeclaredMethod("DivideNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedModuloNullableTests).GetTypeInfo().GetDeclaredMethod("ModuloNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedMultiplyCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyCheckedNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a & b;
 
@@ -151,7 +151,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == false ? false : a & b;
 
@@ -170,7 +170,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a | b;
 
@@ -189,7 +189,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == true ? true : a | b;
 
@@ -208,7 +208,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a & b;
 
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == false ? false : a & b;
 
@@ -246,7 +246,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a | b;
 
@@ -265,7 +265,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         null),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? expected = a == true ? true : a | b;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedSubtractCheckedNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractCheckedNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableByte")));
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte);
             Exception fEx = null;
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableChar")));
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char);
             Exception fEx = null;
@@ -333,7 +333,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableDecimal")));
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal);
             Exception fEx = null;
@@ -377,7 +377,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableDouble")));
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double);
             Exception fEx = null;
@@ -421,7 +421,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableFloat")));
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float);
             Exception fEx = null;
@@ -465,7 +465,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableInt")));
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int);
             Exception fEx = null;
@@ -509,7 +509,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableLong")));
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long);
             Exception fEx = null;
@@ -553,7 +553,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableSByte")));
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte);
             Exception fEx = null;
@@ -597,7 +597,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableShort")));
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short);
             Exception fEx = null;
@@ -641,7 +641,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableUInt")));
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint);
             Exception fEx = null;
@@ -685,7 +685,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableULong")));
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?)),
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableUShort")));
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -210,7 +210,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -226,7 +226,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -242,7 +242,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -258,7 +258,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -290,7 +290,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -306,7 +306,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -322,7 +322,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -338,7 +338,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -354,7 +354,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -370,7 +370,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();
@@ -386,7 +386,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a == b;
             bool result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a > b;
             bool result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a >= b;
             bool result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a < b;
             bool result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
@@ -181,7 +181,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -197,7 +197,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -245,7 +245,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -277,7 +277,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -293,7 +293,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -309,7 +309,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -325,7 +325,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -341,7 +341,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();
@@ -357,7 +357,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a <= b;
             bool result = f();

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
@@ -194,7 +194,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(bool?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -210,7 +210,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(byte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -226,7 +226,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(char?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -242,7 +242,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(decimal?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -258,7 +258,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(double?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -274,7 +274,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(float?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -290,7 +290,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(int?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -306,7 +306,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(long?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -322,7 +322,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(sbyte?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -338,7 +338,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(short?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -354,7 +354,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(uint?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -370,7 +370,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ulong?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();
@@ -386,7 +386,7 @@ namespace Tests.ExpressionCompiler.Lifted
                         Expression.Constant(b, typeof(ushort?)),
                         false,
                         null));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool expected = a != b;
             bool result = f();

--- a/src/System.Linq.Expressions/tests/ListEqualityComparer.cs
+++ b/src/System.Linq.Expressions/tests/ListEqualityComparer.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+namespace System.Collections.Generic
+{
+    class ListEqualityComparer<T> : IEqualityComparer<List<T>>
+    {
+        public static readonly IEqualityComparer<List<T>> Default = new ListEqualityComparer<T>();
+
+        public bool Equals(List<T> x, List<T> y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return x.SequenceEqual(y);
+        }
+
+        public int GetHashCode(List<T> obj)
+        {
+            if (obj == null)
+            {
+                return 0;
+            }
+
+            var eq = EqualityComparer<T>.Default;
+
+            var res = 17;
+
+            unchecked
+            {
+                foreach (var element in obj)
+                {
+                    res += eq.GetHashCode(element);
+                    res *= 17;
+                }
+            }
+            
+            return res;
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -19,7 +19,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         Expression.Constant(new FS() { II = 42 }),
                         "II"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -37,7 +37,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                             typeof(FS),
                             "SI"),
                         Enumerable.Empty<ParameterExpression>());
-                Func<int> f = e.Compile();
+                Func<int> f = e.CompileForTest();
 
                 Assert.Equal(42, f());
             }
@@ -57,7 +57,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         typeof(FS),
                         "CI"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -72,7 +72,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         typeof(FS),
                         "RI"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -86,7 +86,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         Expression.Constant(new PS() { II = 42 }),
                         "II"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -104,7 +104,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                             typeof(PS),
                             "SI"),
                         Enumerable.Empty<ParameterExpression>());
-                Func<int> f = e.Compile();
+                Func<int> f = e.CompileForTest();
 
                 Assert.Equal(42, f());
             }
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         Expression.Constant(new FC() { II = 42 }),
                         "II"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -141,7 +141,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                             typeof(FC),
                             "SI"),
                         Enumerable.Empty<ParameterExpression>());
-                Func<int> f = e.Compile();
+                Func<int> f = e.CompileForTest();
 
                 Assert.Equal(42, f());
             }
@@ -161,7 +161,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         typeof(FC),
                         "CI"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -176,7 +176,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         typeof(FC),
                         "RI"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -190,7 +190,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         Expression.Constant(new PC() { II = 42 }),
                         "II"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Equal(42, f());
         }
@@ -208,7 +208,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                             typeof(PC),
                             "SI"),
                         Enumerable.Empty<ParameterExpression>());
-                Func<int> f = e.Compile();
+                Func<int> f = e.CompileForTest();
 
                 Assert.Equal(42, f());
             }
@@ -227,7 +227,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         Expression.Constant(null, typeof(FC)),
                         "II"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Throws<NullReferenceException>(()=>f());
         }
@@ -243,7 +243,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                             "II"),
                         Expression.Constant(1)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Throws<NullReferenceException>(() => f());
         }
@@ -257,7 +257,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         Expression.Constant(null, typeof(PC)),
                         "II"),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Throws<NullReferenceException>(() => f());
         }
@@ -272,7 +272,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                         "Item",
                         Expression.Constant(1)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Throws<NullReferenceException>(() => f());
         }
@@ -289,7 +289,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                             Expression.Constant(1)),
                         Expression.Constant(1)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             Assert.Throws<NullReferenceException>(() => f());
         }

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -25,7 +25,7 @@ namespace Tests.ExpressionCompiler.MemberInit
 
         private static void VerifyMemberInit<T>(Expression<Func<T>> expr, Func<T, bool> check)
         {
-            Func<T> c = expr.Compile();
+            Func<T> c = expr.CompileForTest();
             Assert.True(check(c()));
 
 #if FEATURE_INTERPRET
@@ -38,7 +38,7 @@ namespace Tests.ExpressionCompiler.MemberInit
 
         #region Helpers
 
-        class X
+        class X : IEquatable<X>
         {
             private readonly Y _y = new Y();
             private readonly List<int> _xs = new List<int>();
@@ -49,15 +49,49 @@ namespace Tests.ExpressionCompiler.MemberInit
             }
 
             public List<int> XS { get { return _xs; } }
+
+            public bool Equals(X obj)
+            {
+                return
+                    EqualityComparer<Y>.Default.Equals(obj.Y, this.Y) &&
+                    ListEqualityComparer<int>.Default.Equals(obj.XS, this.XS);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as X);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0; // just for testing equality
+            }
         }
 
-        class Y
+        class Y : IEquatable<Y>
         {
             private readonly List<int> _ys = new List<int>();
 
             public int Z { get; set; }
 
             public List<int> YS { get { return _ys; } }
+
+            public bool Equals(Y obj)
+            {
+                return
+                    obj.Z == this.Z &&
+                    ListEqualityComparer<int>.Default.Equals(obj.YS, this.YS);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as Y);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0; // just for testing equality
+            }
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -19,7 +19,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<C>>(
                     Expression.New(typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             Assert.Equal(new C(), f());
         }
@@ -31,7 +31,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<E>>(
                     Expression.New(typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             Assert.Equal(new E(), f());
         }
@@ -43,7 +43,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<E?>>(
                     Expression.New(typeof(E?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             Assert.Equal(new E?(), f());
         }
@@ -55,7 +55,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<int?>>(
                     Expression.New(typeof(int?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             Assert.Equal(new int?(), f());
         }
@@ -67,7 +67,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<S>>(
                     Expression.New(typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
 
             Assert.Equal(new S(), f());
         }
@@ -79,7 +79,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<S?>>(
                     Expression.New(typeof(S?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f = e.Compile();
+            Func<S?> f = e.CompileForTest();
 
             Assert.Equal(new S?(), f());
         }
@@ -91,7 +91,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sc>>(
                     Expression.New(typeof(Sc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc> f = e.Compile();
+            Func<Sc> f = e.CompileForTest();
 
             Assert.Equal(new Sc(), f());
         }
@@ -103,7 +103,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sc?>>(
                     Expression.New(typeof(Sc?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
 
             Assert.Equal(new Sc?(), f());
         }
@@ -115,7 +115,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Scs>>(
                     Expression.New(typeof(Scs)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f = e.Compile();
+            Func<Scs> f = e.CompileForTest();
 
             Assert.Equal(new Scs(), f());
         }
@@ -127,7 +127,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Scs?>>(
                     Expression.New(typeof(Scs?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f = e.Compile();
+            Func<Scs?> f = e.CompileForTest();
 
             Assert.Equal(new Scs?(), f());
         }
@@ -139,7 +139,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sp>>(
                     Expression.New(typeof(Sp)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f = e.Compile();
+            Func<Sp> f = e.CompileForTest();
 
             Assert.Equal(new Sp(), f());
         }
@@ -151,7 +151,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sp?>>(
                     Expression.New(typeof(Sp?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f = e.Compile();
+            Func<Sp?> f = e.CompileForTest();
 
             Assert.Equal(new Sp?(), f());
         }
@@ -202,7 +202,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Ts>>(
                     Expression.New(typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
 
             Assert.Equal(new Ts(), f());
         }
@@ -213,7 +213,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Ts?>>(
                     Expression.New(typeof(Ts?)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f = e.Compile();
+            Func<Ts?> f = e.CompileForTest();
 
             Assert.Equal(new Ts?(), f());
         }
@@ -235,7 +235,17 @@ namespace Tests.ExpressionCompiler.New
             public static Func<TestPrivateDefaultConstructor> GetInstanceFunc()
             {
                 var lambda = Expression.Lambda<Func<TestPrivateDefaultConstructor>>(Expression.New(typeof(TestPrivateDefaultConstructor)), new ParameterExpression[] { });
-                return lambda.Compile();
+                return lambda.CompileForTest();
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is TestPrivateDefaultConstructor;
+            }
+
+            public override int GetHashCode()
+            {
+                return 0;
             }
 
             public override string ToString()

--- a/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
@@ -119,7 +119,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<E?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
             Assert.Equal(new E?(value), f());
         }
 
@@ -131,7 +131,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<int?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal(new int?(value), f());
         }
 
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<S?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f = e.Compile();
+            Func<S?> f = e.CompileForTest();
             Assert.Equal(new S?(value), f());
         }
 
@@ -155,7 +155,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sc?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
             Assert.Equal(new Sc?(value), f());
         }
 
@@ -167,7 +167,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Scs?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f = e.Compile();
+            Func<Scs?> f = e.CompileForTest();
             Assert.Equal(new Scs?(value), f());
         }
 
@@ -179,7 +179,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sc?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
             Assert.Equal(new Sc?(value), f());
         }
 
@@ -191,7 +191,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sp?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f = e.Compile();
+            Func<Sp?> f = e.CompileForTest();
             Assert.Equal(new Sp?(value), f());
         }
 
@@ -203,7 +203,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Ts?>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f = e.Compile();
+            Func<Ts?> f = e.CompileForTest();
             Assert.Equal(new Ts?(value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
@@ -70,7 +70,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Sp>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f = e.Compile();
+            Func<Sp> f = e.CompileForTest();
 
             Assert.Equal(new Sp(a, b), f());
         }
@@ -83,7 +83,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<D>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             Assert.Equal(new D(a, b), f());
         }
@@ -96,7 +96,7 @@ namespace Tests.ExpressionCompiler.New
                 Expression.Lambda<Func<Scs>>(
                     Expression.New(constructor, exprArgs),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f = e.Compile();
+            Func<Scs> f = e.CompileForTest();
 
             Assert.Equal(new Scs(a, b), f());
         }

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -2907,10 +2907,20 @@ namespace Tests
         [Fact]
         public static void CallCompiledLambdaWithTypeMissing()
         {
+            //
+            // NB: Using Compile here rather than CompileForTest.
+            //
+            //     See https://github.com/dotnet/corefx/issues/4112 for the issue with the interpreter
+            //     which gets triggered when passing Type.Missing. This only repros when the "compiled"
+            //     delegate below gets compiled while the "lambda" delegate gets interpreted. The reason
+            //     for this is that the Run method of the CallInstruction will go through the slow path
+            //     because TryGetLightLambdaTarget returns false, thus triggering a call to the Invoke
+            //     method on MethodInfo which doesn't like Type.Missing as an argument.
+            //
             Expression<Func<object, bool>> f = x => x == Type.Missing;
-            var compiled = f.CompileForTest();
+            var compiled = f.Compile();
             Expression<Func<object, bool>> lambda = x => compiled(x);
-            Func<object, bool> d = lambda.CompileForTest();
+            Func<object, bool> d = lambda.Compile();
             Assert.Equal(true, d(Type.Missing));
         }
 

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -737,7 +737,7 @@ namespace Tests
             lambda = (Expression<Func<int, double, decimal, short, int>>)((int i, double j, decimal k, short l) => i);
 
             Assert.Equal(typeof(Func<int, double, decimal, short, Func<int, double, decimal, short, int>>),
-                Expression.Lambda(lambda, new[] { paramI, paramJ, paramK, paramL }).Compile().GetType());
+                Expression.Lambda(lambda, new[] { paramI, paramJ, paramK, paramL }).CompileForTest().GetType());
 
             Assert.False(String.IsNullOrEmpty(lambda.ToString()));
         }
@@ -1312,7 +1312,7 @@ namespace Tests
                   );
 
             string result = "";
-            foreach (var x in e.Compile()(new[] { 1, 2, 3 }))
+            foreach (var x in e.CompileForTest()(new[] { 1, 2, 3 }))
                 result += ", " + x.ToString();
 
             Assert.Equal(", 1, 2, 3", result);
@@ -1842,7 +1842,7 @@ namespace Tests
             AndAlso r1 = f1();
 
             Expression<Func<AndAlso>> e = () => a1 && !a1;
-            AndAlso r2 = e.Compile()();
+            AndAlso r2 = e.CompileForTest()();
 
             Assert.Equal(r2.value, r1.value);
         }
@@ -1870,7 +1870,7 @@ namespace Tests
             object st_local = new TC1();
             var mi = typeof(object).GetMethod("ToString");
             var lam = Expression.Lambda<Func<string>>(Expression.Call(Expression.Constant(st_local), mi, null), null);
-            var f = lam.Compile();
+            var f = lam.CompileForTest();
         }
 
         [Fact]
@@ -1891,7 +1891,7 @@ namespace Tests
                     new Expression[] { left, right }),
                Enumerable.Empty<ParameterExpression>());
 
-            Func<TC1?> f1 = e1.Compile();
+            Func<TC1?> f1 = e1.CompileForTest();
             Assert.NotNull(f1());
             Assert.Equal(f1().Value.Name, "And");
 
@@ -1902,7 +1902,7 @@ namespace Tests
                     new Expression[] { left, right }),
                Enumerable.Empty<ParameterExpression>());
 
-            Func<TC1?> f2 = e2.Compile();
+            Func<TC1?> f2 = e2.CompileForTest();
             Assert.NotNull(f2());
             Assert.Equal(f2().Value.Name, "lhs");
 
@@ -2000,7 +2000,7 @@ namespace Tests
                     Expression.Lambda<Func<int>>(
                         Expression.Call(typeof(CustomerWriteBack).GetMethod("Funct1"), new[] { Expression.Property(null, typeof(CustomerWriteBack).GetProperty("Prop")) }),
                         null);
-            var f1 = e1.Compile();
+            var f1 = e1.CompileForTest();
             int result = f1();
             Assert.Equal(5, result);
 
@@ -2011,7 +2011,7 @@ namespace Tests
                      new Expression[] { Expression.Property(Expression.Constant(a, typeof(CustomerWriteBack)), pi) }
                      ),
                  null);
-            var f = e.Compile();
+            var f = e.CompileForTest();
             var r = f();
             Assert.Equal(a.m_x, "Changed");
 
@@ -2022,7 +2022,7 @@ namespace Tests
                      new Expression[] { Expression.Property(Expression.Constant(a, typeof(CustomerWriteBack)), piCust) }
                      ),
                  null);
-            var f2 = e2.Compile();
+            var f2 = e2.CompileForTest();
             var r2 = f2();
             Assert.True(a.Cust.zip == 90008 && a.Cust.name == "SreeCho");
         }
@@ -2050,13 +2050,13 @@ namespace Tests
                 Expression.Lambda<Func<Complex>>(
                     Expression.UnaryPlus(Expression.Constant(comp, typeof(Complex))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Complex> f1 = e1.Compile();
+            Func<Complex> f1 = e1.CompileForTest();
             Complex comp1 = f1();
             Assert.True((comp1.x == comp.x + 1 && comp1.y == comp.y + 1));
 
             Expression<Func<Complex, Complex>> testExpr = (x) => +x;
             Assert.Equal(testExpr.ToString(), "x => +x");
-            var v = testExpr.Compile();
+            var v = testExpr.CompileForTest();
         }
 
         private struct S
@@ -2073,37 +2073,37 @@ namespace Tests
 
             Expression<Func<int?, int?, bool?>> e = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.GreaterThan(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            var f = e.Compile();
+            var f = e.CompileForTest();
             var r = f(x, y);
             Assert.True(r.Value);
 
             Expression<Func<int?, int?, bool?>> e1 = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.LessThan(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            f = e1.Compile();
+            f = e1.CompileForTest();
             r = f(x, y);
             Assert.False(r.Value);
 
             Expression<Func<int?, int?, bool?>> e2 = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.GreaterThanOrEqual(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            f = e2.Compile();
+            f = e2.CompileForTest();
             r = f(x, y);
             Assert.True(r.Value);
 
             Expression<Func<int?, int?, bool?>> e3 = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.Equal(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            f = e3.Compile();
+            f = e3.CompileForTest();
             r = f(x, y);
             Assert.False(r.Value);
 
             Expression<Func<int?, int?, bool?>> e4 = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.LessThanOrEqual(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            f = e4.Compile();
+            f = e4.CompileForTest();
             r = f(x, y);
             Assert.False(r.Value);
 
             Expression<Func<int?, int?, bool?>> e5 = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.NotEqual(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            f = e5.Compile();
+            f = e5.CompileForTest();
             r = f(x, y);
             Assert.True(r.Value);
 
@@ -2115,7 +2115,7 @@ namespace Tests
                     true,
                     null),
                 null);
-            var f6 = e6.Compile();
+            var f6 = e6.CompileForTest();
             Assert.Null(f6());
         }
 
@@ -2165,7 +2165,7 @@ namespace Tests
             Expression<Func<TestClass>> e = Expression.Lambda<Func<TestClass>>(
                Expression.New(constructor, expressions, members),
                Enumerable.Empty<ParameterExpression>());
-            Func<TestClass> f = e.Compile();
+            Func<TestClass> f = e.CompileForTest();
             Assert.True(object.Equals(f(), new TestClass(s, val)));
 
             List<MemberInfo> members1 = new List<MemberInfo>();
@@ -2175,7 +2175,7 @@ namespace Tests
             Expression<Func<TestClass>> e1 = Expression.Lambda<Func<TestClass>>(
                Expression.New(constructor, expressions, members1),
                Enumerable.Empty<ParameterExpression>());
-            Func<TestClass> f1 = e1.Compile();
+            Func<TestClass> f1 = e1.CompileForTest();
             Assert.True(object.Equals(f1(), new TestClass(s, val)));
             MemberInfo mem1 = typeof(AnonHelperClass1).GetField("mem1");
             LambdaExpression ce1 = Expression.Lambda(Expression.Constant(45m, typeof(decimal)));
@@ -2192,7 +2192,7 @@ namespace Tests
         public static void TypeAsNullableToObject()
         {
             Expression<Func<object>> e = Expression.Lambda<Func<object>>(Expression.TypeAs(Expression.Constant(0, typeof(int?)), typeof(object)));
-            Func<object> f = e.Compile(); // System.ArgumentException: Unhandled unary: TypeAs
+            Func<object> f = e.CompileForTest(); // System.ArgumentException: Unhandled unary: TypeAs
             Assert.Equal(0, f());
         }
 
@@ -2200,7 +2200,7 @@ namespace Tests
         public static void TypesIsConstantValueType()
         {
             Expression<Func<bool>> e = Expression.Lambda<Func<bool>>(Expression.TypeIs(Expression.Constant(5), typeof(object)));
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.True(f());
         }
 
@@ -2208,7 +2208,7 @@ namespace Tests
         public static void ConstantEmitsValidIL()
         {
             Expression<Func<byte>> e = Expression.Lambda<Func<byte>>(Expression.Constant((byte)0), Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
             Assert.Equal((byte)0, f());
         }
 
@@ -2292,7 +2292,7 @@ namespace Tests
 
         private static S TestCast<T, S>(T value)
         {
-            Func<S> d = Expression.Lambda<Func<S>>(Expression.Convert(Expression.Constant(value, typeof(T)), typeof(S))).Compile();
+            Func<S> d = Expression.Lambda<Func<S>>(Expression.Convert(Expression.Constant(value, typeof(T)), typeof(S))).CompileForTest();
             return d();
         }
 
@@ -2652,13 +2652,13 @@ namespace Tests
 
         private static S TestConvert<T, S>(T value)
         {
-            Func<S> d = Expression.Lambda<Func<S>>(Expression.Convert(Expression.Constant(value, typeof(T)), typeof(S))).Compile();
+            Func<S> d = Expression.Lambda<Func<S>>(Expression.Convert(Expression.Constant(value, typeof(T)), typeof(S))).CompileForTest();
             return d();
         }
 
         private static S TestConvertChecked<T, S>(T value)
         {
-            Func<S> d = Expression.Lambda<Func<S>>(Expression.ConvertChecked(Expression.Constant(value, typeof(T)), typeof(S))).Compile();
+            Func<S> d = Expression.Lambda<Func<S>>(Expression.ConvertChecked(Expression.Constant(value, typeof(T)), typeof(S))).CompileForTest();
             return d();
         }
 
@@ -2670,7 +2670,7 @@ namespace Tests
             Assert.Throws<NullReferenceException>(() =>
             {
                 Expression<Func<ValueType, int>> e = v => (int)v;
-                Func<ValueType, int> f = e.Compile();
+                Func<ValueType, int> f = e.CompileForTest();
                 f(null);
             });
         }
@@ -2679,7 +2679,7 @@ namespace Tests
         public static void ShiftWithMismatchedNulls()
         {
             Expression<Func<byte?, int, int?>> e = (byte? b, int i) => (byte?)(b << i);
-            var f = e.Compile();
+            var f = e.CompileForTest();
             Assert.Equal(20, f(5, 2));
         }
 
@@ -2692,20 +2692,20 @@ namespace Tests
                 Expression.Lambda<Func<char?, char?, char?>>(
                     Expression.Coalesce(x, y),
                     new ParameterExpression[] { x, y });
-            Func<char?, char?, char?> f = e.Compile();
+            Func<char?, char?, char?> f = e.CompileForTest();
         }
         [Fact]
         public static void ConvertToChar()
         {
-            Func<char> f = Expression.Lambda<Func<Char>>(Expression.Convert(Expression.Constant((byte)65), typeof(char))).Compile();
+            Func<char> f = Expression.Lambda<Func<Char>>(Expression.Convert(Expression.Constant((byte)65), typeof(char))).CompileForTest();
             Assert.Equal('A', f());
 
-            Func<char> f2 = Expression.Lambda<Func<Char>>(Expression.Convert(Expression.Constant(65), typeof(char))).Compile();
+            Func<char> f2 = Expression.Lambda<Func<Char>>(Expression.Convert(Expression.Constant(65), typeof(char))).CompileForTest();
             Assert.Equal('A', f2());
 
-            Func<char> f3 = Expression.Lambda<Func<Char>>(Expression.Convert(Expression.Constant(-1), typeof(char))).Compile();
+            Func<char> f3 = Expression.Lambda<Func<Char>>(Expression.Convert(Expression.Constant(-1), typeof(char))).CompileForTest();
             char c3 = f3();
-            Func<int> f4 = Expression.Lambda<Func<int>>(Expression.Convert(Expression.Constant(c3), typeof(int))).Compile();
+            Func<int> f4 = Expression.Lambda<Func<int>>(Expression.Convert(Expression.Constant(c3), typeof(int))).CompileForTest();
             Assert.Equal(UInt16.MaxValue, f4());
         }
 
@@ -2713,7 +2713,7 @@ namespace Tests
         public static void MixedTypeNullableOps()
         {
             Expression<Func<decimal, int?, decimal?>> e = (d, i) => d + i;
-            var f = e.Compile();
+            var f = e.CompileForTest();
             var result = f(1.0m, 4);
             Debug.WriteLine(result);
         }
@@ -2722,7 +2722,7 @@ namespace Tests
         public static void NullGuidConstant()
         {
             Expression<Func<Guid?, bool>> f2 = g2 => g2 != null;
-            var d2 = f2.Compile();
+            var d2 = f2.CompileForTest();
             Assert.True(d2(Guid.NewGuid()));
             Assert.False(d2(null));
         }
@@ -2736,7 +2736,7 @@ namespace Tests
                     Expression.Constant(1, typeof(int?))
                     ));
 
-            var result = f.Compile()();
+            var result = f.CompileForTest()();
             Debug.WriteLine(result);
         }
 
@@ -2744,7 +2744,7 @@ namespace Tests
         public static void CallWithRefParam()
         {
             Expression<Func<int, int>> f = x => x + MethodWithRefParam(ref x) + x;
-            Func<int, int> d = f.Compile();
+            Func<int, int> d = f.CompileForTest();
             Assert.Equal(113, d(10));
         }
 
@@ -2758,7 +2758,7 @@ namespace Tests
         public static void CallWithOutParam()
         {
             Expression<Func<int, int>> f = x => x + MethodWithOutParam(out x) + x;
-            Func<int, int> d = f.Compile();
+            Func<int, int> d = f.CompileForTest();
             Assert.Equal(113, d(10));
         }
 
@@ -2774,7 +2774,7 @@ namespace Tests
             Expression<Func<int, string[]>> linq1 = (a => new string[a]);
             InvocationExpression linq1a = Expression.Invoke(linq1, new Expression[] { Expression.Constant(3) });
             Expression<Func<string[]>> linq1b = Expression.Lambda<Func<string[]>>(linq1a, new ParameterExpression[] { });
-            Func<string[]> f = linq1b.Compile();
+            Func<string[]> f = linq1b.CompileForTest();
         }
 
         [Fact]
@@ -2783,7 +2783,7 @@ namespace Tests
             Expression<Func<DateTime?, TimeSpan, DateTime?>> f = (x, y) => x + y;
             Assert.Equal(ExpressionType.Add, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime?, TimeSpan, DateTime?> d = f.Compile();
+            Func<DateTime?, TimeSpan, DateTime?> d = f.CompileForTest();
             DateTime? dt = DateTime.Now;
             TimeSpan ts = new TimeSpan(3, 2, 1);
             DateTime? dt2 = dt + ts;
@@ -2797,7 +2797,7 @@ namespace Tests
             Expression<Func<DateTime?, TimeSpan?, DateTime?>> f = (x, y) => x + y;
             Assert.Equal(ExpressionType.Add, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime?, TimeSpan?, DateTime?> d = f.Compile();
+            Func<DateTime?, TimeSpan?, DateTime?> d = f.CompileForTest();
             DateTime? dt = DateTime.Now;
             TimeSpan? ts = new TimeSpan(3, 2, 1);
             DateTime? dt2 = dt + ts;
@@ -2813,7 +2813,7 @@ namespace Tests
             Expression<Func<DateTime?, DateTime?, TimeSpan?>> f = (x, y) => x - y;
             Assert.Equal(ExpressionType.Subtract, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime?, DateTime?, TimeSpan?> d = f.Compile();
+            Func<DateTime?, DateTime?, TimeSpan?> d = f.CompileForTest();
             DateTime? dt1 = DateTime.Now;
             DateTime? dt2 = new DateTime(2006, 5, 1);
             TimeSpan? ts = dt1 - dt2;
@@ -2829,7 +2829,7 @@ namespace Tests
             Expression<Func<DateTime?, DateTime?, bool>> f = (x, y) => x == y;
             Assert.Equal(ExpressionType.Equal, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime?, DateTime?, bool> d = f.Compile();
+            Func<DateTime?, DateTime?, bool> d = f.CompileForTest();
             DateTime? dt1 = DateTime.Now;
             DateTime? dt2 = new DateTime(2006, 5, 1);
             Assert.True(d(dt1, dt1));
@@ -2845,7 +2845,7 @@ namespace Tests
             Expression<Func<DateTime?, DateTime?, bool>> f = (x, y) => x != y;
             Assert.Equal(ExpressionType.NotEqual, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime?, DateTime?, bool> d = f.Compile();
+            Func<DateTime?, DateTime?, bool> d = f.CompileForTest();
             DateTime? dt1 = DateTime.Now;
             DateTime? dt2 = new DateTime(2006, 5, 1);
             Assert.False(d(dt1, dt1));
@@ -2861,7 +2861,7 @@ namespace Tests
             Expression<Func<DateTime?, DateTime?, bool>> f = (x, y) => x < y;
             Assert.Equal(ExpressionType.LessThan, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime?, DateTime?, bool> d = f.Compile();
+            Func<DateTime?, DateTime?, bool> d = f.CompileForTest();
             DateTime? dt1 = DateTime.Now;
             DateTime? dt2 = new DateTime(2006, 5, 1);
             Assert.False(d(dt1, dt1));
@@ -2877,7 +2877,7 @@ namespace Tests
             Expression<Func<DateTime, DateTime, bool>> f = (x, y) => x < y;
             Assert.Equal(ExpressionType.LessThan, f.Body.NodeType);
             Debug.WriteLine(f);
-            Func<DateTime, DateTime, bool> d = f.Compile();
+            Func<DateTime, DateTime, bool> d = f.CompileForTest();
             DateTime dt1 = DateTime.Now;
             DateTime dt2 = new DateTime(2006, 5, 1);
             Assert.False(d(dt1, dt1));
@@ -2890,7 +2890,7 @@ namespace Tests
             Expression<Func<int, int>> f = x => x + 1;
             InvocationExpression ie = Expression.Invoke(f, Expression.Constant(5));
             Expression<Func<int>> lambda = Expression.Lambda<Func<int>>(ie);
-            Func<int> d = lambda.Compile();
+            Func<int> d = lambda.CompileForTest();
             Assert.Equal(6, d());
         }
 
@@ -2898,9 +2898,9 @@ namespace Tests
         public static void CallCompiledLambda()
         {
             Expression<Func<int, int>> f = x => x + 1;
-            var compiled = f.Compile();
+            var compiled = f.CompileForTest();
             Expression<Func<int>> lambda = () => compiled(5);
-            Func<int> d = lambda.Compile();
+            Func<int> d = lambda.CompileForTest();
             Assert.Equal(6, d());
         }
 
@@ -2908,9 +2908,9 @@ namespace Tests
         public static void CallCompiledLambdaWithTypeMissing()
         {
             Expression<Func<object, bool>> f = x => x == Type.Missing;
-            var compiled = f.Compile();
+            var compiled = f.CompileForTest();
             Expression<Func<object, bool>> lambda = x => compiled(x);
-            Func<object, bool> d = lambda.Compile();
+            Func<object, bool> d = lambda.CompileForTest();
             Assert.Equal(true, d(Type.Missing));
         }
 
@@ -2920,7 +2920,7 @@ namespace Tests
             Expression<Func<int, int>> f = x => x + 1;
             InvocationExpression ie = Expression.Invoke(Expression.Quote(f), Expression.Constant(5));
             Expression<Func<int>> lambda = Expression.Lambda<Func<int>>(ie);
-            Func<int> d = lambda.Compile();
+            Func<int> d = lambda.CompileForTest();
             Assert.Equal(6, d());
         }
 
@@ -2933,7 +2933,7 @@ namespace Tests
             InvocationExpression ie = Expression.Invoke(call, x);
             Expression<Func<int, int, int>> lambda = Expression.Lambda<Func<int, int, int>>(ie, x, y);
 
-            Func<int, int, int> d = lambda.Compile();
+            Func<int, int, int> d = lambda.CompileForTest();
             Assert.Equal(14, d(5, 9));
             Assert.Equal(40, d(5, 8));
         }
@@ -2956,7 +2956,7 @@ namespace Tests
             InvocationExpression ie = Expression.Invoke(call, x);
             Expression<Func<int, int, int>> lambda = Expression.Lambda<Func<int, int, int>>(ie, x, y);
 
-            Func<int, int, int> d = lambda.Compile();
+            Func<int, int, int> d = lambda.CompileForTest();
             Assert.Equal(14, d(5, 9));
             Assert.Equal(40, d(5, 8));
         }
@@ -2997,9 +2997,9 @@ namespace Tests
         public static void NestedQuotedLambdas()
         {
             Expression<Func<int, Expression<Func<int, int>>>> f = a => b => a + b;
-            Func<int, Expression<Func<int, int>>> d = f.Compile();
+            Func<int, Expression<Func<int, int>>> d = f.CompileForTest();
             Expression<Func<int, int>> f2 = d(3);
-            Func<int, int> d2 = f2.Compile();
+            Func<int, int> d2 = f2.CompileForTest();
             int v = d2(4);
             Assert.Equal(7, v);
         }
@@ -3008,7 +3008,7 @@ namespace Tests
         public static void StaticMethodCall()
         {
             Expression<Func<int, int, int>> f = (a, b) => Math.Max(a, b);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(4, d(3, 4));
         }
 
@@ -3017,7 +3017,7 @@ namespace Tests
         {
             Foo foo = new Foo();
             Expression<Func<int, int>> f = (a) => foo.Zip(a);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(225, d(15));
         }
 
@@ -3026,7 +3026,7 @@ namespace Tests
         {
             Foo bar = new Bar();
             Expression<Func<Foo, string>> f = foo => foo.Virt();
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal("Bar", d(bar));
         }
 
@@ -3035,7 +3035,7 @@ namespace Tests
         public static void NestedLambda()
         {
             Expression<Func<int, int>> f = (a) => M1(a, (b) => b * b);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(100, d(10));
         }
 
@@ -3043,7 +3043,7 @@ namespace Tests
         public static void NestedLambdaWithOuterArg()
         {
             Expression<Func<int, int>> f = (a) => M1(a + a, (b) => b * a);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(200, d(10));
         }
 
@@ -3051,7 +3051,7 @@ namespace Tests
         public static void NestedExpressionLambda()
         {
             Expression<Func<int, int>> f = (a) => M2(a, (b) => b * b);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(10, d(10));
         }
 
@@ -3059,7 +3059,7 @@ namespace Tests
         public static void NestedExpressionLambdaWithOuterArg()
         {
             Expression<Func<int, int>> f = (a) => M2(a, (b) => b * a);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(99, d(99));
         }
 
@@ -3067,7 +3067,7 @@ namespace Tests
         public static void ArrayInitializedWithLiterals()
         {
             Expression<Func<int[]>> f = () => new int[] { 1, 2, 3, 4, 5 };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             int[] v = d();
             Assert.Equal(5, v.Length);
         }
@@ -3077,7 +3077,7 @@ namespace Tests
         {
             Foo foo = new Foo();
             Expression<Func<Foo[]>> f = () => new Foo[] { foo };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Foo[] v = d();
             Assert.Equal(1, v.Length);
             Assert.Equal(foo, v[0]);
@@ -3087,7 +3087,7 @@ namespace Tests
         public static void NullableAddition()
         {
             Expression<Func<double?, double?>> f = (v) => v + v;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(20.0, d(10.0));
         }
 
@@ -3095,7 +3095,7 @@ namespace Tests
         public static void NullableComparedToLiteral()
         {
             Expression<Func<int?, bool>> f = (v) => v > 10;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.True(d(12));
             Assert.False(d(5));
             Assert.True(d(int.MaxValue));
@@ -3107,7 +3107,7 @@ namespace Tests
         public static void NullableModuloLiteral()
         {
             Expression<Func<double?, double?>> f = (v) => v % 10;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5.0, d(15.0));
         }
 
@@ -3115,7 +3115,7 @@ namespace Tests
         public static void ArrayIndexer()
         {
             Expression<Func<int[], int, int>> f = (v, i) => v[i];
-            var d = f.Compile();
+            var d = f.CompileForTest();
             int[] ints = new[] { 1, 2, 3 };
             Assert.Equal(3, d(ints, 2));
         }
@@ -3124,7 +3124,7 @@ namespace Tests
         public static void ConvertToNullableDouble()
         {
             Expression<Func<int?, double?>> f = (v) => (double?)v;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(10.0, d(10));
         }
 
@@ -3132,7 +3132,7 @@ namespace Tests
         public static void UnboxToInt()
         {
             Expression<Func<object, int>> f = (a) => (int)a;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(5));
         }
 
@@ -3140,7 +3140,7 @@ namespace Tests
         public static void TypeIs()
         {
             Expression<Func<Foo, bool>> f = x => x is Foo;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.True(d(new Foo()));
         }
 
@@ -3148,7 +3148,7 @@ namespace Tests
         public static void TypeAs()
         {
             Expression<Func<Foo, Bar>> f = x => x as Bar;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Null(d(new Foo()));
             Assert.NotNull(d(new Bar()));
         }
@@ -3157,7 +3157,7 @@ namespace Tests
         public static void Coalesce()
         {
             Expression<Func<int?, int>> f = x => x ?? 5;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(null));
             Assert.Equal(2, d(2));
         }
@@ -3166,7 +3166,7 @@ namespace Tests
         public static void CoalesceRefTypes()
         {
             Expression<Func<string, string>> f = x => x ?? "nil";
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal("nil", d(null));
             Assert.Equal("Not Nil", d("Not Nil"));
         }
@@ -3175,7 +3175,7 @@ namespace Tests
         public static void Conditional()
         {
             Expression<Func<int, int, int>> f = (x, y) => x > 5 ? x : y;
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(7, d(7, 4));
             Assert.Equal(6, d(3, 6));
         }
@@ -3185,7 +3185,7 @@ namespace Tests
         public static void MultiDimensionalArrayAccess()
         {
             Expression<Func<int, int, int[,], int>> f = (x, y, a) => a[x, y];
-            var d = f.Compile();
+            var d = f.CompileForTest();
             int[,] array = new int[2, 2] { { 0, 1 }, { 2, 3 } };
             Assert.Equal(3, d(1, 1, array));
         }
@@ -3195,7 +3195,7 @@ namespace Tests
         public static void NewClassWithMemberIntializer()
         {
             Expression<Func<int, ClassX>> f = v => new ClassX { A = v };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(5).A);
         }
 
@@ -3204,7 +3204,7 @@ namespace Tests
         public static void NewStructWithArgs()
         {
             Expression<Func<int, StructZ>> f = v => new StructZ(v);
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(5).A);
         }
 
@@ -3212,7 +3212,7 @@ namespace Tests
         public static void NewStructWithArgsAndMemberInitializer()
         {
             Expression<Func<int, StructZ>> f = v => new StructZ(v) { A = v + 1 };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(6, d(5).A);
         }
 
@@ -3221,7 +3221,7 @@ namespace Tests
         public static void NewClassWithMemberIntializers()
         {
             Expression<Func<int, ClassX>> f = v => new ClassX { A = v, B = v };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(5).A);
             Assert.Equal(7, d(7).B);
         }
@@ -3230,7 +3230,7 @@ namespace Tests
         public static void NewStructWithMemberIntializer()
         {
             Expression<Func<int, StructX>> f = v => new StructX { A = v };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(5).A);
         }
 
@@ -3238,7 +3238,7 @@ namespace Tests
         public static void NewStructWithMemberIntializers()
         {
             Expression<Func<int, StructX>> f = v => new StructX { A = v, B = v };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             Assert.Equal(5, d(5).A);
             Assert.Equal(7, d(7).B);
         }
@@ -3247,7 +3247,7 @@ namespace Tests
         public static void ListInitializer()
         {
             Expression<Func<int, List<ClassY>>> f = x => new List<ClassY> { new ClassY { B = x } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             List<ClassY> list = d(5);
             Assert.Equal(1, list.Count);
             Assert.Equal(5, list[0].B);
@@ -3257,7 +3257,7 @@ namespace Tests
         public static void ListInitializerLong()
         {
             Expression<Func<int, List<ClassY>>> f = x => new List<ClassY> { new ClassY { B = x }, new ClassY { B = x + 1 }, new ClassY { B = x + 2 } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             List<ClassY> list = d(5);
             Assert.Equal(3, list.Count);
             Assert.Equal(5, list[0].B);
@@ -3269,7 +3269,7 @@ namespace Tests
         public static void ListInitializerInferred()
         {
             Expression<Func<int, List<ClassY>>> f = x => new List<ClassY> { new ClassY { B = x }, new ClassY { B = x + 1 }, new ClassY { B = x + 2 } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             List<ClassY> list = d(5);
             Assert.Equal(3, list.Count);
             Assert.Equal(5, list[0].B);
@@ -3283,7 +3283,7 @@ namespace Tests
         {
             Expression<Func<int, ClassX>> f =
                 v => new ClassX { A = v, B = v + 1, Ys = { new ClassY { B = v + 2 } } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             ClassX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -3296,7 +3296,7 @@ namespace Tests
         {
             Expression<Func<int, ClassX>> f =
                 v => new ClassX { A = v, B = v + 1, SYs = { new StructY { B = v + 2 } } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             ClassX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -3309,7 +3309,7 @@ namespace Tests
         {
             Expression<Func<int, ClassX>> f =
                 v => new ClassX { A = v, B = v + 1, Y = { B = v + 2 } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             ClassX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -3322,7 +3322,7 @@ namespace Tests
         {
             Expression<Func<int, StructX>> f =
                 v => new StructX { A = v, B = v + 1, Ys = { new ClassY { B = v + 2 } } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             StructX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -3335,7 +3335,7 @@ namespace Tests
         {
             Expression<Func<int, StructX>> f =
                 v => new StructX { A = v, B = v + 1, SY = new StructY { B = v + 2 } };
-            var d = f.Compile();
+            var d = f.CompileForTest();
             StructX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -3346,14 +3346,14 @@ namespace Tests
         public static void StructStructMemberInitializationThroughPropertyThrowsException()
         {
             Expression<Func<int, StructX>> f = GetExpressionTreeForMemberInitializationThroughProperty<StructX>();
-            Assert.Throws<InvalidOperationException>(() => f.Compile());
+            Assert.Throws<InvalidOperationException>(() => f.CompileForTest());
         }
 
         [Fact]
         public static void ClassStructMemberInitializationThroughPropertyThrowsException()
         {
             Expression<Func<int, ClassX>> f = GetExpressionTreeForMemberInitializationThroughProperty<ClassX>();
-            Assert.Throws<InvalidOperationException>(() => f.Compile());
+            Assert.Throws<InvalidOperationException>(() => f.CompileForTest());
         }
 
 
@@ -3456,7 +3456,7 @@ namespace Tests
 
         private static R TestUnary<T, R>(Expression<Func<T, R>> f, T v)
         {
-            Func<T, R> d = f.Compile();
+            Func<T, R> d = f.CompileForTest();
             R rv = d(v);
             return rv;
         }
@@ -3479,7 +3479,7 @@ namespace Tests
                         Expression.Constant((ulong)5, typeof(ulong)),
                         Expression.Constant((ulong)1, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-                Func<ulong> f = e.Compile();
+                Func<ulong> f = e.CompileForTest();
                 f();
             });
         }
@@ -3494,7 +3494,7 @@ namespace Tests
                     Expression.Constant((long)-1, typeof(long)),
                     Expression.Constant(long.MinValue, typeof(long))),
                     Enumerable.Empty<ParameterExpression>()
-                    ).Compile();
+                    ).CompileForTest();
                 f();
             });
         }
@@ -3508,7 +3508,7 @@ namespace Tests
                   Expression.MultiplyChecked(
                     Expression.Constant(long.MinValue, typeof(long)),
                     Expression.Constant((long)-1, typeof(long))),
-                  Enumerable.Empty<ParameterExpression>()).Compile();
+                  Enumerable.Empty<ParameterExpression>()).CompileForTest();
                 f();
             });
         }
@@ -3516,28 +3516,28 @@ namespace Tests
         [Fact]
         public static void ConvertSignedToUnsigned()
         {
-            Func<ulong> f = Expression.Lambda<Func<ulong>>(Expression.Convert(Expression.Constant((sbyte)-1), typeof(ulong))).Compile();
+            Func<ulong> f = Expression.Lambda<Func<ulong>>(Expression.Convert(Expression.Constant((sbyte)-1), typeof(ulong))).CompileForTest();
             Assert.Equal(UInt64.MaxValue, f());
         }
 
         [Fact]
         public static void ConvertUnsignedToSigned()
         {
-            Func<sbyte> f = Expression.Lambda<Func<sbyte>>(Expression.Convert(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).Compile();
+            Func<sbyte> f = Expression.Lambda<Func<sbyte>>(Expression.Convert(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).CompileForTest();
             Assert.Equal((sbyte)-1, f());
         }
 
         [Fact]
         public static void ConvertCheckedSignedToUnsigned()
         {
-            Func<ulong> f = Expression.Lambda<Func<ulong>>(Expression.ConvertChecked(Expression.Constant((sbyte)-1), typeof(ulong))).Compile();
+            Func<ulong> f = Expression.Lambda<Func<ulong>>(Expression.ConvertChecked(Expression.Constant((sbyte)-1), typeof(ulong))).CompileForTest();
             Assert.Throws<OverflowException>(() => f());
         }
 
         [Fact]
         public static void ConvertCheckedUnsignedToSigned()
         {
-            Func<sbyte> f = Expression.Lambda<Func<sbyte>>(Expression.ConvertChecked(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).Compile();
+            Func<sbyte> f = Expression.Lambda<Func<sbyte>>(Expression.ConvertChecked(Expression.Constant(UInt64.MaxValue), typeof(sbyte))).CompileForTest();
             Assert.Throws<OverflowException>(() => f());
         }
 
@@ -3554,7 +3554,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<int, string> f = Expression.Lambda<Func<int, string>>(block, p).Compile();
+            Func<int, string> f = Expression.Lambda<Func<int, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f(1));
             Assert.Equal("two", f(2));
@@ -3574,7 +3574,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<int?, string> f = Expression.Lambda<Func<int?, string>>(block, p).Compile();
+            Func<int?, string> f = Expression.Lambda<Func<int?, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f(1));
             Assert.Equal("two", f(2));
@@ -3596,7 +3596,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<int?, string> f = Expression.Lambda<Func<int?, string>>(block, p).Compile();
+            Func<int?, string> f = Expression.Lambda<Func<int?, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f(1));
             Assert.Equal("two", f(2));
@@ -3617,7 +3617,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<byte, string> f = Expression.Lambda<Func<byte, string>>(block, p).Compile();
+            Func<byte, string> f = Expression.Lambda<Func<byte, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f(1));
             Assert.Equal("two", f(2));
@@ -3638,7 +3638,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<uint, string> f = Expression.Lambda<Func<uint, string>>(block, p).Compile();
+            Func<uint, string> f = Expression.Lambda<Func<uint, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f(1));
             Assert.Equal("wow", f(uint.MaxValue));
@@ -3655,7 +3655,7 @@ namespace Tests
                 Expression.SwitchCase(Expression.Constant("hello"), Expression.Constant("hi")),
                 Expression.SwitchCase(Expression.Constant("lala"), Expression.Constant("bye")));
 
-            Func<string, string> f = Expression.Lambda<Func<string, string>>(s, p).Compile();
+            Func<string, string> f = Expression.Lambda<Func<string, string>>(s, p).CompileForTest();
 
             Assert.Equal("hello", f("hi"));
             Assert.Equal("lala", f("bye"));
@@ -3676,7 +3676,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<string, string> f = Expression.Lambda<Func<string, string>>(block, p).Compile();
+            Func<string, string> f = Expression.Lambda<Func<string, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f("hi"));
             Assert.Equal("lala", f("bye"));
@@ -3696,7 +3696,7 @@ namespace Tests
                 Expression.SwitchCase(Expression.Invoke(expr1), Expression.Invoke(expr2)),
                 Expression.SwitchCase(Expression.Constant("lala"), Expression.Constant("bye")));
 
-            Func<string, string> f = Expression.Lambda<Func<string, string>>(s, p).Compile();
+            Func<string, string> f = Expression.Lambda<Func<string, string>>(s, p).CompileForTest();
 
             Assert.Equal("aaaaa", f("qqqqq"));
             Assert.Equal("lala", f("bye"));
@@ -3718,7 +3718,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<object, string> f = Expression.Lambda<Func<object, string>>(block, p).Compile();
+            Func<object, string> f = Expression.Lambda<Func<object, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f("hi"));
             Assert.Equal("lala", f("bye"));
@@ -3734,7 +3734,7 @@ namespace Tests
             {
                 if (call)
                 {
-                    Default<System.Linq.Expressions.Expression<System.Object>>().Compile();
+                    Default<System.Linq.Expressions.Expression<System.Object>>().CompileForTest();
                     Default<System.Linq.Expressions.Expression<System.Object>>().Update(
                 Default<System.Linq.Expressions.Expression>(),
                 Default<System.Collections.Generic.IEnumerable<System.Linq.Expressions.ParameterExpression>>());
@@ -3771,7 +3771,7 @@ namespace Tests
 
             var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
-            Func<string, string> f = Expression.Lambda<Func<string, string>>(block, p).Compile();
+            Func<string, string> f = Expression.Lambda<Func<string, string>>(block, p).CompileForTest();
 
             Assert.Equal("hello", f("hi"));
             Assert.Equal("lala", f("bYe"));
@@ -3808,7 +3808,7 @@ namespace Tests
                             new[] { x },
                             Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod("Bar"), x)));
 
-            expression.Compile()();
+            expression.CompileForTest()();
         }
 
         [Fact]
@@ -3822,7 +3822,7 @@ namespace Tests
                             Expression.Assign(x, Expression.Default(typeof(MyEnum))),
                             Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod("BarRef"), x)));
 
-            expression.Compile()();
+            expression.CompileForTest()();
         }
 
         [Fact]
@@ -4146,7 +4146,7 @@ namespace Tests
 
         private static R TestBinary<T, R>(Expression<Func<T, T, R>> f, T v1, T v2)
         {
-            Func<T, T, R> d = f.Compile();
+            Func<T, T, R> d = f.CompileForTest();
             R rv = d(v1, v2);
             return rv;
         }
@@ -4164,7 +4164,7 @@ namespace Tests
         {
             Expression<Func<int, int?>> f = x => (int?)x;
             Assert.Equal(f.Body.NodeType, ExpressionType.Convert);
-            Func<int, int?> d = f.Compile();
+            Func<int, int?> d = f.CompileForTest();
             Assert.Equal(2, d(2));
         }
 
@@ -4180,7 +4180,7 @@ namespace Tests
             TestNullableCall(5, (v) => v.GetValueOrDefault(), (v) => v.GetValueOrDefault());
 
             Expression<Func<int?, int>> f = x => x.Value;
-            Func<int?, int> d = f.Compile();
+            Func<int?, int> d = f.CompileForTest();
             Assert.Equal(2, d(2));
             Assert.Throws<InvalidOperationException>(() => d(null));
         }
@@ -4188,7 +4188,7 @@ namespace Tests
         private static void TestNullableCall<T, U>(T arg, Func<T?, U> f, Expression<Func<T?, U>> e)
             where T : struct
         {
-            Func<T?, U> d = e.Compile();
+            Func<T?, U> d = e.CompileForTest();
             Assert.Equal(f(arg), d(arg));
             Assert.Equal(f(null), d(null));
         }
@@ -4234,7 +4234,7 @@ namespace Tests
             }
         }
 
-        public class ClassX
+        public class ClassX : IEquatable<ClassX>
         {
             public int A;
             public int B;
@@ -4251,9 +4251,34 @@ namespace Tests
             {
                 get { return this.SY; }
             }
+
+            public bool Equals(ClassX obj)
+            {
+                if (obj == null)
+                {
+                    return false;
+                }
+
+                return 
+                    obj.A == this.A && obj.B == this.B && obj.C == this.C &&
+                    EqualityComparer<ClassY>.Default.Equals(obj.Y, this.Y) &&
+                    EqualityComparer<StructY>.Default.Equals(obj.SY, this.SY) &&
+                    ListEqualityComparer<ClassY>.Default.Equals(obj.Ys, this.Ys) &&
+                    ListEqualityComparer<StructY>.Default.Equals(obj.SYs, this.SYs);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as ClassX);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0; // just for testing equality
+            }
         }
 
-        public class ClassY
+        public class ClassY : IEquatable<ClassY>
         {
             public int B;
             public int PB
@@ -4261,9 +4286,29 @@ namespace Tests
                 get { return this.B; }
                 set { this.B = value; }
             }
+
+            public bool Equals(ClassY obj)
+            {
+                if (obj == null)
+                {
+                    return false;
+                }
+
+                return obj.B == this.B;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as ClassY);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0; // just for testing equality
+            }
         }
 
-        public class StructX
+        public class StructX : IEquatable<StructX>
         {
             public int A;
             public int B;
@@ -4278,6 +4323,30 @@ namespace Tests
             public StructY SYP
             {
                 get { return this.SY; }
+            }
+
+            public bool Equals(StructX obj)
+            {
+                return
+                    obj.A == this.A && obj.B == this.B && obj.C == this.C &&
+                    EqualityComparer<ClassY>.Default.Equals(obj.Y, this.Y) &&
+                    EqualityComparer<StructY>.Default.Equals(obj.SY, this.SY) &&
+                    ListEqualityComparer<ClassY>.Default.Equals(obj.Ys, this.Ys);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is StructX))
+                {
+                    return false;
+                }
+
+                return Equals((StructX)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0; // just for testing equality
             }
         }
 
@@ -4307,11 +4376,11 @@ namespace Tests
             ParameterExpression c = Expression.Parameter(typeof(NWindProxy.Customer), "c");
             ParameterExpression c2 = Expression.Parameter(typeof(NWindProxy.Customer), "c2");
 
-            Assert.Equal(cust, Expression.Lambda(c, c).Compile().DynamicInvoke(cust));
-            Assert.Equal(cust.ContactName, Expression.Lambda(Expression.PropertyOrField(c, "ContactName"), c).Compile().DynamicInvoke(cust));
-            Assert.Equal(cust.Orders, Expression.Lambda(Expression.PropertyOrField(c, "Orders"), c).Compile().DynamicInvoke(cust));
-            Assert.Equal(cust.CustomerID, Expression.Lambda(Expression.PropertyOrField(c, "CustomerId"), c).Compile().DynamicInvoke(cust));
-            Assert.True((bool)Expression.Lambda(Expression.Equal(Expression.PropertyOrField(c, "CustomerId"), Expression.PropertyOrField(c, "CUSTOMERID")), c).Compile().DynamicInvoke(cust));
+            Assert.Equal(cust, Expression.Lambda(c, c).CompileForTest().DynamicInvoke(cust));
+            Assert.Equal(cust.ContactName, Expression.Lambda(Expression.PropertyOrField(c, "ContactName"), c).CompileForTest().DynamicInvoke(cust));
+            Assert.Equal(cust.Orders, Expression.Lambda(Expression.PropertyOrField(c, "Orders"), c).CompileForTest().DynamicInvoke(cust));
+            Assert.Equal(cust.CustomerID, Expression.Lambda(Expression.PropertyOrField(c, "CustomerId"), c).CompileForTest().DynamicInvoke(cust));
+            Assert.True((bool)Expression.Lambda(Expression.Equal(Expression.PropertyOrField(c, "CustomerId"), Expression.PropertyOrField(c, "CUSTOMERID")), c).CompileForTest().DynamicInvoke(cust));
             Assert.True((bool)
                 Expression.Lambda(
                     Expression.And(
@@ -4319,31 +4388,31 @@ namespace Tests
                         Expression.Equal(Expression.PropertyOrField(c, "ContactName"), Expression.PropertyOrField(c2, "ContactName"))
                         ),
                     c, c2)
-                .Compile().DynamicInvoke(cust, cust));
+                .CompileForTest().DynamicInvoke(cust, cust));
         }
 
         private static void ArimeticOperatorTests(Type type, object value, bool testUnSigned)
         {
             ParameterExpression p = Expression.Parameter(type, "x");
             if (testUnSigned)
-                Expression.Lambda(Expression.Negate(p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.Add(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.Subtract(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.Multiply(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.Divide(p, p), p).Compile().DynamicInvoke(new object[] { value });
+                Expression.Lambda(Expression.Negate(p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Add(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Subtract(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Multiply(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Divide(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
         }
 
         private static void RelationalOperatorTests(Type type, object value, bool testModulo)
         {
             ParameterExpression p = Expression.Parameter(type, "x");
             if (testModulo)
-                Expression.Lambda(Expression.Modulo(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.Equal(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.NotEqual(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.LessThan(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.LessThanOrEqual(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.GreaterThan(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.GreaterThanOrEqual(p, p), p).Compile().DynamicInvoke(new object[] { value });
+                Expression.Lambda(Expression.Modulo(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Equal(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.NotEqual(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.LessThan(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.LessThanOrEqual(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.GreaterThan(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.GreaterThanOrEqual(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
         }
 
         private static void NumericOperatorTests(Type type, object value, bool testModulo, bool testUnSigned)
@@ -4366,10 +4435,10 @@ namespace Tests
         private static void LogicalOperatorTests(Type type, object value)
         {
             ParameterExpression p = Expression.Parameter(type, "x");
-            Expression.Lambda(Expression.Not(p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.Or(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.And(p, p), p).Compile().DynamicInvoke(new object[] { value });
-            Expression.Lambda(Expression.ExclusiveOr(p, p), p).Compile().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Not(p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.Or(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.And(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
+            Expression.Lambda(Expression.ExclusiveOr(p, p), p).CompileForTest().DynamicInvoke(new object[] { value });
         }
 
         private static void IntegerOperatorTests(Type type, object value)
@@ -4418,8 +4487,8 @@ namespace Tests
         {
             ParameterExpression x = Expression.Parameter(type, "x");
             ParameterExpression y = Expression.Parameter(type, "y");
-            Expression.Lambda(Expression.AndAlso(x, y), x, y).Compile().DynamicInvoke(new object[] { arg1, arg2 });
-            Expression.Lambda(Expression.OrElse(x, y), x, y).Compile().DynamicInvoke(new object[] { arg1, arg2 });
+            Expression.Lambda(Expression.AndAlso(x, y), x, y).CompileForTest().DynamicInvoke(new object[] { arg1, arg2 });
+            Expression.Lambda(Expression.OrElse(x, y), x, y).CompileForTest().DynamicInvoke(new object[] { arg1, arg2 });
             GeneralBooleanOperatorTests(type, arg1, arg2);
         }
 
@@ -4427,11 +4496,11 @@ namespace Tests
         {
             ParameterExpression x = Expression.Parameter(type, "x");
             ParameterExpression y = Expression.Parameter(type, "y");
-            Expression.Lambda(Expression.And(x, y), x, y).Compile().DynamicInvoke(new object[] { arg1, arg2 });
-            Expression.Lambda(Expression.Or(x, y), x, y).Compile().DynamicInvoke(new object[] { arg1, arg2 });
-            Expression.Lambda(Expression.Not(x), x).Compile().DynamicInvoke(new object[] { arg1 });
-            Expression.Lambda(Expression.Equal(x, y), x, y).Compile().DynamicInvoke(new object[] { arg1, arg2 });
-            Expression.Lambda(Expression.NotEqual(x, y), x, y).Compile().DynamicInvoke(new object[] { arg1, arg2 });
+            Expression.Lambda(Expression.And(x, y), x, y).CompileForTest().DynamicInvoke(new object[] { arg1, arg2 });
+            Expression.Lambda(Expression.Or(x, y), x, y).CompileForTest().DynamicInvoke(new object[] { arg1, arg2 });
+            Expression.Lambda(Expression.Not(x), x).CompileForTest().DynamicInvoke(new object[] { arg1 });
+            Expression.Lambda(Expression.Equal(x, y), x, y).CompileForTest().DynamicInvoke(new object[] { arg1, arg2 });
+            Expression.Lambda(Expression.NotEqual(x, y), x, y).CompileForTest().DynamicInvoke(new object[] { arg1, arg2 });
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>System.Linq.Expressions.Tests</AssemblyName>
     <RootNamespace>System.Linq.Expressions.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
@@ -166,6 +167,7 @@
     <Compile Include="Lifted\NonLiftedComparisonLessThanNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonLessThanOrEqualNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonNotEqualNullableTests.cs" />
+    <Compile Include="ListEqualityComparer.cs" />
     <Compile Include="MemberInit\MemberInitTests.cs" />
     <Compile Include="Member\MemberAccessTests.cs" />
     <Compile Include="New\NewTests.cs" />
@@ -177,6 +179,7 @@
     <Compile Include="Ternary\TernaryArrayTests.cs" />
     <Compile Include="Ternary\TernaryNullableTests.cs" />
     <Compile Include="Ternary\TernaryTests.cs" />
+    <Compile Include="TestExtensions.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateNullableOneOffTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateCheckedNullableTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateNullableTests.cs" />

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>System.Linq.Expressions.Tests</AssemblyName>
     <RootNamespace>System.Linq.Expressions.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition=" '$(EnableCrossCheckTests)' == 'true' ">$(DefineConstants);ENABLE_CROSSCHECK</DefineConstants>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
@@ -369,7 +369,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(bool?[])),
                         Expression.Constant(b, typeof(bool?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?[]> f = e.Compile();
+            Func<bool?[]> f = e.CompileForTest();
 
             bool?[] result = default(bool?[]);
             Exception fEx = null;
@@ -414,7 +414,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(byte?[])),
                         Expression.Constant(b, typeof(byte?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?[]> f = e.Compile();
+            Func<byte?[]> f = e.CompileForTest();
 
             byte?[] result = default(byte?[]);
             Exception fEx = null;
@@ -459,7 +459,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(char?[])),
                         Expression.Constant(b, typeof(char?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?[]> f = e.Compile();
+            Func<char?[]> f = e.CompileForTest();
 
             char?[] result = default(char?[]);
             Exception fEx = null;
@@ -504,7 +504,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(decimal?[])),
                         Expression.Constant(b, typeof(decimal?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?[]> f = e.Compile();
+            Func<decimal?[]> f = e.CompileForTest();
 
             decimal?[] result = default(decimal?[]);
             Exception fEx = null;
@@ -549,7 +549,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(double?[])),
                         Expression.Constant(b, typeof(double?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?[]> f = e.Compile();
+            Func<double?[]> f = e.CompileForTest();
 
             double?[] result = default(double?[]);
             Exception fEx = null;
@@ -594,7 +594,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(float?[])),
                         Expression.Constant(b, typeof(float?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?[]> f = e.Compile();
+            Func<float?[]> f = e.CompileForTest();
 
             float?[] result = default(float?[]);
             Exception fEx = null;
@@ -639,7 +639,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(int?[])),
                         Expression.Constant(b, typeof(int?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?[]> f = e.Compile();
+            Func<int?[]> f = e.CompileForTest();
 
             int?[] result = default(int?[]);
             Exception fEx = null;
@@ -684,7 +684,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(long?[])),
                         Expression.Constant(b, typeof(long?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?[]> f = e.Compile();
+            Func<long?[]> f = e.CompileForTest();
 
             long?[] result = default(long?[]);
             Exception fEx = null;
@@ -729,7 +729,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(S?[])),
                         Expression.Constant(b, typeof(S?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?[]> f = e.Compile();
+            Func<S?[]> f = e.CompileForTest();
 
             S?[] result = default(S?[]);
             Exception fEx = null;
@@ -774,7 +774,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(sbyte?[])),
                         Expression.Constant(b, typeof(sbyte?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?[]> f = e.Compile();
+            Func<sbyte?[]> f = e.CompileForTest();
 
             sbyte?[] result = default(sbyte?[]);
             Exception fEx = null;
@@ -819,7 +819,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sc?[])),
                         Expression.Constant(b, typeof(Sc?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?[]> f = e.Compile();
+            Func<Sc?[]> f = e.CompileForTest();
 
             Sc?[] result = default(Sc?[]);
             Exception fEx = null;
@@ -864,7 +864,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Scs?[])),
                         Expression.Constant(b, typeof(Scs?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?[]> f = e.Compile();
+            Func<Scs?[]> f = e.CompileForTest();
 
             Scs?[] result = default(Scs?[]);
             Exception fEx = null;
@@ -909,7 +909,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(short?[])),
                         Expression.Constant(b, typeof(short?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?[]> f = e.Compile();
+            Func<short?[]> f = e.CompileForTest();
 
             short?[] result = default(short?[]);
             Exception fEx = null;
@@ -954,7 +954,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sp?[])),
                         Expression.Constant(b, typeof(Sp?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?[]> f = e.Compile();
+            Func<Sp?[]> f = e.CompileForTest();
 
             Sp?[] result = default(Sp?[]);
             Exception fEx = null;
@@ -999,7 +999,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ss?[])),
                         Expression.Constant(b, typeof(Ss?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?[]> f = e.Compile();
+            Func<Ss?[]> f = e.CompileForTest();
 
             Ss?[] result = default(Ss?[]);
             Exception fEx = null;
@@ -1044,7 +1044,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(uint?[])),
                         Expression.Constant(b, typeof(uint?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?[]> f = e.Compile();
+            Func<uint?[]> f = e.CompileForTest();
 
             uint?[] result = default(uint?[]);
             Exception fEx = null;
@@ -1089,7 +1089,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ulong?[])),
                         Expression.Constant(b, typeof(ulong?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?[]> f = e.Compile();
+            Func<ulong?[]> f = e.CompileForTest();
 
             ulong?[] result = default(ulong?[]);
             Exception fEx = null;
@@ -1134,7 +1134,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ushort?[])),
                         Expression.Constant(b, typeof(ushort?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?[]> f = e.Compile();
+            Func<ushort?[]> f = e.CompileForTest();
 
             ushort?[] result = default(ushort?[]);
             Exception fEx = null;
@@ -1179,7 +1179,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ts?[])),
                         Expression.Constant(b, typeof(Ts?[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?[]> f = e.Compile();
+            Func<Ts?[]> f = e.CompileForTest();
 
             Ts?[] result = default(Ts?[]);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
@@ -702,7 +702,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(bool[])),
                         Expression.Constant(b, typeof(bool[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool[]> f = e.Compile();
+            Func<bool[]> f = e.CompileForTest();
 
             bool[] result = default(bool[]);
             Exception fEx = null;
@@ -747,7 +747,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(byte[])),
                         Expression.Constant(b, typeof(byte[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte[]> f = e.Compile();
+            Func<byte[]> f = e.CompileForTest();
 
             byte[] result = default(byte[]);
             Exception fEx = null;
@@ -792,7 +792,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(C[])),
                         Expression.Constant(b, typeof(C[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.CompileForTest();
 
             C[] result = default(C[]);
             Exception fEx = null;
@@ -837,7 +837,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(char[])),
                         Expression.Constant(b, typeof(char[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char[]> f = e.Compile();
+            Func<char[]> f = e.CompileForTest();
 
             char[] result = default(char[]);
             Exception fEx = null;
@@ -882,7 +882,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(D[])),
                         Expression.Constant(b, typeof(D[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.CompileForTest();
 
             D[] result = default(D[]);
             Exception fEx = null;
@@ -927,7 +927,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(decimal[])),
                         Expression.Constant(b, typeof(decimal[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal[]> f = e.Compile();
+            Func<decimal[]> f = e.CompileForTest();
 
             decimal[] result = default(decimal[]);
             Exception fEx = null;
@@ -972,7 +972,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Delegate[])),
                         Expression.Constant(b, typeof(Delegate[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate[]> f = e.Compile();
+            Func<Delegate[]> f = e.CompileForTest();
 
             Delegate[] result = default(Delegate[]);
             Exception fEx = null;
@@ -1017,7 +1017,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(double[])),
                         Expression.Constant(b, typeof(double[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double[]> f = e.Compile();
+            Func<double[]> f = e.CompileForTest();
 
             double[] result = default(double[]);
             Exception fEx = null;
@@ -1062,7 +1062,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(E[])),
                         Expression.Constant(b, typeof(E[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E[]> f = e.Compile();
+            Func<E[]> f = e.CompileForTest();
 
             E[] result = default(E[]);
             Exception fEx = null;
@@ -1107,7 +1107,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(El[])),
                         Expression.Constant(b, typeof(El[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El[]> f = e.Compile();
+            Func<El[]> f = e.CompileForTest();
 
             El[] result = default(El[]);
             Exception fEx = null;
@@ -1152,7 +1152,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(float[])),
                         Expression.Constant(b, typeof(float[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float[]> f = e.Compile();
+            Func<float[]> f = e.CompileForTest();
 
             float[] result = default(float[]);
             Exception fEx = null;
@@ -1197,7 +1197,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Func<object>[])),
                         Expression.Constant(b, typeof(Func<object>[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>[]> f = e.Compile();
+            Func<Func<object>[]> f = e.CompileForTest();
 
             Func<object>[] result = default(Func<object>[]);
             Exception fEx = null;
@@ -1242,7 +1242,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(I[])),
                         Expression.Constant(b, typeof(I[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I[]> f = e.Compile();
+            Func<I[]> f = e.CompileForTest();
 
             I[] result = default(I[]);
             Exception fEx = null;
@@ -1287,7 +1287,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(IEquatable<C>[])),
                         Expression.Constant(b, typeof(IEquatable<C>[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>[]> f = e.Compile();
+            Func<IEquatable<C>[]> f = e.CompileForTest();
 
             IEquatable<C>[] result = default(IEquatable<C>[]);
             Exception fEx = null;
@@ -1332,7 +1332,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(IEquatable<D>[])),
                         Expression.Constant(b, typeof(IEquatable<D>[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>[]> f = e.Compile();
+            Func<IEquatable<D>[]> f = e.CompileForTest();
 
             IEquatable<D>[] result = default(IEquatable<D>[]);
             Exception fEx = null;
@@ -1377,7 +1377,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(int[])),
                         Expression.Constant(b, typeof(int[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int[]> f = e.Compile();
+            Func<int[]> f = e.CompileForTest();
 
             int[] result = default(int[]);
             Exception fEx = null;
@@ -1422,7 +1422,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(long[])),
                         Expression.Constant(b, typeof(long[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long[]> f = e.Compile();
+            Func<long[]> f = e.CompileForTest();
 
             long[] result = default(long[]);
             Exception fEx = null;
@@ -1467,7 +1467,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(object[])),
                         Expression.Constant(b, typeof(object[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.CompileForTest();
 
             object[] result = default(object[]);
             Exception fEx = null;
@@ -1512,7 +1512,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(S[])),
                         Expression.Constant(b, typeof(S[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.CompileForTest();
 
             S[] result = default(S[]);
             Exception fEx = null;
@@ -1557,7 +1557,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(sbyte[])),
                         Expression.Constant(b, typeof(sbyte[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte[]> f = e.Compile();
+            Func<sbyte[]> f = e.CompileForTest();
 
             sbyte[] result = default(sbyte[]);
             Exception fEx = null;
@@ -1602,7 +1602,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sc[])),
                         Expression.Constant(b, typeof(Sc[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc[]> f = e.Compile();
+            Func<Sc[]> f = e.CompileForTest();
 
             Sc[] result = default(Sc[]);
             Exception fEx = null;
@@ -1647,7 +1647,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Scs[])),
                         Expression.Constant(b, typeof(Scs[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs[]> f = e.Compile();
+            Func<Scs[]> f = e.CompileForTest();
 
             Scs[] result = default(Scs[]);
             Exception fEx = null;
@@ -1692,7 +1692,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(short[])),
                         Expression.Constant(b, typeof(short[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short[]> f = e.Compile();
+            Func<short[]> f = e.CompileForTest();
 
             short[] result = default(short[]);
             Exception fEx = null;
@@ -1737,7 +1737,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sp[])),
                         Expression.Constant(b, typeof(Sp[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp[]> f = e.Compile();
+            Func<Sp[]> f = e.CompileForTest();
 
             Sp[] result = default(Sp[]);
             Exception fEx = null;
@@ -1782,7 +1782,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ss[])),
                         Expression.Constant(b, typeof(Ss[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss[]> f = e.Compile();
+            Func<Ss[]> f = e.CompileForTest();
 
             Ss[] result = default(Ss[]);
             Exception fEx = null;
@@ -1827,7 +1827,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(string[])),
                         Expression.Constant(b, typeof(string[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string[]> f = e.Compile();
+            Func<string[]> f = e.CompileForTest();
 
             string[] result = default(string[]);
             Exception fEx = null;
@@ -1872,7 +1872,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(uint[])),
                         Expression.Constant(b, typeof(uint[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint[]> f = e.Compile();
+            Func<uint[]> f = e.CompileForTest();
 
             uint[] result = default(uint[]);
             Exception fEx = null;
@@ -1917,7 +1917,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ulong[])),
                         Expression.Constant(b, typeof(ulong[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong[]> f = e.Compile();
+            Func<ulong[]> f = e.CompileForTest();
 
             ulong[] result = default(ulong[]);
             Exception fEx = null;
@@ -1962,7 +1962,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ushort[])),
                         Expression.Constant(b, typeof(ushort[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort[]> f = e.Compile();
+            Func<ushort[]> f = e.CompileForTest();
 
             ushort[] result = default(ushort[]);
             Exception fEx = null;
@@ -2007,7 +2007,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(T[])),
                         Expression.Constant(b, typeof(T[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T[]> f = e.Compile();
+            Func<T[]> f = e.CompileForTest();
 
             T[] result = default(T[]);
             Exception fEx = null;
@@ -2052,7 +2052,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Tc[])),
                         Expression.Constant(b, typeof(Tc[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc[]> f = e.Compile();
+            Func<Tc[]> f = e.CompileForTest();
 
             Tc[] result = default(Tc[]);
             Exception fEx = null;
@@ -2097,7 +2097,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(TC[])),
                         Expression.Constant(b, typeof(TC[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC[]> f = e.Compile();
+            Func<TC[]> f = e.CompileForTest();
 
             TC[] result = default(TC[]);
             Exception fEx = null;
@@ -2142,7 +2142,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Tcn[])),
                         Expression.Constant(b, typeof(Tcn[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn[]> f = e.Compile();
+            Func<Tcn[]> f = e.CompileForTest();
 
             Tcn[] result = default(Tcn[]);
             Exception fEx = null;
@@ -2187,7 +2187,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(TCn[])),
                         Expression.Constant(b, typeof(TCn[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn[]> f = e.Compile();
+            Func<TCn[]> f = e.CompileForTest();
 
             TCn[] result = default(TCn[]);
             Exception fEx = null;
@@ -2232,7 +2232,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ts[])),
                         Expression.Constant(b, typeof(Ts[]))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts[]> f = e.Compile();
+            Func<Ts[]> f = e.CompileForTest();
 
             Ts[] result = default(Ts[]);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
@@ -403,7 +403,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(bool?)),
                         Expression.Constant(b, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
 
             bool? result = default(bool?);
             Exception fEx = null;
@@ -448,7 +448,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(byte?)),
                         Expression.Constant(b, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
 
             byte? result = default(byte?);
             Exception fEx = null;
@@ -493,7 +493,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(char?)),
                         Expression.Constant(b, typeof(char?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char?> f = e.Compile();
+            Func<char?> f = e.CompileForTest();
 
             char? result = default(char?);
             Exception fEx = null;
@@ -538,7 +538,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(decimal?)),
                         Expression.Constant(b, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             decimal? result = default(decimal?);
             Exception fEx = null;
@@ -583,7 +583,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(double?)),
                         Expression.Constant(b, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             double? result = default(double?);
             Exception fEx = null;
@@ -628,7 +628,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(E?)),
                         Expression.Constant(b, typeof(E?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E?> f = e.Compile();
+            Func<E?> f = e.CompileForTest();
 
             E? result = default(E?);
             Exception fEx = null;
@@ -673,7 +673,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(El?)),
                         Expression.Constant(b, typeof(El?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El?> f = e.Compile();
+            Func<El?> f = e.CompileForTest();
 
             El? result = default(El?);
             Exception fEx = null;
@@ -718,7 +718,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             float? result = default(float?);
             Exception fEx = null;
@@ -763,7 +763,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(int?)),
                         Expression.Constant(b, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             int? result = default(int?);
             Exception fEx = null;
@@ -808,7 +808,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(long?)),
                         Expression.Constant(b, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             long? result = default(long?);
             Exception fEx = null;
@@ -853,7 +853,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(S?)),
                         Expression.Constant(b, typeof(S?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S?> f = e.Compile();
+            Func<S?> f = e.CompileForTest();
 
             S? result = default(S?);
             Exception fEx = null;
@@ -898,7 +898,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(sbyte?)),
                         Expression.Constant(b, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
 
             sbyte? result = default(sbyte?);
             Exception fEx = null;
@@ -943,7 +943,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sc?)),
                         Expression.Constant(b, typeof(Sc?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc?> f = e.Compile();
+            Func<Sc?> f = e.CompileForTest();
 
             Sc? result = default(Sc?);
             Exception fEx = null;
@@ -988,7 +988,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Scs?)),
                         Expression.Constant(b, typeof(Scs?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs?> f = e.Compile();
+            Func<Scs?> f = e.CompileForTest();
 
             Scs? result = default(Scs?);
             Exception fEx = null;
@@ -1033,7 +1033,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(short?)),
                         Expression.Constant(b, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             short? result = default(short?);
             Exception fEx = null;
@@ -1078,7 +1078,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sp?)),
                         Expression.Constant(b, typeof(Sp?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp?> f = e.Compile();
+            Func<Sp?> f = e.CompileForTest();
 
             Sp? result = default(Sp?);
             Exception fEx = null;
@@ -1123,7 +1123,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ss?)),
                         Expression.Constant(b, typeof(Ss?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss?> f = e.Compile();
+            Func<Ss?> f = e.CompileForTest();
 
             Ss? result = default(Ss?);
             Exception fEx = null;
@@ -1168,7 +1168,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(uint?)),
                         Expression.Constant(b, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
 
             uint? result = default(uint?);
             Exception fEx = null;
@@ -1213,7 +1213,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ulong?)),
                         Expression.Constant(b, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
 
             ulong? result = default(ulong?);
             Exception fEx = null;
@@ -1258,7 +1258,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ushort?)),
                         Expression.Constant(b, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
 
             ushort? result = default(ushort?);
             Exception fEx = null;
@@ -1303,7 +1303,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ts?)),
                         Expression.Constant(b, typeof(Ts?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts?> f = e.Compile();
+            Func<Ts?> f = e.CompileForTest();
 
             Ts? result = default(Ts?);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
@@ -702,7 +702,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(bool)),
                         Expression.Constant(b, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
 
             bool result = default(bool);
             Exception fEx = null;
@@ -747,7 +747,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(byte)),
                         Expression.Constant(b, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
 
             byte result = default(byte);
             Exception fEx = null;
@@ -792,7 +792,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(C)),
                         Expression.Constant(b, typeof(C))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.CompileForTest();
 
             C result = default(C);
             Exception fEx = null;
@@ -837,7 +837,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(char)),
                         Expression.Constant(b, typeof(char))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<char> f = e.Compile();
+            Func<char> f = e.CompileForTest();
 
             char result = default(char);
             Exception fEx = null;
@@ -882,7 +882,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(D)),
                         Expression.Constant(b, typeof(D))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.CompileForTest();
 
             D result = default(D);
             Exception fEx = null;
@@ -927,7 +927,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(decimal)),
                         Expression.Constant(b, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             decimal result = default(decimal);
             Exception fEx = null;
@@ -972,7 +972,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Delegate)),
                         Expression.Constant(b, typeof(Delegate))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.CompileForTest();
 
             Delegate result = default(Delegate);
             Exception fEx = null;
@@ -1017,7 +1017,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(double)),
                         Expression.Constant(b, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             double result = default(double);
             Exception fEx = null;
@@ -1062,7 +1062,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(E)),
                         Expression.Constant(b, typeof(E))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.CompileForTest();
 
             E result = default(E);
             Exception fEx = null;
@@ -1107,7 +1107,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(El)),
                         Expression.Constant(b, typeof(El))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<El> f = e.Compile();
+            Func<El> f = e.CompileForTest();
 
             El result = default(El);
             Exception fEx = null;
@@ -1152,7 +1152,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(float)),
                         Expression.Constant(b, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             float result = default(float);
             Exception fEx = null;
@@ -1197,7 +1197,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Func<object>)),
                         Expression.Constant(b, typeof(Func<object>))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.CompileForTest();
 
             Func<object> result = default(Func<object>);
             Exception fEx = null;
@@ -1242,7 +1242,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(I)),
                         Expression.Constant(b, typeof(I))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.CompileForTest();
 
             I result = default(I);
             Exception fEx = null;
@@ -1287,7 +1287,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(IEquatable<C>)),
                         Expression.Constant(b, typeof(IEquatable<C>))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.CompileForTest();
 
             IEquatable<C> result = default(IEquatable<C>);
             Exception fEx = null;
@@ -1332,7 +1332,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(IEquatable<D>)),
                         Expression.Constant(b, typeof(IEquatable<D>))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.CompileForTest();
 
             IEquatable<D> result = default(IEquatable<D>);
             Exception fEx = null;
@@ -1377,7 +1377,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(int)),
                         Expression.Constant(b, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             int result = default(int);
             Exception fEx = null;
@@ -1422,7 +1422,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(long)),
                         Expression.Constant(b, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             long result = default(long);
             Exception fEx = null;
@@ -1467,7 +1467,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(object)),
                         Expression.Constant(b, typeof(object))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             object result = default(object);
             Exception fEx = null;
@@ -1512,7 +1512,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(S)),
                         Expression.Constant(b, typeof(S))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.CompileForTest();
 
             S result = default(S);
             Exception fEx = null;
@@ -1557,7 +1557,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(sbyte)),
                         Expression.Constant(b, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
 
             sbyte result = default(sbyte);
             Exception fEx = null;
@@ -1602,7 +1602,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sc)),
                         Expression.Constant(b, typeof(Sc))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sc> f = e.Compile();
+            Func<Sc> f = e.CompileForTest();
 
             Sc result = default(Sc);
             Exception fEx = null;
@@ -1647,7 +1647,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Scs)),
                         Expression.Constant(b, typeof(Scs))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Scs> f = e.Compile();
+            Func<Scs> f = e.CompileForTest();
 
             Scs result = default(Scs);
             Exception fEx = null;
@@ -1692,7 +1692,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(short)),
                         Expression.Constant(b, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             short result = default(short);
             Exception fEx = null;
@@ -1737,7 +1737,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Sp)),
                         Expression.Constant(b, typeof(Sp))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Sp> f = e.Compile();
+            Func<Sp> f = e.CompileForTest();
 
             Sp result = default(Sp);
             Exception fEx = null;
@@ -1782,7 +1782,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ss)),
                         Expression.Constant(b, typeof(Ss))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ss> f = e.Compile();
+            Func<Ss> f = e.CompileForTest();
 
             Ss result = default(Ss);
             Exception fEx = null;
@@ -1827,7 +1827,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(string)),
                         Expression.Constant(b, typeof(string))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<string> f = e.Compile();
+            Func<string> f = e.CompileForTest();
 
             string result = default(string);
             Exception fEx = null;
@@ -1872,7 +1872,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(uint)),
                         Expression.Constant(b, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
 
             uint result = default(uint);
             Exception fEx = null;
@@ -1917,7 +1917,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ulong)),
                         Expression.Constant(b, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
 
             ulong result = default(ulong);
             Exception fEx = null;
@@ -1962,7 +1962,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(ushort)),
                         Expression.Constant(b, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
 
             ushort result = default(ushort);
             Exception fEx = null;
@@ -2007,7 +2007,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(T)),
                         Expression.Constant(b, typeof(T))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T> f = e.Compile();
+            Func<T> f = e.CompileForTest();
 
             T result = default(T);
             Exception fEx = null;
@@ -2052,7 +2052,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Tc)),
                         Expression.Constant(b, typeof(Tc))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.CompileForTest();
 
             Tc result = default(Tc);
             Exception fEx = null;
@@ -2097,7 +2097,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(TC)),
                         Expression.Constant(b, typeof(TC))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TC> f = e.Compile();
+            Func<TC> f = e.CompileForTest();
 
             TC result = default(TC);
             Exception fEx = null;
@@ -2142,7 +2142,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Tcn)),
                         Expression.Constant(b, typeof(Tcn))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tcn> f = e.Compile();
+            Func<Tcn> f = e.CompileForTest();
 
             Tcn result = default(Tcn);
             Exception fEx = null;
@@ -2187,7 +2187,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(TCn)),
                         Expression.Constant(b, typeof(TCn))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<TCn> f = e.Compile();
+            Func<TCn> f = e.CompileForTest();
 
             TCn result = default(TCn);
             Exception fEx = null;
@@ -2232,7 +2232,7 @@ namespace Tests.ExpressionCompiler.Ternary
                         Expression.Constant(a, typeof(Ts)),
                         Expression.Constant(b, typeof(Ts))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.CompileForTest();
 
             Ts result = default(Ts);
             Exception fEx = null;

--- a/src/System.Linq.Expressions/tests/TestExtensions.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Expressions
         {
 #if FEATURE_INTERPRET && FEATURE_COMPILE
             var c = expr.Compile();
-            var i = expr.Compile(/*true*/); // TODO: reenable
+            var i = expr.Compile(true);
 
             return (T)(object)Combine(typeof(T), c as Delegate, i as Delegate);
 #else
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions
         {
 #if FEATURE_INTERPRET && FEATURE_COMPILE
             var c = expr.Compile();
-            var i = expr.Compile(/*true*/); // TODO: reenable
+            var i = expr.Compile(true);
 
             return Combine(expr.Type, c, i);
 #else

--- a/src/System.Linq.Expressions/tests/TestExtensions.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions
     {
         public static T CompileForTest<T>(this Expression<T> expr)
         {
-#if FEATURE_INTERPRET && FEATURE_COMPILE
+#if FEATURE_INTERPRET && FEATURE_COMPILE && ENABLE_CROSSCHECK
             var c = expr.Compile();
             var i = expr.Compile(true);
 
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions
 
         public static Delegate CompileForTest(this LambdaExpression expr)
         {
-#if FEATURE_INTERPRET && FEATURE_COMPILE
+#if FEATURE_INTERPRET && FEATURE_COMPILE && ENABLE_CROSSCHECK
             var c = expr.Compile();
             var i = expr.Compile(true);
 

--- a/src/System.Linq.Expressions/tests/TestExtensions.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions
+{
+    static class TestExtensions
+    {
+        public static T CompileForTest<T>(this Expression<T> expr)
+        {
+#if FEATURE_INTERPRET && FEATURE_COMPILE
+            var c = expr.Compile();
+            var i = expr.Compile(/*true*/); // TODO: reenable
+
+            return (T)(object)Combine(typeof(T), c as Delegate, i as Delegate);
+#else
+            return expr.Compile();
+#endif
+        }
+
+        public static Delegate CompileForTest(this LambdaExpression expr)
+        {
+#if FEATURE_INTERPRET && FEATURE_COMPILE
+            var c = expr.Compile();
+            var i = expr.Compile(/*true*/); // TODO: reenable
+
+            return Combine(expr.Type, c, i);
+#else
+            return expr.Compile();
+#endif
+        }
+
+        private static IDictionary<Type, Func<Delegate, Delegate, Delegate>> s_combiners = new Dictionary<Type, Func<Delegate, Delegate, Delegate>>();
+
+        private static Delegate Combine(Type type, Delegate d1, Delegate d2)
+        {
+            var combine = default(Func<Delegate, Delegate, Delegate>);
+
+            lock (s_combiners)
+            {
+                if (s_combiners.TryGetValue(type, out combine))
+                {
+                    return combine(d1, d2);
+                }
+            }
+
+            var pd1 = Expression.Parameter(typeof(Delegate));
+            var pd2 = Expression.Parameter(typeof(Delegate));
+
+            var ad1 = Expression.Convert(pd1, type);
+            var ad2 = Expression.Convert(pd2, type);
+
+            var invoke = type.GetTypeInfo().GetDeclaredMethod("Invoke");
+
+            var ps = invoke.GetParameters().Select((p, i) => Expression.Parameter(p.ParameterType, "p" + i)).ToArray();
+            var ret = invoke.ReturnType;
+
+            var validate = default(Expression);
+
+            if (ret == typeof(void))
+            {
+                var exd1 = Expression.Parameter(typeof(Exception), "exd1");
+                var exd2 = Expression.Parameter(typeof(Exception), "exd2");
+
+                validate =
+                    Expression.Block(
+                        new[] { exd1, exd2 },
+                        InvokeWithCatch(ad1, ps, exd1),
+                        InvokeWithCatch(ad2, ps, exd2),
+                        Expression.Call(s_assertVoid, exd1, exd2)
+                    );
+            }
+            else
+            {
+                var exd1 = Expression.Parameter(typeof(Exception), "exd1");
+                var exd2 = Expression.Parameter(typeof(Exception), "exd2");
+
+                var rd1 = Expression.Parameter(ret, "rd1");
+                var rd2 = Expression.Parameter(ret, "rd2");
+
+                validate =
+                    Expression.Block(
+                        new[] { rd1, rd2, exd1, exd2 },
+                        Expression.Assign(rd1, InvokeWithCatch(ad1, ps, exd1)),
+                        Expression.Assign(rd2, InvokeWithCatch(ad2, ps, exd2)),
+                        Expression.Call(s_assertNonVoid, Expression.Convert(rd1, typeof(object)), Expression.Convert(rd2, typeof(object)), exd1, exd2),
+                        rd1
+                    );
+            }
+
+            var body = Expression.Lambda(type, validate, ps);
+
+            combine = Expression.Lambda<Func<Delegate, Delegate, Delegate>>(body, pd1, pd2).Compile();
+
+            lock (s_combiners)
+            {
+                s_combiners[type] = combine;
+            }
+
+            return combine(d1, d2);
+        }
+
+        static Expression InvokeWithCatch(Expression d, ParameterExpression[] ps, ParameterExpression ex)
+        {
+            var exp = Expression.Parameter(typeof(Exception), "ex");
+
+            var i = Expression.Invoke(d, ps);
+
+            return
+                Expression.TryCatch(
+                    i,
+                    Expression.Catch(
+                        exp,
+                        Expression.Block(
+                            Expression.Assign(ex, exp),
+                            Expression.Default(i.Type)
+                        )
+                    )
+                );
+        }
+
+        private static MethodInfo s_assertVoid = ((MethodCallExpression)((Expression<Action>)(() => AssertVoid(default(Exception), default(Exception)))).Body).Method;
+        private static MethodInfo s_assertNonVoid = ((MethodCallExpression)((Expression<Action>)(() => AssertNonVoid(default(object), default(object), default(Exception), default(Exception)))).Body).Method;
+
+        static void AssertVoid(Exception e1, Exception e2)
+        {
+            if (e1 != null || e2 != null)
+            {
+                if (e1 == null || e2 == null)
+                {
+                    Assert.Equal(e1, e2);
+                }
+
+                Assert.Equal(e1.GetType(), e2.GetType());
+
+                throw e1;
+            }
+        }
+
+        static void AssertNonVoid(object o1, object o2, Exception e1, Exception e2)
+        {
+            AssertVoid(e1, e2);
+
+            if (o1 != null && o2 != null)
+            {
+                // NB: This is a work-around for Lambda tests that return curried functions. There's no value equality for
+                //     delegates, so we'll just check the delegate type matches. The test itself is responsible to check
+                //     whether the outcome is semantically equivalent.
+                if (o1 is Delegate)
+                {
+                    Assert.Equal(o1.GetType(), o2.GetType());
+                    return;
+                }
+
+                // NB: Similar to above, for Quote tests that return expressions.
+                if (o1 is LambdaExpression)
+                {
+                    Assert.Equal(o1.GetType(), o2.GetType());
+                    return;
+                }
+            }
+
+            Assert.Equal(o1, o2);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
 
             // add with expression tree
             decimal? etResult = default(decimal?);
@@ -169,7 +169,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
 
             // add with expression tree
             double? etResult = default(double?);
@@ -215,7 +215,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
 
             // add with expression tree
             float? etResult = default(float?);
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
 
             // add with expression tree
             int? etResult = default(int?);
@@ -307,7 +307,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
 
             // add with expression tree
             long? etResult = default(long?);
@@ -358,7 +358,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
 
             // add with expression tree
             short? etResult = default(short?);

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
 
             // add with expression tree
             decimal etResult = default(decimal);
@@ -169,7 +169,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
 
             // add with expression tree
             double etResult = default(double);
@@ -215,7 +215,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
 
             // add with expression tree
             float etResult = default(float);
@@ -261,7 +261,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
 
             // add with expression tree
             int etResult = default(int);
@@ -307,7 +307,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
 
             // add with expression tree
             long etResult = default(long);
@@ -358,7 +358,7 @@ namespace Tests.ExpressionCompiler.Unary
                     Expression.NegateChecked(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
 
             // add with expression tree
             short etResult = default(short);

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
@@ -20,7 +20,7 @@ namespace Tests.ExpressionCompiler.Unary
                 )
             );
 
-            var f = e.Compile();
+            var f = e.CompileForTest();
 
             Assert.True(f() == 1.0m);
         }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<decimal?>>(
                     Expression.Negate(Expression.Constant(value, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
             Assert.Equal((decimal?)(-value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double?>>(
                     Expression.Negate(Expression.Constant(value, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
             Assert.Equal((double?)(-value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float?>>(
                     Expression.Negate(Expression.Constant(value, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
             Assert.Equal((float?)(-value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int?>>(
                     Expression.Negate(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal((int?)(-value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long?>>(
                     Expression.Negate(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal((long?)(-value), f());
         }
 
@@ -177,7 +177,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short?>>(
                     Expression.Negate(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal((short?)(-value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<decimal>>(
                     Expression.Negate(Expression.Constant(value, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
             Assert.Equal((decimal)(-value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double>>(
                     Expression.Negate(Expression.Constant(value, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
             Assert.Equal((double)(-value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float>>(
                     Expression.Negate(Expression.Constant(value, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
             Assert.Equal((float)(-value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int>>(
                     Expression.Negate(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal((int)(-value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long>>(
                     Expression.Negate(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal((long)(-value), f());
         }
 
@@ -177,7 +177,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short>>(
                     Expression.Negate(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal((short)(-value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
@@ -112,7 +112,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<bool?>>(
                     Expression.Not(Expression.Constant(value, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
             Assert.Equal((bool?)(!value), f());
         }
 
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<byte?>>(
                     Expression.Not(Expression.Constant(value, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
             Assert.Equal((byte?)(~value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int?>>(
                     Expression.Not(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal((int?)(~value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long?>>(
                     Expression.Not(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal((long?)(~value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.Not(Expression.Constant(value, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
             Assert.Equal((sbyte?)(~value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short?>>(
                     Expression.Not(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal((short?)(~value), f());
         }
 
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint?>>(
                     Expression.Not(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             Assert.Equal((uint?)(~value), f());
         }
 
@@ -182,7 +182,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Not(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             Assert.Equal((ulong?)(~value), f());
         }
 
@@ -192,7 +192,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Not(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             Assert.Equal((ushort?)(~value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -112,7 +112,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<bool>>(
                     Expression.Not(Expression.Constant(value, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.Equal((bool)(!value), f());
         }
 
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<byte>>(
                     Expression.Not(Expression.Constant(value, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
             Assert.Equal((byte)(~value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int>>(
                     Expression.Not(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal((int)(~value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long>>(
                     Expression.Not(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal((long)(~value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<sbyte>>(
                     Expression.Not(Expression.Constant(value, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
             Assert.Equal((sbyte)(~value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short>>(
                     Expression.Not(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal((short)(~value), f());
         }
 
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint>>(
                     Expression.Not(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             Assert.Equal((uint)(~value), f());
         }
 
@@ -182,7 +182,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong>>(
                     Expression.Not(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             Assert.Equal((ulong)(~value), f());
         }
 
@@ -192,7 +192,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort>>(
                     Expression.Not(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             Assert.Equal((ushort)(~value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
@@ -102,7 +102,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal((short?)(--value), f());
         }
 
@@ -112,7 +112,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             Assert.Equal((ushort?)(--value), f());
         }
 
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal((int?)(--value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             Assert.Equal((uint?)(--value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal((long?)(--value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             Assert.Equal((ulong?)(--value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
             Assert.Equal((float?)(--value), f());
         }
 
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double?>>(
                     Expression.Decrement(Expression.Constant(value, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
             Assert.Equal((double?)(--value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -102,7 +102,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short>>(
                     Expression.Decrement(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal((short)(--value), f());
         }
 
@@ -112,7 +112,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort>>(
                     Expression.Decrement(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             Assert.Equal((ushort)(--value), f());
         }
 
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int>>(
                     Expression.Decrement(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal((int)(--value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint>>(
                     Expression.Decrement(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             Assert.Equal((uint)(--value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long>>(
                     Expression.Decrement(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal((long)(--value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong>>(
                     Expression.Decrement(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             Assert.Equal((ulong)(--value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float>>(
                     Expression.Decrement(Expression.Constant(value, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
             Assert.Equal((float)(--value), f());
         }
 
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double>>(
                     Expression.Decrement(Expression.Constant(value, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
             Assert.Equal((double)(--value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
@@ -102,7 +102,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short?>>(
                     Expression.Increment(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal((short?)(++value), f());
         }
 
@@ -112,7 +112,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort?>>(
                     Expression.Increment(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             Assert.Equal((ushort?)(++value), f());
         }
 
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int?>>(
                     Expression.Increment(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal((int?)(++value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint?>>(
                     Expression.Increment(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             Assert.Equal((uint?)(++value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long?>>(
                     Expression.Increment(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal((long?)(++value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong?>>(
                     Expression.Increment(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             Assert.Equal((ulong?)(++value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float?>>(
                     Expression.Increment(Expression.Constant(value, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
             Assert.Equal((float?)(++value), f());
         }
 
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double?>>(
                     Expression.Increment(Expression.Constant(value, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
             Assert.Equal((double?)(++value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -102,7 +102,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short>>(
                     Expression.Increment(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal((short)(++value), f());
         }
 
@@ -112,7 +112,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort>>(
                     Expression.Increment(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             Assert.Equal((ushort)(++value), f());
         }
 
@@ -122,7 +122,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int>>(
                     Expression.Increment(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal((int)(++value), f());
         }
 
@@ -132,7 +132,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint>>(
                     Expression.Increment(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             Assert.Equal((uint)(++value), f());
         }
 
@@ -142,7 +142,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long>>(
                     Expression.Increment(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal((long)(++value), f());
         }
 
@@ -152,7 +152,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong>>(
                     Expression.Increment(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             Assert.Equal((ulong)(++value), f());
         }
 
@@ -162,7 +162,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float>>(
                     Expression.Increment(Expression.Constant(value, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
             Assert.Equal((float)(++value), f());
         }
 
@@ -172,7 +172,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double>>(
                     Expression.Increment(Expression.Constant(value, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
             Assert.Equal((double)(++value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
@@ -33,7 +33,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<bool?>>(
                     Expression.IsFalse(Expression.Constant(value, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
             Assert.Equal((bool?)(value == default(bool?) ? default(bool?) : value == false), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -33,7 +33,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<bool>>(
                     Expression.IsFalse(Expression.Constant(value, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.Equal((bool)(value == false), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
@@ -33,7 +33,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<bool?>>(
                     Expression.IsTrue(Expression.Constant(value, typeof(bool?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool?> f = e.Compile();
+            Func<bool?> f = e.CompileForTest();
             Assert.Equal((bool?)(value == default(bool?) ? default(bool?) : value == true), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -33,7 +33,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<bool>>(
                     Expression.IsTrue(Expression.Constant(value, typeof(bool))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.CompileForTest();
             Assert.Equal((bool)(value == true), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
@@ -103,7 +103,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal((short?)(~value), f());
         }
 
@@ -113,7 +113,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             Assert.Equal((ushort?)(~value), f());
         }
 
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal((int?)(~value), f());
         }
 
@@ -133,7 +133,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             Assert.Equal((uint?)(~value), f());
         }
 
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal((long?)(~value), f());
         }
 
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             Assert.Equal((ulong?)(~value), f());
         }
 
@@ -163,7 +163,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<byte?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte?> f = e.Compile();
+            Func<byte?> f = e.CompileForTest();
             Assert.Equal((byte?)(~value), f());
         }
 
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<sbyte?>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(sbyte?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte?> f = e.Compile();
+            Func<sbyte?> f = e.CompileForTest();
             Assert.Equal((sbyte?)(~value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -103,7 +103,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal((short)(~value), f());
         }
 
@@ -113,7 +113,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             Assert.Equal((ushort)(~value), f());
         }
 
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal((int)(~value), f());
         }
 
@@ -133,7 +133,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             Assert.Equal((uint)(~value), f());
         }
 
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal((long)(~value), f());
         }
 
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             Assert.Equal((ulong)(~value), f());
         }
 
@@ -163,7 +163,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<byte>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<byte> f = e.Compile();
+            Func<byte> f = e.CompileForTest();
             Assert.Equal((byte)(~value), f());
         }
 
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<sbyte>>(
                     Expression.OnesComplement(Expression.Constant(value, typeof(sbyte))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<sbyte> f = e.Compile();
+            Func<sbyte> f = e.CompileForTest();
             Assert.Equal((sbyte)(~value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
@@ -113,7 +113,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short?> f = e.Compile();
+            Func<short?> f = e.CompileForTest();
             Assert.Equal((short?)(+value), f());
         }
 
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort?> f = e.Compile();
+            Func<ushort?> f = e.CompileForTest();
             Assert.Equal((ushort?)(+value), f());
         }
 
@@ -133,7 +133,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int?> f = e.Compile();
+            Func<int?> f = e.CompileForTest();
             Assert.Equal((int?)(+value), f());
         }
 
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint?> f = e.Compile();
+            Func<uint?> f = e.CompileForTest();
             Assert.Equal((uint?)(+value), f());
         }
 
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long?> f = e.Compile();
+            Func<long?> f = e.CompileForTest();
             Assert.Equal((long?)(+value), f());
         }
 
@@ -163,7 +163,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong?> f = e.Compile();
+            Func<ulong?> f = e.CompileForTest();
             Assert.Equal((ulong?)(+value), f());
         }
 
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float?> f = e.Compile();
+            Func<float?> f = e.CompileForTest();
             Assert.Equal((float?)(+value), f());
         }
 
@@ -183,7 +183,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(double?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double?> f = e.Compile();
+            Func<double?> f = e.CompileForTest();
             Assert.Equal((double?)(+value), f());
         }
 
@@ -193,7 +193,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<decimal?>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(decimal?))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal?> f = e.Compile();
+            Func<decimal?> f = e.CompileForTest();
             Assert.Equal((decimal?)(+value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -113,7 +113,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<short>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<short> f = e.Compile();
+            Func<short> f = e.CompileForTest();
             Assert.Equal((short)(+value), f());
         }
 
@@ -123,7 +123,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ushort>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ushort> f = e.Compile();
+            Func<ushort> f = e.CompileForTest();
             Assert.Equal((ushort)(+value), f());
         }
 
@@ -133,7 +133,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<int>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.CompileForTest();
             Assert.Equal((int)(+value), f());
         }
 
@@ -143,7 +143,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<uint>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<uint> f = e.Compile();
+            Func<uint> f = e.CompileForTest();
             Assert.Equal((uint)(+value), f());
         }
 
@@ -153,7 +153,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<long>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<long> f = e.Compile();
+            Func<long> f = e.CompileForTest();
             Assert.Equal((long)(+value), f());
         }
 
@@ -163,7 +163,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<ulong>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ulong> f = e.Compile();
+            Func<ulong> f = e.CompileForTest();
             Assert.Equal((ulong)(+value), f());
         }
 
@@ -173,7 +173,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<float>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(float))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<float> f = e.Compile();
+            Func<float> f = e.CompileForTest();
             Assert.Equal((float)(+value), f());
         }
 
@@ -183,7 +183,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<double>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(double))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<double> f = e.Compile();
+            Func<double> f = e.CompileForTest();
             Assert.Equal((double)(+value), f());
         }
 
@@ -193,7 +193,7 @@ namespace Tests.ExpressionCompiler.Unary
                 Expression.Lambda<Func<decimal>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(decimal))),
                     Enumerable.Empty<ParameterExpression>());
-            Func<decimal> f = e.Compile();
+            Func<decimal> f = e.CompileForTest();
             Assert.Equal((decimal)(+value), f());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -35,7 +35,7 @@ namespace Tests.ExpressionCompiler.Unary
                         typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
 
-            Func<object> f = e.Compile();
+            Func<object> f = e.CompileForTest();
 
             if (shouldThrow)
             {


### PR DESCRIPTION
This continues the work on #3995.

Sorry for the huge amount of ketchup and mustard in this PR :-). It may be easier to look at the first commit in isolation from the second:

- First commit introduces two extension methods called CompileForTest to replace .Compile() in test code. It provides one place in the test project where we can cause every use of .CompileForTest() to have the side-effect of performing a cross-check. It does so by implementing a custom Delegate.Combine method (using expression trees and .Compile() iself, so we get even more extra testing of the compiler) that will invoke both the compiled and interpreted delegate and cross-check their outcomes for exceptions and value equality of the result.
- Second commit does a search-and-replace for all .Compile() to .CompileForTest() and hence is huge. This was the easiest way to enable this rather than rewriting all the tests (which were code-generated to begin with).

Please note that both CompileForTest methods right now call .Compile() twice, rather than .Compile() and .Compile(true) when the interpreter is available. This is awaiting a fix for #4112 which was uncovered by enabling this type of testing.