### PR TITLE
Port to RC1: Trim response headers in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -565,7 +565,7 @@ namespace System.Net.Http
                             if (colonIndex > 0)
                             {
                                 string headerName = responseHeader.Substring(0, colonIndex);
-                                string headerValue = responseHeader.Substring(colonIndex + 1);
+                                string headerValue = responseHeader.Substring(colonIndex + 1).Trim();
 
                                 if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
                                 {


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/corefx/pull/4194 for RC1
The original fix contained test changes as well, but those tests are not in the RC1 branch.