### PR TITLE
Fixing issues with NewExpression parameterized by static or abstract constructors

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -636,4 +636,10 @@
   <data name="OperatorNotImplementedForType" xml:space="preserve">
     <value>The operator '{0}' is not implemented for type '{1}'</value>
   </data>
+  <data name="NonStaticConstructorRequired" xml:space="preserve">
+    <value>The constructor should not be static</value>
+  </data>
+  <data name="NonAbstractConstructorRequired" xml:space="preserve">
+    <value>Can't compile a NewExpression with a constructor declared on an abstract class</value>
+  </data>
 </root>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -581,6 +581,9 @@ namespace System.Linq.Expressions.Compiler
 
             if (node.Constructor != null)
             {
+                if (node.Constructor.DeclaringType.GetTypeInfo().IsAbstract)
+                    throw Error.NonAbstractConstructorRequired();
+
                 List<WriteBack> wb = EmitArguments(node.Constructor, node);
                 _ilg.Emit(OpCodes.Newobj, node.Constructor);
                 EmitWriteBack(wb);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1124,5 +1124,21 @@ namespace System.Linq.Expressions
             return NotImplemented.ByDesignWithMessage(Strings.OperatorNotImplementedForType(p0, p1));
         }
 #endif
+
+        /// <summary>
+        /// ArgumentException with message like "The constructor should not be static"
+        /// </summary>
+        internal static Exception NonStaticConstructorRequired()
+        {
+            return new ArgumentException(Strings.NonStaticConstructorRequired);
+        }
+
+        /// <summary>
+        /// InvalidOperationException with message like "Can't compile a NewExpression with a constructor declared on an abstract class"
+        /// </summary>
+        internal static Exception NonAbstractConstructorRequired()
+        {
+            return new InvalidOperationException(Strings.NonAbstractConstructorRequired);
+        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2324,6 +2324,9 @@ namespace System.Linq.Expressions.Interpreter
 
             if (node.Constructor != null)
             {
+                if (node.Constructor.DeclaringType.GetTypeInfo().IsAbstract)
+                    throw Error.NonAbstractConstructorRequired();
+
                 var parameters = node.Constructor.GetParameters();
                 List<ByRefUpdater> updaters = null;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -164,6 +164,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(constructor, "constructor");
             ContractUtils.RequiresNotNull(constructor.DeclaringType, "constructor.DeclaringType");
             TypeUtils.ValidateType(constructor.DeclaringType);
+            ValidateConstructor(constructor);
             var argList = arguments.ToReadOnly();
             ValidateArgumentTypes(constructor, ExpressionType.New, ref argList);
 
@@ -181,6 +182,7 @@ namespace System.Linq.Expressions
         public static NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members)
         {
             ContractUtils.RequiresNotNull(constructor, "constructor");
+            ValidateConstructor(constructor);
             var memberList = members.ToReadOnly();
             var argList = arguments.ToReadOnly();
             ValidateNewArgs(constructor, ref argList, ref memberList);
@@ -364,6 +366,12 @@ namespace System.Linq.Expressions
                 return;
             }
             throw Error.ArgumentMustBeFieldInfoOrPropertInfoOrMethod();
+        }
+
+        private static void ValidateConstructor(ConstructorInfo constructor)
+        {
+            if (constructor.IsStatic)
+                throw Error.NonStaticConstructorRequired();
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -1467,5 +1467,27 @@ namespace System.Linq.Expressions
             return SR.Format(SR.OperatorNotImplementedForType, p0, p1);
         }
 #endif
+
+        /// <summary>
+        /// A string like "The constructor should not be static"
+        /// </summary>
+        internal static string NonStaticConstructorRequired
+        {
+            get
+            {
+                return SR.NonStaticConstructorRequired;
+            }
+        }
+
+        /// <summary>
+        /// A string like "The constructor should not be declared on an abstract class"
+        /// </summary>
+        internal static string NonAbstractConstructorRequired
+        {
+            get
+            {
+                return SR.NonAbstractConstructorRequired;
+            }
+        }
     }
 }


### PR DESCRIPTION
This fixes issue #4135. However, a discussion on backwards compatibility is warranted. It used to be possible to create NewExpression with the following:

- a static constructor - this is nonsense for that a) it can't be executed (causes `InvalidProgramException` from `RuntimeHelpers._CompileMethod`), and b) the expression type is not the declaring type (calling a static constructor has no meaning)
- a constructor on an abstract class - this may be used as an intermediate code generation target for subsequent rewrite using a visitor but it can't be executed (causes `InvalidOperationException` from `RuntimeHelpers._CompileMethod`). We don't have declaration nodes in the expression tree API, so some kind of base call to a constructor higher up the class hierarchy has little use.

This PR reflects a change where both are rejected from the `Expression.New` factories. I'm on the fence for the second case though (and one could argue for compatibility in the first case as well), so alternatively we could push down the check to the compiler's and interpreter's code generation and throw an exception from the call to `Compile`. This way, we'd still get consistent behavior across compiler and interpreter, and avoid emitting invalid code.

@VSadov, what do you think?