### PR TITLE
Interpreted expressions shouldn't write back to delegate instances of calls.

### DIFF
--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -27,5 +27,42 @@ namespace Tests
 
             b.Compile().DynamicInvoke();
         }
+
+        private class FuncHolder
+        {
+            public Func<int> Function;
+
+            public FuncHolder()
+            {
+                Function = () =>
+                {
+                    Function = () => 1;
+                    return 0;
+                };
+            }
+        }
+
+        [Fact]
+        public static void InvocationDoesNotChangeFunctionInvokedCompiled()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(false);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
+
+        [Fact]
+        [ActiveIssue(4150)]
+        public static void InvocationDoesNotChangeFunctionInvokedInterpreted()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(true);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -54,7 +54,6 @@ namespace Tests
         }
 
         [Fact]
-        [ActiveIssue(4150)]
         public static void InvocationDoesNotChangeFunctionInvokedInterpreted()
         {
             FuncHolder holder = new FuncHolder();


### PR DESCRIPTION
Fixes #4150

Interpreted expressions executing a `‎Call()` write back to the instance of the
method after the call, so that mutable structs are mutated correctly. This is
harmless in most cases to which it doesn't apply, but can cause bugs when the
instance is mutated from the outside over the course of the call, including
when delegates are `Invoke()`d as that becomes a `Call()` with the delegate
as its instance.