### PR TITLE
Add HttpClient tests to support all HTTP verbs

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -638,6 +638,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Various HTTP Method Tests
 
+        [ActiveIssue(4187, PlatformID.AnyUnix)]
         [Theory, MemberData("HttpMethods")]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithNoContent_MethodCorrectlySent(
             string method,
@@ -656,6 +657,7 @@ namespace System.Net.Http.Functional.Tests
             }        
         }
 
+        [ActiveIssue(4187, PlatformID.AnyUnix)]
         [Theory, MemberData("HttpMethodsThatAllowContent")]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithContent_Success(
             string method,

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -35,46 +35,24 @@ namespace System.Net.Http.Functional.Tests
 
         public readonly static object[][] GetServers = HttpTestServers.GetServers;
         public readonly static object[][] PostServers = HttpTestServers.PostServers;
-        public readonly static object[][] HttpMethods = 
-            new object[][]
+
+        // Standard HTTP methods defined in RFC7231: http://tools.ietf.org/html/rfc7231#section-4.3
+        //     "GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"
+        public readonly static IEnumerable<object[]> HttpMethods =
+            GetMethods("GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "TRACE", "CUSTOM1");
+        public readonly static IEnumerable<object[]> HttpMethodsThatAllowContent =
+            GetMethods("GET", "POST", "PUT", "DELETE", "CUSTOM1");
+
+        private static IEnumerable<object[]> GetMethods(params string[] methods)
+        {
+            foreach (string method in methods)
+            {
+                foreach (bool secure in new[] { true, false })
                 {
-                    // Standard HTTP methods defined in RFC7231: http://tools.ietf.org/html/rfc7231#section-4.3
-                    new object[] { "GET", false },
-                    new object[] { "GET", true },
-                    new object[] { "HEAD", false },
-                    new object[] { "HEAD", true },
-                    new object[] { "POST", false },
-                    new object[] { "POST", true },
-                    new object[] { "PUT", false },
-                    new object[] { "PUT", true },
-                    new object[] { "DELETE", false },
-                    new object[] { "DELETE", true },
-                    new object[] { "OPTIONS", false },
-                    new object[] { "OPTIONS", true },
-                    new object[] { "TRACE", false },
-                    new object[] { "TRACE", true },
-                    
-                    // Custom HTTP method
-                    new object[] { "CUSTOM1", false },
-                    new object[] { "CUSTOM1", true }
-                };
-        public readonly static object[][] HttpMethodsThatAllowContent = 
-            new object[][]
-                {
-                    // Standard HTTP methods defined in RFC7231: http://tools.ietf.org/html/rfc7231#section-4.3
-                    new object[] { "GET", false },
-                    new object[] { "GET", true },
-                    new object[] { "POST", false },
-                    new object[] { "POST", true },
-                    new object[] { "PUT", false },
-                    new object[] { "PUT", true },
-                    new object[] { "DELETE", false },
-                    new object[] { "DELETE", true },
-                    
-                    // Custom HTTP method
-                    new object[] { "CUSTOM1", false },
-                    new object[] { "CUSTOM1", true }
-                };
+                    yield return new object[] { method, secure };
+                }
+            }
+        }
 
         private static async Task AssertSuccessfulGetResponse(HttpResponseMessage response, Uri uri, ITestOutputHelper output)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -160,7 +160,7 @@ namespace System.Net.Http.Functional.Tests
                         useChunkedEncodingUpload = true;
                     }
 
-                    VerifyResponseBody(
+                    TestHelper.VerifyResponseBody(
                         responseContent,
                         response.Content.Headers.ContentMD5,
                         useChunkedEncodingUpload,
@@ -202,48 +202,13 @@ namespace System.Net.Http.Functional.Tests
                     string responseContent = await response.Content.ReadAsStringAsync();
                     _output.WriteLine(responseContent);
 
-                    VerifyResponseBody(
+                    TestHelper.VerifyResponseBody(
                         responseContent,
                         response.Content.Headers.ContentMD5,
                         true,
                         requestBody);
                 }
             }
-        }
-
-        private bool JsonMessageContainsKeyValue(string message, string key, string value)
-        {
-            // TODO: Align with the rest of tests w.r.t response parsing once the test server is finalized.
-            // Currently not adding any new dependencies
-            string pattern = string.Format(@"""{0}"": ""{1}""", key, value);
-            return message.Contains(pattern);
-        }
-
-        private void VerifyResponseBody(
-            string responseContent,
-            byte[] expectedMD5Hash,
-            bool chunkedUpload,
-            string requestBody)
-        {
-            // Compare computed hash with transmitted hash.
-            using (MD5 md5 = MD5.Create())
-            {
-                byte[] bytes = Encoding.ASCII.GetBytes(responseContent);
-                byte[] actualMD5Hash = md5.ComputeHash(bytes);
-                Assert.Equal(expectedMD5Hash, actualMD5Hash);
-            }
-
-            // Verify upload semsntics: 'Content-Length' vs. 'Transfer-Encoding: chunked'.
-            bool requestUsedContentLengthUpload =
-                JsonMessageContainsKeyValue(responseContent, "Content-Length", requestBody.Length.ToString());
-            bool requestUsedChunkedUpload =
-                JsonMessageContainsKeyValue(responseContent, "Transfer-Encoding", "chunked");
-            Assert.NotEqual(requestUsedContentLengthUpload, requestUsedChunkedUpload);
-            Assert.Equal(chunkedUpload, requestUsedChunkedUpload);
-            Assert.Equal(!chunkedUpload, requestUsedContentLengthUpload);
-
-            // Verify that request body content was correctly sent to server.
-            Assert.True(JsonMessageContainsKeyValue(responseContent, "BodyContent", requestBody), "Valid request body");
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="StringContentTest.cs" />
     <Compile Include="SyncBlockingContent.cs" />
+    <Compile Include="TestHelper.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//using System;
+using System.Collections.Generic;
+//using System.Net.Tests;
+using System.Security.Cryptography;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    // TODO: This class will eventually be moved to Common once the HttpTestServers are finalized.
+    public static class TestHelper
+    {
+        public static bool JsonMessageContainsKeyValue(string message, string key, string value)
+        {
+            // TODO: Align with the rest of tests w.r.t response parsing once the test server is finalized.
+            // Currently not adding any new dependencies
+            string pattern = string.Format(@"""{0}"": ""{1}""", key, value);
+            return message.Contains(pattern);
+        }
+
+        public static bool JsonMessageContainsKey(string message, string key)
+        {
+            // TODO: Align with the rest of tests w.r.t response parsing once the test server is finalized.
+            // Currently not adding any new dependencies
+            string pattern = string.Format(@"""{0}"": """, key);
+            return message.Contains(pattern);
+        }
+
+        public static void VerifyResponseBody(
+            string responseContent,
+            byte[] expectedMD5Hash,
+            bool chunkedUpload,
+            string requestBody)
+        {
+            // Compare computed hash with transmitted hash.
+            using (MD5 md5 = MD5.Create())
+            {
+                byte[] bytes = Encoding.ASCII.GetBytes(responseContent);
+                byte[] actualMD5Hash = md5.ComputeHash(bytes);
+                Assert.Equal(expectedMD5Hash, actualMD5Hash);
+            }
+
+            // Verify upload semsntics: 'Content-Length' vs. 'Transfer-Encoding: chunked'.
+            bool requestUsedContentLengthUpload =
+                JsonMessageContainsKeyValue(responseContent, "Content-Length", requestBody.Length.ToString());
+            bool requestUsedChunkedUpload =
+                JsonMessageContainsKeyValue(responseContent, "Transfer-Encoding", "chunked");
+            if (requestBody.Length > 0)
+            {
+                Assert.NotEqual(requestUsedContentLengthUpload, requestUsedChunkedUpload);
+                Assert.Equal(chunkedUpload, requestUsedChunkedUpload);
+                Assert.Equal(!chunkedUpload, requestUsedContentLengthUpload);
+            }
+
+            // Verify that request body content was correctly sent to server.
+            Assert.True(JsonMessageContainsKeyValue(responseContent, "BodyContent", requestBody), "Valid request body");
+        }
+
+        public static void VerifyRequestMethod(HttpResponseMessage response, string expectedMethod)
+        {
+           IEnumerable<string> values = response.Headers.GetValues("X-HttpRequest-Method");
+           foreach (string value in values)
+           {
+               Assert.Equal(expectedMethod, value);
+           }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-//using System;
 using System.Collections.Generic;
-//using System.Net.Tests;
 using System.Security.Cryptography;
 using System.Text;
 


### PR DESCRIPTION
Added tests for validating against all standard and custom HTTP verbs. These tests use the new networking test server.

Cosolidated some existing tests that were duplicative. More test porting and reorganzing will be done in later PRs.