### PR TITLE
Several changes to Debug.Assert

### DIFF
--- a/src/Common/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Windows.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security;
-using System.Threading;
 
 namespace System.Diagnostics
 {
@@ -24,16 +23,14 @@ namespace System.Diagnostics
             [SecuritySafeCritical]
             public void ShowAssertDialog(string stackTrace, string message, string detailMessage)
             {
-                string fullMessage = message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace;
-
-                Debug.WriteLine(fullMessage);
                 if (Debugger.IsAttached)
                 {
                     Debugger.Break();
                 }
                 else
                 {
-                    Environment.FailFast(fullMessage);
+                    // TODO: #3708 Determine if/how to put up a dialog instead.
+                    throw new DebugAssertException(message, detailMessage, stackTrace);
                 }
             }
 

--- a/src/Common/src/System/Diagnostics/Debug.cs
+++ b/src/Common/src/System/Diagnostics/Debug.cs
@@ -219,5 +219,13 @@ namespace System.Diagnostics
             void ShowAssertDialog(string stackTrace, string message, string detailMessage);
             void WriteCore(string message);
         }
+
+        private sealed class DebugAssertException : Exception
+        {
+            internal DebugAssertException(string message, string detailMessage, string stackTrace) : 
+                base(message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
This is another attempt at #4212, which was then immediately reverted in #4220 because it broke some internal build stuff due to the APIs being used.

Changes on Windows:
- When an Assert fires and the debugger isn't attached, instead of Environment.FailFast'ing, we throw an exception.
- When an Assert fires, we were previously calling Debug.WriteLine twice; now we only call it once.

Changes on Unix:
- Made the Assert functionality match that of Windows in terms of the APIs being called.
- Changed WriteCore to check Debugger.IsLogging and, if it's true, do a Debugger.Log, just as we do on Windows.  Right now these are nops, but when that changes this will become useful.  The fallback when IsLogging is false remains the same: write to syslog.
- Fixed the WriteToStderr function to ignore errors from Write, as we don't want this function throwing exceptions due to failed attempts to output to stderr, such as if it was piped to another program that ended before this one (as with #4221).

cc: @ellismg, @mellinoe, @davidsh, @weshaggard 