### PR TITLE
WinHttpHandler: Fix POSTs with zero length content

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -211,6 +211,13 @@ namespace System.Net.Http
 
         private Task<bool> InternalWriteDataAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
+            Debug.Assert(count >= 0);
+            
+            if (count == 0)
+            {
+                return Task.FromResult<bool>(true);
+            }
+            
             // TODO (Issue 2505): replace with PinnableBufferCache.
             if (!_cachedSendPinnedBuffer.IsAllocated || _cachedSendPinnedBuffer.Target != buffer)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -43,6 +43,27 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("EchoServers")]
+        public async Task PostNoContentUsingContentLengthSemantics_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, string.Empty, null,
+                useContentLengthUpload: true, useChunkedEncodingUpload: false);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostEmptyContentUsingContentLengthSemantics_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, string.Empty, new StringContent(string.Empty),
+                useContentLengthUpload: true, useChunkedEncodingUpload: false);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task PostEmptyContentUsingChunkedEncoding_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, string.Empty, new StringContent(string.Empty),
+                useContentLengthUpload: false, useChunkedEncodingUpload: true);
+        }
+
+        [Theory, MemberData("EchoServers")]
         public async Task PostUsingContentLengthSemantics_Success(Uri serverUri)
         {
             await PostHelper(serverUri, ExpectedContent, new StringContent(ExpectedContent),
@@ -118,7 +139,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var client = new HttpClient())
             {
-                if (!useContentLengthUpload)
+                if (!useContentLengthUpload && requestContent != null)
                 {
                     requestContent.Headers.ContentLength = null;
                 }


### PR DESCRIPTION
While researching #3292, I discovered that POST'ing zero length content throws an exception. This was because we were calling WinHttpWriteData() and passing in a zero length for the buffer size. This returns an error back from WinHTTP.

We don't need to call WinHTTP APIs to write zero length data. We simply need to return a completed task back to the caller.

Added tests to verify the fix.