### PR TITLE
Trim response headers in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -565,7 +565,7 @@ namespace System.Net.Http
                             if (colonIndex > 0)
                             {
                                 string headerName = responseHeader.Substring(0, colonIndex);
-                                string headerValue = responseHeader.Substring(colonIndex + 1);
+                                string headerValue = responseHeader.Substring(colonIndex + 1).Trim();
 
                                 if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
                                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -616,7 +616,6 @@ namespace System.Net.Http.Functional.Tests
 
         #region Various HTTP Method Tests
 
-        [ActiveIssue(4187, PlatformID.AnyUnix)]
         [Theory, MemberData("HttpMethods")]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithNoContent_MethodCorrectlySent(
             string method,
@@ -635,7 +634,6 @@ namespace System.Net.Http.Functional.Tests
             }        
         }
 
-        [ActiveIssue(4187, PlatformID.AnyUnix)]
         [Theory, MemberData("HttpMethodsThatAllowContent")]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithContent_Success(
             string method,


### PR DESCRIPTION
Apply same header response trimming done by WinHttpHandler.
Fixes #4187
cc: @kapilash, @davidsh 

(At some point I'd like to go through and replace all Substring(...).Trim() calls with a more efficient SubstringTrim(...) that doesn't allocate an intermediate string.  But in the meantime, this addresses the problem.)