### PR TITLE
Implement GetCertContentType for Unix

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -600,21 +600,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportCert()
         {
             TestExportSingleCert(X509ContentType.Cert);
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)]
         public static void ExportSerializedCert()
         {
             TestExportSingleCert(X509ContentType.SerializedCert);
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)]
         public static void ExportSerializedStore()
         {
             TestExportStore(X509ContentType.SerializedStore);

--- a/src/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    public class ContentTypeTests
+    {
+        [Theory]
+        [InlineData("My.pfx", X509ContentType.Pkcs12)]
+        [InlineData("My.cer", X509ContentType.Cert)]
+        public static void TestFileContentType(string fileName, X509ContentType contentType)
+        {
+            string fullPath = Path.Combine("TestData", fileName);
+            X509ContentType fileType = X509Certificate2.GetCertContentType(fullPath);
+            Assert.Equal(contentType, fileType);
+        }
+
+        [Theory]
+        [MemberData("GetContentBlobsWithType")]
+        public static void TestBlobContentType(byte[] blob, X509ContentType contentType)
+        {
+            X509ContentType blobType = X509Certificate2.GetCertContentType(blob);
+            Assert.Equal(contentType, blobType);
+        }
+
+        public static IEnumerable<object[]> GetContentBlobsWithType()
+        {
+            return new[]
+            {
+                new object[] { TestData.MsCertificate, X509ContentType.Cert }, 
+                new object[] { TestData.MsCertificatePemBytes, X509ContentType.Cert },
+                new object[] { TestData.Pkcs7ChainDerBytes, X509ContentType.Pkcs7 },
+                new object[] { TestData.Pkcs7ChainPemBytes, X509ContentType.Pkcs7 },
+                new object[] { TestData.Pkcs7EmptyDerBytes, X509ContentType.Pkcs7 },
+                new object[] { TestData.Pkcs7EmptyPemBytes, X509ContentType.Pkcs7 },
+                new object[] { TestData.Pkcs7SingleDerBytes, X509ContentType.Pkcs7 },
+                new object[] { TestData.Pkcs7SinglePemBytes, X509ContentType.Pkcs7 },
+                new object[] { TestData.PfxData, X509ContentType.Pkcs12 },
+                new object[] { TestData.EmptyPfx, X509ContentType.Pkcs12 },
+                new object[] { TestData.MultiPrivateKeyPfx, X509ContentType.Pkcs12 },
+                new object[] { TestData.ChainPfxBytes, X509ContentType.Pkcs12 },
+            };
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
 using Test.Cryptography;
 using Xunit;
 
@@ -102,17 +101,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.Equal(cert, certFromPfx);
                 }
             }
-        }
-
-        [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void TestContentType()
-        {
-            string fileName = Path.Combine("TestData", "My.pfx");
-            if (!File.Exists(fileName))
-                throw new Exception("Test infrastructure failure: Expected to find file: \"" + fileName + "\".");
-            X509ContentType ct = X509Certificate2.GetCertContentType(fileName);
-            Assert.Equal(X509ContentType.Pkcs12, ct);
         }
 
         private static readonly byte[] s_expectedSig =

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -196,7 +196,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestContentType()
         {
             X509ContentType ct = X509Certificate2.GetCertContentType(TestData.MsCertificate);

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="ChainTests.cs" />
     <Compile Include="CollectionImportTests.cs" />
     <Compile Include="CollectionTests.cs" />
+    <Compile Include="ContentTypeTests.cs" />
     <Compile Include="CtorTests.cs" />
     <Compile Include="ExportTests.cs" />
     <Compile Include="ExtensionsTests.cs" />


### PR DESCRIPTION
The file form of the overload was verified locally, but there aren't enough file-based test cases to ensure long term-reliability. #2635 tracks the addition of new test files, and I added a note there to update the TestFileContentType test when the new test file types are added.

This is a partial fix for #1993 (which essentially covers all outstanding NotImplementedExceptions)