### PR TITLE
Change Debug.Assert on Windows when no debugger attached

### DIFF
--- a/src/Common/src/System/Diagnostics/Debug.cs
+++ b/src/Common/src/System/Diagnostics/Debug.cs
@@ -58,16 +58,6 @@ namespace System.Diagnostics
             Assert(false, message, detailMessage);
         }
 
-        private static string FormatAssert(string stackTrace, string message, string detailMessage)
-        {
-            return SR.DebugAssertBanner + Environment.NewLine
-                   + SR.DebugAssertShortMessage + Environment.NewLine
-                   + message + Environment.NewLine
-                   + SR.DebugAssertLongMessage + Environment.NewLine
-                   + detailMessage + Environment.NewLine
-                   + stackTrace;
-        }
-
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition, string message, string detailMessageFormat, params object[] args)
         {
@@ -212,6 +202,16 @@ namespace System.Diagnostics
             {
                 WriteLine(value, category);
             }
+        }
+
+        private static string FormatAssert(string stackTrace, string message, string detailMessage)
+        {
+            return SR.DebugAssertBanner + Environment.NewLine
+                   + SR.DebugAssertShortMessage + Environment.NewLine
+                   + message + Environment.NewLine
+                   + SR.DebugAssertLongMessage + Environment.NewLine
+                   + detailMessage + Environment.NewLine
+                   + stackTrace;
         }
 
         internal interface IDebugLogger

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -12,12 +12,10 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NuGetTargetFrameworkMoniker>DNXCore,Version=v5.0</NuGetTargetFrameworkMoniker>
     <NoWarn>0436</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Suppress warnings for type conflicts between SafeFileHandle in partial facade and mscorlib -->
     <UsePackageTargetRuntimeDefaults>true</UsePackageTargetRuntimeDefaults>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />
@@ -41,8 +39,17 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetStdHandle.cs">
+      <Link>Common\Interop\Windows\Interop.GetStdHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.HandleTypes.cs">
+      <Link>Common\Interop\Windows\Interop.HandleTypes.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OutputDebugString.cs">
       <Link>Common\Interop\Windows\mincore\Interop.OutputDebugString.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.WriteFile_IntPtr.cs">
+      <Link>Common\Interop\Windows\Interop.WriteFile.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -66,8 +66,17 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetStdHandle.cs">
+      <Link>Common\Interop\Windows\Interop.GetStdHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.HandleTypes.cs">
+      <Link>Common\Interop\Windows\Interop.HandleTypes.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OutputDebugString.cs">
       <Link>Common\Interop\Windows\mincore\Interop.OutputDebugString.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.WriteFile_IntPtr.cs">
+      <Link>Common\Interop\Windows\Interop.WriteFile.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.Windows.cs">
       <Link>Common\System\StringNormalizationExtensions.Windows.cs</Link>


### PR DESCRIPTION
cc: @ellismg, @mmitche, @davidsh, @weshaggard 
What do you guys think of this behavior change to what we have with Assert today on Windows?

Today on Windows if no debugger is attached, Debug.Assert fail fasts, which makes diagnosing difficult in a continuous integration environment; it also causes any other tests in the same process to be abandoned.

This commit changes Assert to instead write to stderr and throw an exception in such situations.  The exception helps to ensure that code containing the assert is alerted to the failure, and the stderr output helps to ensure that it's noticed even if the exception is eaten.