### PR TITLE
Removing ActiveIssue since the test timeouts have been already increased

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
@@ -309,7 +309,6 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4007, PlatformID.AnyUnix)]
-        [ActiveIssue(3497, PlatformID.Windows)]
         public void SendPacketsElement_FilePart_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 10, 20), 20);


### PR DESCRIPTION
Removing ActiveIssue since the test timeouts have been already increased

Fix #3497