### PR TITLE
Code formatting and untabification for System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -39,7 +39,7 @@ namespace System.Dynamic.Utils
         public static void ValidateType(Type type)
         {
             if (type != typeof(void))
-            { 
+            {
                 // A check to avoid a bunch of reflection (currently not supported) during cctor
                 if (type.GetTypeInfo().IsGenericTypeDefinition)
                 {

--- a/src/Common/src/System/SR.vb
+++ b/src/Common/src/System/SR.vb
@@ -55,7 +55,7 @@ Namespace System
             Return resourceString
         End Function
 
-        Friend Shared Function Format(ByVal resourceFormat As String, ParamArray args() As object) As String
+        Friend Shared Function Format(ByVal resourceFormat As String, ParamArray args() As Object) As String
             If args IsNot Nothing Then
                 If (UsingResourceKeys()) Then
                     Return resourceFormat + String.Join(", ", args)
@@ -66,7 +66,7 @@ Namespace System
         End Function
 
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
-        Friend Shared Function Format(ByVal resourceFormat As String, p1 As object) As String
+        Friend Shared Function Format(ByVal resourceFormat As String, p1 As Object) As String
             If (UsingResourceKeys()) Then
                 Return String.Join(", ", resourceFormat, p1)
             End If
@@ -75,7 +75,7 @@ Namespace System
         End Function
 
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
-        Friend Shared Function Format(ByVal resourceFormat As String, p1 As object, p2 As object) As String
+        Friend Shared Function Format(ByVal resourceFormat As String, p1 As Object, p2 As Object) As String
             If (UsingResourceKeys()) Then
                 Return String.Join(", ", resourceFormat, p1, p2)
             End If
@@ -84,7 +84,7 @@ Namespace System
         End Function
 
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
-        Friend Shared Function Format(ByVal resourceFormat As String, p1 As object, p2 As object, p3 As object) As String
+        Friend Shared Function Format(ByVal resourceFormat As String, p1 As Object, p2 As Object, p3 As Object) As String
             If (UsingResourceKeys()) Then
                 Return String.Join(", ", resourceFormat, p1, p2, p3)
             End If

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Compiler
             CompilationFlags startEmitted = emitStart ? EmitExpressionStart(node) : CompilationFlags.EmitNoExpressionStart;
             // only pass tail call flags to emit the expression
             flags = flags & CompilationFlags.EmitAsTailCallMask;
-            
+
             switch (node.NodeType)
             {
                 case ExpressionType.Add:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -126,8 +126,8 @@ namespace System.Linq.Expressions.Compiler
         /// Creates a lambda compiler for an inlined lambda
         /// </summary>
         private LambdaCompiler(
-            LambdaCompiler parent, 
-            LambdaExpression lambda, 
+            LambdaCompiler parent,
+            LambdaExpression lambda,
             InvocationExpression invocation)
         {
             _tree = parent._tree;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class AddInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -203,7 +203,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class AddOvfInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class DivInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -202,7 +202,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class ModuloInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -13,8 +13,8 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class EqualInstruction : Instruction
     {
         // Perf: EqualityComparer<T> but is 3/2 to 2 times slower.
-        private static Instruction s_reference,s_boolean,s_SByte,s_int16,s_char,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
-        private static Instruction s_referenceLiftedToNull,s_booleanLiftedToNull,s_SByteLiftedToNull,s_int16LiftedToNull,s_charLiftedToNull,s_int32LiftedToNull,s_int64LiftedToNull,s_byteLiftedToNull,s_UInt16LiftedToNull,s_UInt32LiftedToNull,s_UInt64LiftedToNull,s_singleLiftedToNull,s_doubleLiftedToNull;
+        private static Instruction s_reference, s_boolean, s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_referenceLiftedToNull, s_booleanLiftedToNull, s_SByteLiftedToNull, s_int16LiftedToNull, s_charLiftedToNull, s_int32LiftedToNull, s_int64LiftedToNull, s_byteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_singleLiftedToNull, s_doubleLiftedToNull;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -13,8 +13,8 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class GreaterThanInstruction : Instruction
     {
         private readonly object _nullValue;
-        private static Instruction s_SByte,s_int16,s_char,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
-        private static Instruction s_liftedToNullSByte,s_liftedToNullInt16,s_liftedToNullChar,s_liftedToNullInt32,s_liftedToNullInt64,s_liftedToNullByte,s_liftedToNullUInt16,s_liftedToNullUInt32,s_liftedToNullUInt64,s_liftedToNullSingle,s_liftedToNullDouble;
+        private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -335,8 +335,8 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class GreaterThanOrEqualInstruction : Instruction
     {
         private readonly object _nullValue;
-        private static Instruction s_SByte,s_int16,s_char,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
-        private static Instruction s_liftedToNullSByte,s_liftedToNullInt16,s_liftedToNullChar,s_liftedToNullInt32,s_liftedToNullInt64,s_liftedToNullByte,s_liftedToNullUInt16,s_liftedToNullUInt32,s_liftedToNullUInt64,s_liftedToNullSingle,s_liftedToNullDouble;
+        private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -88,7 +88,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 throw new NullReferenceException();
             }
-            
+
             return +1;
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -14,8 +14,8 @@ namespace System.Linq.Expressions.Interpreter
     {
         private readonly object _nullValue;
 
-        private static Instruction s_SByte,s_int16,s_char,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
-        private static Instruction s_liftedToNullSByte,s_liftedToNullInt16,s_liftedToNullChar,s_liftedToNullInt32,s_liftedToNullInt64,s_liftedToNullByte,s_liftedToNullUInt16,s_liftedToNullUInt32,s_liftedToNullUInt64,s_liftedToNullSingle,s_liftedToNullDouble;
+        private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -334,8 +334,8 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class LessThanOrEqualInstruction : Instruction
     {
         private readonly object _nullValue;
-        private static Instruction s_SByte,s_int16,s_char,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
-        private static Instruction s_liftedToNullSByte,s_liftedToNullInt16,s_liftedToNullChar,s_liftedToNullInt32,s_liftedToNullInt64,s_liftedToNullByte,s_liftedToNullUInt16,s_liftedToNullUInt32,s_liftedToNullUInt64,s_liftedToNullSingle,s_liftedToNullDouble;
+        private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1013,7 +1013,7 @@ namespace System.Linq.Expressions.Interpreter
                 Compile(node.Operand);
                 _instructions.EmitStoreLocal(opTemp.Index);
 
-                if (!node.Operand.Type.GetTypeInfo().IsValueType || 
+                if (!node.Operand.Type.GetTypeInfo().IsValueType ||
                     (TypeUtils.IsNullableType(node.Operand.Type) && node.IsLiftedToNull))
                 {
                     _instructions.EmitLoadLocal(opTemp.Index);
@@ -1023,7 +1023,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
 
                 _instructions.EmitLoadLocal(opTemp.Index);
-                if(TypeUtils.IsNullableType(node.Operand.Type) &&
+                if (TypeUtils.IsNullableType(node.Operand.Type) &&
                     node.Method.GetParametersCached()[0].ParameterType.Equals(TypeUtils.GetNonNullableType(node.Operand.Type)))
                 {
                     _instructions.Emit(NullableMethodCallInstruction.CreateGetValue());
@@ -1517,12 +1517,12 @@ namespace System.Linq.Expressions.Interpreter
             LocalDefinition temp = _locals.DefineLocal(Expression.Parameter(node.SwitchValue.Type), _instructions.Count);
             Compile(node.SwitchValue);
             _instructions.EmitStoreLocal(temp.Index);
-                        
+
             var doneLabel = Expression.Label(node.Type, "done");
 
-            foreach(var @case in node.Cases)
+            foreach (var @case in node.Cases)
             {
-                foreach(var val in @case.TestValues)
+                foreach (var val in @case.TestValues)
                 {
                     //  temp == val ? 
                     //          goto(Body) doneLabel: 
@@ -2768,7 +2768,7 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileUnboxUnaryExpression(Expression expr)
         {
             var node = (UnaryExpression)expr;
-            
+
             Compile(node.Operand);
 
             if (expr.Type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(expr.Type))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class MulInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class MulOvfInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -13,8 +13,8 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class NotEqualInstruction : Instruction
     {
         // Perf: EqualityComparer<T> but is 3/2 to 2 times slower.
-        private static Instruction s_reference,s_boolean,s_SByte,s_int16,s_char,s_int32,s_int64,s_byte,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
-        private static Instruction s_referenceLiftedToNull,s_booleanLiftedToNull,s_SByteLiftedToNull,s_int16LiftedToNull,s_charLiftedToNull,s_int32LiftedToNull,s_int64LiftedToNull,s_byteLiftedToNull,s_UInt16LiftedToNull,s_UInt32LiftedToNull,s_UInt64LiftedToNull,s_singleLiftedToNull,s_doubleLiftedToNull;
+        private static Instruction s_reference, s_boolean, s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_referenceLiftedToNull, s_booleanLiftedToNull, s_SByteLiftedToNull, s_int16LiftedToNull, s_charLiftedToNull, s_int32LiftedToNull, s_int64LiftedToNull, s_byteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_singleLiftedToNull, s_doubleLiftedToNull;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class SubInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class SubOvfInstruction : Instruction
     {
-        private static Instruction s_int16,s_int32,s_int64,s_UInt16,s_UInt32,s_UInt64,s_single,s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Interpreter
 
             return i;
         }
-        
+
         private static readonly object Int32_m = -1;
         private static readonly object Int32_0 = 0;
         private static readonly object Int32_1 = 1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -546,9 +546,11 @@ namespace System.Linq.Expressions
 
             MethodInfo mi;
             var ldc = s_lambdaDelegateCache;
-            if (!ldc.TryGetValue(delegateType, out mi)) {
+            if (!ldc.TryGetValue(delegateType, out mi))
+            {
                 mi = delegateType.GetMethod("Invoke");
-                if (TypeUtils.CanCache(delegateType)) {
+                if (TypeUtils.CanCache(delegateType))
+                {
                     ldc[delegateType] = mi;
                 }
             }

--- a/src/System.Linq.Expressions/src/project.json
+++ b/src/System.Linq.Expressions/src/project.json
@@ -23,6 +23,6 @@
     "System.Threading.Tasks": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": { }
   }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -750,7 +750,7 @@ namespace Tests.ExpressionCompiler.Binary
             Exception csException = null;
             try
             {
-                csResult = checked((long)(a * b)); 
+                csResult = checked((long)(a * b));
             }
             catch (Exception ex)
             {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -14,7 +14,7 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression variable = Expression.Variable(typeof(int));
             LabelTarget target = Expression.Label(typeof(int));
             Expression exp = Expression.Block(
-                new ParameterExpression[] {variable},
+                new ParameterExpression[] { variable },
                 Expression.Assign(variable, Expression.Constant(42)),
                 Expression.Return(target, variable),
                 Expression.Label(target, Expression.Default(typeof(int)))

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Assign.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Assign.cs
@@ -12,784 +12,784 @@ namespace Tests.Expressions
     {
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssign()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Add(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Add(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssign_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssignChecked()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Add(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Add(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AddAssignChecked_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AddAssignChecked(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AddAssignChecked, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssign()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Subtract(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Subtract(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssign_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssignChecked()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Subtract(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Subtract(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> SubtractAssignChecked_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.SubtractAssignChecked(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.SubtractAssignChecked, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssign()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Multiply(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Multiply(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssign_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssignChecked()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Multiply(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Multiply(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> MultiplyAssignChecked_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.MultiplyAssignChecked(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.MultiplyAssignChecked, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> DivideAssign()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Divide(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Divide(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> DivideAssign_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.DivideAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.DivideAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ModuloAssign()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Modulo(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Modulo(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ModuloAssign_Nullable()
         {
-			foreach (var t in s_binaryArithTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryArithTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ModuloAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ModuloAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> LeftShiftAssign()
         {
-			foreach (var t in s_binaryShiftTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[typeof(int)])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryShiftTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[typeof(int)])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.LeftShift(Expression.Default(typeof(S1)), Expression.Default(typeof(int))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.LeftShift(Expression.Default(typeof(S1)), Expression.Default(typeof(int))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(int)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(int)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> LeftShiftAssign_Nullable()
         {
-			foreach (var t in s_binaryShiftTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[typeof(int)])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryShiftTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[typeof(int)])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.LeftShiftAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.LeftShiftAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> RightShiftAssign()
         {
-			foreach (var t in s_binaryShiftTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[typeof(int)])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryShiftTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[typeof(int)])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.RightShift(Expression.Default(typeof(S1)), Expression.Default(typeof(int))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.RightShift(Expression.Default(typeof(S1)), Expression.Default(typeof(int))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(int)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(int)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> RightShiftAssign_Nullable()
         {
-			foreach (var t in s_binaryShiftTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[typeof(int)])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryShiftTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[typeof(int)])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.RightShiftAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.RightShiftAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AndAssign()
         {
-			foreach (var t in s_binaryLogicTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryLogicTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.And(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.And(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> AndAssign_Nullable()
         {
-			foreach (var t in s_binaryLogicTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryLogicTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.AndAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.AndAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> OrAssign()
         {
-			foreach (var t in s_binaryLogicTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryLogicTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.Or(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.Or(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> OrAssign_Nullable()
         {
-			foreach (var t in s_binaryLogicTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryLogicTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.OrAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.OrAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ExclusiveOrAssign()
         {
-			foreach (var t in s_binaryLogicTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryLogicTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = Expression.ExclusiveOr(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = Expression.ExclusiveOr(Expression.Default(typeof(S1)), Expression.Default(typeof(S1))).Method;
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
-					}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+                    }
 
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs, null, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
-					}
-				}
-			}
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs, null, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> ExclusiveOrAssign_Nullable()
         {
-			foreach (var t in s_binaryLogicTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryLogicTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.ExclusiveOrAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.ExclusiveOrAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PowerAssign()
         {
-			foreach (var t in s_binaryPowerTypes)
-			{
-				foreach (var l in s_exprs[t])
-				{
-					foreach (var r in s_exprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryPowerTypes)
+            {
+                foreach (var l in s_exprs[t])
+                {
+                    foreach (var r in s_exprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
+                        }
+                    }
+                }
+            }
 
-			var x = Expression.Parameter(typeof(S1));
-			var c = Expression.Lambda(Expression.Negate(x), x);
-			var m = typeof(S1).GetTypeInfo().GetDeclaredMethod("Pow");
+            var x = Expression.Parameter(typeof(S1));
+            var c = Expression.Lambda(Expression.Negate(x), x);
+            var m = typeof(S1).GetTypeInfo().GetDeclaredMethod("Pow");
 
-			foreach (var l in s_exprs[typeof(S1)])
-			{
-				foreach (var r in s_exprs[typeof(S1)])
-				{
-					foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs, m, c)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
-					}
-				}
-			}
+            foreach (var l in s_exprs[typeof(S1)])
+            {
+                foreach (var r in s_exprs[typeof(S1)])
+                {
+                    foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs, m, c)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PowerAssign_Nullable()
         {
-			foreach (var t in s_binaryPowerTypes)
-			{
-				foreach (var l in s_nullableExprs[t])
-				{
-					foreach (var r in s_nullableExprs[t])
-					{
-						foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs)))
-						{
-							yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
-						}
-					}
-				}
-			}
+            foreach (var t in s_binaryPowerTypes)
+            {
+                foreach (var l in s_nullableExprs[t])
+                {
+                    foreach (var r in s_nullableExprs[t])
+                    {
+                        foreach (var e in GetAssignments(l, r, (lhs, rhs) => Expression.PowerAssign(lhs, rhs)))
+                        {
+                            yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PowerAssign, e);
+                        }
+                    }
+                }
+            }
 
-			// TODO: conversion
+            // TODO: conversion
         }
 
-		private static IEnumerable<Expression> GetAssignments(Expression initialValue, Expression value, Func<Expression, Expression, Expression> createAssignment)
+        private static IEnumerable<Expression> GetAssignments(Expression initialValue, Expression value, Func<Expression, Expression, Expression> createAssignment)
         {
             // Parameter
             {
@@ -798,7 +798,7 @@ namespace Tests.Expressions
 
                 yield return Expression.Block(new[] { p }, a, createAssignment(p, value));
             }
-            
+
             // Member
             {
                 var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(initialValue.Type));
@@ -819,7 +819,7 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, a, b, createAssignment(e, value));
             }
 
-			// Vector
+            // Vector
             {
                 var p = Expression.Parameter(typeof(Vector<>).MakeGenericType(initialValue.Type));
                 var a = Expression.Assign(p, Expression.New(p.Type));
@@ -830,6 +830,6 @@ namespace Tests.Expressions
             }
         }
 
-		// TODO: conversion lambda
+        // TODO: conversion lambda
     }
 }

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Block.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Block.cs
@@ -366,8 +366,8 @@ namespace Tests.Expressions
                             )
                         );
 
-                        return new InstrumentWithLog(log).Visit(body);
-                    });
+                    return new InstrumentWithLog(log).Visit(body);
+                });
 
             yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.Block, expr);
         }

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.Generated.cs
@@ -238,7 +238,7 @@ namespace Tests.Expressions
 
             public int I0()
             {
-                _addToLog("I0(" + string.Join(", ", new object[] {  }) + ")");
+                _addToLog("I0(" + string.Join(", ", new object[] { }) + ")");
                 return 42;
             }
 
@@ -419,7 +419,7 @@ namespace Tests.Expressions
 
             public E I0()
             {
-                _addToLog("I0(" + string.Join(", ", new object[] {  }) + ")");
+                _addToLog("I0(" + string.Join(", ", new object[] { }) + ")");
                 return E.Red;
             }
 

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Conditional.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Conditional.cs
@@ -91,8 +91,8 @@ namespace Tests.Expressions
                                 summary
                             )
                         );
-                    });
-                }
+                });
             }
         }
     }
+}

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Assign.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Assign.cs
@@ -12,117 +12,117 @@ namespace Tests.Expressions
     {
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreIncrementAssign()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_exprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PreIncrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreIncrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_exprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PreIncrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreIncrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreIncrementAssign_Nullable()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_nullableExprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PreIncrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreIncrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_nullableExprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PreIncrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreIncrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostIncrementAssign()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_exprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PostIncrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostIncrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_exprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PostIncrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostIncrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostIncrementAssign_Nullable()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_nullableExprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PostIncrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostIncrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_nullableExprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PostIncrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostIncrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreDecrementAssign()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_exprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PreDecrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreDecrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_exprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PreDecrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreDecrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PreDecrementAssign_Nullable()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_nullableExprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PreDecrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreDecrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_nullableExprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PreDecrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PreDecrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostDecrementAssign()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_exprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PostDecrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostDecrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_exprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PostDecrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostDecrementAssign, e);
+                    }
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<ExpressionType, Expression>> PostDecrementAssign_Nullable()
         {
-			foreach (var t in s_unaryIncrDecrTypes)
-			{
-				foreach (var o in s_nullableExprs[t])
-				{
-					foreach (var e in GetAssignments(o, (op) => Expression.PostDecrementAssign(op)))
-					{
-						yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostDecrementAssign, e);
-					}
-				}
-			}
+            foreach (var t in s_unaryIncrDecrTypes)
+            {
+                foreach (var o in s_nullableExprs[t])
+                {
+                    foreach (var e in GetAssignments(o, (op) => Expression.PostDecrementAssign(op)))
+                    {
+                        yield return new KeyValuePair<ExpressionType, Expression>(ExpressionType.PostDecrementAssign, e);
+                    }
+                }
+            }
         }
 
-		private static IEnumerable<Expression> GetAssignments(Expression initialValue, Func<Expression, Expression> createAssignment)
+        private static IEnumerable<Expression> GetAssignments(Expression initialValue, Func<Expression, Expression> createAssignment)
         {
             // Parameter
             {
@@ -131,7 +131,7 @@ namespace Tests.Expressions
 
                 yield return Expression.Block(new[] { p }, a, createAssignment(p));
             }
-            
+
             // Member
             {
                 var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(initialValue.Type));
@@ -152,7 +152,7 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, a, b, createAssignment(e));
             }
 
-			// Vector
+            // Vector
             {
                 var p = Expression.Parameter(typeof(Vector<>).MakeGenericType(initialValue.Type));
                 var a = Expression.Assign(p, Expression.New(p.Type));

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.MemberAccess
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile();
 
-            Assert.Throws<NullReferenceException>(()=>f());
+            Assert.Throws<NullReferenceException>(() => f());
         }
 
         [Fact] // [Issue(3217, "https://github.com/dotnet/corefx/issues/3217")]

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -229,7 +229,7 @@ namespace Tests.ExpressionCompiler.New
         class TestPrivateDefaultConstructor
         {
             private TestPrivateDefaultConstructor()
-            { 
+            {
             }
 
             public static Func<TestPrivateDefaultConstructor> GetInstanceFunc()

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -29,6 +29,6 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": { }
   }
 }


### PR DESCRIPTION
Automated code cleanup for the System.Linq.Expressions projects in order to avoid future PRs that contain whitespace formatting changes that can be distracting. Automation based on http://haacked.com/archive/2011/05/22/an-obsessive-compulsive-guide-to-source-code-formatting.aspx and https://gist.github.com/davidfowl/984358 but tweaked a bit to:

- Get rid of the language filter which didn't yield any results (GUIDs for C# and VB changed maybe?)
- Get rid of "remove and sort usings" which is unreliable with the conditional compilation
- Add untabification

```powershell
function Format-Document {
    param(
        [parameter(ValueFromPipelineByPropertyName = $true)]
        [string[]]$ProjectName
    )
    Process {
        $ProjectName | %{ 
            Recurse-Project -ProjectName $_ -Action { param($item)
                if($item.Type -eq 'Folder') {
                    return
                }

                Write-Host $item.ProjectItem.Name

                $window = $item.ProjectItem.Open('{7651A701-06E5-11D1-8EBD-00A0C90F26EA}')
                if ($window) {
                    Write-Host "Processing `"$($item.ProjectItem.Name)`""
                    [System.Threading.Thread]::Sleep(100)
                    $window.Activate()
                    $Item.ProjectItem.Document.DTE.ExecuteCommand('Edit.FormatDocument')
                    $Item.ProjectItem.Document.DTE.ExecuteCommand('Edit.SelectAll')
                    $Item.ProjectItem.Document.DTE.ExecuteCommand('Edit.UntabifySelectedLines')
                    $window.Close(1)
                }
            }
        }
    }
}
```