### PR TITLE
Test for issue 4150.

### DIFF
--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -27,5 +27,42 @@ namespace Tests
 
             b.Compile().DynamicInvoke();
         }
+
+        private class FuncHolder
+        {
+            public Func<int> Function;
+
+            public FuncHolder()
+            {
+                Function = () =>
+                {
+                    Function = () => 1;
+                    return 0;
+                };
+            }
+        }
+
+        [Fact]
+        public static void InvocationDoesNotChangeFunctionInvokedCompiled()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(false);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
+
+        [Fact]
+        [ActiveIssue(4150)]
+        public static void InvocationDoesNotChangeFunctionInvokedInterpreted()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(true);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
     }
 }


### PR DESCRIPTION
Tests #4150 including both compilation (works) and interpreter (currently fails so marked as `ActiveIssue`).