### PR TITLE
Support for http delete method for CurlHandler

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.libcurl_types.cs
@@ -43,6 +43,7 @@ internal static partial class Interop
             internal const int CURLOPT_COOKIE = CurlOptionObjectPointBase + 22;
             internal const int CURLOPT_HTTPHEADER = CurlOptionObjectPointBase + 23;
             internal const int CURLOPT_HEADERDATA = CurlOptionObjectPointBase + 29;
+            internal const int CURLOPT_CUSTOMREQUEST = CurlOptionObjectPointBase + 36;
             internal const int CURLOPT_ACCEPTENCODING = CurlOptionObjectPointBase + 102;
             internal const int CURLOPT_PRIVATE = CurlOptionObjectPointBase + 103;
             internal const int CURLOPT_COPYPOSTFIELDS = CurlOptionObjectPointBase + 165;

--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -16,6 +16,7 @@ namespace System.Net.Tests
         public readonly static Uri RemoteGetServer = new Uri("http://" + Host + "/get");
         public readonly static Uri RemotePostServer = new Uri("http://" + Host + "/post");
         public readonly static Uri RemotePutServer = new Uri("http://" + Host + "/put");
+        public readonly static Uri RemoteDeleteServer = new Uri("http://" + Host + "/delete");
         public readonly static Uri SecureRemoteGetServer = new Uri("https://" + Host + "/get");
         public readonly static Uri SecureRemotePostServer = new Uri("https://" + Host + "/post");
         public readonly static Uri RemoteServerGzipUri = new Uri("http://" + Host + "/gzip");
@@ -23,6 +24,7 @@ namespace System.Net.Tests
         public readonly static Uri RemoteServerCookieUri = new Uri("http://" + Host + "/cookies");
         public readonly static Uri RemoteServerHeadersUri = new Uri("http://" + Host + "/headers");
         public readonly static Uri SecureRemotePutServer = new Uri("https://" + Host + "/put");
+        public readonly static Uri SecureRemoteDeleteServer = new Uri("https://" + Host + "/delete");
 
         public const string RemoteStatusCodeServerFormat = "http://" + Host + "/status/{0}";
         public const string SecureRemoteStatusCodeServerFormat = "https://" + Host + "/status/{0}";
@@ -30,6 +32,7 @@ namespace System.Net.Tests
         public readonly static object[][] GetServers = { new object[] { RemoteGetServer }, new object[] { SecureRemoteGetServer } };
         public readonly static object[][] PostServers = { new object[] { RemotePostServer }, new object[] { SecureRemotePostServer } };
         public readonly static object[][] PutServers = { new object[] { RemotePutServer }, new object[] { SecureRemotePutServer } };
+        public readonly static object[][] DeleteServers = { new object[] { RemoteDeleteServer }, new object[] { SecureRemoteDeleteServer } };
 
         public static Uri BasicAuthUriForCreds(string userName, string password)
         {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -205,6 +205,11 @@ namespace System.Net.Http
                         SetCurlOption(CURLoption.CURLOPT_COPYPOSTFIELDS, string.Empty);
                     }
                 }
+                else if (_requestMessage.Method == HttpMethod.Trace)
+                {
+                    SetCurlOption(CURLoption.CURLOPT_CUSTOMREQUEST, _requestMessage.Method.Method);
+                    SetCurlOption(CURLoption.CURLOPT_NOBODY, 1L);
+                }
                 else
                 {
                     SetCurlOption(CURLoption.CURLOPT_CUSTOMREQUEST, _requestMessage.Method.Method);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -205,6 +205,14 @@ namespace System.Net.Http
                         SetCurlOption(CURLoption.CURLOPT_COPYPOSTFIELDS, string.Empty);
                     }
                 }
+                else
+                {
+                    SetCurlOption(CURLoption.CURLOPT_CUSTOMREQUEST, _requestMessage.Method.Method);
+                    if (_requestMessage.Content != null)
+                    {
+                        SetCurlOption(CURLoption.CURLOPT_UPLOAD, 1L);
+                    }
+                }
             }
 
             private void SetDecompressionOptions()


### PR DESCRIPTION
Update CurlHandler to allow sending Http 'delete' method.
Add two test cases for delete