### PR TITLE
Reenabling tests that were disabled due to CoreCLR bugs

### DIFF
--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -760,7 +760,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_TypeAs()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1084,7 +1083,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_AddAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1102,7 +1100,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_AndAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1120,7 +1117,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_DivideAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1138,7 +1134,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_ExclusiveOrAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1156,7 +1151,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_LeftShiftAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1174,7 +1168,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_ModuloAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1192,7 +1185,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_MultiplyAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1210,7 +1202,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_OrAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1228,7 +1219,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         [ActiveIssue(/*coreclr*/ 1835, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_PowerAssign()
         {
@@ -1247,7 +1237,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_RightShiftAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1265,7 +1254,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_SubtractAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1283,7 +1271,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_AddAssignChecked()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1301,7 +1288,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_MultiplyAssignChecked()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1319,7 +1305,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_SubtractAssignChecked()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1337,7 +1322,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_PreIncrementAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1355,7 +1339,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_PreDecrementAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1373,7 +1356,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_PostIncrementAssign()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1391,7 +1373,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1831, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_PostDecrementAssign()
         {
             var exprs = default(IEnumerable<Expression>);

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -674,7 +674,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1835, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_Power()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -1219,7 +1218,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue(/*coreclr*/ 1835, PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_PowerAssign()
         {
             var exprs = default(IEnumerable<Expression>);


### PR DESCRIPTION
Reenabling tests that were stuck on Unix-based platforms due to:

- https://github.com/dotnet/coreclr/issues/1831
- https://github.com/dotnet/coreclr/issues/1835