### PR TITLE
Add a hook for executing targets after the main build.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -2,8 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
+  <!-- required to build the projects in their specified order -->
+  <PropertyGroup>
+    <SerializeProjects>true</SerializeProjects>
+  </PropertyGroup>
+
   <ItemGroup>
     <Project Include="src\dirs.proj" />
+    <Project Include="src\post.msbuild" />
   </ItemGroup>
 
   <Import Project="dir.targets" />

--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00110</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00111</BuildToolsVersion>
     <DnxVersion>1.0.0-rc1-15838</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00110" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00111" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-rc1-15838" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00110" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00111" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-rc1-15838" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -22,8 +22,8 @@
   <!-- Performance Tests -->  
   <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true'">  
     <Compile Include="Performance\Perf.Deserialization.cs" />  
-    <Compile Include="$(CommonTestPath)\Performance\PerfUtils.cs">  
-      <Link>Common\Performance\PerfUtils.cs</Link>  
+    <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
+      <Link>Common\System\PerfUtils.cs</Link>
     </Compile>  
   </ItemGroup>  
   <ItemGroup>

--- a/src/post.msbuild
+++ b/src/post.msbuild
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="dir.props" />
+  <Import Project="..\dir.targets" />
+  <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets')" />
+
+  <!-- provides a hook for executing targets after the product and tests have been built -->
+  <Target Name="Build" />
+  <Target Name="Clean" />
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+
+</Project>


### PR DESCRIPTION
There is a need to execute some targets after the product and test
binaries have been built; this change adds such a hook,
PostBuildDependsOn, allowing targets to execute post-build.

Move to latest version of build tools.

Fixed a build issue for XML serialization perf tests.