### PR TITLE
Fix for MethodCallExpression write-back behavior in the interpreter

### DIFF
--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_INTERPRET
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.Expressions
+{
+    partial class InterpreterTests
+    {
+        [Fact(Skip = "4150")]
+        public static void CompileInterpretCrossCheck_Call_WriteBacks()
+        {
+            foreach (var e in Call_WriteBacks())
+            {
+                Verify(e);
+            }
+        }
+
+        private static IEnumerable<Expression> Call_WriteBacks()
+        {
+            // OK
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(t);
+                var m = Expression.PropertyOrField(p, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(t)), Expression.Call(p, mtd), m);
+            }
+
+            // OK
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(t.MakeArrayType());
+                var o = Expression.ArrayIndex(p, Expression.Constant(0));
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayInit(t, Expression.New(t))), Expression.Call(o, mtd), m);
+            }
+
+            // OK
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(t.MakeArrayType(2));
+                var o = Expression.ArrayAccess(p, Expression.Constant(0), Expression.Constant(0));
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayBounds(t, Expression.Constant(1), Expression.Constant(1))), Expression.Assign(o, Expression.New(t)), Expression.Call(o, mtd), m);
+            }
+
+            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
+                var o = Expression.Property(p, "Value");
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
+            }
+
+            // OK - Surprising compared to previous
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
+                var o = Expression.Field(p, "_value");
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
+            }
+
+            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(typeof(List<>).MakeGenericType(t));
+                var o = Expression.MakeIndex(p, p.Type.GetRuntimeProperty("Item"), new[] { Expression.Constant(0) });
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+                var add = p.Type.GetTypeInfo().GetDeclaredMethod("Add");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.ListInit(Expression.New(p.Type), Expression.ElementInit(add, Expression.New(t)))), Expression.Call(o, mtd), m);
+            }
+        }
+
+        class C
+        {
+            public int X;
+
+            public void Do()
+            {
+                X = 1;
+            }
+        }
+
+        struct S
+        {
+            public int X;
+
+            public void Do()
+            {
+                X = 1;
+            }
+        }
+
+        class Holder<T>
+        {
+            public T _value;
+
+            public Holder(T value)
+            {
+                _value = value;
+            }
+
+            public T Value
+            {
+                get
+                {
+                    return _value;
+                }
+                set
+                {
+                    _value = value;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if FEATURE_INTERPRET
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,7 +12,7 @@ namespace Tests.Expressions
 {
     partial class InterpreterTests
     {
-        [Fact(Skip = "4150")]
+        [Fact]
         public static void CompileInterpretCrossCheck_Call_WriteBacks()
         {
             foreach (var e in Call_WriteBacks())
@@ -24,7 +23,6 @@ namespace Tests.Expressions
 
         private static IEnumerable<Expression> Call_WriteBacks()
         {
-            // OK
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(t);
@@ -34,7 +32,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(t)), Expression.Call(p, mtd), m);
             }
 
-            // OK
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(t.MakeArrayType());
@@ -45,7 +42,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayInit(t, Expression.New(t))), Expression.Call(o, mtd), m);
             }
 
-            // OK
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(t.MakeArrayType(2));
@@ -56,7 +52,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayBounds(t, Expression.Constant(1), Expression.Constant(1))), Expression.Assign(o, Expression.New(t)), Expression.Call(o, mtd), m);
             }
 
-            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
@@ -67,7 +62,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
             }
 
-            // OK - Surprising compared to previous
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
@@ -78,7 +72,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
             }
 
-            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(typeof(List<>).MakeGenericType(t));

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -27,5 +27,43 @@ namespace Tests
 
             b.Compile().DynamicInvoke();
         }
+
+        [Fact(Skip = "4150")]
+        public static void NoWriteBackToInstance()
+        {
+            new NoThread(false).DoTest();
+            new NoThread(true).DoTest(); // This case fails
+        }
+
+        public class NoThread
+        {
+            private readonly bool _preferInterpretation;
+
+            public NoThread(bool preferInterpretation)
+            {
+                _preferInterpretation = preferInterpretation;
+            }
+
+            public Func<NoThread, int> DoItA = (nt) =>
+            {
+                nt.DoItA = (nt0) => 1;
+                return 0;
+            };
+
+            public Action Compile()
+            {
+                var ind0 = Expression.Constant(this);
+                var fld = Expression.PropertyOrField(ind0, "DoItA");
+                var block = Expression.Block(typeof(void), Expression.Invoke(fld, ind0));
+                return Expression.Lambda<Action>(block).Compile(_preferInterpretation);
+            }
+
+            public void DoTest()
+            {
+                var act = Compile();
+                act();
+                Assert.Equal(1, DoItA(this));
+            }
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Xunit;
 
@@ -28,7 +26,7 @@ namespace Tests
             b.Compile().DynamicInvoke();
         }
 
-        [Fact(Skip = "4150")]
+        [Fact]
         public static void NoWriteBackToInstance()
         {
             new NoThread(false).DoTest();

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -65,5 +65,42 @@ namespace Tests
                 Assert.Equal(1, DoItA(this));
             }
         }
+
+        private class FuncHolder
+        {
+            public Func<int> Function;
+
+            public FuncHolder()
+            {
+                Function = () =>
+                {
+                    Function = () => 1;
+                    return 0;
+                };
+            }
+        }
+
+        [Fact]
+        public static void InvocationDoesNotChangeFunctionInvokedCompiled()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(false);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
+
+        [Fact]
+        [ActiveIssue(4150)]
+        public static void InvocationDoesNotChangeFunctionInvokedInterpreted()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(true);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -92,7 +92,6 @@ namespace Tests
         }
 
         [Fact]
-        [ActiveIssue(4150)]
         public static void InvocationDoesNotChangeFunctionInvokedInterpreted()
         {
             FuncHolder holder = new FuncHolder();

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="HelperTypes.cs" />
     <Compile Include="Interpreter\InterpreterTests.cs" />
     <Compile Include="Interpreter\InterpreterTests.Generated.cs" />
+    <Compile Include="Interpreter\InterpreterTests.Call.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />
     <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Lambda\LambdaAddNullableTests.cs" />


### PR DESCRIPTION
Repro to isolate the reported behavior to the interpreter. The compiler seems to be fine:

```csharp
var asm = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("bar"), System.Reflection.Emit.AssemblyBuilderAccess.Save);
var mod = asm.DefineDynamicModule("bar.dll");
var typ = mod.DefineType("Foo");
var mtd = typ.DefineMethod("Qux", MethodAttributes.Public | MethodAttributes.Static, typeof(void), new[] { typeof(Bar) });

var b = Expression.Parameter(typeof(Bar));
var f = Expression.PropertyOrField(b, "F");
Expression.Lambda<Action<Bar>>(Expression.Block(typeof(void), Expression.Invoke(f)), b).CompileToMethod(mtd);

typ.CreateType();

asm.Save("bar.dll");
```

with

```csharp
class Bar
{
    public Func<int> F = () => 0;
}
```

produces

```
.method public static 
	void Qux (
		class [ConsoleApplication20]Bar ''
	) cil managed 
{
	// Method begins at RVA 0x2050
	// Code size 13 (0xd)
	.maxstack 1

	IL_0000: ldarg.0
	IL_0001: ldfld class [mscorlib]System.Func`1<int32> [ConsoleApplication20]Bar::F
	IL_0006: callvirt instance !0 class [mscorlib]System.Func`1<int32>::Invoke()
	IL_000b: pop
	IL_000c: ret
} // end of method Foo::Qux
```

with no write-back into the instance of the invocation.