### PR TITLE
Fixing some faulty expression interpreter write-back behaviors

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2250,7 +2250,11 @@ namespace System.Linq.Expressions.Interpreter
                     if (field != null)
                     {
                         _instructions.EmitLoadField(field);
-                        return new FieldByRefUpdater(memberTemp, field, index);
+                        if (!field.IsLiteral && !field.IsInitOnly)
+                        {
+                            return new FieldByRefUpdater(memberTemp, field, index);
+                        }
+                        return null;
                     }
                     PropertyInfo property = member.Member as PropertyInfo;
                     if (property != null)
@@ -3113,7 +3117,16 @@ namespace System.Linq.Expressions.Interpreter
         public override void Update(InterpretedFrame frame, object value)
         {
             var obj = _object == null ? null : frame.Data[_object.Value.Index];
-            _property.SetValue(obj, value);
+
+            try
+            {
+                _property.SetValue(obj, value);
+            }
+            catch (TargetInvocationException e)
+            {
+                ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                throw e.InnerException;
+            }
         }
 
         public override void UndefineTemps(InstructionList instructions, LocalVariables locals)
@@ -3147,10 +3160,18 @@ namespace System.Linq.Expressions.Interpreter
                 args[i] = frame.Data[_args[i].Index];
             }
             args[args.Length - 1] = value;
-            _indexer.Invoke(
-                _obj == null ? null : frame.Data[_obj.Value.Index],
-                args
-            );
+
+            object instance = _obj == null ? null : frame.Data[_obj.Value.Index];
+
+            try
+            {
+                _indexer.Invoke(instance, args);
+            }
+            catch (TargetInvocationException e)
+            {
+                ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                throw e.InnerException;
+            }
         }
 
         public override void UndefineTemps(InstructionList instructions, LocalVariables locals)

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Address.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Address.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_INTERPRET
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.Expressions
+{
+    public static partial class InterpreterTests
+    {
+        #region Test methods
+
+        [Fact] // [Issue(4174, "https://github.com/dotnet/corefx/issues/4174")]
+        public static void InterpretCompileCrossChecks_Address_NonWritableField()
+        {
+            var mtd = typeof(WriteBack).GetMethod("Test");
+
+            foreach (var m in new Expression[]
+            {
+                Expression.Field(null, typeof(Holder).GetField("FSR")),
+                Expression.Field(null, typeof(Holder).GetField("FC")),
+                Expression.Field(Expression.Constant(new Holder()), typeof(Holder).GetField("FR")),
+            })
+            {
+                Verify(Expression.Call(mtd, m));
+            }
+        }
+
+        [Fact] // [Issue(4174, "https://github.com/dotnet/corefx/issues/4174")]
+        public static void InterpretCompileCrossChecks_Address_ThrowingPropertySetter()
+        {
+            var mtd = typeof(WriteBack).GetMethod("Test");
+
+            foreach (var m in new Expression[]
+            {
+                Expression.Property(Expression.Constant(new Holder()), typeof(Holder).GetProperty("P")),
+                Expression.MakeIndex(Expression.Constant(new Holder()), typeof(Holder).GetProperty("Item"), new[] { Expression.Constant(0) }),
+            })
+            {
+                Verify(Expression.Call(mtd, m));
+            }
+        }
+
+        class WriteBack
+        {
+            public static void Test(ref int value)
+            {
+                value = -1;
+            }
+        }
+
+        class Holder
+        {
+            public static readonly int FSR = 41;
+            public readonly int FR = 42;
+            public const int FC = 43;
+
+            public int P
+            {
+                get { return 42; }
+                set { throw new Exception("Oops!"); }
+            }
+
+            public int this[int index]
+            {
+                get { return 42; }
+                set { throw new Exception("Oops!"); }
+            }
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
@@ -34,9 +34,20 @@ namespace Tests.Expressions
 
         private static void Verify(Expression expr)
         {
+            Expression res;
+
+            if (expr.Type == typeof(void))
+            {
+                res = Expression.Block(expr, Expression.Constant(null));
+            }
+            else
+            {
+                res = Expression.Convert(expr, typeof(object));
+            }
+
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
-                    Expression.Convert(expr, typeof(object)),
+                    res,
                     Enumerable.Empty<ParameterExpression>());
 
             try

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="HelperTypes.cs" />
+    <Compile Include="Interpreter\InterpreterTests.Address.cs" />
     <Compile Include="Interpreter\InterpreterTests.cs" />
     <Compile Include="Interpreter\InterpreterTests.Generated.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />


### PR DESCRIPTION
This fixes the following issues:

- Exceptions thrown from `SetValue` calls during property write-back did not unwrap the `TargetInvocationException`
- Exceptions thrown from `Invoke` calls during indexer write-back did not unwrap the `TargetInvocationException`
- Write-backs were emitted for read-only fields, causing `SetValue` to fail
- Write-backs were emitted for constant fields, causing `SetValue` to fail

See #4174 as well.