### PR TITLE
Removing APM and synchronous methods from System.Net.NetworkInformation

### DIFF
--- a/src/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
+++ b/src/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
@@ -129,8 +129,6 @@ namespace System.Net.NetworkInformation
         public abstract string HostName { get; }
         public abstract bool IsWinsProxy { get; }
         public abstract System.Net.NetworkInformation.NetBiosNodeType NodeType { get; }
-        public virtual System.IAsyncResult BeginGetUnicastAddresses(System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public virtual System.Net.NetworkInformation.UnicastIPAddressInformationCollection EndGetUnicastAddresses(System.IAsyncResult asyncResult) { return default(System.Net.NetworkInformation.UnicastIPAddressInformationCollection); }
         public abstract System.Net.NetworkInformation.TcpConnectionInformation[] GetActiveTcpConnections();
         public abstract System.Net.IPEndPoint[] GetActiveTcpListeners();
         public abstract System.Net.IPEndPoint[] GetActiveUdpListeners();
@@ -143,7 +141,6 @@ namespace System.Net.NetworkInformation
         public abstract System.Net.NetworkInformation.TcpStatistics GetTcpIPv6Statistics();
         public abstract System.Net.NetworkInformation.UdpStatistics GetUdpIPv4Statistics();
         public abstract System.Net.NetworkInformation.UdpStatistics GetUdpIPv6Statistics();
-        public virtual System.Net.NetworkInformation.UnicastIPAddressInformationCollection GetUnicastAddresses() { return default(System.Net.NetworkInformation.UnicastIPAddressInformationCollection); }
         public virtual System.Threading.Tasks.Task<System.Net.NetworkInformation.UnicastIPAddressInformationCollection> GetUnicastAddressesAsync() { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.UnicastIPAddressInformationCollection>); }
     }
     public abstract partial class IPGlobalStatistics

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
@@ -80,24 +80,9 @@ namespace System.Net.NetworkInformation
 
         public abstract IPGlobalStatistics GetIPv6GlobalStatistics();
 
-        public virtual UnicastIPAddressInformationCollection GetUnicastAddresses()
-        {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
-        }
-
-        public virtual IAsyncResult BeginGetUnicastAddresses(AsyncCallback callback, object state)
-        {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
-        }
-
-        public virtual UnicastIPAddressInformationCollection EndGetUnicastAddresses(IAsyncResult asyncResult)
-        {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
-        }
-
         public virtual Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
         {
-            return Task<UnicastIPAddressInformationCollection>.Factory.FromAsync(BeginGetUnicastAddresses, EndGetUnicastAddresses, null);
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -193,7 +193,7 @@ namespace System.Net.NetworkInformation
             return LinuxUdpStatistics.CreateUdpIPv6Statistics();
         }
 
-        public override UnicastIPAddressInformationCollection GetUnicastAddresses()
+        private UnicastIPAddressInformationCollection GetUnicastAddresses()
         {
             UnicastIPAddressInformationCollection collection = new UnicastIPAddressInformationCollection();
             foreach (UnicastIPAddressInformation info in
@@ -204,17 +204,6 @@ namespace System.Net.NetworkInformation
             }
 
             return collection;
-        }
-
-        public override IAsyncResult BeginGetUnicastAddresses(AsyncCallback callback, object state)
-        {
-            Task<UnicastIPAddressInformationCollection> t = GetUnicastAddressesAsync();
-            return TaskToApm.Begin(t, callback, state);
-        }
-
-        public override UnicastIPAddressInformationCollection EndGetUnicastAddresses(IAsyncResult asyncResult)
-        {
-            return TaskToApm.End<UnicastIPAddressInformationCollection>(asyncResult);
         }
 
         public override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
@@ -184,7 +184,7 @@ namespace System.Net.NetworkInformation
             return new OsxUdpStatistics();
         }
 
-        public override UnicastIPAddressInformationCollection GetUnicastAddresses()
+        private UnicastIPAddressInformationCollection GetUnicastAddresses()
         {
             UnicastIPAddressInformationCollection collection = new UnicastIPAddressInformationCollection();
             foreach (UnicastIPAddressInformation info in
@@ -195,17 +195,6 @@ namespace System.Net.NetworkInformation
             }
 
             return collection;
-        }
-
-        public override IAsyncResult BeginGetUnicastAddresses(AsyncCallback callback, object state)
-        {
-            Task<UnicastIPAddressInformationCollection> t = GetUnicastAddressesAsync();
-            return TaskToApm.Begin(t, callback, state);
-        }
-
-        public override UnicastIPAddressInformationCollection EndGetUnicastAddresses(IAsyncResult asyncResult)
-        {
-            return TaskToApm.End<UnicastIPAddressInformationCollection>(asyncResult);
         }
 
         public override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()


### PR DESCRIPTION
Removing APM and synchronous methods from System.Net.NetworkInformation

Fix #4044
