### PR TITLE
Handling Invalid http response

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -348,4 +348,7 @@
   <data name="net_http_no_concurrent_io_allowed" xml:space="preserve">
     <value>The stream does not support concurrent I/O read or write operations.</value>
   </data>
+  <data name="net_http_unix_invalid_response" xml:space="preserve">
+    <value>The server returned an invalid or unrecognized response.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -139,6 +139,7 @@
     <Compile Include="System\Net\Http\Unix\CurlHandler.SslProvider.cs" />
     <Compile Include="System\Net\Http\Unix\CurlException.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.CurlResponseMessage.cs" />
+    <Compile Include="System\Net\Http\Unix\CurlResponseParseUtils.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -560,14 +560,11 @@ namespace System.Net.Http
 
                         if (!TryParseStatusLine(response, responseHeader, easy))
                         {
-                            int colonIndex = responseHeader.IndexOf(':');
-
-                            // Skip malformed header lines that are missing the colon character.
-                            if (colonIndex > 0)
+                            int index = 0;
+                            string headerName = CurlResponseParseUtils.ReadHeaderName(responseHeader, out index);
+                            if (headerName != null)
                             {
-                                string headerName = responseHeader.Substring(0, colonIndex);
-                                string headerValue = responseHeader.SubstringTrim(colonIndex + 1);
-
+                                string headerValue = responseHeader.Substring(index).Trim();
                                 if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
                                 {
                                     response.Content.Headers.TryAddWithoutValidation(headerName, headerValue);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -20,7 +20,6 @@ namespace System.Net.Http
         #region Constants
 
         private const string VerboseDebuggingConditional = "CURLHANDLER_VERBOSE";
-        private const string HttpPrefix = "HTTP/";
         private const char SpaceChar = ' ';
         private const int StatusCodeLength = 3;
 
@@ -557,90 +556,20 @@ namespace System.Net.Http
 
         private static bool TryParseStatusLine(HttpResponseMessage response, string responseHeader, EasyRequest state)
         {
-            if (!responseHeader.StartsWith(HttpPrefix, StringComparison.OrdinalIgnoreCase))
+            if (!responseHeader.StartsWith(CurlResponseParseUtils.HttpPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
             // Clear the header if status line is recieved again. This signifies that there are multiple response headers (like in redirection).
             response.Headers.Clear();
-
             response.Content.Headers.Clear();
 
-            int responseHeaderLength = responseHeader.Length;
-
-            // Check if line begins with HTTP/1.1 or HTTP/1.0
-            int prefixLength = HttpPrefix.Length;
-            int versionIndex = prefixLength + 2;
-
-            if ((versionIndex < responseHeaderLength) && (responseHeader[prefixLength] == '1') && (responseHeader[prefixLength + 1] == '.'))
-            {
-                response.Version =
-                    responseHeader[versionIndex] == '1' ? HttpVersion.Version11 :
-                    responseHeader[versionIndex] == '0' ? HttpVersion.Version10 :
-                    new Version(0, 0);
-            }
-            else
-            {
-                response.Version = new Version(0, 0);
-            }
-
-            // TODO: Parsing errors are treated as fatal. Find right behaviour
-
-            int spaceIndex = responseHeader.IndexOf(SpaceChar);
-
-            if (spaceIndex > -1)
-            {
-                int codeStartIndex = spaceIndex + 1;
-                int statusCode = 0;
-
-                // Parse first 3 characters after a space as status code
-                if (TryParseStatusCode(responseHeader, codeStartIndex, out statusCode))
-                {
-                    response.StatusCode = (HttpStatusCode)statusCode;
-
-                    int codeEndIndex = codeStartIndex + StatusCodeLength;
-
-                    int reasonPhraseIndex = codeEndIndex + 1;
-
-                    if (reasonPhraseIndex < responseHeaderLength && responseHeader[codeEndIndex] == SpaceChar)
-                    {
-                        int newLineCharIndex = responseHeader.IndexOfAny(s_newLineCharArray, reasonPhraseIndex);
-                        int reasonPhraseEnd = newLineCharIndex >= 0 ? newLineCharIndex : responseHeaderLength;
-                        response.ReasonPhrase = responseHeader.Substring(reasonPhraseIndex, reasonPhraseEnd - reasonPhraseIndex);
-                    }
-                    state._isRedirect = state._handler.AutomaticRedirection &&
+            CurlResponseParseUtils.ReadStatusLine(response, responseHeader);
+            state._isRedirect = state._handler.AutomaticRedirection &&
                          (response.StatusCode == HttpStatusCode.Redirect ||
                          response.StatusCode == HttpStatusCode.RedirectKeepVerb ||
                          response.StatusCode == HttpStatusCode.RedirectMethod) ;
-                }
-            }
-
-            return true;
-        }
-
-        private static bool TryParseStatusCode(string responseHeader, int statusCodeStartIndex, out int statusCode)
-        {
-            if (statusCodeStartIndex + StatusCodeLength > responseHeader.Length)
-            {
-                statusCode = 0;
-                return false;
-            }
-
-            char c100 = responseHeader[statusCodeStartIndex];
-            char c10 = responseHeader[statusCodeStartIndex + 1];
-            char c1 = responseHeader[statusCodeStartIndex + 2];
-
-            if (c100 < '0' || c100 > '9' ||
-                c10 < '0' || c10 > '9' ||
-                c1 < '0' || c1 > '9')
-            {
-                statusCode = 0;
-                return false;
-            }
-
-            statusCode = (c100 - '0') * 100 + (c10 - '0') * 10 + (c1 - '0');
-
             return true;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseParseUtils.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseParseUtils.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.Net.Http
+{
+    internal static class CurlResponseParseUtils
+    {
+        internal const string HttpPrefix = "HTTP/";
+
+        private static int ReadInt(string responseHeader, ref int index)
+        {
+            int value = 0;
+            for ( ; index < responseHeader.Length; index++)
+            {
+                char c = responseHeader[index];
+                if (c < '0' || c > '9')
+                {
+                    break;
+                }
+
+                value = (value * 10) + (c - '0');
+            }
+
+            return value;
+        }
+
+        private static void SkipMandatorySpace(string responseHeader, ref int index)
+        {
+            bool foundSpace = false;
+            for ( ; index < responseHeader.Length; index++)
+            {
+                if (responseHeader[index] == ' ' || responseHeader[index] == '\t')
+                {
+                    foundSpace = true;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            CheckResponseMsgFormat(foundSpace);
+        }
+
+        private static bool ValidHeaderNameChar(char c)
+        {
+            const string invalidChars = "()<>@,;:\\\"/[]?={}";
+            return c > ' ' && invalidChars.IndexOf(c) < 0 ;
+        }
+
+        private static void CheckResponseMsgFormat(bool condition)
+        {
+            if (!condition)
+            {
+                throw new HttpRequestException(SR.net_http_unix_invalid_response);
+            }
+        }
+
+        internal static void ReadStatusLine(HttpResponseMessage response, string responseHeader)
+        {
+            Debug.Assert(responseHeader.StartsWith(HttpPrefix, StringComparison.OrdinalIgnoreCase), "Status Line starts with http prefix");
+
+            int index =  HttpPrefix.Length;
+            int majorVersion = ReadInt(responseHeader, ref index);
+            CheckResponseMsgFormat(majorVersion != 0);
+
+            CheckResponseMsgFormat(index < responseHeader.Length && responseHeader[index] == '.');
+            index++;
+
+            // Need minor version
+            CheckResponseMsgFormat(index < responseHeader.Length && responseHeader[index] >= '0' && responseHeader[index] <= '9');
+            int minorVersion = ReadInt(responseHeader, ref index);
+
+            SkipMandatorySpace(responseHeader, ref index);
+
+            //  parse status code
+            int statusCode = ReadInt(responseHeader, ref index);
+            CheckResponseMsgFormat(statusCode >= 100 && statusCode < 600);
+
+            SkipMandatorySpace(responseHeader, ref index);
+
+            // we need reason phrase
+            CheckResponseMsgFormat( index < responseHeader.Length);
+
+            // Check if version is  HTTP/1.1 or HTTP/1.0
+            if (majorVersion == 1)
+            {
+                response.Version =
+                    minorVersion == 1 ? HttpVersion.Version11 :
+                    minorVersion == 0 ? HttpVersion.Version10 :
+                    new Version(0, 0);
+            }
+            else
+            {
+                response.Version = new Version(0, 0);
+            }
+
+            response.StatusCode = (HttpStatusCode)statusCode;
+            response.ReasonPhrase = responseHeader.Substring(index);
+        }
+
+        internal static string ReadHeaderName(string responseHeader, out int index)
+        {
+            index = 0;
+            while (index < responseHeader.Length && ValidHeaderNameChar(responseHeader[index]))
+            {
+                index++;
+            }
+
+            if (index > 0)
+            {
+                CheckResponseMsgFormat(index < responseHeader.Length);
+                CheckResponseMsgFormat(responseHeader[index] == ':');
+                string headerName = responseHeader.Substring(0, index);
+                CheckResponseMsgFormat(headerName.Length > 0);
+                index++;
+                return headerName;
+            }
+
+            return null;
+        }
+    }
+}
+

--- a/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseParseUtilsTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseParseUtilsTest.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+using Xunit;
+
+namespace System.Net.Http.Tests
+{
+    public class CurlResponseParseUtilsTest
+    {
+        private const string StatusCodeTemplate = "HTTP/1.1 {0} {1}";
+        private const string MissingSpaceFormat = "HTTP/1.1 {0}InvalidPhrase";
+
+        private const string StatusCodeVersionFormat = "HTTP/{0}.{1} 200 OK";
+
+        private const string ValidHeader = "Content-Type: text/xml; charset=utf-8";
+        private const string HeaderNameWithInvalidChar = "Content{0}Type: text/xml; charset=utf-8";
+
+        private const string invalidChars = "()<>@,;\\\"/[]?={} \t";
+
+        public readonly static IEnumerable<object[]> ValidStatusCodeLines = GetStatusCodeLines(StatusCodeTemplate);
+        public readonly static IEnumerable<object[]> InvalidStatusCodeLines = GetStatusCodeLines(MissingSpaceFormat);
+        public readonly static IEnumerable<object[]> StatusCodeVersionLines = GetStatusCodeLinesForVersions(1, 10);
+        public readonly static IEnumerable<object[]> InvalidHeaderLines = GetInvalidHeaderLines();
+
+        private static IEnumerable<object[]> GetStatusCodeLines(string template)
+        {
+            const string reasonPhrase = "Test Phrase";
+            foreach(int code in Enum.GetValues(typeof(HttpStatusCode)))
+            {
+                yield return new object[] { string.Format(template, code, reasonPhrase), code, reasonPhrase};
+            }
+        }
+
+        private static IEnumerable<object[]> GetStatusCodeLinesForVersions(int min, int max)
+        {
+            for(int major = min; major < max; major++)
+            {
+                for(int minor = min; minor < max; minor++)
+                {
+                    yield return new object[] {string.Format(StatusCodeVersionFormat, major, minor), major, minor};
+                }
+            }
+        }
+
+        private static IEnumerable<object[]> GetInvalidHeaderLines()
+        {
+            foreach(char c in invalidChars)
+            {
+                yield return new object[] { string.Format(HeaderNameWithInvalidChar, c) };
+            }
+        }
+
+        public CurlResponseParseUtilsTest()
+        {
+        }
+
+        #region StatusCode
+        [Theory, MemberData("ValidStatusCodeLines")]
+        public void ReadStatusLine_ValidStatusCode_ResponseMessageValueSet(string statusLine, HttpStatusCode expectedCode, string expectedPhrase)
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            CurlResponseParseUtils.ReadStatusLine(response, statusLine);
+            Assert.Equal<HttpStatusCode>(expectedCode, response.StatusCode);
+            Assert.Equal<string>(expectedPhrase, response.ReasonPhrase);
+        }
+
+        [Theory, MemberData("InvalidStatusCodeLines")]
+        public void ReadStatusLine_InvalidStatusCode_ThrowsHttpRequestException(string statusLine, HttpStatusCode expectedCode, string phrase)
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            Assert.Throws<HttpRequestException>(() => CurlResponseParseUtils.ReadStatusLine(response, statusLine));
+        }
+
+        [Theory, MemberData("StatusCodeVersionLines")]
+        public void ReadStatusLine_ValidStatusCodeLine_ResponseMessageVersionSet(string statusLine, int major, int minor)
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            CurlResponseParseUtils.ReadStatusLine(response, statusLine);
+            int expectedMajor = 0;
+            int expectedMinor = 0;
+            if (major == 1 && (minor == 0 || minor == 1))
+            {
+                expectedMajor = 1;
+                expectedMinor = minor;
+            }
+
+            Assert.Equal<int>(expectedMajor, response.Version.Major);
+            Assert.Equal<int>(expectedMinor, response.Version.Minor);
+        }
+
+        #endregion
+
+        #region Headers
+        [Fact]
+        public void ReadHeaderName_ValidHeaderLine_HeaderReturnedAndIndexSet()
+        {
+            string headerName = "TestHeader";
+            string headerValue = "Test header value";
+            string headerLine = string.Format("{0}:{1}", headerName, headerValue);
+            int index;
+            Assert.Equal<string>(headerName, CurlResponseParseUtils.ReadHeaderName(headerLine, out index));
+            Assert.Equal<string>(headerValue, headerLine.Substring(index));
+        }
+
+        [Fact]
+        public void ReadHeaderName_ValidLineWithEmptyHeaderValue_HeaderReturnedAndIndexSet()
+        {
+            string headerName = "TestHeader";
+            string headerLine = string.Format("{0}:", headerName);
+            int index;
+            Assert.Equal<string>(headerName, CurlResponseParseUtils.ReadHeaderName(headerLine, out index));
+            Assert.Equal<string>(string.Empty, headerLine.Substring(index));
+        }
+
+        [Fact]
+        public void ReadHeaderName_EmptyString_ReturnsNull()
+        {
+            int index;
+            Assert.Null(CurlResponseParseUtils.ReadHeaderName(string.Empty, out index));
+        }
+
+        [Theory, MemberData("InvalidHeaderLines")]
+        public void ReadHeaderName_InvalidHeaderLine_ThrowsHttpRequestException(string headerLine)
+        {
+            int index;
+            Assert.Throws<HttpRequestException>(() => CurlResponseParseUtils.ReadHeaderName(headerLine, out index));
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -259,6 +259,9 @@
     <Compile Include="..\..\src\System\Net\Http\StringContent.cs">
       <Link>ProductionCode\System\Net\Http\StringContent.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\Unix\CurlResponseParseUtils.cs">
+      <Link>ProductionCode\System\Net\Http\CurlResponseParseUtils.cs</Link>
+    </Compile>
     <Compile Include="Fakes\HttpClientHandler.cs" />
     <Compile Include="Headers\AuthenticationHeaderValueTest.cs" />
     <Compile Include="Headers\ByteArrayHeaderParserTest.cs" />
@@ -266,6 +269,7 @@
     <Compile Include="Headers\CacheControlHeaderValueTest.cs" />
     <Compile Include="Headers\ContentDispositionHeaderValueTest.cs" />
     <Compile Include="Headers\ContentRangeHeaderValueTest.cs" />
+    <Compile Include="Headers\CurlResponseParseUtilsTest.cs" />
     <Compile Include="Headers\DateHeaderParserTest.cs" />
     <Compile Include="Headers\EntityTagHeaderValueTest.cs" />
     <Compile Include="Headers\GenericHeaderParserTest\AuthenticationParserTest.cs" />


### PR DESCRIPTION
This PR introduces changes in CurlHandler so that its behavior matches that of  WinHttpHandler vis-a-vis invalid status line or invalid http headers in the response.

Fix for #3269

 