### PR TITLE
Port to RC1: Fix CurlHandler deadlock with synchronous CopyToAsync

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -78,7 +78,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData("EchoServers")]
-        [ActiveIssue(4093, PlatformID.AnyUnix)]
         public async Task PostSyncBlockingContentUsingChunkedEncoding_Success(Uri serverUri)
         {
             await PostHelper(serverUri, ExpectedContent, new SyncBlockingContent(ExpectedContent),


### PR DESCRIPTION
CurlHandler calls to HttpContext.CopyToAsync with a stream that CopyToAsync should write to asynchronously.  If, however, the call to CopyToAsync writes to it synchronously as part of the synchronous call to CopyToAsync, CurlHandler will deadlock.

As a precaution, we ensure that the CopyToAsync call is asynchronous from the perspective of CurlHandler.