### PR TITLE
Replace Substring(...).Trim() with SubstringTrim(...)

### DIFF
--- a/src/Common/src/System/StringExtensions.cs
+++ b/src/Common/src/System/StringExtensions.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System
+{
+    internal static class StringExtensions
+    {
+        internal static string SubstringTrim(this string value, int startIndex)
+        {
+            return SubstringTrim(value, startIndex, value.Length - startIndex);
+        }
+
+        internal static string SubstringTrim(this string value, int startIndex, int length)
+        {
+            Debug.Assert(value != null, "string must be non-null");
+            Debug.Assert(startIndex >= 0, "startIndex must be non-negative");
+            Debug.Assert(length >= 0, "length must be non-negative");
+            Debug.Assert(startIndex <= value.Length - length, "startIndex + length must be <= value.Length");
+
+            if (length == 0)
+            {
+                return string.Empty;
+            }
+
+            int endIndex = startIndex + length - 1;
+
+            while (startIndex <= endIndex && char.IsWhiteSpace(value[startIndex]))
+            {
+                startIndex++;
+            }
+
+            while (endIndex >= startIndex && char.IsWhiteSpace(value[endIndex]))
+            {
+                endIndex--;
+            }
+
+            int newLength = endIndex - startIndex + 1;
+            Debug.Assert(newLength >= 0 && newLength <= value.Length, "Expected resulting length to be within value's length");
+
+            return
+                newLength == 0 ? string.Empty :
+                newLength == value.Length ? value :
+                value.Substring(startIndex, newLength);
+        }
+    }
+}

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -26,6 +26,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\src\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\src\System\IO\PathInternal.cs">
       <Link>Common\System\IO\PathInternal.cs</Link>
     </Compile>
@@ -41,6 +44,7 @@
     <Compile Include="..\src\System\IO\TaskHelpers.cs">
       <Link>Common\System\IO\TaskHelpers.cs</Link>
     </Compile>
+    <Compile Include="Tests\System\StringExtensions.Tests.cs" />
     <Compile Include="Tests\System\IO\PathInternal.Tests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">

--- a/src/Common/tests/Tests/System/StringExtensions.Tests.cs
+++ b/src/Common/tests/Tests/System/StringExtensions.Tests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace Tests.System
+{
+    public class StringExtensionTests
+    {
+        [Theory]
+        [InlineData("", 0, 0, "")]
+        [InlineData("  ", 0, 0, "")]
+        [InlineData("  ", 0, 2, "")]
+        [InlineData("  ", 1, 1, "")]
+        [InlineData("hello", 1, 0, "")]
+        [InlineData("hello", 0, 5, "hello")]
+        [InlineData("hello", 1, 4, "ello")]
+        [InlineData("hello", 1, 3, "ell")]
+        [InlineData("hello", 2, 1, "l")]
+        [InlineData("hello", 4, 1, "o")]
+        [InlineData(" hello\t\t ", 0, 9, "hello")]
+        [InlineData(" hello\r\t ", 1, 5, "hello")]
+        [InlineData(" hello\t\n ", 6, 3, "")]
+        [InlineData(" hello\t\n ", 8, 1, "")]
+        [InlineData(" hello\t\n ", 9, 0, "")]
+        public void SubstringTrim_VariousInputsOutputs(string source, int startIndex, int length, string expectedResult)
+        {
+            Action<string> validate = result =>
+            {
+                Assert.Equal(expectedResult, result);
+                if (result.Length == 0)
+                {
+                    Assert.Same(string.Empty, result);
+                }
+                else if (result.Length == source.Length)
+                {
+                    Assert.Same(source, result);
+                }
+            };
+
+            validate(source.SubstringTrim(startIndex, length));
+
+            if (length == source.Length - startIndex)
+            {
+                validate(source.SubstringTrim(startIndex));
+            }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -14,6 +14,7 @@
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.winhttp_types.cs" />
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.winhttp.cs" />
     <CompileItem Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
+    <CompileItem Include="$(CommonPath)\System\StringExtensions.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\HttpVersion.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\UriScheme.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -198,7 +198,7 @@ namespace System.Net.Http
                 if (colonIndex > 0)
                 {
                     string headerName = responseHeaderArray[i].Substring(0, colonIndex);
-                    string headerValue = responseHeaderArray[i].Substring(colonIndex + 1).Trim(); // Normalize header value by trimming white space.
+                    string headerValue = responseHeaderArray[i].SubstringTrim(colonIndex + 1); // Normalize header value by trimming white space.
 
                     if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
                     {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -41,6 +41,9 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
       <Link>Common\System\Net\HttpVersion.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/Internal/Mail/MailAddressParser.cs
+++ b/src/System.Net.Http/src/Internal/Mail/MailAddressParser.cs
@@ -303,11 +303,9 @@ namespace System.Net.Mail
 
                 Debug.Assert(index < 0 || data[index] == MailBnfHelper.Comma, "Mis-alligned index: " + index);
 
-                // Do not include the Comma (if any)
-                displayName = data.Substring(index + 1, startingIndex - index);
-
-                // Because there were no bounding quotes, trim extra whitespace 
-                displayName = displayName.Trim();
+                // Do not include the Comma (if any), and because there were no bounding quotes, 
+                // trim extra whitespace.
+                displayName = data.SubstringTrim(index + 1, startingIndex - index);
             }
             return NormalizeOrThrow(displayName);
         }

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -217,6 +217,9 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
       <Link>Common\System\Net\HttpVersion.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -565,7 +565,7 @@ namespace System.Net.Http
                             if (colonIndex > 0)
                             {
                                 string headerName = responseHeader.Substring(0, colonIndex);
-                                string headerValue = responseHeader.Substring(colonIndex + 1).Trim();
+                                string headerValue = responseHeader.SubstringTrim(colonIndex + 1);
 
                                 if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
                                 {

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -25,6 +25,9 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>ProductionCode\Common\System\NotImplemented.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>ProductionCode\Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -55,6 +55,9 @@
     <Compile Include="System\Security\Authentication\ExtendedProtection\ChannelBinding.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ChannelBindingKind.cs" />
 
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs" >
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -1009,7 +1009,7 @@ namespace System.Net
         // Gets the full string of the cookie
         internal string GetCookieString()
         {
-            return _tokenStream.Substring(_cookieStartIndex, _cookieLength).Trim();
+            return _tokenStream.SubstringTrim(_cookieStartIndex, _cookieLength);
         }
 
         // Extract
@@ -1021,11 +1021,9 @@ namespace System.Net
 
             if (_tokenLength != 0)
             {
-                tokenString = _tokenStream.Substring(_start, _tokenLength);
-                if (!Quoted)
-                {
-                    tokenString = tokenString.Trim();
-                }
+                tokenString = Quoted ?
+                    _tokenStream.Substring(_start, _tokenLength) :
+                    _tokenStream.SubstringTrim(_start, _tokenLength);
             }
             return tokenString;
         }

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\..\src\System\Net\Sockets\SocketError.cs" >
       <Link>ProductionCode\System\Net\Sockets\SocketError.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs" >
       <Link>ProductionCode\Common\System\Net\ByteOrder.cs</Link>
     </Compile>

--- a/src/System.Net.WebHeaderCollection/src/System.Net.WebHeaderCollection.csproj
+++ b/src/System.Net.WebHeaderCollection/src/System.Net.WebHeaderCollection.csproj
@@ -24,6 +24,9 @@
     <Compile Include="System\Net\HttpRequestHeader.cs" />
     <Compile Include="System\Net\HeaderInfo.cs" />
     <Compile Include="System\Net\HeaderInfoTable.cs" />
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>

--- a/src/System.Net.WebHeaderCollection/src/System/Net/HeaderInfoTable.cs
+++ b/src/System.Net.WebHeaderCollection/src/System/Net/HeaderInfoTable.cs
@@ -32,7 +32,7 @@ namespace System.Net
                 }
                 else if ((value[i] == ',') && !inquote)
                 {
-                    tempStringCollection.Add(SubstringTrim(value, startIndex, length));
+                    tempStringCollection.Add(value.SubstringTrim(startIndex, length));
                     startIndex = i + 1;
                     length = 0;
                     continue;
@@ -43,7 +43,7 @@ namespace System.Net
             // Now add the last of the header values to the stringtable.
             if (startIndex < value.Length && length > 0)
             {
-                tempStringCollection.Add(SubstringTrim(value, startIndex, length));
+                tempStringCollection.Add(value.SubstringTrim(startIndex, length));
             }
 
             return tempStringCollection.ToArray();
@@ -104,35 +104,6 @@ namespace System.Net
             { HttpKnownHeaderNames.Warning,            new HeaderInfo(HttpKnownHeaderNames.Warning,            false,  false,  true,   s_multiParser) },
             { HttpKnownHeaderNames.WWWAuthenticate,    new HeaderInfo(HttpKnownHeaderNames.WWWAuthenticate,    false,  true,   true,   s_singleParser) }
         };
-
-        private static string SubstringTrim(string value, int startIndex, int length)
-        {
-            int offset = 0;
-            while (offset < length && char.IsWhiteSpace(value[startIndex + offset]))
-            {
-                offset++;
-            }
-
-            int end = length - 1;
-            while (end >= offset && char.IsWhiteSpace(value[startIndex + end]))
-            {
-                end--;
-            }
-
-            int newLength = end - offset + 1;
-            if (newLength == 0)
-            {
-                return string.Empty;
-            }
-
-            int newStartIndex = startIndex + offset;
-            if (newStartIndex == 0 && newLength == value.Length)
-            {
-                return value;
-            }
-
-            return value.Substring(newStartIndex, newLength);
-        }
 
         internal static HeaderInfo GetKnownHeaderInfo(string name)
         {


### PR DESCRIPTION
System.Net.WebHeaderCollection already had a SubstringTrim helper that's used instead of Substring(...).Trim() to avoid first creating the substring and then trimming it, instead just offsetting the startIndex and length appropriately to do the Substring and create only one string.

I've factored this helper out into Common, cleaned it up a bit, added unit tests for it, and used it in a few more places in System.Net.

cc: @ellismg, @davidsh, @cipop

(@justinvp, I know you have an outstanding PR that touches one of these locations, though I think that's already needing updates based on other changes that have gone in.  Sorry for any additional churn.)