### PR TITLE
Increasing test timeout for System.Net.Security (SslStream).

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -16,7 +16,6 @@ namespace System.Net.Security.Tests
         private readonly byte[] sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
         private readonly TimeSpan TestTimeoutSpan = TimeSpan.FromSeconds(TestConfiguration.TestTimeoutSeconds);
 
-        [ActiveIssue(3845)]
         [Fact]
         public void SslStream_StreamToStream_Authentication_Success()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -11,7 +11,7 @@ namespace System.Net.Security.Tests
 {
     internal static class TestConfiguration
     {
-        public const int TestTimeoutSeconds = 3; 
+        public const int TestTimeoutSeconds = 10;
         
         public const SslProtocols DefaultSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
 


### PR DESCRIPTION
Increasing test timeout for System.Net.Security (SslStream).

Fix #3845
