### PR TITLE
Removing unsafe modifier from System.Linq.Expressions tests.

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ArrayArrayIndexTests
+    public static class ArrayArrayIndexTests
     {
         #region Bool tests
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ArrayArrayLengthTests
+    public static class ArrayArrayLengthTests
     {
         #region Bool tests
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ArrayBoundsOneOffTests
+    public static class ArrayBoundsOneOffTests
     {
         [Fact]
         public static void CompileWithCastTest()

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ArrayBoundsTests
+    public static class ArrayBoundsTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ArrayIndexTests
+    public static class ArrayIndexTests
     {
         #region Bool tests
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ArrayLengthTests
+    public static class ArrayLengthTests
     {
         #region Bool tests
 

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class NewArrayListTests
+    public static class NewArrayListTests
     {
         #region Tests
 

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayBoundsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class NullableArrayBoundsTests
+    public static class NullableArrayBoundsTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class NullableArrayIndexTests
+    public static class NullableArrayIndexTests
     {
         #region NullableBool tests
 

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class NullableArrayLengthTests
+    public static class NullableArrayLengthTests
     {
         #region NullableBool tests
 

--- a/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class NullableNewArrayListTests
+    public static class NullableNewArrayListTests
     {
         #region Tests
 

--- a/src/System.Linq.Expressions/tests/Array/ObjectArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ObjectArrayBoundsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Array
 {
-    public static unsafe class ObjectArrayBoundsTests
+    public static class ObjectArrayBoundsTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryAddTests
+    public static class BinaryAddTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryDivideTests
+    public static class BinaryDivideTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryModuloTests
+    public static class BinaryModuloTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryMultiplyTests
+    public static class BinaryMultiplyTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableAddTests
+    public static class BinaryNullableAddTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableDivideTests
+    public static class BinaryNullableDivideTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableModuloTests
+    public static class BinaryNullableModuloTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableMultiplyTests
+    public static class BinaryNullableMultiplyTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullablePowerTests
+    public static class BinaryNullablePowerTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableSubtractTests
+    public static class BinaryNullableSubtractTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryShiftTests
+    public static class BinaryShiftTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinarySubtractTests
+    public static class BinarySubtractTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryAndTests
+    public static class BinaryAndTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryExclusiveOrTests
+    public static class BinaryExclusiveOrTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableAndTests
+    public static class BinaryNullableAndTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableExclusiveOrTests
+    public static class BinaryNullableExclusiveOrTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableOrTests
+    public static class BinaryNullableOrTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryOrTests
+    public static class BinaryOrTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryCoalesceTests
+    public static class BinaryCoalesceTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryNullableCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryNullableCoalesceTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableCoalesceTests
+    public static class BinaryNullableCoalesceTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryEqualTests
+    public static class BinaryEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryGreaterThanOrEqualTests
+    public static class BinaryGreaterThanOrEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryGreaterThanTests
+    public static class BinaryGreaterThanTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryLessThanOrEqualTests
+    public static class BinaryLessThanOrEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryLessThanTests
+    public static class BinaryLessThanTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNotEqualTests
+    public static class BinaryNotEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableEqualTests
+    public static class BinaryNullableEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanOrEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableGreaterThanOrEqualTests
+    public static class BinaryNullableGreaterThanOrEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableGreaterThanTests
+    public static class BinaryNullableGreaterThanTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanOrEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableLessThanOrEqualTests
+    public static class BinaryNullableLessThanOrEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableLessThanTests
+    public static class BinaryNullableLessThanTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableNotEqualTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableNotEqualTests
+    public static class BinaryNullableNotEqualTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryLogicalTests
+    public static class BinaryLogicalTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Binary
 {
-    public static unsafe class BinaryNullableLogicalTests
+    public static class BinaryNullableLogicalTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Block
 {
-    public static unsafe class BlockTests
+    public static class BlockTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Cast
 {
-    public static unsafe class AsNullableTests
+    public static class AsNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Cast
 {
-    public static unsafe class AsTests
+    public static class AsTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Cast
 {
-    public static unsafe class CastNullableTests
+    public static class CastNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Cast
 {
-    public static unsafe class CastTests
+    public static class CastTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Cast
 {
-    public static unsafe class IsNullableTests
+    public static class IsNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Cast/IsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Cast
 {
-    public static unsafe class IsTests
+    public static class IsTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalOneOffTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tests.Expressions.Conditional
 {
-    public static unsafe class ConditionalOneOffTests
+    public static class ConditionalOneOffTests
     {
         [Fact] // [Issue(3223, "https://github.com/dotnet/corefx/issues/3223")]
         public static void VisitIfThenDoesNotCloneTree()

--- a/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Constant
 {
-    public static unsafe class ConstantArrayTests
+    public static class ConstantArrayTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Constant
 {
-    public static unsafe class ConstantNullableTests
+    public static class ConstantNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Constant
 {
-    public static unsafe class ConstantTests
+    public static class ConstantTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Convert
 {
-    public static unsafe class ConvertCheckedTests
+    public static class ConvertCheckedTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Convert
 {
-    public static unsafe class ConvertTests
+    public static class ConvertTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaAddNullableTests
+    public static class LambdaAddNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaAddTests
+    public static class LambdaAddTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaDivideNullableTests
+    public static class LambdaDivideNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaDivideTests
+    public static class LambdaDivideTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaIdentityNullableTests
+    public static class LambdaIdentityNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaIdentityTests
+    public static class LambdaIdentityTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaModuloNullableTests
+    public static class LambdaModuloNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaModuloTests
+    public static class LambdaModuloTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaMultiplyNullableTests
+    public static class LambdaMultiplyNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaMultiplyTests
+    public static class LambdaMultiplyTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaSubtractNullableTests
+    public static class LambdaSubtractNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaSubtractTests
+    public static class LambdaSubtractTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaUnaryNotNullableTests
+    public static class LambdaUnaryNotNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lambda
 {
-    public static unsafe class LambdaUnaryNotTests
+    public static class LambdaUnaryNotTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedAddCheckedNullableTests
+    public static class LiftedAddCheckedNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedAddNullableTests
+    public static class LiftedAddNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedBitwiseAndNullableTests
+    public static class LiftedBitwiseAndNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedBitwiseExclusiveOrNullableTests
+    public static class LiftedBitwiseExclusiveOrNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedBitwiseOrNullableTests
+    public static class LiftedBitwiseOrNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedComparisonEqualNullableTests
+    public static class LiftedComparisonEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedComparisonGreaterThanNullableTests
+    public static class LiftedComparisonGreaterThanNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedComparisonGreaterThanOrEqualNullableTests
+    public static class LiftedComparisonGreaterThanOrEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedComparisonLessThanNullableTests
+    public static class LiftedComparisonLessThanNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedComparisonLessThanOrEqualNullableTests
+    public static class LiftedComparisonLessThanOrEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedComparisonNotEqualNullableTests
+    public static class LiftedComparisonNotEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedDivideNullableTests
+    public static class LiftedDivideNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedModuloNullableTests
+    public static class LiftedModuloNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedMultiplyCheckedNullableTests
+    public static class LiftedMultiplyCheckedNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedMultiplyNullableTests
+    public static class LiftedMultiplyNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedNullableTests
+    public static class LiftedNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedSubtractCheckedNullableTests
+    public static class LiftedSubtractCheckedNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class LiftedSubtractNullableTests
+    public static class LiftedSubtractNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class NonLiftedComparisonEqualNullableTests
+    public static class NonLiftedComparisonEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class NonLiftedComparisonGreaterThanNullableTests
+    public static class NonLiftedComparisonGreaterThanNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class NonLiftedComparisonGreaterThanOrEqualNullableTests
+    public static class NonLiftedComparisonGreaterThanOrEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class NonLiftedComparisonLessThanNullableTests
+    public static class NonLiftedComparisonLessThanNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class NonLiftedComparisonLessThanOrEqualNullableTests
+    public static class NonLiftedComparisonLessThanOrEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Lifted
 {
-    public static unsafe class NonLiftedComparisonNotEqualNullableTests
+    public static class NonLiftedComparisonNotEqualNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.MemberAccess
 {
-    public static unsafe class MemberAccessTests
+    public static class MemberAccessTests
     {
         [Fact]
         public static void CheckMemberAccessStructInstanceFieldTest()

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.MemberInit
 {
-    public static unsafe class MemberInitTests
+    public static class MemberInitTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.New
 {
-    public static unsafe class NewTests
+    public static class NewTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.New
 {
-    public static unsafe class NewWithParameterTests
+    public static class NewWithParameterTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.New
 {
-    public static unsafe class NewWithTwoParametersTests
+    public static class NewWithTwoParametersTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -12,7 +12,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Linq.Expressions.Tests</AssemblyName>
     <RootNamespace>System.Linq.Expressions.Tests</RootNamespace>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Ternary
 {
-    public static unsafe class TernaryArrayNullableTests
+    public static class TernaryArrayNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Ternary
 {
-    public static unsafe class TernaryArrayTests
+    public static class TernaryArrayTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Ternary
 {
-    public static unsafe class TernaryNullableTests
+    public static class TernaryNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Ternary
 {
-    public static unsafe class TernaryTests
+    public static class TernaryTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryArithmeticNegateCheckedNullableTests
+    public static class UnaryArithmeticNegateCheckedNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryArithmeticNegateCheckedTests
+    public static class UnaryArithmeticNegateCheckedTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryArithmeticNegateNullableOneOffTests
+    public static class UnaryArithmeticNegateNullableOneOffTests
     {
         [Fact] //[WorkItem(3197, "https://github.com/dotnet/corefx/issues/3197")]
         public static void UnaryArithmeticNegateNullableStackBalance()

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryArithmeticNegateNullableTests
+    public static class UnaryArithmeticNegateNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryArithmeticNegateTests
+    public static class UnaryArithmeticNegateTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryBitwiseNotNullableTests
+    public static class UnaryBitwiseNotNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryBitwiseNotTests
+    public static class UnaryBitwiseNotTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryDecrementNullableTests
+    public static class UnaryDecrementNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryDecrementTests
+    public static class UnaryDecrementTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryIncrementNullableTests
+    public static class UnaryIncrementNullableTests
     {
         #region Test methods
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Tests.ExpressionCompiler.Unary
 {
-    public static unsafe class UnaryIncrementTests
+    public static class UnaryIncrementTests
     {
         #region Test methods
 


### PR DESCRIPTION
For some historical reason, all of those tests had the `unsafe` modifier on them. It has bitten us already once when using `partial` classes in combination with `unsafe` due to a C# 5.0 native compiler bug (fixed in Roslyn). Given that we don't do any unsafe operations, we can safely remove this modifier throughout the test code.