### PR TITLE
Modified perf testing targets

### DIFF
--- a/Documentation/project-docs/performance-tests.md
+++ b/Documentation/project-docs/performance-tests.md
@@ -43,18 +43,22 @@ For the time being, perf tests should reside within their own "Performance" fold
 
 Start by adding the following lines to the tests csproj:
 ```
- <!-- Performance Tests -->  
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">  
-    <Compile Include="Performance\Perf.Dictionary.cs" />  
-    <Compile Include="Performance\Perf.List.cs" />  
-    <Compile Include="$(CommonTestPath)\Performance\PerfUtils.cs">  
-      <Link>Common\Performance\PerfUtils.cs</Link>  
-    </Compile>  
-  </ItemGroup>  
+  <ItemGroup>
+    <!-- Performance Tests -->
+    <Compile Include="Performance\Perf.Dictionary.cs" />
+    <Compile Include="Performance\Perf.List.cs" />
+    <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
+      <Link>Common\System\PerfUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Optimizations to configure Xunit for performance -->
+  <ItemGroup>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
+  </ItemGroup>
 ```
 (Replace Dictionary/List with whatever class you’re testing.)
 
-Next, the project.json for the tests directory also needs to import the perf stuff:
+Next, the project.json for the tests directory also needs to import the xunit libraries:
 
 ```
     "Microsoft.DotNet.xunit.performance": "1.0.0-*",

--- a/dir.props
+++ b/dir.props
@@ -283,11 +283,6 @@
     <MakePriExtensionPath_x64>$(_WindowsPhoneKitBinPath)\x64\MrmEnvironmentExtDl.dll</MakePriExtensionPath_x64>
   </PropertyGroup>
   
-  <!-- Perf test setup - Required until v5.0 is mandatory across CoreFX-->
-  <PropertyGroup>
-    <RunPerfTestsForProject Condition="'$(Performance)' == 'true' and '$(OsEnvironment)' == 'Windows_NT' and Exists('$(MSBuildProgramFiles32)\MSBuild\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets')">true</RunPerfTestsForProject>
-  </PropertyGroup>
-
   <Import Project="$(RoslynPropsFile)" Condition="'$(OsEnvironment)'=='Unix' and Exists('$(RoslynPropsFile)')" />
 
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00116</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00117</BuildToolsVersion>
     <DnxVersion>1.0.0-rc1-15838</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00116" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00117" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-rc1-15838" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00116" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00117" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-rc1-15838" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -9,8 +9,8 @@
       "OpenCover": "4.6.166",
       "ReportGenerator": "2.3.1",
 
-      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0022",
-      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0022",
+      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0025",
+      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0025",
 
       "xunit": "2.1.0",
       "xunit.console.netcore": "1.0.2-prerelease-00101",

--- a/src/Common/test-runtime/project.lock.json
+++ b/src/Common/test-runtime/project.lock.json
@@ -33,10 +33,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0025": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0025": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -2003,10 +2003,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0025": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0025": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -4718,10 +4718,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0025": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0025": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -7433,10 +7433,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0025": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0025": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -10027,10 +10027,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0025": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0025": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -12655,13 +12655,13 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0025": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JwQJjSTP1HXDf9J2isVDlVauz/tcN9QJRuaABaAe9Y3qVlX56kcIr6mT22oEaWUOGo9kGIzt4iGHlZ/E655lhg==",
+      "sha512": "2J6XPeQ+/faZXR4l1bcxlzCDtHqHnoo1YytQBllfvs4oPnw5DEvmWstb2AcFuyeFjhuiAZ9gezDmoIqFurTqPA==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0022.nupkg",
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0022.nupkg.sha512",
+        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0025.nupkg",
+        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0025.nupkg.sha512",
         "Microsoft.DotNet.xunit.performance.analysis.nuspec",
         "tools/MathNet.Numerics.dll",
         "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
@@ -12670,13 +12670,13 @@
         "tools/xunit.performance.analysis.pdb"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0025": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YiCRPElKD5Rl1z8EVHYCeh9G74QSXe5EkSIFbSNbyGysEoS01i7apL6CzPUlJGyAigbLNUCsWmqtDsMhWTBvDA==",
+      "sha512": "ru0tFfvyUso/7UmFs7cNelA/uW4VcJsURXZfH6IT5lf2kZH7X2DqByh0S/mDzbea1/zViMe/DRk33U1T+TQeEw==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0022.nupkg",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0022.nupkg.sha512",
+        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0025.nupkg",
+        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0025.nupkg.sha512",
         "Microsoft.DotNet.xunit.performance.runner.Windows.nuspec",
         "tools/amd64/KernelTraceControl.dll",
         "tools/amd64/msdia120.dll",
@@ -12686,6 +12686,7 @@
         "tools/x86/KernelTraceControl.dll",
         "tools/x86/msdia120.dll",
         "tools/xunit.abstractions.dll",
+        "tools/xunit.core.dll",
         "tools/xunit.performance.core.dll",
         "tools/xunit.performance.core.pdb",
         "tools/xunit.performance.logger.exe",
@@ -17666,8 +17667,8 @@
       "coveralls.io >= 1.4.0",
       "OpenCover >= 4.6.166",
       "ReportGenerator >= 2.3.1",
-      "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0022",
-      "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0022",
+      "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0025",
+      "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0025",
       "xunit >= 2.1.0",
       "xunit.console.netcore >= 1.0.2-prerelease-00101",
       "xunit.runner.utility >= 2.1.0"

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the configurations -->
@@ -147,9 +148,7 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.HashTable.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -143,15 +144,16 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Dictionary.cs" />
     <Compile Include="Performance\Perf.List.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
   </ItemGroup>
+  <PropertyGroup Condition="'$(Performance)' == 'true'">
+    <IncludePerformanceTests>true</IncludePerformanceTests>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,6 +9,7 @@
     <AssemblyName>System.Console.Tests</AssemblyName>
     <RootNamespace>System.Console.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -47,9 +48,7 @@
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <Compile Include="WindowAndCursorProps.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Console.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -10,6 +10,7 @@
     <AssemblyName>System.Diagnostics.Process.Tests</AssemblyName>
     <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -38,9 +39,7 @@
     <Compile Include="ProcessThreadTests.cs" />
     <Compile Include="ProcessWaitingTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Process.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,6 +9,7 @@
     <RootNamespace>System.Globalization.Tests</RootNamespace>
     <AssemblyName>System.Globalization.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -169,9 +170,7 @@
     <Compile Include="TextInfo\TextInfoToUpper2.cs" />
     <Compile Include="UnicodeCategory\UnicodeCategoryTests.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.CultureInfo.cs" />
     <Compile Include="Performance\Perf.DateTimeCultureInfo.cs" />
     <Compile Include="Performance\Perf.NumberCultureInfo.cs" />

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -7,6 +7,7 @@
     <ProjectGuid>{BC2E1649-291D-412E-9529-EDDA94FA7AD6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Compression.Tests</AssemblyName>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
@@ -47,9 +48,7 @@
     <Compile Include="$(CommonTestPath)\System\IO\Compression\ZipTestHelper.cs">
       <Link>Common\System\IO\Compression\ZipTestHelper.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.DeflateStream.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.IO.FileSystem/tests/Performance/Perf.FileStream.cs
+++ b/src/System.IO.FileSystem/tests/Performance/Perf.FileStream.cs
@@ -56,7 +56,7 @@ namespace System.IO.Tests
         /// </summary>
         [Benchmark]
         [MemberData("ReadWriteTestParameters")]
-        public async void Read(bool useAsync, int bufferSize, int totalSize)
+        public async Task Read(bool useAsync, int bufferSize, int totalSize)
         {
             byte[] bytes = new byte[bufferSize];
             // Actual file size may be slightly over the desired size due to rounding if totalSize % readSize != 0
@@ -95,7 +95,7 @@ namespace System.IO.Tests
         /// </summary>
         [Benchmark]
         [MemberData("ReadWriteTestParameters")]
-        public async void Write(bool useAsync, int bufferSize, int totalSize)
+        public async Task Write(bool useAsync, int bufferSize, int totalSize)
         {
             byte[] bytes = CreateBytesToWrite(bufferSize);
             // Actual file size may be slightly over the desired size due to rounding if totalSize % bufferSize != 0

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -163,9 +164,7 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Directory.cs" />
     <Compile Include="Performance\Perf.File.cs" />
     <Compile Include="Performance\Perf.FileInfo.cs" />

--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -10,6 +10,7 @@
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{9D6F6254-B5A3-40FF-8925-68AA8D1CE933}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -30,9 +31,7 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.MemoryMappedFile.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.IO.Pipes/tests/Performance/Perf.PipeTest.cs
+++ b/src/System.IO.Pipes/tests/Performance/Perf.PipeTest.cs
@@ -11,7 +11,7 @@ namespace System.IO.Pipes.Tests
     {
         [Benchmark]
         [InlineData(1000000)]
-        public async void ReadWrite(int size)
+        public async Task ReadWrite(int size)
         {
             Random rand = new Random(314);
             byte[] sent = new byte[size];

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -11,6 +11,7 @@
     <ProjectGuid>{142469EC-D665-4FE2-845A-FDA69F9CC557}</ProjectGuid>
     <NuGetPackageImportStamp>d2615b94</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -36,9 +37,6 @@
     <Compile Include="PipeTestBase.cs" />
     <Compile Include="PipeTest.Read.cs" />
     <Compile Include="PipeTest.Write.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
     <Compile Include="Performance\Perf.AnonymousPipeStream.cs" />
     <Compile Include="Performance\Perf.NamedPipeStream.cs" />
     <Compile Include="Performance\Perf.PipeTest.cs" />

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Linq.Tests</AssemblyName>
     <RootNamespace>System.Linq.Tests</RootNamespace>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -67,9 +68,7 @@
     <Compile Include="UnionTests.cs" />
     <Compile Include="WhereTests.cs" />
     <Compile Include="ZipTests.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Linq.cs" />
     <Compile Include="Performance\Perf.LinqTestBase.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">

--- a/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>System.Numerics.Vectors.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>11f13d9c</NuGetPackageImportStamp>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -38,9 +39,7 @@
     <Compile Include="Matrix4x4Tests.cs" />
     <Compile Include="PlaneTests.cs" />
     <Compile Include="QuaternionTests.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Vector2.cs" />
     <Compile Include="Performance\Perf.Vector3.cs" />
     <Compile Include="Performance\Perf.Vector4.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -10,6 +10,7 @@
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <RestorePackages>true</RestorePackages>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -54,9 +55,7 @@
     <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
     <Compile Include="System\StringComparer.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Environment.cs" />
     <Compile Include="Performance\Perf.Path.cs" />
     <Compile Include="Performance\Perf.Random.cs" />

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -10,6 +10,7 @@
     <RootNamespace>System.Runtime.Serialization.Xml.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Serialization.Xml.Tests</AssemblyName>
     <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Utils.cs" />
@@ -18,14 +19,12 @@
     <Compile Include="DataContractSerializerTestData.cs" />
     <Compile Include="MyResolver.cs" />
     <Compile Include="XmlDictionaryWriterTest.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->  
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">  
-    <Compile Include="Performance\Perf.Deserialization.cs" />  
+    <!-- Performance Tests -->
+    <Compile Include="Performance\Perf.Deserialization.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
-    </Compile>  
-  </ItemGroup>  
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">
       <Project>{6B4C1660-D158-4820-BE1C-D7A29CEBEC9B}</Project>

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
     "System.Collections": "4.0.10",
     "System.Collections.Concurrent": "4.0.10",
     "System.Collections.NonGeneric": "4.0.0",
@@ -27,7 +28,6 @@
     "System.Xml.XmlDocument": "4.0.0",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0022",
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Runtime.Serialization.Xml/tests/project.lock.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.lock.json
@@ -3,7 +3,7 @@
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
-      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0023": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -653,7 +653,7 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x86": {
-      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0023": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1303,7 +1303,7 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x64": {
-      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0023": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1954,9 +1954,9 @@
     }
   },
   "libraries": {
-    "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0022": {
+    "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0023": {
       "type": "package",
-      "sha512": "uh4WpDAs7mW9aiMqcHojn1MEGNUND03qmSsWFyVApAcRQQ0ppCJvQ2sUGBdL1/8DB12NGzKizaGg0Tnd4PCnfA==",
+      "sha512": "7TOhATYXNVMF3HHGuM/WFHLt7r4uvFIUliplzIHsfL/KwxaHUbV6RI1f7EZRAioMbJI5520BGOOZ+9XIqtTQuA==",
       "files": [
         "lib/dotnet/xunit.performance.core.dll",
         "lib/dotnet/xunit.performance.core.pdb",
@@ -1968,8 +1968,8 @@
         "lib/net46/xunit.performance.core.XML",
         "lib/net46/xunit.performance.execution.desktop.dll",
         "lib/net46/xunit.performance.execution.desktop.pdb",
-        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0022.nupkg",
-        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0022.nupkg.sha512",
+        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0023.nupkg",
+        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0023.nupkg.sha512",
         "Microsoft.DotNet.xunit.performance.nuspec"
       ]
     },
@@ -3244,6 +3244,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "Microsoft.DotNet.xunit.performance >= 1.0.0-*",
       "System.Collections >= 4.0.10",
       "System.Collections.Concurrent >= 4.0.10",
       "System.Collections.NonGeneric >= 4.0.0",
@@ -3270,8 +3271,7 @@
       "System.Xml.XDocument >= 4.0.10",
       "System.Xml.XmlDocument >= 4.0.0",
       "xunit >= 2.1.0",
-      "xunit.netcore.extensions >= 1.0.0-prerelease-*",
-      "Microsoft.DotNet.xunit.performance >= 1.0.0-alpha-build0022"
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RestorePackages>true</RestorePackages>
     <NoWarn>1718</NoWarn>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -88,9 +89,7 @@
     <Compile Include="System\ValueType.cs" />
     <Compile Include="System\Version.cs" />
     <Compile Include="System\WeakReference.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Boolean.cs" />
     <Compile Include="Performance\Perf.Enum.cs" />
     <Compile Include="Performance\Perf.Guid.cs" />

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Text.Encoding.Tests</AssemblyName>
     <RootNamespace>System.Text.Encoding.Tests</RootNamespace>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -116,9 +117,7 @@
     <Compile Include="UTF8Encoding\UTF8EncodingGetPreamble.cs" />
     <Compile Include="UTF8Encoding\UTF8EncodingGetString.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Encoding.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tests</AssemblyName>
     <ProjectGuid>{33F5A50E-B823-4FDD-8571-365C909ACEAE}</ProjectGuid>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -34,9 +35,7 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.EventWaitHandle.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$(CommonTestPath)\Tests.props" />
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XmlDocument.UnitTests</RootNamespace>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -103,9 +104,7 @@
     <Compile Include="XmlProcessingInstructionTests\DataTests.cs" />
     <Compile Include="XmlProcessingInstructionTests\TargetTests.cs" />
     <Compile Include="XmlTextTests\SplitTextTests.cs" />
-  </ItemGroup>
-  <!-- Performance Tests -->
-  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <!-- Performance Tests -->
     <Compile Include="Performance\Perf.XmlDocument.cs" />
     <Compile Include="Performance\Perf.XmlNode.cs" />
     <Compile Include="Performance\Perf.XmlNodeList.cs" />


### PR DESCRIPTION
Perf test targets were buggy and required specific setup to not fail. I've hardened them so that the tests can be more easily built without also running them. I also removed the v5.0 libraries requirement.

Specifically, the targets needed to protect against multiple possible scenarios when Performance=true is passed:

- while building a project with no perf tests
- while building a project that is not a test project
- while building a perf test project but not running it
- while building and running a perf test project

This update primarily solves the case where Performance=true but there were no performance tests to be run. Previously the code would error out; now it will finish compilation normally.

@mellinoe @jhendrixMSFT 

Requires https://github.com/dotnet/buildtools/pull/319