### PR TITLE
Fixing expression compiler support for multi-dimensional arrays of rank 1

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -730,5 +730,13 @@ namespace System.Dynamic.Utils
             }
         }
 #endif 
+
+        public static bool IsVector(this Type type)
+        {
+            // Unfortunately, the IsSzArray property of System.Type is inaccessible to us,
+            // but the ToString representation of the type is sufficient to differentiate
+            // a vector (X[]) from a multi-dimensional array of rank 1 (X[*]).
+            return type.GetArrayRank() == 1 && type.ToString().EndsWith("[]");
+        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -734,9 +734,8 @@ namespace System.Dynamic.Utils
         public static bool IsVector(this Type type)
         {
             // Unfortunately, the IsSzArray property of System.Type is inaccessible to us,
-            // but the ToString representation of the type is sufficient to differentiate
-            // a vector (X[]) from a multi-dimensional array of rank 1 (X[*]).
-            return type.GetArrayRank() == 1 && type.ToString().EndsWith("[]");
+            // so we use a little equality comparison trick instead:
+            return type == type.GetElementType().MakeArrayType();
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1096,13 +1096,14 @@ namespace System.Linq.Expressions.Compiler
             ContractUtils.RequiresNotNull(arrayType, "arrayType");
             if (!arrayType.IsArray) throw Error.ArrayTypeMustBeArray();
 
-            int rank = arrayType.GetArrayRank();
-            if (rank == 1)
+            if (arrayType.IsVector())
             {
                 il.Emit(OpCodes.Newarr, arrayType.GetElementType());
             }
             else
             {
+                int rank = arrayType.GetArrayRank();
+
                 Type[] types = new Type[rank];
                 for (int i = 0; i < rank; i++)
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Compiler
                     {
                         throw ContractUtils.Unreachable;
                     }
-                    _ilg.EmitLoadElement(leftType.GetElementType());
+                    EmitGetArrayElement(leftType);
                     return;
                 case ExpressionType.Coalesce:
                     throw Error.UnexpectedCoalesceOperator();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -291,15 +291,23 @@ namespace System.Linq.Expressions.Compiler
                 var method = node.Indexer.GetGetMethod(true);
                 EmitCall(objectType, method);
             }
-            else if (node.Arguments.Count != 1)
+            else
+            {
+                EmitGetArrayElement(objectType);
+            }
+        }
+
+        private void EmitGetArrayElement(Type arrayType)
+        {
+            if (!arrayType.IsVector())
             {
                 // Multidimensional arrays, call get
-                _ilg.Emit(OpCodes.Call, node.Object.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance));
+                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance));
             }
             else
             {
                 // For one dimensional arrays, emit load
-                _ilg.EmitLoadElement(node.Type);
+                _ilg.EmitLoadElement(arrayType.GetElementType());
             }
         }
 
@@ -311,15 +319,23 @@ namespace System.Linq.Expressions.Compiler
                 var method = node.Indexer.GetSetMethod(true);
                 EmitCall(objectType, method);
             }
-            else if (node.Arguments.Count != 1)
+            else
+            {
+                EmitSetArrayElement(objectType);
+            }
+        }
+
+        private void EmitSetArrayElement(Type arrayType)
+        {
+            if (!arrayType.IsVector())
             {
                 // Multidimensional arrays, call set
-                _ilg.Emit(OpCodes.Call, node.Object.Type.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance));
+                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance));
             }
             else
             {
                 // For one dimensional arrays, emit store
-                _ilg.EmitStoreElement(node.Type);
+                _ilg.EmitStoreElement(arrayType.GetElementType());
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -855,7 +855,7 @@ namespace System.Linq.Expressions
             {
                 throw Error.ArgumentMustBeArray();
             }
-            if (array.Type.GetArrayRank() != 1)
+            if (!array.Type.IsVector())
             {
                 throw Error.ArgumentMustBeSingleDimensionalArrayType();
             }

--- a/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.ExpressionCompiler.Array
+{
+    public static unsafe class ArrayAccessTests
+    {
+        [Fact]
+        public static void ArrayAccess_MultiDimensionalOf1()
+        {
+            var arrayType = typeof(int).MakeArrayType(1);
+            var arrayCtor = arrayType.GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.GetParameters().Length == 2);
+            var arr = (System.Array)arrayCtor.Invoke(new object[] { 1, 1 });
+            var c = Expression.Constant(arr);
+            var e = Expression.ArrayAccess(c, Expression.Constant(1));
+
+            var set = Expression.Lambda<Action>(Expression.Assign(e, Expression.Constant(42))).Compile();
+            set();
+            Assert.Equal(42, arr.GetValue(1));
+
+            var get = Expression.Lambda<Func<int>>(e).Compile();
+            Assert.Equal(42, get());
+        }
+
+        [Fact]
+        public static void ArrayIndex_MultiDimensionalOf1()
+        {
+            var arrayType = typeof(int).MakeArrayType(1);
+            var arrayCtor = arrayType.GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.GetParameters().Length == 2);
+            var arr = (System.Array)arrayCtor.Invoke(new object[] { 1, 1 });
+            arr.SetValue(42, 1);
+            var c = Expression.Constant(arr);
+            var e = Expression.ArrayIndex(c, Expression.Constant(1));
+
+            var get = Expression.Lambda<Func<int>>(e).Compile();
+            Assert.Equal(42, get());
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -2088,5 +2088,18 @@ namespace Tests.ExpressionCompiler.Array
         }
 
         #endregion
+
+        #region Regression tests
+
+        [Fact]
+        public static void ArrayLength_MultiDimensionalOf1()
+        {
+            foreach (var e in new Expression[] { Expression.Parameter(typeof(int).MakeArrayType(1)), Expression.Constant(new int[2, 2]) })
+            {
+                Assert.Throws<ArgumentException>(() => Expression.ArrayLength(e));
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -24,6 +24,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Array\ArrayAccessTests.cs" />
     <Compile Include="Array\ArrayArrayIndexTests.cs" />
     <Compile Include="Array\ArrayArrayLengthTests.cs" />
     <Compile Include="Array\ArrayBoundsOneOffTests.cs" />


### PR DESCRIPTION
This fixes issue #4161. The following issues were found and resolved for multi-dimensional arrays of rank 1 (MDR1s):

- ArrayLength nodes could be created over MDR1s, leading to a `VerificationException` upon executing the `ldlen` instruction. Creation of those nodes is now rejected, just like it was for any other multi-dimensional array.
- ArrayAccess nodes could be used to read from and write to MDR1s, leading to `VerificationException` for the `ldelem` and `stelem` instructions. Those compile to `Get` and `Set` method calls just fine now.
- ArrayIndex nodes could be used to read from MDR1s, leading to `VerificationException` for the `ldelem` instruction. Those compile to `Get` method calls just fine now.

Expression interpreter works fine thanks to the use of `GetValue` and `SetValue` methods for late-bound access to the arrays.