### PR TITLE
Delete unused references to Interop.GetLastError.cs 

### DIFF
--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -78,9 +78,6 @@
     <Compile Include="$(CommonPath)\System\Diagnostics\Debug.Windows.cs">
       <Link>Common\System\Diagnostics\Debug.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetLastError.cs">
-      <Link>Common\Interop\Windows\mincore\Interop.GetLastError.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetLastError.cs">
       <Link>Common\Interop\Windows\mincore\Interop.SetLastError.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -71,9 +71,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetFullPathNameW.cs">
       <Link>Common\Interop\Windows\mincore\Interop.GetFullPathNameW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetLastError.cs">
-      <Link>Common\Interop\Windows\mincore\Interop.GetLastError.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetLongPathNameW.cs">
       <Link>Common\Interop\Windows\mincore\Interop.GetLongPathNameW.cs</Link>
     </Compile>


### PR DESCRIPTION
It is unused, and it should not be ever used either - Marshal.GetLastWin32Error should be used instead.