### PR TITLE
Revert "Change Debug.Assert on Windows when no debugger attached"

### DIFF
--- a/src/Common/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Windows.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security;
-using System.Text;
 using System.Threading;
 
 namespace System.Diagnostics
@@ -25,17 +24,16 @@ namespace System.Diagnostics
             [SecuritySafeCritical]
             public void ShowAssertDialog(string stackTrace, string message, string detailMessage)
             {
+                string fullMessage = message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace;
+
+                Debug.WriteLine(fullMessage);
                 if (Debugger.IsAttached)
                 {
-                    string fullMessage = message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace;
-                    Debug.WriteLine(fullMessage);
                     Debugger.Break();
                 }
                 else
                 {
-                    string fullMessage = FormatAssert(stackTrace, message, detailMessage) + Environment.NewLine;
-                    WriteToStdErr(fullMessage); // ignore return value indicating whether or not write was successful
-                    throw new InvalidOperationException(fullMessage);
+                    Environment.FailFast(fullMessage);
                 }
             }
 
@@ -76,25 +74,6 @@ namespace System.Diagnostics
                 {
                     Interop.mincore.OutputDebugString(message ?? string.Empty);
                 }
-            }
-
-            private static unsafe bool WriteToStdErr(string message)
-            {
-                IntPtr handle = Interop.mincore.GetStdHandle(Interop.mincore.HandleTypes.STD_ERROR_HANDLE);
-                if (handle != IntPtr.Zero && handle != new IntPtr(-1))
-                {
-                    byte[] messageBytes = Encoding.ASCII.GetBytes(message);
-                    fixed (byte* messageBytesPtr = messageBytes)
-                    {
-                        int numBytesWritten;
-                        if (Interop.mincore.WriteFile(handle, messageBytesPtr, messageBytes.Length, out numBytesWritten, IntPtr.Zero) != 0)
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
             }
         }
     }

--- a/src/Common/src/System/Diagnostics/Debug.cs
+++ b/src/Common/src/System/Diagnostics/Debug.cs
@@ -58,6 +58,16 @@ namespace System.Diagnostics
             Assert(false, message, detailMessage);
         }
 
+        private static string FormatAssert(string stackTrace, string message, string detailMessage)
+        {
+            return SR.DebugAssertBanner + Environment.NewLine
+                   + SR.DebugAssertShortMessage + Environment.NewLine
+                   + message + Environment.NewLine
+                   + SR.DebugAssertLongMessage + Environment.NewLine
+                   + detailMessage + Environment.NewLine
+                   + stackTrace;
+        }
+
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition, string message, string detailMessageFormat, params object[] args)
         {
@@ -202,16 +212,6 @@ namespace System.Diagnostics
             {
                 WriteLine(value, category);
             }
-        }
-
-        private static string FormatAssert(string stackTrace, string message, string detailMessage)
-        {
-            return SR.DebugAssertBanner + Environment.NewLine
-                   + SR.DebugAssertShortMessage + Environment.NewLine
-                   + message + Environment.NewLine
-                   + SR.DebugAssertLongMessage + Environment.NewLine
-                   + detailMessage + Environment.NewLine
-                   + stackTrace;
         }
 
         internal interface IDebugLogger

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -12,10 +12,12 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NuGetTargetFrameworkMoniker>DNXCore,Version=v5.0</NuGetTargetFrameworkMoniker>
     <NoWarn>0436</NoWarn>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Suppress warnings for type conflicts between SafeFileHandle in partial facade and mscorlib -->
     <UsePackageTargetRuntimeDefaults>true</UsePackageTargetRuntimeDefaults>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />
@@ -39,17 +41,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetStdHandle.cs">
-      <Link>Common\Interop\Windows\Interop.GetStdHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.HandleTypes.cs">
-      <Link>Common\Interop\Windows\Interop.HandleTypes.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OutputDebugString.cs">
       <Link>Common\Interop\Windows\mincore\Interop.OutputDebugString.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.WriteFile_IntPtr.cs">
-      <Link>Common\Interop\Windows\Interop.WriteFile.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -66,17 +66,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetStdHandle.cs">
-      <Link>Common\Interop\Windows\Interop.GetStdHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.HandleTypes.cs">
-      <Link>Common\Interop\Windows\Interop.HandleTypes.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OutputDebugString.cs">
       <Link>Common\Interop\Windows\mincore\Interop.OutputDebugString.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.WriteFile_IntPtr.cs">
-      <Link>Common\Interop\Windows\Interop.WriteFile.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.Windows.cs">
       <Link>Common\System\StringNormalizationExtensions.Windows.cs</Link>


### PR DESCRIPTION
Reverts dotnet/corefx#4212

Breaks the internal TFS build.  Will try another approach later.
cc: @ellismg 