### PR TITLE
Remove StringBuilder marshaling from Unix interop

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 internal static partial class Interop
 {
@@ -42,7 +43,7 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative)]
         internal unsafe static extern int IPAddressToString(byte* address, int addressLength, bool isIPv6, byte* str, int stringLength, uint scope = 0);
 
-        internal unsafe static uint IPAddressToString(byte[] address, bool isIPv6, System.Text.StringBuilder addressString, uint scope = 0)
+        internal unsafe static uint IPAddressToString(byte[] address, bool isIPv6, StringBuilder addressString, uint scope = 0)
         {
             Debug.Assert(address != null);
             Debug.Assert((address.Length == IPv4AddressBytes) || (address.Length == IPv6AddressBytes));

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.BIO.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.BIO.cs
@@ -20,8 +20,8 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool BioDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
-        internal static extern int BioGets(SafeBioHandle b, [Out] StringBuilder buf, int size);
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int BioGets(SafeBioHandle b, byte[] buf, int size);
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern int BioRead(SafeBioHandle b, byte[] data, int len);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -20,15 +20,17 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative)]
         internal static extern IntPtr ErrReasonErrorString(ulong error);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
-        private static extern void ErrErrorStringN(ulong e, [Out] StringBuilder buf, int len);
+        [DllImport(Libraries.CryptoNative)]
+        private static unsafe extern void ErrErrorStringN(ulong e, byte* buf, int len);
 
-        private static string ErrErrorStringN(ulong error)
+        private static unsafe string ErrErrorStringN(ulong error)
         {
-            StringBuilder buf = new StringBuilder(1024);
-
-            ErrErrorStringN(error, buf, buf.Capacity);
-            return buf.ToString();
+            var buffer = new byte[1024];
+            fixed (byte* buf = buffer)
+            {
+                ErrErrorStringN(error, buf, buffer.Length);
+                return Marshal.PtrToStringAnsi((IntPtr)buf);
+            }
         }
 
         internal static Exception CreateOpenSslCryptographicException()

--- a/src/Common/src/Interop/Unix/libcoreclr/Interop.FormatMessage.cs
+++ b/src/Common/src/Interop/Unix/libcoreclr/Interop.FormatMessage.cs
@@ -31,7 +31,7 @@ internal static partial class Interop
                 IntPtr.Zero, (uint)errorCode, 0, buffer, (uint)buffer.Length, IntPtr.Zero);
             if (result != 0)
             {
-                // result is the # of characters copied to the StringBuilder.
+                // result is the # of characters copied.
                 return new string(buffer, 0, (int)result);
             }
             else

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OpenSslAsnFormatter.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OpenSslAsnFormatter.cs
@@ -51,10 +51,15 @@ namespace Internal.Cryptography
                     int printLen = Interop.Crypto.GetMemoryBioSize(bio);
 
                     // Account for the null terminator that it'll want to write.
-                    StringBuilder builder = new StringBuilder(printLen + 1);
-                    Interop.Crypto.BioGets(bio, builder, builder.Capacity);
+                    var buf = new byte[printLen + 1];
+                    int read = Interop.Crypto.BioGets(bio, buf, buf.Length);
 
-                    return builder.ToString();
+                    if (read < 0)
+                    {
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                    }
+
+                    return Encoding.UTF8.GetString(buf, 0, read);
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -283,15 +283,15 @@ namespace Internal.Cryptography.Pal
 
                 int bioSize = Interop.Crypto.GetMemoryBioSize(bioHandle);
                 // Ensure space for the trailing \0
-                StringBuilder builder = new StringBuilder(bioSize + 1);
-                int read = Interop.Crypto.BioGets(bioHandle, builder, builder.Capacity);
+                var buf = new byte[bioSize + 1];
+                int read = Interop.Crypto.BioGets(bioHandle, buf, buf.Length);
 
                 if (read < 0)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
 
-                return builder.ToString();
+                return Encoding.UTF8.GetString(buf, 0, read);
             }
         }
 


### PR DESCRIPTION
We use StringBuilder marshaling in our Unix interop code in a few places, all in crypto, and it's unnecessarily expensive.  We need to allocate the StringBuilder, and allocate its underlying char[].  The marshaling implementation will then allocate some native memory to store the results, and on the way back a new char[] is allocated to store the result and is copied into the StringBuilder.  Then a string is built from the contents of the StringBuilder.

We can instead just allocate a byte[] (or if we expect it to be small enough, put it on the stack), have the native code write into that, and decode it into a string.

cc: @bartonjs, @eerhardt 